### PR TITLE
perf(util): cache regex result for URL path(s)

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -8,6 +8,10 @@ describe('url', () => {
     ps = splitPath('/hello')
     expect(ps).toStrictEqual(['hello'])
 
+    // Is cache OK?
+    ps = splitPath('/hello')
+    expect(ps).toStrictEqual(['hello'])
+
     ps = splitPath('*')
     expect(ps).toStrictEqual(['*'])
 
@@ -36,6 +40,9 @@ describe('url', () => {
     it('getPathFromURL - no trailing slash', () => {
       let path = getPathFromURL('https://example.com/')
       expect(path).toBe('/')
+      path = getPathFromURL('https://example.com/hello')
+      expect(path).toBe('/hello')
+      // Is cache OK?
       path = getPathFromURL('https://example.com/hello')
       expect(path).toBe('/hello')
       path = getPathFromURL('https://example.com/hello/hey')


### PR DESCRIPTION
Made it faster!

```
hono - org x 708,830 ops/sec ±3.48% (83 runs sampled)
hono - trie-router(default) x 800,532 ops/sec ±4.11% (65 runs sampled)
```