### PR TITLE
chore: absolute import to relative import

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,10 +3,6 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  modulePaths: ['<rootDir>/src'],
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-  },
   testPathIgnorePatterns: ['./examples'],
   testEnvironment: 'miniflare',
   testEnvironmentOptions: {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test": "jest",
     "lint": "eslint --ext js,ts src .eslintrc.js",
     "lint:fix": "eslint --ext js,ts src .eslintrc.js --fix",
-    "build": "rimraf dist && tsc --project tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "watch": "tsc -w --project tsconfig.build.json & tsc-alias -w -p tsconfig.build.json",
+    "build": "rimraf dist && tsc",
+    "watch": "tsc -w",
     "prepublishOnly": "yarn build"
   },
   "exports": {
@@ -131,7 +131,6 @@
     "prettier-plugin-md-nocjsp": "^1.2.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.4",
-    "tsc-alias": "^1.6.7",
     "typescript": "^4.6.3"
   },
   "engines": {

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -1,5 +1,5 @@
-import { compose } from '@/compose'
-import { Context } from '@/context'
+import { compose } from './compose'
+import { Context } from './context'
 
 type C = {
   req: Record<string, string>

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,5 @@
-import { Context } from '@/context'
-import type { ErrorHandler, NotFoundHandler } from '@/hono'
+import { Context } from './context'
+import type { ErrorHandler, NotFoundHandler } from './hono'
 
 // Based on the code in the MIT licensed `koa-compose` package.
 export const compose = <C>(

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,4 +1,4 @@
-import { Context } from '@/context'
+import { Context } from './context'
 
 describe('Context', () => {
   const req = new Request('http://localhost/')

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
-import type { StatusCode } from '@/utils/http-status'
-import { getStatusText } from '@/utils/http-status'
-import { isAbsoluteURL } from '@/utils/url'
+import type { StatusCode } from './utils/http-status'
+import { getStatusText } from './utils/http-status'
+import { isAbsoluteURL } from './utils/url'
 
 type Headers = Record<string, string>
 type Data = string | ArrayBuffer | ReadableStream

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1,7 +1,7 @@
+import type { Context } from './context'
+import type { Next } from './hono'
+import { Hono, Route } from './hono'
 import { poweredBy } from './middleware/powered-by'
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { Hono, Route } from '@/hono'
 
 describe('GET Request', () => {
   const app = new Hono()

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,11 +1,11 @@
-import { compose } from '@/compose'
-import { Context } from '@/context'
-import type { Env } from '@/context'
-import type { Result, Router } from '@/router'
-import { METHOD_NAME_ALL } from '@/router'
-import { METHOD_NAME_ALL_LOWERCASE } from '@/router'
-import { TrieRouter } from '@/router/trie-router' // Default Router
-import { getPathFromURL, mergePath } from '@/utils/url'
+import { compose } from './compose'
+import { Context } from './context'
+import type { Env } from './context'
+import type { Result, Router } from './router'
+import { METHOD_NAME_ALL } from './router'
+import { METHOD_NAME_ALL_LOWERCASE } from './router'
+import { TrieRouter } from './router/trie-router' // Default Router
+import { getPathFromURL, mergePath } from './utils/url'
 
 declare global {
   interface Request<ParamKeyType = string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Hono, Route } from '@/hono'
-export type { Handler, Next } from '@/hono'
-export { Context } from '@/context'
-export type { Env } from '@/context'
+export { Hono, Route } from './hono'
+export type { Handler, Next } from './hono'
+export { Context } from './context'
+export type { Env } from './context'

--- a/src/middleware/basic-auth/index.test.ts
+++ b/src/middleware/basic-auth/index.test.ts
@@ -1,6 +1,6 @@
 import { SHA256 } from 'crypto-js'
-import { Hono } from '@/hono'
-import { basicAuth } from '@/middleware/basic-auth'
+import { Hono } from '../../hono'
+import { basicAuth } from '.'
 
 describe('Basic Auth by Middleware', () => {
   const crypto = global.crypto

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -1,7 +1,7 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { timingSafeEqual } from '@/utils/buffer'
-import { decodeBase64 } from '@/utils/encode'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { timingSafeEqual } from '../../utils/buffer'
+import { decodeBase64 } from '../../utils/encode'
 
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/

--- a/src/middleware/body-parse/index.test.ts
+++ b/src/middleware/body-parse/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { bodyParse } from '@/middleware/body-parse'
+import { Hono } from '../../hono'
+import { bodyParse } from '.'
 
 describe('Parse Body Middleware', () => {
   const app = new Hono()

--- a/src/middleware/body-parse/index.ts
+++ b/src/middleware/body-parse/index.ts
@@ -1,6 +1,6 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { parseBody } from '@/utils/body'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { parseBody } from '../../utils/body'
 
 declare global {
   interface Request {

--- a/src/middleware/cookie/index.test.ts
+++ b/src/middleware/cookie/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { cookie } from '@/middleware/cookie'
+import { Hono } from '../../hono'
+import { cookie } from '.'
 
 describe('Cookie Middleware', () => {
   const app = new Hono()

--- a/src/middleware/cookie/index.ts
+++ b/src/middleware/cookie/index.ts
@@ -1,5 +1,5 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
 
 declare global {
   interface Request {
@@ -7,7 +7,7 @@ declare global {
   }
 }
 
-declare module '@/context' {
+declare module '../../context' {
   interface Context {
     cookie: (name: string, value: string, options?: CookieOptions) => void
   }

--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { cors } from '@/middleware/cors'
+import { Hono } from '../../hono'
+import { cors } from '../../middleware/cors'
 
 describe('CORS by Middleware', () => {
   const app = new Hono()

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -1,5 +1,5 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
 
 type CORSOptions = {
   origin: string

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { etag } from '@/middleware/etag'
+import { Hono } from '../../hono'
+import { etag } from '.'
 
 describe('Etag Middleware', () => {
   const app = new Hono()

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -1,7 +1,7 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { parseBody } from '@/utils/body'
-import { sha1 } from '@/utils/crypto'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { parseBody } from '../../utils/body'
+import { sha1 } from '../../utils/crypto'
 
 type ETagOptions = {
   weak: boolean

--- a/src/middleware/graphql-server/index.test.ts
+++ b/src/middleware/graphql-server/index.test.ts
@@ -5,8 +5,8 @@ import {
   GraphQLObjectType,
   GraphQLNonNull,
 } from 'graphql'
-import { Hono } from '@/hono'
-import { errorMessages, graphqlServer } from '@/middleware/graphql-server'
+import { Hono } from '../../hono'
+import { errorMessages, graphqlServer } from '.'
 
 // Do not show `console.error` messages
 jest.spyOn(console, 'error').mockImplementation()

--- a/src/middleware/graphql-server/index.ts
+++ b/src/middleware/graphql-server/index.ts
@@ -20,9 +20,9 @@ import type {
   GraphQLFormattedError,
 } from 'graphql'
 
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { parseBody } from '@/middleware/graphql-server/parse-body'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { parseBody } from './parse-body'
 
 type Options = {
   schema: GraphQLSchema

--- a/src/middleware/graphql-server/parse-body.test.ts
+++ b/src/middleware/graphql-server/parse-body.test.ts
@@ -1,4 +1,4 @@
-import { parseBody } from '@/middleware/graphql-server/parse-body'
+import { parseBody } from './parse-body'
 
 describe('parseBody', () => {
   it('Should return a blank JSON object', async () => {

--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { jwt } from '@/middleware/jwt'
+import { Hono } from '../../hono'
+import { jwt } from '.'
 
 describe('Jwt Auth by Middleware', () => {
   const crypto = global.crypto
@@ -12,15 +12,9 @@ describe('Jwt Auth by Middleware', () => {
 
   const app = new Hono()
 
-  app.use(
-    '/auth/*',
-    jwt({ secret: 'a-secret' })
-  )
+  app.use('/auth/*', jwt({ secret: 'a-secret' }))
 
-  app.use(
-    '/auth-unicode/*',
-    jwt({ secret: 'a-secret'})
-  )
+  app.use('/auth-unicode/*', jwt({ secret: 'a-secret' }))
 
   app.get('/auth/*', () => new Response('auth'))
   app.get('/auth-unicode/*', () => new Response('auth'))
@@ -34,7 +28,8 @@ describe('Jwt Auth by Middleware', () => {
   })
 
   it('Should authorize', async () => {
-    const credential = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+    const credential =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
     const req = new Request('http://localhost/auth/a')
     req.headers.set('Authorization', `Bearer ${credential}`)
     const res = await app.request(req)
@@ -44,7 +39,8 @@ describe('Jwt Auth by Middleware', () => {
   })
 
   it('Should authorize Unicode', async () => {
-    const credential = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+    const credential =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
 
     const req = new Request('http://localhost/auth-unicode/a')
     req.headers.set('Authorization', `Basic ${credential}`)
@@ -55,7 +51,8 @@ describe('Jwt Auth by Middleware', () => {
   })
 
   it('Should authorize Unicode', async () => {
-    const invalidToken = 'ssyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+    const invalidToken =
+      'ssyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
 
     const req = new Request('http://localhost/auth-unicode/a')
     req.headers.set('Authorization', `Basic ${invalidToken}`)

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -1,7 +1,7 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { Jwt } from '@/utils/jwt'
-import type { AlgorithmTypes } from '@/utils/jwt/types'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { Jwt } from '../../utils/jwt'
+import type { AlgorithmTypes } from '../../utils/jwt/types'
 
 export const jwt = (options: { secret: string; alg?: string }) => {
   if (!options) {

--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { logger } from '@/middleware/logger'
+import { Hono } from '../../hono'
+import { logger } from '.'
 
 describe('Logger by Middleware', () => {
   const app = new Hono()

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -1,6 +1,6 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { getPathFromURL } from '@/utils/url'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { getPathFromURL } from '../../utils/url'
 
 const humanize = (n: string[], opts?: { delimiter?: string; separator?: string }) => {
   const options = opts || {}

--- a/src/middleware/mustache/index.test.ts
+++ b/src/middleware/mustache/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { mustache } from '@/middleware/mustache'
+import { Hono } from '../../hono'
+import { mustache } from '.'
 
 // Mock
 const store: { [key: string]: string } = {

--- a/src/middleware/mustache/index.ts
+++ b/src/middleware/mustache/index.ts
@@ -1,7 +1,7 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { bufferToString } from '@/utils/buffer'
-import { getContentFromKVAsset, getKVFilePath } from '@/utils/cloudflare'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { bufferToString } from '../../utils/buffer'
+import { getContentFromKVAsset, getKVFilePath } from '../../utils/cloudflare'
 
 const EXTENSION = '.mustache'
 const DEFAULT_DOCUMENT = 'index.mustache'

--- a/src/middleware/powered-by/index.test.ts
+++ b/src/middleware/powered-by/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { poweredBy } from '@/middleware/powered-by'
+import { Hono } from '../../hono'
+import { poweredBy } from '.'
 
 describe('Powered by Middleware', () => {
   const app = new Hono()

--- a/src/middleware/powered-by/index.ts
+++ b/src/middleware/powered-by/index.ts
@@ -1,5 +1,5 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
 
 export const poweredBy = () => {
   return async (c: Context, next: Next) => {

--- a/src/middleware/pretty-json/index.test.ts
+++ b/src/middleware/pretty-json/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { prettyJSON } from '@/middleware/pretty-json'
+import { Hono } from '../../hono'
+import { prettyJSON } from '.'
 
 describe('JSON pretty by Middleware', () => {
   const app = new Hono()

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -1,5 +1,5 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
 
 type prettyOptions = {
   space: number

--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from '@/hono'
-import { serveStatic } from '@/middleware/serve-static'
+import { Hono } from '../../hono'
+import { serveStatic } from '.'
 
 // Mock
 const store: { [key: string]: string } = {

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -1,7 +1,7 @@
-import type { Context } from '@/context'
-import type { Next } from '@/hono'
-import { getContentFromKVAsset, getKVFilePath } from '@/utils/cloudflare'
-import { getMimeType } from '@/utils/mime'
+import type { Context } from '../../context'
+import type { Next } from '../../hono'
+import { getContentFromKVAsset, getKVFilePath } from '../../utils/cloudflare'
+import { getMimeType } from '../../utils/mime'
 
 type Options = {
   root: string

--- a/src/router/reg-exp-router/index.ts
+++ b/src/router/reg-exp-router/index.ts
@@ -1,1 +1,1 @@
-export { RegExpRouter } from '@/router/reg-exp-router/router'
+export { RegExpRouter } from './router'

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -1,5 +1,5 @@
-import { METHOD_NAME_ALL } from '@/router'
-import { RegExpRouter } from '@/router/reg-exp-router/router'
+import { METHOD_NAME_ALL } from '../../router'
+import { RegExpRouter } from './router'
 
 describe('Basic Usage', () => {
   const router = new RegExpRouter<string>()

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -1,6 +1,6 @@
-import { Router, Result, METHOD_NAME_ALL } from '@/router'
-import type { ParamMap } from '@/router/reg-exp-router/trie'
-import { Trie } from '@/router/reg-exp-router/trie'
+import { Router, Result, METHOD_NAME_ALL } from '../../router'
+import type { ParamMap } from './trie'
+import { Trie } from './trie'
 
 interface Hint {
   components: string[]

--- a/src/router/reg-exp-router/trie.ts
+++ b/src/router/reg-exp-router/trie.ts
@@ -1,7 +1,7 @@
-import type { ParamMap, Context } from '@/router/reg-exp-router/node'
-import { Node } from '@/router/reg-exp-router/node'
+import type { ParamMap, Context } from './node'
+import { Node } from './node'
 
-export type { ParamMap } from '@/router/reg-exp-router/node'
+export type { ParamMap } from './node'
 export type ReplacementMap = number[]
 
 interface InitOptions {

--- a/src/router/trie-router/index.ts
+++ b/src/router/trie-router/index.ts
@@ -1,1 +1,1 @@
-export { TrieRouter } from '@/router/trie-router/router'
+export { TrieRouter } from './router'

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -1,4 +1,4 @@
-import { Node } from '@/router/trie-router/node'
+import { Node } from './node'
 
 describe('Root Node', () => {
   const node = new Node()

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -1,6 +1,6 @@
-import { Result, METHOD_NAME_ALL } from '@/router'
-import type { Pattern } from '@/utils/url'
-import { splitPath, getPattern } from '@/utils/url'
+import { Result, METHOD_NAME_ALL } from '../../router'
+import type { Pattern } from '../../utils/url'
+import { splitPath, getPattern } from '../../utils/url'
 
 type Next<T> = {
   nodes: Node<T>[]

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -1,4 +1,4 @@
-import { TrieRouter } from '@/router/trie-router/router'
+import { TrieRouter } from './router'
 
 describe('Basic Usage', () => {
   const router = new TrieRouter<string>()

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -1,6 +1,6 @@
-import { Router } from '@/router'
-import type { Result } from '@/router'
-import { Node } from '@/router/trie-router/node'
+import { Router } from '../../router'
+import type { Result } from '../../router'
+import { Node } from './node'
 
 export class TrieRouter<T> extends Router<T> {
   node: Node<T>

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -1,4 +1,4 @@
-import { parseBody } from '@/utils/body'
+import { parseBody } from './body'
 
 describe('Parse Body Middleware', () => {
   it('should parse JSON', async () => {

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,5 +1,5 @@
 import { SHA256 as sha256CryptoJS } from 'crypto-js'
-import { timingSafeEqual, bufferToString } from '@/utils/buffer'
+import { timingSafeEqual, bufferToString } from './buffer'
 
 describe('buffer', () => {
   it('positive', async () => {

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,4 +1,4 @@
-import { sha256 } from '@/utils/crypto'
+import { sha256 } from './crypto'
 
 export const equal = (a: ArrayBuffer, b: ArrayBuffer) => {
   if (a === b) {

--- a/src/utils/cloudflare.test.ts
+++ b/src/utils/cloudflare.test.ts
@@ -1,4 +1,4 @@
-import { getContentFromKVAsset, getKVFilePath } from '@/utils/cloudflare'
+import { getContentFromKVAsset, getKVFilePath } from './cloudflare'
 
 // Mock
 const store: { [key: string]: string } = {

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,4 +1,4 @@
-import { sha256, sha1 } from '@/utils/crypto'
+import { sha256, sha1 } from './crypto'
 
 describe('crypto', () => {
   it('sha256', async () => {

--- a/src/utils/encode.test.ts
+++ b/src/utils/encode.test.ts
@@ -4,7 +4,7 @@ import {
   encodeBase64,
   encodeBase64URL,
   decodeBase64URL,
-} from '@/utils/encode'
+} from './encode'
 
 describe('encode', () => {
   describe('base64', () => {

--- a/src/utils/http-status.test.ts
+++ b/src/utils/http-status.test.ts
@@ -1,4 +1,4 @@
-import { getStatusText } from '@/utils/http-status'
+import { getStatusText } from './http-status'
 
 describe('http-status utility', () => {
   it('getStatusText', () => {

--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -1,4 +1,4 @@
-import { getMimeType } from '@/utils/mime'
+import { getMimeType } from './mime'
 
 describe('mime', () => {
   it('getMimeType', () => {

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { splitPath, getPattern, getPathFromURL, isAbsoluteURL, mergePath } from '@/utils/url'
+import { splitPath, getPattern, getPathFromURL, isAbsoluteURL, mergePath } from './url'
 
 describe('url', () => {
   it('splitPath', () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "src/**/*.test.ts"
-  ]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,12 +15,6 @@
       "node",
       "@cloudflare/workers-types"
     ],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    },
   },
   "include": [
     "src/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,7 +1153,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
@@ -1269,11 +1269,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1282,7 +1277,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1381,21 +1376,6 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chokidar@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 ci-info@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
@@ -1455,11 +1435,6 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@^9.0.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
-  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2083,7 +2058,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -2135,7 +2110,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2345,13 +2320,6 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -2394,7 +2362,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3235,11 +3203,6 @@ mustache@^4.2.0:
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
   integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
-mylas@^2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/mylas/-/mylas-2.1.9.tgz#8329626f95c0ce522ca7d3c192eca6221d172cdc"
-  integrity sha512-pa+cQvmhoM8zzgitPYZErmDt9EdTNVnXsH1XFjMeM4TyG4FFcgxrvK1+jwabVFwUOEDaSWuXBMjg43kqt/Ydlg==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3260,7 +3223,7 @@ node-releases@^2.0.1:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -3439,7 +3402,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
+picomatch@^2.0.4, picomatch@^2.2.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3455,13 +3418,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-plimit-lit@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/plimit-lit/-/plimit-lit-1.2.6.tgz#8c1336f26a042b6e9f1acc665be5eee4c2a55fb3"
-  integrity sha512-EuVnKyDeFgr58aidKf2G7DI41r23bxphlvBKAZ8e8dT9of0Ez2g9w6JbJGUP1YBNC2yG9+ZCCbjLj4yS1P5Gzw==
-  dependencies:
-    queue-lit "^1.2.7"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -3519,11 +3475,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-queue-lit@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/queue-lit/-/queue-lit-1.2.7.tgz#69081656c9e7b81f09770bb2de6aa007f1a90763"
-  integrity sha512-K/rTdggORRcmf3+c89ijPlgJ/ldGP4oBj6Sm7VcTup4B2clf03Jo8QaXTnMst4EEQwkUbOZFN4frKocq2I85gw==
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -3533,13 +3484,6 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
 
 regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
@@ -3917,18 +3861,6 @@ ts-jest@^27.1.4:
     make-error "1.x"
     semver "7.x"
     yargs-parser "20.x"
-
-tsc-alias@^1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.6.7.tgz#354840d6444db79dd13fcc4f9ec37574ff9d5120"
-  integrity sha512-GRbZx/zTee01JtrHB7hkddgxn+aQqYDmRaFv/MTYIqBbk/L8Zf0nA/T60wXOr/Q7002YXppUFXsqsu5ViWB4vQ==
-  dependencies:
-    chokidar "^3.5.3"
-    commander "^9.0.0"
-    globby "^11.0.4"
-    mylas "^2.1.9"
-    normalize-path "^3.0.0"
-    plimit-lit "^1.2.6"
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"


### PR DESCRIPTION
Disable absolute import. Use relative import. To support Deno, must be *relative import*.
And, it was not so convenient.