### PR TITLE
feat: Introduce html template literals tag.

### DIFF
--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -115,6 +115,6 @@ export const memo = <T>(
   }) as FC<T>
 }
 
-export const Fragment = (props: { key?: string; children?: any }): EscapedString => {
+export const Fragment = (props: { key?: string; children?: any }): HtmlEscapedString => {
   return h('', {}, ...(props.children || []))
 }

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -1,6 +1,7 @@
 import type { Context } from '../../context'
 import type { Next } from '../../hono'
 import { escape } from '../../utils/html'
+import type { HtmlEscapedString } from '../../utils/html'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -21,13 +22,11 @@ export const jsx = () => {
   }
 }
 
-type EscapedString = string & { isEscaped: true }
-
 export const h = (
   tag: string | Function,
   props: Record<string, any>,
-  ...children: (string | EscapedString)[]
-): EscapedString => {
+  ...children: (string | HtmlEscapedString)[]
+): HtmlEscapedString => {
   if (typeof tag === 'function') {
     return tag.call(null, { ...props, children: children.length <= 1 ? children[0] : children })
   }
@@ -42,7 +41,7 @@ export const h = (
         throw 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
       }
 
-      const escapedString = new String(v.__html) as EscapedString
+      const escapedString = new String(v.__html) as HtmlEscapedString
       escapedString.isEscaped = true
       children = [escapedString]
       continue
@@ -69,13 +68,13 @@ export const h = (
 
   result += `</${tag}>`
 
-  const escapedString = new String(result) as EscapedString
+  const escapedString = new String(result) as HtmlEscapedString
   escapedString.isEscaped = true
 
   return escapedString
 }
 
-type FC<T = Record<string, any>> = (props: T) => EscapedString
+type FC<T = Record<string, any>> = (props: T) => HtmlEscapedString
 
 const shallowEqual = (a: Record<string, any>, b: Record<string, any>): boolean => {
   if (a === b) {
@@ -103,7 +102,7 @@ export const memo = <T>(
 ): FC<T> => {
   let computed = undefined
   let prevProps: T | undefined = undefined
-  return ((props: T): EscapedString => {
+  return ((props: T): HtmlEscapedString => {
     if (prevProps && !propsAreEqual(prevProps, props)) {
       computed = undefined
     }

--- a/src/utils/html.test.ts
+++ b/src/utils/html.test.ts
@@ -1,8 +1,15 @@
-import { escape } from './html'
+import { escape, html } from './html'
 
 describe('HTML escape', () => {
   it('Should escape special characters', () => {
     expect(escape('I <b>think</b> this is good.')).toBe('I &lt;b&gt;think&lt;/b&gt; this is good.')
     expect(escape('John "Johnny" Smith')).toBe('John &quot;Johnny&quot; Smith')
+  })
+})
+
+describe('Tagged Template Literals', () => {
+  it('Should escape special characters', () => {
+    const name = 'John "Johnny" Smith'
+    expect(html`<p>I'm ${name}.</p>`.toString()).toBe('<p>I\'m John &quot;Johnny&quot; Smith.</p>')
   })
 })

--- a/src/utils/html.test.ts
+++ b/src/utils/html.test.ts
@@ -12,4 +12,26 @@ describe('Tagged Template Literals', () => {
     const name = 'John "Johnny" Smith'
     expect(html`<p>I'm ${name}.</p>`.toString()).toBe('<p>I\'m John &quot;Johnny&quot; Smith.</p>')
   })
+
+  describe('Booleans, Null, and Undefined Are Ignored', () => {
+    it.each([true, false, undefined, null])('%s', (item) => {
+      expect(html`${item}`.toString()).toBe('')
+    })
+
+    it('falsy value', () => {
+      expect(html`${0}`.toString()).toBe('0')
+    })
+  })
+
+  it('Should call $array.flat(Infinity)', () => {
+    const values = [
+      'Name:',
+      ['John "Johnny" Smith', undefined, null],
+      ' Contact:',
+      [html`<a href="http://example.com/">My Website</a>`],
+    ]
+    expect(html`<p>${values}</p>`.toString()).toBe(
+      '<p>Name:John &quot;Johnny&quot; Smith Contact:<a href=\"http://example.com/\">My Website</a></p>'
+    )
+  })
 })

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -18,13 +18,16 @@ export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscap
   for (let i = 0, len = strings.length - 1; i < len; i++) {
     result += strings[i]
 
-    const value = values[i]
-    if (typeof value === 'boolean' || value === null || value === undefined) {
-      continue
-    } else if (typeof value === 'object' && (value as any).isEscaped) {
-      result += value
-    } else {
-      result += escape(value.toString())
+    const children = values[i] instanceof Array ? values[i].flat(Infinity) : [values[i]]
+    for (let i = 0, len = children.length; i < len; i++) {
+      const child = children[i]
+      if (typeof child === 'boolean' || child === null || child === undefined) {
+        continue
+      } else if (typeof child === 'object' && (child as any).isEscaped) {
+        result += child
+      } else {
+        result += escape(child.toString())
+      }
     }
   }
   result += strings[strings.length - 1]

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,3 +1,5 @@
+export type HtmlEscapedString = string & { isEscaped: true }
+
 const entityMap: Record<string, string> = {
   '&': '&amp;',
   '<': '&lt;',

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -11,3 +11,26 @@ const replaceFn = (m: string) => entityMap[m]
 export const escape = (str: string): string => {
   return str.replace(escapeRe, replaceFn)
 }
+
+export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscapedString => {
+  let result = ''
+
+  for (let i = 0, len = strings.length - 1; i < len; i++) {
+    result += strings[i]
+
+    const value = values[i]
+    if (typeof value === 'boolean' || value === null || value === undefined) {
+      continue
+    } else if (typeof value === 'object' && (value as any).isEscaped) {
+      result += value
+    } else {
+      result += escape(value.toString())
+    }
+  }
+  result += strings[strings.length - 1]
+
+  const escapedString = new String(result) as HtmlEscapedString
+  escapedString.isEscaped = true
+
+  return escapedString
+}


### PR DESCRIPTION
This PR is a small addition but one that I believe has great potential.
What we will be able to do is explained below.

## Advance information

There is a precedent for a library that handles HTML template literals with a tag named "html", and I refer to this as an idea.

* https://github.com/lit/lit/tree/main/packages/lit-html
* https://github.com/developit/htm

Thanks to these libraries, VisualStudioCode and vim also interprets template literals as HTML, allowing syntax highlighting and formatting to be applied.

* https://marketplace.visualstudio.com/items?itemName=bierner.lit-html
* https://github.com/MaxMEllon/vim-jsx-pretty

## What we will be able to do

### Render HTML

```typescript
app.get('/:username', (c) => {
  const { username } = c.req.param()
  return c.html(
    html`<!DOCTYPE html>
      <h1>Hello! ${username}!</h1>`
  )
})
```

### Insert snippet into JSX

```typescript
const snippet = html`
  <script async src="https://www.googletagmanager.com/gtag/js?id=MEASUREMENT_ID"></script>
  <script>
    window.dataLayer = window.dataLayer || []
    function gtag() {
      dataLayer.push(arguments)
    }
    gtag('js', new Date())

    gtag('config', 'MEASUREMENT_ID')
  </script>
`

app.get('/', (c) => {
  return c.render(
    <html>
      <head>
        <title>Test Site</title>
        {snippet}
      </head>
      <body>Hello!</body>
    </html>
  )
})
```

### Insert inline script into JSX

```typescript
app.get('/', (c) => {
  return c.render(
    <html>
      <head>
        <title>Test Site</title>
        {html`
          <script>
            // No need to use dangerouslySetInnerHTML. If you write it here, it will not be escaped.
          </script>
        `}
      </head>
      <body>Hello!</body>
    </html>
  )
})
```

### Act as functional component

Since `html` returns an HtmlEscapedString, it can act as a fully functional component without using JSX.

#### Use `html` to speed up the process instead of `memo`

```typescript
const Footer = () => html`
  <footer>
    <address>My Address...</address>
  </footer>
`
```

#### Receives props and embeds values

```typescript
interface SiteData {
  title: string
  description: string
  image: string
  children?: any
}
const Layout = (props: SiteData) => html`
<html>
<head>
  <meta charset="UTF-8">
  <title>${props.title}</title>
  <meta name="description" content="${props.description}">
  <head prefix="og: http://ogp.me/ns#">
  <meta property="og:type" content="article">
  <!-- More elements slow down JSX, but not template literals. -->
  <meta property="og:title" content="${props.title}">
  <meta property="og:image" content="${props.image}">
</head>
<body>
  ${props.children}
</body>
</html>
`

const Content = (props: { siteData: SiteData; name: string }) => (
  <Layout {...props.siteData}>
    <h1>Hello {props.name}</h1>
  </Layout>
)

app.get('/', (c) => {
  const props = {
    name: 'World',
    siteData: {
      title: 'Hello <> World',
      description: 'This is a description',
      image: 'https://example.com/image.png',
    },
  }
  return c.render(<Content {...props} />)
})
```

<img width="567" alt="image" src="https://user-images.githubusercontent.com/30598/173151579-d497c73a-f454-4876-ae90-405c8f26b914.png">

I understand that using multiple template engines within a single project is generally a bad option.
Nevertheless, it doesn't look too bad, and I think it is possible to both improve execution speed and the developer experience by using it differently as follows.

* Layout-like component with many HTML elements, simply filling in values => template literals with `html` tag
* Call other components or perform repetitive processing => JSX