### PR TITLE
feat(reg-exp-router): error handling for duplicate param name

### DIFF
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -241,6 +241,7 @@ export class Hono<E = Env, P extends string = ''> extends defineDynamicClass()<E
   }
 
   fire(): void {
+    this.#router.prepare()
     addEventListener('fetch', (event: FetchEvent): void => {
       event.respondWith(this.handleEvent(event))
     })

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,6 +4,9 @@ export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
 export abstract class Router<T> {
   abstract add(method: string, path: string, handler: T): void
   abstract match(method: string, path: string): Result<T> | null
+  prepare(): void {
+    // preprocessing, validity checks, etc.
+  }
 }
 
 export class Result<T> {

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -144,6 +144,39 @@ function buildMatcherFromPreprocessedRoutes<T>(
   return [regexp, handlerMap]
 }
 
+function verifyDuplicateParam<T>(routes: Route<T>[]): boolean {
+  const nameMap: Record<string, number> = {}
+  for (let i = 0, len = routes.length; i < len; i++) {
+    const route = routes[i]
+
+    for (let k = 0, len = route.hint.namedParams.length; k < len; k++) {
+      const [index, name] = route.hint.namedParams[k]
+      if (name in nameMap && index !== nameMap[name]) {
+        return false
+      } else {
+        nameMap[name] = index
+      }
+    }
+
+    const paramAliasMap = route.paramAliasMap
+    const paramAliasMapKeys = Object.keys(paramAliasMap)
+    for (let k = 0, len = paramAliasMapKeys.length; k < len; k++) {
+      const aliasFrom = paramAliasMapKeys[k]
+      for (let l = 0, len = paramAliasMap[aliasFrom].length; l < len; l++) {
+        const aliasTo = paramAliasMap[aliasFrom][l]
+        const index = nameMap[aliasFrom]
+        if (aliasTo in nameMap && index !== nameMap[aliasTo]) {
+          return false
+        } else {
+          nameMap[aliasTo] = index
+        }
+      }
+    }
+  }
+
+  return true
+}
+
 export class RegExpRouter<T> extends Router<T> {
   routeData?: {
     routes: Route<T>[]
@@ -361,7 +394,15 @@ export class RegExpRouter<T> extends Router<T> {
         } else if (compareResult === 2) {
           // ambiguous
           hasAmbiguous = true
+
+          if (!verifyDuplicateParam([routes[i], routes[j]])) {
+            throw new Error('Duplicate param name')
+          }
         }
+      }
+
+      if (!verifyDuplicateParam([routes[i]])) {
+        throw new Error('Duplicate param name')
       }
     }
 


### PR DESCRIPTION
The actual check feature was added by bd42c418100a28bba2cd584ad43424e48325baf5;  f969924a144705663d6be42294e77af40135b01a and 2baa25302d63250af7155212471d98a844eb86d7 are optional.

I made one PR because it has to do with the timing of the check. If we cannot agree on the implementation of an optional part, I will reconsider.


### Check for duplicate parameter names bd42c418100a28bba2cd5

I think it's OK because it's implemented honestly.


### Add router.prepare and invoke #router.prepare() in hono.fire f969924a144705663d6be42294e77af40135b01a and 2baa25302d63250af7155212471d98a844eb86d7

The RegExpRouter architecture makes it difficult to perform detailed routing checks during the `add()` phase, so we would like to perform the checks later, when all routing information is available. This would be a different behavior than the TrieRouter, but I think that the different timing of detection would be permissible with respect to this issue.

While this check can do on the "initial request" as it has been in the current master branch, I think it would be better if it could do on prior phase.

As such, I hope to have an API that allows the router to know that `hono.fire()` has been executed.

This API also allows control over when to `delete this.routeData`, so that RegExpRouter, like TrieRouter, can call `match()` and then `add()`. This makes it easier to write tests.

```typescript
router.add('GET', '/:type/:action', 'foo')
const res = router.match('GET', '/posts/123')
expect(res).not.toBeNull()
router.add('GET', '/posts/:id', 'bar') // error on the current branch. API would allow us to do this.
```
