### PR TITLE
feat: [BREAKING] deprecate `Route`, use `Hono` instead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Hono, Route } from './hono'
+export { Hono } from './hono'
 export type { Handler, Next } from './hono'
 export { Context } from './context'
 export type { Env } from './context'


### PR DESCRIPTION
`Route` will be ***obsolete***! in this PR.
For grouping routes, use `Hono` instead.

```ts
// const api = new Route() <--- obsolete
const api = new Hono()

api.get('/posts', (c) => c.text('list'))
api.post('/posts', (c) => c.text('create'))

app.route('/v1', api)
```


Close #236 