### PR TITLE
feat(utils/html): Introduce a function `raw`.

### DIFF
--- a/src/utils/html.test.ts
+++ b/src/utils/html.test.ts
@@ -1,4 +1,4 @@
-import { escape, html } from './html'
+import { escape, html, raw } from './html'
 
 describe('HTML escape', () => {
   it('Should escape special characters', () => {
@@ -33,5 +33,12 @@ describe('Tagged Template Literals', () => {
     expect(html`<p>${values}</p>`.toString()).toBe(
       '<p>Name:John &quot;Johnny&quot; Smith Contact:<a href=\"http://example.com/\">My Website</a></p>'
     )
+  })
+})
+
+describe('raw', () => {
+  it('Should be marked as escaped.', () => {
+    const name = 'John &quot;Johnny&quot; Smith'
+    expect(html`<p>I'm ${raw(name)}.</p>`.toString()).toBe('<p>I\'m John &quot;Johnny&quot; Smith.</p>')
   })
 })

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -12,6 +12,13 @@ export const escape = (str: string): string => {
   return str.replace(escapeRe, replaceFn)
 }
 
+export const raw = (value: any): HtmlEscapedString => {
+  const escapedString = new String(value) as HtmlEscapedString
+  escapedString.isEscaped = true
+
+  return escapedString
+}
+
 export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscapedString => {
   let result = ''
 
@@ -32,8 +39,5 @@ export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscap
   }
   result += strings[strings.length - 1]
 
-  const escapedString = new String(result) as HtmlEscapedString
-  escapedString.isEscaped = true
-
-  return escapedString
+  return raw(result)
 }


### PR DESCRIPTION
Fixes #314

Although `raw` could be used in the following locations, I did not apply it to these locations to avoid the overhead of function calls, since they are very frequently executed.

https://github.com/honojs/hono/blob/master/src/middleware/jsx/index.ts#L75-L76