### PR TITLE
feat(middleware/jsx): We need Fragment.

### DIFF
--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { h, jsx, memo } from '.'
+import { h, jsx, memo, Fragment } from '.'
 
 describe('JSX middleware', () => {
   const app = new Hono()
@@ -146,8 +146,8 @@ describe('memo', () => {
 
   it('custom propsAreEqual', () => {
     const Body = memo(
-      ({ counter }: { counter: number, refresh?: boolean }) => <span>{counter}</span>,
-      (_, nextProps) => typeof nextProps.refresh == 'undefined' ? true : !nextProps.refresh
+      ({ counter }: { counter: number; refresh?: boolean }) => <span>{counter}</span>,
+      (_, nextProps) => (typeof nextProps.refresh == 'undefined' ? true : !nextProps.refresh)
     )
 
     let template = <Body counter={0} />
@@ -158,5 +158,27 @@ describe('memo', () => {
 
     template = <Body counter={2} refresh={true} />
     expect(template.toString()).toBe('<span>2</span>')
+  })
+})
+
+describe('Fragment', () => {
+  it('Should render children', () => {
+    const template = (
+      <>
+        <p>1</p>
+        <p>2</p>
+      </>
+    )
+    expect(template.toString()).toBe('<p>1</p><p>2</p>')
+  })
+
+  it('Should render nothing for empty Fragment', () => {
+    const template = <></>
+    expect(template.toString()).toBe('')
+  })
+
+  it('Should render nothing for undefined', () => {
+    const template = <>{undefined}</>
+    expect(template.toString()).toBe('')
   })
 })

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -32,7 +32,7 @@ export const h = (
     return tag.call(null, { ...props, children: children.length <= 1 ? children[0] : children })
   }
 
-  let result = `<${tag}`
+  let result = tag !== '' ? `<${tag}` : ''
 
   const propsKeys = Object.keys(props || {})
   for (let i = 0, len = propsKeys.length; i < len; i++) {
@@ -53,7 +53,9 @@ export const h = (
     result += ` ${propsKeys[i]}="${escape(v.toString())}"`
   }
 
-  result += '>'
+  if (tag !== '') {
+    result += '>'
+  }
 
   const flattenChildren = children.flat(Infinity)
   for (let i = 0, len = flattenChildren.length; i < len; i++) {
@@ -67,7 +69,9 @@ export const h = (
     }
   }
 
-  result += `</${tag}>`
+  if (tag !== '') {
+    result += `</${tag}>`
+  }
 
   const escapedString = new String(result) as EscapedString
   escapedString.isEscaped = true
@@ -110,4 +114,8 @@ export const memo = <T>(
     prevProps = props
     return (computed ||= component(props))
   }) as FC<T>
+}
+
+export const Fragment = (props: { key?: string; children?: any }): EscapedString => {
+  return h('', {}, ...(props.children || []))
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     ],
     "jsx": "react",
     "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
I think we also need Fragment.

### Why accept key?

Although `key` is not used in hono, it would be useful to be able to bring the template with React as is, so this was added for compatibility.

> key is the only attribute that can be passed to Fragment. 
https://reactjs.org/docs/fragments.html#keyed-fragments