### PR TITLE
fix(test): upgrade the miniflare to consume the fix on node18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "form-data": "^4.0.0",
     "graphql": "^16.4.0",
     "jest": "27.5.1",
-    "jest-environment-miniflare": "^2.4.0",
+    "jest-environment-miniflare": "^2.5.0",
     "mustache": "^4.2.0",
     "prettier": "^2.6.2",
     "prettier-plugin-md-nocjsp": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,6 +507,16 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/environment@>=27":
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-28.1.0.tgz#dedf7d59ec341b9292fcf459fd0ed819eb2e228a"
+  integrity sha512-S44WGSxkRngzHslhV6RoAExekfF7Qhwa6R5+IYFa81mpcj0YgdBnRSmvHe3SNwOt64yXaE5GG8Y2xM28ii5ssA==
+  dependencies:
+    "@jest/fake-timers" "^28.1.0"
+    "@jest/types" "^28.1.0"
+    "@types/node" "*"
+    jest-mock "^28.1.0"
+
 "@jest/environment@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.5.1.tgz#d7425820511fe7158abbecc010140c3fd3be9c74"
@@ -516,6 +526,18 @@
     "@jest/types" "^27.5.1"
     "@types/node" "*"
     jest-mock "^27.5.1"
+
+"@jest/fake-timers@>=27", "@jest/fake-timers@^28.1.0":
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-28.1.0.tgz#ea77878aabd5c5d50e1fc53e76d3226101e33064"
+  integrity sha512-Xqsf/6VLeAAq78+GNPzI7FZQRf5cCHj1qgQxCjws9n8rKw8r1UYoeaALwBvyuzOkpU3c1I6emeMySPa96rxtIg==
+  dependencies:
+    "@jest/types" "^28.1.0"
+    "@sinonjs/fake-timers" "^9.1.1"
+    "@types/node" "*"
+    jest-message-util "^28.1.0"
+    jest-mock "^28.1.0"
+    jest-util "^28.1.0"
 
 "@jest/fake-timers@^27.5.1":
   version "27.5.1"
@@ -569,6 +591,13 @@
     terminal-link "^2.0.0"
     v8-to-istanbul "^8.1.0"
 
+"@jest/schemas@^28.0.2":
+  version "28.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.0.2.tgz#08c30df6a8d07eafea0aef9fb222c5e26d72e613"
+  integrity sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==
+  dependencies:
+    "@sinclair/typebox" "^0.23.3"
+
 "@jest/source-map@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.5.1.tgz#6608391e465add4205eae073b55e7f279e04e8cf"
@@ -618,6 +647,18 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
+
+"@jest/types@>=27", "@jest/types@^28.1.0":
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.0.tgz#508327a89976cbf9bd3e1cc74641a29fd7dfd519"
+  integrity sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==
+  dependencies:
+    "@jest/schemas" "^28.0.2"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
 
 "@jest/types@^27.4.2":
   version "27.4.2"
@@ -672,142 +713,143 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@miniflare/cache@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/cache/-/cache-2.4.0.tgz#1b02e0519ef9306af51a366ec0e1c9189c676fd3"
-  integrity sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==
+"@miniflare/cache@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/cache/-/cache-2.5.0.tgz#2292ca0459942177ae5bf4d51286fefaed17967d"
+  integrity sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==
   dependencies:
-    "@miniflare/core" "2.4.0"
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/shared" "2.5.0"
     http-cache-semantics "^4.1.0"
-    undici "4.13.0"
+    undici "5.3.0"
 
-"@miniflare/cli-parser@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz#20e7c71588fe5e62aeeaa804fbb297b503a835c8"
-  integrity sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==
+"@miniflare/cli-parser@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz#034723ffdc841e67e8b9310c7f686ec6fc2b12ec"
+  integrity sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==
   dependencies:
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/shared" "2.5.0"
     kleur "^4.1.4"
 
-"@miniflare/core@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/core/-/core-2.4.0.tgz#11a454aae60f87cf6523c259b3384698dac19403"
-  integrity sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==
+"@miniflare/core@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/core/-/core-2.5.0.tgz#c5cab53fbae4f0c37f2d185b2f64fcc19565e3c0"
+  integrity sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==
   dependencies:
     "@iarna/toml" "^2.2.5"
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/watcher" "2.4.0"
-    busboy "^0.3.1"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/watcher" "2.5.0"
+    busboy "^1.6.0"
     dotenv "^10.0.0"
     kleur "^4.1.4"
     set-cookie-parser "^2.4.8"
-    undici "4.13.0"
+    undici "5.3.0"
+    urlpattern-polyfill "^4.0.3"
 
-"@miniflare/durable-objects@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz#5a9e487f4cc6255069f5fcff053d399c501d0e61"
-  integrity sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==
+"@miniflare/durable-objects@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz#b92b5f7bebdf7743ba2948edfe999f6ad939ad22"
+  integrity sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==
   dependencies:
-    "@miniflare/core" "2.4.0"
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/storage-memory" "2.4.0"
-    undici "4.13.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/storage-memory" "2.5.0"
+    undici "5.3.0"
 
-"@miniflare/html-rewriter@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz#d0025eeb7488b2b7a5167557eacdb8f2f28d92b1"
-  integrity sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==
+"@miniflare/html-rewriter@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz#777542c0062703ecce578e3a630658a66722c56d"
+  integrity sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==
   dependencies:
-    "@miniflare/core" "2.4.0"
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/shared" "2.5.0"
     html-rewriter-wasm "^0.4.1"
-    undici "4.13.0"
+    undici "5.3.0"
 
-"@miniflare/http-server@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/http-server/-/http-server-2.4.0.tgz#c0ef4734610fb6f512338bafa28f329be664c224"
-  integrity sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==
+"@miniflare/http-server@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/http-server/-/http-server-2.5.0.tgz#6460e67cf11d079d9a2a1b6feb43cdf1d8c77173"
+  integrity sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==
   dependencies:
-    "@miniflare/core" "2.4.0"
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/web-sockets" "2.4.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/web-sockets" "2.5.0"
     kleur "^4.1.4"
     selfsigned "^2.0.0"
-    undici "4.13.0"
+    undici "5.3.0"
     ws "^8.2.2"
     youch "^2.2.2"
 
-"@miniflare/kv@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/kv/-/kv-2.4.0.tgz#d76ebd4f8bac53619058e747fafb1427d3fbda5c"
-  integrity sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==
+"@miniflare/kv@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/kv/-/kv-2.5.0.tgz#c5683a323f5420ff3354a97ad039a953d0fab30a"
+  integrity sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==
   dependencies:
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/shared" "2.5.0"
 
-"@miniflare/runner-vm@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz#79d1286dab7e93d3acfec3c1f99a08c0a675a61c"
-  integrity sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==
+"@miniflare/runner-vm@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz#7f025e130c5d307fa79ed6f8354c8d921136fc0e"
+  integrity sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==
   dependencies:
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/shared" "2.5.0"
 
-"@miniflare/scheduler@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/scheduler/-/scheduler-2.4.0.tgz#3bfbd4f50cd8f9aa9af38e1f8ac901ccfd976d2a"
-  integrity sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==
+"@miniflare/scheduler@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/scheduler/-/scheduler-2.5.0.tgz#f893d6ed33b263eaee7620841a58f5144af08378"
+  integrity sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==
   dependencies:
-    "@miniflare/core" "2.4.0"
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/shared" "2.5.0"
     cron-schedule "^3.0.4"
 
-"@miniflare/shared@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/shared/-/shared-2.4.0.tgz#dde0c1fd1c668969720b282901a6fe60cf4e1447"
-  integrity sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==
+"@miniflare/shared@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/shared/-/shared-2.5.0.tgz#eaf47da30e800213d4888969f8783e0ca9bb9a36"
+  integrity sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==
   dependencies:
     ignore "^5.1.8"
     kleur "^4.1.4"
 
-"@miniflare/sites@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/sites/-/sites-2.4.0.tgz#24b59986661e3ba837ad257ff293506a10d94c47"
-  integrity sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==
+"@miniflare/sites@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/sites/-/sites-2.5.0.tgz#433c81c9c62d658b7d3efd399e4f16f6041aa021"
+  integrity sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==
   dependencies:
-    "@miniflare/kv" "2.4.0"
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/storage-file" "2.4.0"
+    "@miniflare/kv" "2.5.0"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/storage-file" "2.5.0"
 
-"@miniflare/storage-file@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/storage-file/-/storage-file-2.4.0.tgz#a86c6a866130c4148b2a5e4bbe7e978befa97968"
-  integrity sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==
+"@miniflare/storage-file@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/storage-file/-/storage-file-2.5.0.tgz#d784d7a2be728f602cca3fbc284e84007a0c6708"
+  integrity sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==
   dependencies:
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/storage-memory" "2.4.0"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/storage-memory" "2.5.0"
 
-"@miniflare/storage-memory@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz#af3214bd17bc08e93f8f5750bf666c0152f5353e"
-  integrity sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==
+"@miniflare/storage-memory@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz#b49db62730fec2d6b9d17238a5f64c4406120872"
+  integrity sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==
   dependencies:
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/shared" "2.5.0"
 
-"@miniflare/watcher@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/watcher/-/watcher-2.4.0.tgz#3ac422d53461ef7ad0b335d4d58f925c6584a7f2"
-  integrity sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==
+"@miniflare/watcher@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/watcher/-/watcher-2.5.0.tgz#eec9e3418d7bc6355ad7bf45938fadff3e809263"
+  integrity sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==
   dependencies:
-    "@miniflare/shared" "2.4.0"
+    "@miniflare/shared" "2.5.0"
 
-"@miniflare/web-sockets@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz#db9a080af7d5251fb388bdb86ffe8eac9009da2c"
-  integrity sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==
+"@miniflare/web-sockets@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz#6abf085485c61d79f7cb724ff5c41ae004174c17"
+  integrity sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==
   dependencies:
-    "@miniflare/core" "2.4.0"
-    "@miniflare/shared" "2.4.0"
-    undici "4.13.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/shared" "2.5.0"
+    undici "5.3.0"
     ws "^8.2.2"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -831,6 +873,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@sinclair/typebox@^0.23.3":
+  version "0.23.5"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
+  integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -842,6 +889,13 @@
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz#3fdc2b6cb58935b21bfb8d1625eb1300484316e7"
   integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/fake-timers@^9.1.1":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
@@ -989,6 +1043,13 @@
   version "16.0.4"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.8":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.10.tgz#591522fce85d8739bca7b8bb90d048e4478d186a"
+  integrity sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1319,12 +1380,12 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-busboy@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.3.1.tgz#170899274c5bf38aae27d5c62b71268cd585fd1b"
-  integrity sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
   dependencies:
-    dicer "0.3.0"
+    streamsearch "^1.1.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -1562,13 +1623,6 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-dicer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
-  integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
-  dependencies:
-    streamsearch "0.1.2"
 
 diff-sequences@^27.5.1:
   version "27.5.1"
@@ -2605,22 +2659,27 @@ jest-environment-jsdom@^27.5.1:
     jest-util "^27.5.1"
     jsdom "^16.6.0"
 
-jest-environment-miniflare@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-miniflare/-/jest-environment-miniflare-2.4.0.tgz#4f64690a426362e92bbf1b9cc46fdf895fda2886"
-  integrity sha512-WTsUBXrjyX1yNWCnKyzTSNFfBNm3QxT+f4AXaaSBrZEHCjE4/zl08/BE0fSmVQah6Vp/N3pgrM2efYQD6xiaHw==
+jest-environment-miniflare@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz#05ecc0e860e14caef7978f6357d70c0e2a04b3b7"
+  integrity sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==
   dependencies:
-    "@miniflare/cache" "2.4.0"
-    "@miniflare/core" "2.4.0"
-    "@miniflare/durable-objects" "2.4.0"
-    "@miniflare/html-rewriter" "2.4.0"
-    "@miniflare/kv" "2.4.0"
-    "@miniflare/runner-vm" "2.4.0"
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/sites" "2.4.0"
-    "@miniflare/storage-memory" "2.4.0"
-    "@miniflare/web-sockets" "2.4.0"
-    miniflare "2.4.0"
+    "@jest/environment" ">=27"
+    "@jest/fake-timers" ">=27"
+    "@jest/types" ">=27"
+    "@miniflare/cache" "2.5.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/durable-objects" "2.5.0"
+    "@miniflare/html-rewriter" "2.5.0"
+    "@miniflare/kv" "2.5.0"
+    "@miniflare/runner-vm" "2.5.0"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/sites" "2.5.0"
+    "@miniflare/storage-memory" "2.5.0"
+    "@miniflare/web-sockets" "2.5.0"
+    jest-mock ">=27"
+    jest-util ">=27"
+    miniflare "2.5.0"
 
 jest-environment-node@^27.5.1:
   version "27.5.1"
@@ -2714,6 +2773,29 @@ jest-message-util@^27.5.1:
     pretty-format "^27.5.1"
     slash "^3.0.0"
     stack-utils "^2.0.3"
+
+jest-message-util@^28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-28.1.0.tgz#7e8f0b9049e948e7b94c2a52731166774ba7d0af"
+  integrity sha512-RpA8mpaJ/B2HphDMiDlrAZdDytkmwFqgjDZovM21F35lHGeUeCvYmm6W+sbQ0ydaLpg5bFAUuWG1cjqOl8vqrw==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^28.1.0"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^28.1.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-mock@>=27, jest-mock@^28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-28.1.0.tgz#ccc7cc12a9b330b3182db0c651edc90d163ff73e"
+  integrity sha512-H7BrhggNn77WhdL7O1apG0Q/iwl0Bdd5E1ydhCJzL3oBLh/UYxAwR3EJLsBZ9XA3ZU4PA3UNw4tQjduBTCTmLw==
+  dependencies:
+    "@jest/types" "^28.1.0"
+    "@types/node" "*"
 
 jest-mock@^27.5.1:
   version "27.5.1"
@@ -2848,6 +2930,18 @@ jest-snapshot@^27.5.1:
     natural-compare "^1.4.0"
     pretty-format "^27.5.1"
     semver "^7.3.2"
+
+jest-util@>=27, jest-util@^28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.0.tgz#d54eb83ad77e1dd441408738c5a5043642823be5"
+  integrity sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==
+  dependencies:
+    "@jest/types" "^28.1.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
 
 jest-util@^27.0.0:
   version "27.4.2"
@@ -3135,29 +3229,29 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-miniflare@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-2.4.0.tgz#e09aa92a7146760943710c69ea94b99b7a15e0fb"
-  integrity sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==
+miniflare@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-2.5.0.tgz#befe1e5cf598f9b6e67af74669747e9730b27da7"
+  integrity sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==
   dependencies:
-    "@miniflare/cache" "2.4.0"
-    "@miniflare/cli-parser" "2.4.0"
-    "@miniflare/core" "2.4.0"
-    "@miniflare/durable-objects" "2.4.0"
-    "@miniflare/html-rewriter" "2.4.0"
-    "@miniflare/http-server" "2.4.0"
-    "@miniflare/kv" "2.4.0"
-    "@miniflare/runner-vm" "2.4.0"
-    "@miniflare/scheduler" "2.4.0"
-    "@miniflare/shared" "2.4.0"
-    "@miniflare/sites" "2.4.0"
-    "@miniflare/storage-file" "2.4.0"
-    "@miniflare/storage-memory" "2.4.0"
-    "@miniflare/web-sockets" "2.4.0"
+    "@miniflare/cache" "2.5.0"
+    "@miniflare/cli-parser" "2.5.0"
+    "@miniflare/core" "2.5.0"
+    "@miniflare/durable-objects" "2.5.0"
+    "@miniflare/html-rewriter" "2.5.0"
+    "@miniflare/http-server" "2.5.0"
+    "@miniflare/kv" "2.5.0"
+    "@miniflare/runner-vm" "2.5.0"
+    "@miniflare/scheduler" "2.5.0"
+    "@miniflare/shared" "2.5.0"
+    "@miniflare/sites" "2.5.0"
+    "@miniflare/storage-file" "2.5.0"
+    "@miniflare/storage-memory" "2.5.0"
+    "@miniflare/web-sockets" "2.5.0"
     kleur "^4.1.4"
     semiver "^1.1.0"
     source-map-support "^0.5.20"
-    undici "4.13.0"
+    undici "5.3.0"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -3457,6 +3551,16 @@ pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+pretty-format@^28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.0.tgz#8f5836c6a0dfdb834730577ec18029052191af55"
+  integrity sha512-79Z4wWOYCdvQkEoEuSlBhHJqWeZ8D8YRPiPctJFCtvuaClGpiwiQYSCUOE6IEKUbbFukKOTFIUAXE8N4EQTo1Q==
+  dependencies:
+    "@jest/schemas" "^28.0.2"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -3484,6 +3588,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
+  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
 regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
@@ -3679,10 +3788,10 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-streamsearch@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
-  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -3935,10 +4044,10 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-undici@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-4.13.0.tgz#7d10fe150c3241a6b3b0eba80eff59c9fb40f359"
-  integrity sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==
+undici@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.3.0.tgz#869d47bafa7f72ccaf8738258f0283bf3dd179ca"
+  integrity sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==
 
 universalify@^0.1.2:
   version "0.1.2"
@@ -3951,6 +4060,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+urlpattern-polyfill@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz#c1fa7a73eb4e6c6a1ffb41b24cf31974f7392d3b"
+  integrity sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
This PR is to close https://github.com/honojs/hono/issues/214 by upgrading to latest release of miniflare https://github.com/cloudflare/miniflare/releases/tag/v2.5.0