### PR TITLE
feat: enable adding types for Env variables

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -115,4 +115,17 @@ describe('Context', () => {
     expect(res.status).toBe(200)
     expect(res.statusText).toBe('OK')
   })
+
+  it('Should be able read env', async () => {
+    const req = new Request('http://localhost/')
+    const key = 'a-secret-key'
+    const ctx = new Context(req, {
+      env: {
+        API_KEY: key,
+      },
+      res: null,
+      event: null,
+    })
+    expect(ctx.env.API_KEY).toBe(key)
+  })
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,12 +5,12 @@ import { isAbsoluteURL } from '@/utils/url'
 type Headers = Record<string, string>
 type Data = string | ArrayBuffer | ReadableStream
 
-export interface Env {}
+export type Env = Record<string, any>
 
-export class Context<RequestParamKeyType = string> {
+export class Context<RequestParamKeyType = string, E = Env> {
   req: Request<RequestParamKeyType>
   res: Response
-  env: Env
+  env: E
   event: FetchEvent
 
   #headers: Headers
@@ -24,7 +24,7 @@ export class Context<RequestParamKeyType = string> {
 
   constructor(
     req: Request<RequestParamKeyType>,
-    opts?: { res: Response; env: Env; event: FetchEvent }
+    opts?: { res: Response; env: E; event: FetchEvent }
   ) {
     this.req = this.initRequest<RequestParamKeyType>(req)
     Object.assign(this, opts)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1,3 +1,4 @@
+import type { Context } from '@/context'
 import { Hono } from '@/hono'
 
 describe('GET Request', () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -37,9 +37,9 @@ type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
 
 interface HandlerInterface<T extends string, E = Env> {
   <Path extends string>(path: Path, handler: Handler<ParamKeys<Path>, E>): Hono<E, Path>
-  <Path extends string>(path: Path, handler: Handler<string, E>): Hono<E, Path>
+  (path: string, handler: Handler<string, E>): Hono<E, T>
   <Path extends T>(handler: Handler<ParamKeys<T>, E>): Hono<E, Path>
-  <Path extends T>(handler: Handler<string, E>): Hono<E, Path>
+  (handler: Handler<string, E>): Hono<E, T>
 }
 
 const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch', 'all'] as const

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -14,13 +14,12 @@ declare global {
   }
 }
 
-export type Handler<RequestParamKeyType = string> = (
-  c: Context<RequestParamKeyType>,
-  next?: Next
+export type Handler<RequestParamKeyType = string, E = Env> = (
+  c: Context<RequestParamKeyType, E>
 ) => Response | Promise<Response>
-export type MiddlewareHandler = (c: Context, next: Next) => Promise<void>
-export type NotFoundHandler = (c: Context) => Response | Promise<Response>
-export type ErrorHandler = (err: Error, c: Context) => Response
+export type MiddlewareHandler<E = Env> = (c: Context<string, E>, next: Next) => Promise<void>
+export type NotFoundHandler<E = Env> = (c: Context<string, E>) => Response | Promise<Response>
+export type ErrorHandler<E = Env> = (err: Error, c: Context<string, E>) => Response
 export type Next = () => Promise<void>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,36 +35,38 @@ type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
   ? ParamKey<Component> | ParamKeys<Rest>
   : ParamKey<Path>
 
-interface HandlerInterface<T extends string> {
-  <Path extends string>(path: Path, handler: Handler<ParamKeys<Path>>): Hono<Path>
-  <Path extends T>(handler: Handler<ParamKeys<T>>): Hono<Path>
+interface HandlerInterface<T extends string, E = Env> {
+  <Path extends string>(path: Path, handler: Handler<ParamKeys<Path>, E>): Hono<E, Path>
+  <Path extends string>(path: Path, handler: Handler<string, E>): Hono<E, Path>
+  <Path extends T>(handler: Handler<ParamKeys<T>, E>): Hono<E, Path>
+  <Path extends T>(handler: Handler<string, E>): Hono<E, Path>
 }
 
 const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch', 'all'] as const
 type Methods = typeof methods[number]
 
 function defineDynamicClass(): {
-  new <T extends string>(): {
-    [K in Methods]: HandlerInterface<T>
+  new <E extends Env, T extends string>(): {
+    [K in Methods]: HandlerInterface<T, E>
   }
 } {
   return class {} as any
 }
 
-export class Hono<P extends string> extends defineDynamicClass()<P> {
+export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E, P> {
   readonly routerClass: { new (): Router<any> } = TrieRouter
   readonly strict: boolean = true // strict routing - default is true
-  #router: Router<Handler>
+  #router: Router<Handler<string, E>>
   #middlewareRouters: Router<MiddlewareHandler>[]
   #tempPath: string
   private path: string
 
-  constructor(init: Partial<Pick<Hono<P>, 'routerClass' | 'strict'>> = {}) {
+  constructor(init: Partial<Pick<Hono, 'routerClass' | 'strict'>> = {}) {
     super()
     methods.map((method) => {
       this[method] = <Path extends string>(
-        arg1: Path | Handler<ParamKeys<P>>,
-        arg2?: Handler<ParamKeys<Path>>
+        arg1: Path | Handler<ParamKeys<P>, E>,
+        arg2?: Handler<ParamKeys<Path>, E>
       ) => {
         if (typeof arg1 === 'string') {
           this.path = arg1
@@ -93,17 +94,17 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
     return c.text(message, 500)
   }
 
-  route(path: string): Hono<P> {
-    const newHono: Hono<P> = new Hono()
+  route(path: string): Hono<E, P> {
+    const newHono: Hono<E, P> = new Hono()
     newHono.#tempPath = path
     newHono.#router = this.#router
     return newHono
   }
 
-  use(path: string, middleware: MiddlewareHandler): Hono<P>
-  use(middleware: MiddlewareHandler): Hono<P>
-  use(arg1: string | MiddlewareHandler, arg2?: MiddlewareHandler): Hono<P> {
-    let handler: MiddlewareHandler
+  use(path: string, middleware: MiddlewareHandler<E>): Hono<E, P>
+  use(middleware: MiddlewareHandler<E>): Hono<E, P>
+  use(arg1: string | MiddlewareHandler<E>, arg2?: MiddlewareHandler<E>): Hono<E, P> {
+    let handler: MiddlewareHandler<E>
     if (typeof arg1 === 'string') {
       this.path = arg1
       handler = arg2
@@ -119,17 +120,17 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
     return this
   }
 
-  onError(handler: ErrorHandler): Hono<P> {
-    this.errorHandler = handler
+  onError(handler: ErrorHandler<E>): Hono<E, P> {
+    this.errorHandler = handler as ErrorHandler
     return this
   }
 
-  notFound(handler: NotFoundHandler): Hono<P> {
-    this.notFoundHandler = handler
+  notFound(handler: NotFoundHandler<E>): Hono<E, P> {
+    this.notFoundHandler = handler as NotFoundHandler
     return this
   }
 
-  private addRoute(method: string, path: string, handler: Handler): Hono<P> {
+  private addRoute(method: string, path: string, handler: Handler<string, E>): Hono<E, P> {
     method = method.toUpperCase()
     if (this.#tempPath) {
       path = mergePath(this.#tempPath, path)
@@ -138,11 +139,11 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
     return this
   }
 
-  private async matchRoute(method: string, path: string): Promise<Result<Handler>> {
+  private async matchRoute(method: string, path: string): Promise<Result<Handler<string, E>>> {
     return this.#router.match(method, path)
   }
 
-  private async dispatch(request: Request, env?: Env, event?: FetchEvent): Promise<Response> {
+  private async dispatch(request: Request, event?: FetchEvent, env?: E): Promise<Response> {
     const path = getPathFromURL(request.url, { strict: this.strict })
     const method = request.method
 
@@ -162,7 +163,7 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
       if (mwResult) middleware.push(mwResult.handler)
     }
 
-    const wrappedHandler = async (context: Context, next: Next) => {
+    const wrappedHandler = async (context: Context<string, E>, next: Next) => {
       const res = await handler(context)
       if (!(res instanceof Response)) {
         throw new TypeError('response must be a instance of Response')
@@ -174,7 +175,7 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
     middleware.push(wrappedHandler)
 
     const composed = compose<Context>(middleware, this.errorHandler)
-    const c = new Context(request, { env: env, event: event, res: null })
+    const c = new Context<string, E>(request, { env: env, event: event, res: null })
     c.notFound = () => this.notFoundHandler(c)
 
     const context = await composed(c)
@@ -183,11 +184,11 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
   }
 
   async handleEvent(event: FetchEvent): Promise<Response> {
-    return this.dispatch(event.request, {}, event)
+    return this.dispatch(event.request, event)
   }
 
-  async fetch(request: Request, env?: Env, event?: FetchEvent): Promise<Response> {
-    return this.dispatch(request, env, event)
+  async fetch(request: Request, env?: E, event?: FetchEvent): Promise<Response> {
+    return this.dispatch(request, event, env)
   }
 
   request(input: RequestInfo, requestInit?: RequestInit): Promise<Response> {

--- a/src/utils/encode.test.ts
+++ b/src/utils/encode.test.ts
@@ -31,7 +31,9 @@ describe('encode', () => {
   describe('base64url', () => {
     it('encodeBase64URL', () => {
       expect(encodeBase64URL('hooooooooo')).toBe('aG9vb29vb29vbw')
-      expect(encodeBase64URL('http://github.com/honojs/hono')).toBe('aHR0cDovL2dpdGh1Yi5jb20vaG9ub2pzL2hvbm8')
+      expect(encodeBase64URL('http://github.com/honojs/hono')).toBe(
+        'aHR0cDovL2dpdGh1Yi5jb20vaG9ub2pzL2hvbm8'
+      )
       expect(encodeBase64URL('炎')).toBe('54KO')
       expect(encodeBase64URL('abcdef')).not.toBe('abcdedf')
       expect(encodeBase64URL('')).toBe('')
@@ -42,7 +44,9 @@ describe('encode', () => {
 
     it('decodeBase64URL', async () => {
       expect(decodeBase64URL('aG9vb29vb29vbw')).toBe('hooooooooo')
-      expect(decodeBase64URL('aHR0cDovL2dpdGh1Yi5jb20vaG9ub2pzL2hvbm8')).toBe('http://github.com/honojs/hono')
+      expect(decodeBase64URL('aHR0cDovL2dpdGh1Yi5jb20vaG9ub2pzL2hvbm8')).toBe(
+        'http://github.com/honojs/hono'
+      )
       expect(decodeBase64URL('54KO')).toBe('炎')
       expect(decodeBase64URL('abcdedf')).not.toBe('abcdef')
       expect(decodeBase64URL('')).toBe('')
@@ -53,7 +57,7 @@ describe('encode', () => {
   })
 
   describe('utf8ToUint8Array', () => {
-    it.only('should be equal', () => {
+    it('should be equal', () => {
       const k = 'a-secret-key'
       const arr = utf8ToUint8Array(k)
       expect(String(arr)).toEqual('97,45,115,101,99,114,101,116,45,107,101,121')


### PR DESCRIPTION
Enable adding types for Env variables using generics in Module Worker mode.

```ts
interface Env {
  API_KEY: string
  API_SECRET: string
  MY_KV: KVNamespace
}

const app = new Hono<Env>()

app.get('/', (c) => {
  const key = c.env.API_KEY
  const secret = c.env.API_SECRET
  const message = getMessage({ key, secret })
  return c.text(`Hono! ${message}`)
})

export default app
```

<img width="678" alt="スクリーンショット 2022-05-01 20 01 48" src="https://user-images.githubusercontent.com/10682/166143430-a3b57db5-e558-4c7d-a6bf-85391a0fb209.png">

