### PR TITLE
fix(Context): `c.body()` accept null for 204 response

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -116,6 +116,14 @@ describe('Context', () => {
     expect(res.statusText).toBe('OK')
   })
 
+  it('Should return 204 response', async () => {
+    c.status(204)
+    const res = c.body(null)
+    expect(res.status).toBe(204)
+    expect(res.statusText).toBe('No Content')
+    expect(await res.text()).toBe('')
+  })
+
   it('Should be able read env', async () => {
     const req = new Request('http://localhost/')
     const key = 'a-secret-key'

--- a/src/context.ts
+++ b/src/context.ts
@@ -96,7 +96,11 @@ export class Context<RequestParamKeyType extends string = string, E = Env> {
     return new Response(data, init)
   }
 
-  body(data: Data, status: StatusCode = this._status, headers: Headers = this._headers): Response {
+  body(
+    data: Data | null,
+    status: StatusCode = this._status,
+    headers: Headers = this._headers
+  ): Response {
     return this.newResponse(data, {
       status: status,
       headers: headers,


### PR DESCRIPTION
Fix #242