### PR TITLE
feat(context): add executionCtx to Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,10 +483,22 @@ app.use('/', async (c, next) => {
 })
 ```
 
+### c.executionCtx
+
+```ts
+// ExecutionContext object
+app.get('/foo', async (c) => {
+  c.executionCtx.waitUntil(
+    c.env.KV.put(key, data)
+  )
+  ...
+})
+```
+
 ### c.event
 
 ```ts
-// FetchEvent object
+// FetchEvent object (only set when using Service Worker syntax)
 app.get('/foo', async (c) => {
   c.event.waitUntil(
     c.env.KV.put(key, data)
@@ -523,8 +535,8 @@ addEventListener('fetch', (event) => {
 
 ```ts
 export default {
-  fetch(request: Request, env: Env, event: FetchEvent) {
-    return app.fetch(request, env, event)
+  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    return app.fetch(request, env, ctx)
   },
 }
 ```

--- a/src/context.ts
+++ b/src/context.ts
@@ -11,6 +11,7 @@ export class Context<RequestParamKeyType extends string = string, E = Env> {
   req: Request<RequestParamKeyType>
   env: E
   event: FetchEvent | undefined
+  executionCtx: ExecutionContext | undefined
   finalized: boolean
 
   private _status: StatusCode = 200
@@ -26,7 +27,7 @@ export class Context<RequestParamKeyType extends string = string, E = Env> {
   constructor(
     req: Request<RequestParamKeyType>,
     env: E | undefined = undefined,
-    event: FetchEvent | undefined = undefined,
+    eventOrExecutionCtx: FetchEvent | ExecutionContext | undefined = undefined,
     notFoundHandler: NotFoundHandler = () => new Response()
   ) {
     this.req = req
@@ -34,7 +35,13 @@ export class Context<RequestParamKeyType extends string = string, E = Env> {
     if (env) {
       this.env = env
     }
-    this.event = event
+
+    this.executionCtx = eventOrExecutionCtx
+
+    if (eventOrExecutionCtx && 'respondWith' in eventOrExecutionCtx) {
+      this.event = eventOrExecutionCtx
+    }
+
     this.notFoundHandler = notFoundHandler
     this.finalized = false
   }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -160,7 +160,7 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this.router.match(method, path)
   }
 
-  private async dispatch(request: Request, event?: FetchEvent, env?: E): Promise<Response> {
+  private async dispatch(request: Request, executionCtx?: ExecutionContext, env?: E): Promise<Response> {
     const path = getPathFromURL(request.url, this.strict)
     const method = request.method
 
@@ -170,7 +170,7 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
 
-    const c = new Context<string, E>(request, env, event, this.notFoundHandler)
+    const c = new Context<string, E>(request, env, executionCtx, this.notFoundHandler)
 
     const composed = compose<Context>(handlers, this.errorHandler, this.notFoundHandler)
     let context: Context
@@ -195,8 +195,8 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this.dispatch(event.request, event)
   }
 
-  async fetch(request: Request, env?: E, event?: FetchEvent): Promise<Response> {
-    return this.dispatch(request, event, env)
+  async fetch(request: Request, env?: E, executionCtx?: ExecutionContext): Promise<Response> {
+    return this.dispatch(request, executionCtx, env)
   }
 
   request(input: RequestInfo, requestInit?: RequestInit): Promise<Response> {


### PR DESCRIPTION
When using Module syntax, there is no FetchEvent, only ExecutionContext (FetchEvent implements ExecutionContext's functions as well, `waitUntil` and `passThroughUntilException`).

This PR adds `c.executionCtx`, which is set on both Service Worker syntax and Module syntax. `c.event` is only used on Service Worker syntax.