### PR TITLE
feat: make everything(including Middleware) as `Handler`

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -188,6 +188,11 @@ describe('param and query', () => {
     return c.text(`id is ${id}`)
   })
 
+  app.get('/date/:date{[0-9]+}', (c) => {
+    const date = c.req.param('date')
+    return c.text(`date is ${date}`)
+  })
+
   app.get('/search', (c) => {
     const name = c.req.query('name')
     return c.text(`name is ${name}`)
@@ -202,6 +207,12 @@ describe('param and query', () => {
     const res = await app.request('http://localhost/entry/123')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('id is 123')
+  })
+
+  it('param of /date/:date is found', async () => {
+    const res = await app.request('http://localhost/date/0401')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('date is 0401')
   })
 
   it('query of /search?name=sam is found', async () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -151,7 +151,7 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
     return fake
   }
 
-  private addRoute(method: string, path: string, handler: Handler<string, E>) {
+  private addRoute(method: string, path: string, handler: Handler<string, E>): void {
     method = method.toUpperCase()
 
     if (this.#tempPath) {
@@ -175,8 +175,6 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
     } else {
       this.#router.add(method, path, handler)
     }
-
-    return this
   }
 
   private async matchRoute(method: string, path: string): Promise<Result<Handler<string, E>>> {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -44,8 +44,9 @@ interface HandlerInterface<T extends string, E = Env> {
   (...handlers: Handler<string, E>[]): Hono<E, T>
 }
 
-const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch', 'all'] as const
-type Methods = typeof methods[number]
+const all = 'all' as const // <--- app.all()
+const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
+type Methods = typeof methods[number] | typeof all
 
 function defineDynamicClass(): {
   new <E extends Env, T extends string>(): {
@@ -66,7 +67,8 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
   constructor(init: Partial<Pick<Hono, 'routerClass' | 'strict'>> = {}) {
     super()
 
-    methods.map((method) => {
+    const allMethods = [...methods, all]
+    allMethods.map((method) => {
       this[method] = <Path extends string>(
         args1: Path | Handler<ParamKeys<Path>, E>,
         ...args: [Handler<ParamKeys<Path>, E>]

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,8 +1,9 @@
 import { compose } from '@/compose'
 import { Context } from '@/context'
 import type { Env } from '@/context'
-import { METHOD_NAME_OF_ALL } from '@/router'
 import type { Result, Router } from '@/router'
+import { METHOD_NAME_ALL } from '@/router'
+import { METHOD_NAME_ALL_LOWERCASE } from '@/router'
 import { TrieRouter } from '@/router/trie-router' // Default Router
 import { getPathFromURL, mergePath } from '@/utils/url'
 
@@ -44,9 +45,8 @@ interface HandlerInterface<T extends string, E = Env> {
   (...handlers: Handler<string, E>[]): Hono<E, T>
 }
 
-const all = 'all' as const // <--- app.all()
 const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
-type Methods = typeof methods[number] | typeof all
+type Methods = typeof methods[number] | typeof METHOD_NAME_ALL_LOWERCASE
 
 function defineDynamicClass(): {
   new <E extends Env, T extends string>(): {
@@ -67,7 +67,7 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
   constructor(init: Partial<Pick<Hono, 'routerClass' | 'strict'>> = {}) {
     super()
 
-    const allMethods = [...methods, all]
+    const allMethods = [...methods, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
       this[method] = <Path extends string>(
         args1: Path | Handler<ParamKeys<Path>, E>,
@@ -121,7 +121,7 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
       args.unshift(arg1)
     }
     args.map((handler) => {
-      this.addMiddlewareRoute(METHOD_NAME_OF_ALL, this.path, handler)
+      this.addMiddlewareRoute(METHOD_NAME_ALL, this.path, handler)
     })
     return this
   }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -112,17 +112,17 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
     return newHono
   }
 
-  use(path: string, middleware: Handler<string, E>): Hono<E, P>
-  use(middleware: Handler<string, E>): Hono<E, P>
-  use(arg1: string | Handler<string, E>, arg2?: Handler<string, E>): Hono<E, P> {
-    let handler: Handler<string, E>
+  use(path: string, ...middleware: Handler<string, E>[]): Hono<E, P>
+  use(...middleware: Handler<string, E>[]): Hono<E, P>
+  use(arg1: string | Handler<string, E>, ...args: Handler<string, E>[]): Hono<E, P> {
     if (typeof arg1 === 'string') {
       this.path = arg1
-      handler = arg2
     } else {
-      handler = arg1
+      args.unshift(arg1)
     }
-    this.addMiddlewareRoute(METHOD_NAME_OF_ALL, this.path, handler)
+    args.map((handler) => {
+      this.addMiddlewareRoute(METHOD_NAME_OF_ALL, this.path, handler)
+    })
     return this
   }
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -146,7 +146,6 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
   private createFakeContext = (): Context<string, E> => {
     const request = new Request('http://localhost/')
     request.param = () => ''
-    request.cookie = () => ''
     const fake = new Context<string, E>(request)
     fake.notFound = () => this.notFoundHandler(fake)
     return fake

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Hono } from '@/hono'
-export type { Handler, MiddlewareHandler, Next } from '@/hono'
+export type { Handler, Next } from '@/hono'
 export { Context } from '@/context'
 export type { Env } from '@/context'

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,5 @@
-export const METHOD_NAME_OF_ALL = 'ALL'
+export const METHOD_NAME_ALL = 'ALL' as const
+export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
 
 export abstract class Router<T> {
   abstract add(method: string, path: string, handler: T): void

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -1,4 +1,4 @@
-import { METHOD_NAME_OF_ALL } from '@/router'
+import { METHOD_NAME_ALL } from '@/router'
 import { RegExpRouter } from '@/router/reg-exp-router/router'
 
 describe('Basic Usage', () => {
@@ -77,7 +77,7 @@ describe('Optimization for METHOD_NAME_OF_ALL', () => {
   })
 
   it('Apply to all requests', async () => {
-    router.add(METHOD_NAME_OF_ALL, '*', 'OK')
+    router.add(METHOD_NAME_ALL, '*', 'OK')
     const res = router.match('GET', '/entry/123')
     expect(res).not.toBeNull()
     expect(res.handler).toBe('OK')
@@ -85,7 +85,7 @@ describe('Optimization for METHOD_NAME_OF_ALL', () => {
   })
 
   it('Apply to all requests under a specific path', async () => {
-    router.add(METHOD_NAME_OF_ALL, '/path/to/*', 'OK')
+    router.add(METHOD_NAME_ALL, '/path/to/*', 'OK')
     let res = router.match('GET', '/entry/123')
     expect(res).toBeNull()
 

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -1,4 +1,4 @@
-import { Router, Result, METHOD_NAME_OF_ALL } from '@/router'
+import { Router, Result, METHOD_NAME_ALL } from '@/router'
 import type { ParamMap } from '@/router/reg-exp-router/trie'
 import { Trie } from '@/router/reg-exp-router/trie'
 
@@ -28,8 +28,8 @@ export class RegExpRouter<T> extends Router<T> {
 
     // Optimization for middleware
     const methods = Object.keys(matchers)
-    if (methods.length === 1 && methods[0] === METHOD_NAME_OF_ALL) {
-      const [regexp, handlers] = matchers[METHOD_NAME_OF_ALL]
+    if (methods.length === 1 && methods[0] === METHOD_NAME_ALL) {
+      const [regexp, handlers] = matchers[METHOD_NAME_ALL]
       if (handlers.length === 1) {
         const result = new Result(handlers[0][0], emptyParam)
         if (regexp === regExpMatchAll) {
@@ -41,7 +41,7 @@ export class RegExpRouter<T> extends Router<T> {
     }
 
     match ||= (method, path) => {
-      const matcher = matchers[method] || matchers[METHOD_NAME_OF_ALL]
+      const matcher = matchers[method] || matchers[METHOD_NAME_ALL]
       if (!matcher) {
         return null
       }
@@ -84,8 +84,8 @@ export class RegExpRouter<T> extends Router<T> {
     const handlers: HandlerData<T>[] = []
 
     const targetMethods = [method]
-    if (method !== METHOD_NAME_OF_ALL) {
-      targetMethods.unshift(METHOD_NAME_OF_ALL)
+    if (method !== METHOD_NAME_ALL) {
+      targetMethods.unshift(METHOD_NAME_ALL)
     }
     const routes = targetMethods.flatMap((method) => this.routes[method] || [])
 
@@ -93,7 +93,7 @@ export class RegExpRouter<T> extends Router<T> {
       return null
     }
 
-    if (method === METHOD_NAME_OF_ALL) {
+    if (method === METHOD_NAME_ALL) {
       if (routes.length === 1 && routes[0][0] === '*') {
         return [regExpMatchAll, [[routes[0][1], null]]]
       }

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -1,4 +1,4 @@
-import { Result, METHOD_NAME_OF_ALL } from '@/router'
+import { Result, METHOD_NAME_ALL } from '@/router'
 import type { Pattern } from '@/utils/url'
 import { splitPath, getPattern } from '@/utils/url'
 
@@ -109,7 +109,7 @@ export class Node<T> {
       }
     }
 
-    const handler = curNode.method[METHOD_NAME_OF_ALL] || curNode.method[method]
+    const handler = curNode.method[METHOD_NAME_ALL] || curNode.method[method]
 
     if (!handler) {
       return noRoute()

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -6,9 +6,9 @@ export const parseBody = async (
   if (contentType.includes('application/json')) {
     return await r.json()
   } else if (contentType.includes('application/text')) {
-    return r.text()
+    return await r.text()
   } else if (contentType.startsWith('text')) {
-    return r.text()
+    return await r.text()
   } else if (contentType.includes('form')) {
     const form: Record<string, string | File> = {}
     const data = [...(await r.formData())].reduce((acc, cur) => {


### PR DESCRIPTION
I have made middleware as `Handler`. So, **every handler is a `Handler`**. We can use middleware with app.**HTTP_METHOD**.

```ts
const app = new Hono()

app.all('*', logger())

app.post('/posts', bodyParse(), basicAuth(), (c) => {
  const body = c.req.parsedBody
  const post = createPost(body)
  return c.text(`${post.id} is created!`, 201)
})
```

Also chained routes are available.

```ts
app.get('/posts', (c) => {
  return c.text('POST LIST')
}).post(bodyParse(), basicAuth(), (c) => {
  //...
})
```