### PR TITLE
feat(compose): compose both the ordinary middlewares and response middlewares

### DIFF
--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -101,4 +101,347 @@ describe('compose with Context', () => {
     expect(c.res.status).toBe(500)
     expect(await context.res.text()).toBe('onError')
   })
+
+  it('Run all the middlewares', async () => {
+    const ctx: C = { req: {}, res: {} }
+    const stack: number[] = []
+    const middlewares = [
+      async (ctx: C, next: Function) => {
+        stack.push(0)
+        await next()
+      },
+      async (ctx: C, next: Function) => {
+        stack.push(1)
+        await next()
+      },
+      async (ctx: C, next: Function) => {
+        stack.push(2)
+        await next()
+      },
+    ]
+    const composed = await compose(middlewares)
+    await composed(ctx)
+    expect(stack).toEqual([0, 1, 2])
+  })
+})
+
+describe('Compose', function () {
+  function isPromise(x: any) {
+    return x && typeof x.then === 'function'
+  }
+
+  it('should work', async () => {
+    const arr: number[] = []
+    const stack = []
+
+    stack.push(async (context: C, next: Function) => {
+      arr.push(1)
+      await next()
+      arr.push(6)
+    })
+
+    stack.push(async (context: C, next: Function) => {
+      arr.push(2)
+      await next()
+      arr.push(5)
+    })
+
+    stack.push(async (context: C, next: Function) => {
+      arr.push(3)
+      await next()
+      arr.push(4)
+    })
+
+    await compose(stack)({})
+    expect(arr).toEqual(expect.arrayContaining([1, 2, 3, 4, 5, 6]))
+  })
+
+  it('should be able to be called twice', () => {
+    type C = {
+      arr: number[]
+    }
+    const stack = []
+
+    stack.push(async (context: C, next: Function) => {
+      context.arr.push(1)
+      await next()
+      context.arr.push(6)
+    })
+
+    stack.push(async (context: C, next: Function) => {
+      context.arr.push(2)
+      await next()
+      context.arr.push(5)
+    })
+
+    stack.push(async (context: C, next: Function) => {
+      context.arr.push(3)
+      await next()
+      context.arr.push(4)
+    })
+
+    const fn = compose(stack)
+    const ctx1 = { arr: [] as number[] }
+    const ctx2 = { arr: [] as number[] }
+    const out = [1, 2, 3, 4, 5, 6]
+
+    return fn(ctx1)
+      .then(() => {
+        expect(out).toEqual(ctx1.arr)
+        return fn(ctx2)
+      })
+      .then(() => {
+        expect(out).toEqual(ctx2.arr)
+      })
+  })
+
+  it('should create next functions that return a Promise', function () {
+    const stack: any[] = []
+    const arr: any[] = []
+    for (let i = 0; i < 5; i++) {
+      stack.push((context: C, next: Function) => {
+        arr.push(next())
+      })
+    }
+
+    compose(stack)({})
+
+    for (const next of arr) {
+      expect(isPromise(next)).toBe(true)
+    }
+  })
+
+  it('should work with 0 middleware', function () {
+    return compose([])({})
+  })
+
+  it('should work when yielding at the end of the stack', async () => {
+    const stack = []
+    let called = false
+
+    stack.push(async (ctx: C, next: Function) => {
+      await next()
+      called = true
+    })
+
+    await compose(stack)({})
+    expect(called).toBe(true)
+  })
+
+  it('should reject on errors in middleware', () => {
+    const stack = []
+
+    stack.push(() => {
+      throw new Error()
+    })
+
+    return compose(stack)({}).then(
+      () => {
+        throw new Error('promise was not rejected')
+      },
+      (e) => {
+        expect(e).toBeInstanceOf(Error)
+      }
+    )
+  })
+
+  it('should keep the context', () => {
+    const ctx = {}
+
+    const stack = []
+
+    stack.push(async (ctx2: C, next: Function) => {
+      await next()
+      expect(ctx2).toEqual(ctx)
+    })
+
+    stack.push(async (ctx2: C, next: Function) => {
+      await next()
+      expect(ctx2).toEqual(ctx)
+    })
+
+    stack.push(async (ctx2: C, next: Function) => {
+      await next()
+      expect(ctx2).toEqual(ctx)
+    })
+
+    return compose(stack)(ctx)
+  })
+
+  it('should catch downstream errors', async () => {
+    const arr: any[] = []
+    const stack = []
+
+    stack.push(async (ctx: C, next: Function) => {
+      arr.push(1)
+      try {
+        arr.push(6)
+        await next()
+        arr.push(7)
+      } catch (err) {
+        arr.push(2)
+      }
+      arr.push(3)
+    })
+
+    stack.push(async (ctx: C, next: Function) => {
+      arr.push(4)
+      throw new Error()
+    })
+
+    await compose(stack)({})
+    expect(arr).toEqual([1, 6, 4, 2, 3])
+  })
+
+  it('should compose w/ next', () => {
+    let called = false
+
+    return compose([])({}, async () => {
+      called = true
+    }).then(function () {
+      expect(called).toBe(true)
+    })
+  })
+
+  it('should handle errors in wrapped non-async functions', () => {
+    const stack = []
+
+    stack.push(function () {
+      throw new Error()
+    })
+
+    return compose(stack)({}).then(
+      () => {
+        throw new Error('promise was not rejected')
+      },
+      (e) => {
+        expect(e).toBeInstanceOf(Error)
+      }
+    )
+  })
+
+  // https://github.com/koajs/compose/pull/27#issuecomment-143109739
+  it('should compose w/ other compositions', () => {
+    const called: number[] = []
+
+    return compose([
+      compose([
+        (ctx: C, next: Function) => {
+          called.push(1)
+          return next()
+        },
+        (ctx: C, next: Function) => {
+          called.push(2)
+          return next()
+        },
+      ]),
+      (ctx: C, next: Function) => {
+        called.push(3)
+        return next()
+      },
+    ])({}).then(() => expect(called).toEqual([1, 2, 3]))
+  })
+
+  it('should throw if next() is called multiple times', () => {
+    return compose([
+      async (ctx: C, next: Function) => {
+        await next()
+        await next()
+      },
+    ])({}).then(
+      () => {
+        throw new Error('boom')
+      },
+      (err) => {
+        expect(/multiple times/.test(err.message)).toBe(true)
+      }
+    )
+  })
+
+  it('should return a valid middleware', () => {
+    let val = 0
+    return compose([
+      compose([
+        (ctx: C, next: Function) => {
+          val++
+          return next()
+        },
+        (ctx: C, next: Function) => {
+          val++
+          return next()
+        },
+      ]),
+      (ctx: C, next: Function) => {
+        val++
+        return next()
+      },
+    ])({}).then(function () {
+      expect(val).toEqual(3)
+    })
+  })
+
+  it('should return last return value', async () => {
+    type C = {
+      val: number
+    }
+    const stack = []
+
+    stack.push(async (ctx: C, next: Function) => {
+      await next()
+      expect(ctx.val).toEqual(2)
+      ctx.val = 1
+    })
+
+    stack.push(async (ctx: C, next: Function) => {
+      ctx.val = 2
+      await next()
+      expect(ctx.val).toEqual(2)
+    })
+
+    const res = await compose(stack)({ val: 0 })
+    expect(res).toEqual({ val: 1 })
+  })
+
+  it('should not affect the original middleware array', () => {
+    const middleware = []
+    const fn1 = (ctx: C, next: Function) => {
+      return next()
+    }
+    middleware.push(fn1)
+
+    for (const fn of middleware) {
+      expect(fn).toEqual(fn1)
+    }
+
+    compose(middleware)
+
+    for (const fn of middleware) {
+      expect(fn).toEqual(fn1)
+    }
+  })
+
+  it('should not get stuck on the passed in next', () => {
+    type C = {
+      middleware: number
+      next: number
+    }
+
+    const middleware = [
+      (ctx: C, next: Function) => {
+        ctx.middleware++
+        return next()
+      },
+    ]
+    const ctx = {
+      middleware: 0,
+      next: 0,
+    }
+
+    return compose(middleware)(ctx, (ctx: C, next: Function) => {
+      ctx.next++
+      return next()
+    }).then(() => {
+      expect(ctx).toEqual({ middleware: 1, next: 1 })
+    })
+  })
 })

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -3,18 +3,18 @@ import type { ErrorHandler } from '@/hono'
 
 // Based on the code in the MIT licensed `koa-compose` package.
 export const compose = <C>(middleware: Function[], onError?: ErrorHandler) => {
-  return function (context: C) {
+  return function (context: C, next?: Function) {
     let index = -1
     return dispatch(0)
     async function dispatch(i: number): Promise<C> {
-      if (i === middleware.length) {
-        return context
-      }
       if (i <= index) {
         return Promise.reject(new Error('next() called multiple times'))
       }
-      const handler = middleware[i]
+      let handler = middleware[i]
       index = i
+      if (i === middleware.length) handler = next
+      if (!handler) return Promise.resolve(context)
+
       return Promise.resolve(handler(context, dispatch.bind(null, i + 1)))
         .then(() => {
           return context


### PR DESCRIPTION
This PR is to make compose function to do composition for both ordinary middlewares and response middlewares, then we can make #189 a little more easier. 