### PR TITLE
fix(env): Property 'xxx' does not exist on type 'Env'.

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -115,4 +115,17 @@ describe('Context', () => {
     expect(res.status).toBe(200)
     expect(res.statusText).toBe('OK')
   })
+
+  it('Should be able read env', async () => {
+    const req = new Request('http://localhost/')
+    const key = 'a-secret-key'
+    const ctx = new Context(req, {
+      env: {
+        API_KEY: key,
+      },
+      res: null,
+      event: null,
+    })
+    expect(ctx.env.API_KEY).toBe(key)
+  })
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,7 +5,9 @@ import { isAbsoluteURL } from '@/utils/url'
 type Headers = Record<string, string>
 type Data = string | ArrayBuffer | ReadableStream
 
-export interface Env {}
+export interface Env {
+  [key: string]: string
+}
 
 export class Context<RequestParamKeyType = string> {
   req: Request<RequestParamKeyType>


### PR DESCRIPTION
make the Env interface [string:string], to fix the issue `Property 'xxx' does not exist on type 'Env'.` when we're trying to get the env 'xxx' from `ctx.env` with `ctx.env.xxx`