### PR TITLE
Export `md5` function in src/utils/crypto.ts

### DIFF
--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -16,4 +16,10 @@ describe('crypto', () => {
     expect(await sha1('炎')).toBe('d56e09ae2421b2b8a0b5ee5fdceaed663c8c9472')
     expect(await sha1('abcdedf')).not.toBe('abcdef')
   })
+  
+  it('md5', async () => {
+    expect(await md5('hono')).toBe('cf22a160789a91dd5f737cd3b2640cc2')
+    expect(await md5('炎')).toBe('f620d89a5a782c22b4420acb39121be3')
+    expect(await md5('abcdedf')).not.toBe('abcdef')
+  })
 })

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,4 +1,4 @@
-import { sha256, sha1 } from './crypto'
+import { sha256, sha1, md5 } from './crypto'
 
 describe('crypto', () => {
   it('sha256', async () => {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -17,6 +17,12 @@ export const sha1 = async (data: Data) => {
   return hash
 }
 
+export const md5 = async (data: Data) => {
+  const algorithm: Algorithm = { name: 'MD5', alias: 'md5' }
+  const hash = await createHash(data, algorithm)
+  return hash
+}
+
 export const createHash = async (data: Data, algorithm: Algorithm): Promise<string | null> => {
   if (crypto && crypto.subtle) {
     const buffer = await crypto.subtle.digest(


### PR DESCRIPTION
Export an additional `md5` function in the crypto utility.

Useful when working with R2 and providing a MD5 hash for verification.

```
import { md5 } from "hono/utils/crypto";

...
const md5Digest = md5(body);
const object = await bucket.put(key, body, {md5: md5Digest});
```

It is worth noting, however, that "MD5 is not part of the WebCrypto standard but is supported in Cloudflare Workers for interacting with legacy systems that require MD5." <sup>[1]</sup>

[1]: https://developers.cloudflare.com/workers/runtime-apis/web-crypto/