### PR TITLE
refactor: make `HonoRequest`

### DIFF
--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -1,8 +1,5 @@
 import { compose } from './compose'
 import { Context } from './context'
-import { extendRequestPrototype } from './request'
-
-extendRequestPrototype()
 
 type C = {
   req: Record<string, string>

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,6 @@
 import type { NotFoundHandler } from './hono'
+import { extendHonoRequest } from './request'
+import type { HonoRequest } from './request'
 import type { StatusCode } from './utils/http-status'
 import { isAbsoluteURL } from './utils/url'
 
@@ -8,7 +10,7 @@ export type Data = string | ArrayBuffer | ReadableStream
 export type Env = Record<string, any>
 
 export class Context<RequestParamKeyType extends string = string, E = Env> {
-  req: Request<RequestParamKeyType>
+  req: HonoRequest<RequestParamKeyType>
   env: E
   event: FetchEvent | undefined
   executionCtx: ExecutionContext | undefined
@@ -25,12 +27,16 @@ export class Context<RequestParamKeyType extends string = string, E = Env> {
   render: (content: string, params?: object, options?: object) => Response | Promise<Response>
 
   constructor(
-    req: Request<RequestParamKeyType>,
+    req: HonoRequest | Request,
     env: E | undefined = undefined,
     eventOrExecutionCtx: FetchEvent | ExecutionContext | undefined = undefined,
     notFoundHandler: NotFoundHandler = () => new Response()
   ) {
-    this.req = req
+    if (req instanceof Request) {
+      this.req = extendHonoRequest(req as HonoRequest)
+    } else {
+      this.req = req
+    }
 
     if (env) {
       this.env = env

--- a/src/middleware/body-parse/index.test.ts
+++ b/src/middleware/body-parse/index.test.ts
@@ -1,4 +1,6 @@
 import { Hono } from '../../hono'
+import type { HonoRequest } from '../../request'
+import { extendHonoRequest } from '../../request'
 import { bodyParse } from '.'
 
 describe('Parse Body Middleware', () => {
@@ -25,7 +27,7 @@ describe('Parse Body Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(req.parsedBody).toEqual(payload)
+    expect(extendHonoRequest(req as HonoRequest).parsedBody).toEqual(payload)
     expect(await res.json()).toEqual(payload)
   })
 
@@ -39,7 +41,7 @@ describe('Parse Body Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(req.parsedBody).toEqual(payload)
+    expect(extendHonoRequest(req as HonoRequest).parsedBody).toEqual(payload)
     expect(await res.text()).toEqual(payload)
   })
 
@@ -56,7 +58,7 @@ describe('Parse Body Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(req.parsedBody).toEqual({ message: 'hello' })
+    expect(extendHonoRequest(req as HonoRequest).parsedBody).toEqual({ message: 'hello' })
     expect(await res.json()).toEqual({ message: 'hello' })
   })
 })

--- a/src/middleware/body-parse/index.ts
+++ b/src/middleware/body-parse/index.ts
@@ -2,8 +2,8 @@ import type { Context } from '../../context'
 import type { Next } from '../../hono'
 import { parseBody } from '../../utils/body'
 
-declare global {
-  interface Request {
+declare module '../../request' {
+  interface HonoRequest {
     parsedBody: any
   }
 }

--- a/src/middleware/cookie/index.ts
+++ b/src/middleware/cookie/index.ts
@@ -1,8 +1,8 @@
 import type { Context } from '../../context'
 import type { Next } from '../../hono'
 
-declare global {
-  interface Request {
+declare module '../../request' {
+  interface HonoRequest {
     cookie: {
       (name: string): string
       (): Record<string, string>

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,32 +1,25 @@
-declare global {
-  interface Request<ParamKeyType extends string = string> {
-    param: {
-      (key: ParamKeyType): string
-      (): Record<ParamKeyType, string>
-    }
-    paramData?: Record<ParamKeyType, string>
-    query: {
-      (key: string): string
-      (): Record<string, string>
-    }
-    queries: {
-      (key: string): string[]
-      (): Record<string, string[]>
-    }
-    header: {
-      (name: string): string
-      (): Record<string, string>
-    }
+export class HonoRequest<ParamKeyType extends string = string> extends Request {
+  param: {
+    (key: ParamKeyType): string
+    (): Record<ParamKeyType, string>
+  }
+  paramData?: Record<ParamKeyType, string>
+  query: {
+    (key: string): string
+    (): Record<string, string>
+  }
+  queries: {
+    (key: string): string[]
+    (): Record<string, string[]>
+  }
+  header: {
+    (name: string): string
+    (): Record<string, string>
   }
 }
 
-export function extendRequestPrototype() {
-  if (!!Request.prototype.param as boolean) {
-    // already extended
-    return
-  }
-
-  Request.prototype.param = function (this: Request, key?: string) {
+export function extendHonoRequest(request: HonoRequest): HonoRequest {
+  request.param = function (this: HonoRequest, key?: string) {
     if (this.paramData) {
       if (key) {
         return this.paramData[key]
@@ -35,9 +28,9 @@ export function extendRequestPrototype() {
       }
     }
     return null
-  } as InstanceType<typeof Request>['param']
+  } as InstanceType<typeof HonoRequest>['param']
 
-  Request.prototype.header = function (this: Request, name?: string) {
+  request.header = function (this: HonoRequest, name?: string) {
     if (name) {
       return this.headers.get(name)
     } else {
@@ -47,9 +40,9 @@ export function extendRequestPrototype() {
       }
       return result
     }
-  } as InstanceType<typeof Request>['header']
+  } as InstanceType<typeof HonoRequest>['header']
 
-  Request.prototype.query = function (this: Request, key?: string) {
+  request.query = function (this: HonoRequest, key?: string) {
     const url = new URL(this.url)
     if (key) {
       return url.searchParams.get(key)
@@ -60,9 +53,9 @@ export function extendRequestPrototype() {
       }
       return result
     }
-  } as InstanceType<typeof Request>['query']
+  } as InstanceType<typeof HonoRequest>['query']
 
-  Request.prototype.queries = function (this: Request, key?: string) {
+  request.queries = function (this: HonoRequest, key?: string) {
     const url = new URL(this.url)
     if (key) {
       return url.searchParams.getAll(key)
@@ -73,5 +66,7 @@ export function extendRequestPrototype() {
       }
       return result
     }
-  } as InstanceType<typeof Request>['queries']
+  } as InstanceType<typeof HonoRequest>['queries']
+
+  return request
 }


### PR DESCRIPTION
Instead of extending `Request`, I created `HonoRequest`. APIs such as `c.req.param()` are not changed.

Close #213