### PR TITLE
fix(jwt): ensure the request does not continue if the jwt token is invalid or expired

### DIFF
--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -11,8 +11,6 @@ export const jwt = (options: { secret: string; alg?: string }) => {
   return async (ctx: Context, next: Next) => {
     const credentials = ctx.req.headers.get('Authorization')
 
-    await next()
-
     if (!credentials) {
       ctx.res = new Response('Unauthorized', {
         status: 401,
@@ -31,6 +29,7 @@ export const jwt = (options: { secret: string; alg?: string }) => {
           'WWW-Authenticate': 'Basic ${options.secret}',
         },
       })
+      return
     }
 
     let authorized = false
@@ -48,6 +47,9 @@ export const jwt = (options: { secret: string; alg?: string }) => {
           'WWW-Authenticate': 'Bearer ${options.secret}',
         },
       })
+      return
     }
+    
+    await next()
   }
 }


### PR DESCRIPTION
The current JWT middleware checks the token only after the request has run (because `await next()` is run first). I think this means that whatever code is in your handler is called, _even if_ the JWT token is invalid or expired. 

This PR changes the behaviour to bail out of the request if the token validation fails.