### PR TITLE
fix(status): make the status 401 for the invalid authorization info

### DIFF
--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -33,7 +33,7 @@ describe('Jwt Auth by Middleware', () => {
     const req = new Request('http://localhost/auth/a')
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(401)
     expect(await res.text()).toBe('Unauthorized')
     expect(res.headers.get('x-foo')).toBeFalsy()
   })
@@ -86,7 +86,7 @@ describe('Jwt Auth by Middleware', () => {
     req.headers.set('Authorization', `Bearer ${invalid_token}`)
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(401)
     expect(res.headers.get('www-authenticate')).toEqual(
       `Bearer realm="${url}",error="invalid_request",error_description="no authorization included in request"`
     )

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -13,7 +13,7 @@ export const jwt = (options: { secret: string; alg?: string }) => {
 
     if (!credentials) {
       ctx.res = new Response('Unauthorized', {
-        status: 400,
+        status: 401,
         headers: {
           'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="no authorization included in request"`,
         },
@@ -24,7 +24,7 @@ export const jwt = (options: { secret: string; alg?: string }) => {
     const parts = credentials.split(/\s+/)
     if (parts.length !== 2) {
       ctx.res = new Response('Unauthorized', {
-        status: 400,
+        status: 401,
         headers: {
           'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="no authorization included in request"`,
         },


### PR DESCRIPTION
This PR is correct the status code for no or invalid authorization data provided,   thanks @sdarnell 's reminder.