### PR TITLE
feat(middleware/jsx): Introduce memo.

### DIFF
--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -104,7 +104,7 @@ export const memo = <T>(
   let computed = undefined
   let prevProps: T | undefined = undefined
   return ((props: T): EscapedString => {
-    if (propsAreEqual && prevProps && !propsAreEqual(prevProps, props)) {
+    if (prevProps && !propsAreEqual(prevProps, props)) {
       computed = undefined
     }
     prevProps = props

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -46,8 +46,7 @@ export const h = (
       escapedString.isEscaped = true
       children = [escapedString]
       continue
-    }
-    else if (v === null || v === undefined) {
+    } else if (v === null || v === undefined) {
       continue
     }
 
@@ -74,4 +73,41 @@ export const h = (
   escapedString.isEscaped = true
 
   return escapedString
+}
+
+type FC<T = Record<string, any>> = (props: T) => EscapedString
+
+const shallowEqual = (a: Record<string, any>, b: Record<string, any>): boolean => {
+  if (a === b) {
+    return true
+  }
+
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+
+  for (let i = 0, len = aKeys.length; i < len; i++) {
+    if (a[aKeys[i]] !== b[aKeys[i]]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export const memo = <T>(
+  component: FC<T>,
+  propsAreEqual: (prevProps: Readonly<T>, nextProps: Readonly<T>) => boolean = shallowEqual
+): FC<T> => {
+  let computed = undefined
+  let prevProps: T | undefined = undefined
+  return ((props: T): EscapedString => {
+    if (propsAreEqual && prevProps && !propsAreEqual(prevProps, props)) {
+      computed = undefined
+    }
+    prevProps = props
+    return (computed ||= component(props))
+  }) as FC<T>
 }


### PR DESCRIPTION
This PR provide a memo that can be used in much the same way as React.memo.

I think the React.memo is "do not recalculate the Virtual DOM unless there are changes in the props".
There is no Virtual DOM in hono's jsx engine, but I think we can give a meaning to memo that says "return a calculated EscapedString if there are no changes in props".

This can be used to avoid recalculating the following JSX on every render
https://github.com/yusukebe/iekei/blob/nano-jsx/src/components/footer.tsx