### PR TITLE
refactor: use arrow func for `app.fetch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ Hono also works with Deno. This feature is still experimental.
 
 ```tsx
 /** @jsx jsx */
-import { serve } from 'https://deno.land/std@0.146.0/http/server.ts'
+import { serve } from 'https://deno.land/std/http/server.ts'
 import { Hono, logger, poweredBy, serveStatic, jsx } from 'https://deno.land/x/hono/mod.ts'
 
 const app = new Hono()
@@ -774,7 +774,7 @@ app.get('/', (c) => {
   return c.html(<h1>Hello Deno!</h1>)
 })
 
-serve((req) => app.fetch(req))
+serve(app.fetch)
 ```
 
 ## Related projects

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -762,7 +762,7 @@ Hono also works with Deno. This feature is still experimental.
 
 ```tsx
 /** @jsx jsx */
-import { serve } from 'https://deno.land/std@0.146.0/http/server.ts'
+import { serve } from 'https://deno.land/std/http/server.ts'
 import { Hono, logger, poweredBy, serveStatic, jsx } from 'https://deno.land/x/hono/mod.ts'
 
 const app = new Hono()
@@ -774,7 +774,7 @@ app.get('/', (c) => {
   return c.html(<h1>Hello Deno!</h1>)
 })
 
-serve((req) => app.fetch(req))
+serve(app.fetch)
 ```
 
 ## Related projects

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -198,7 +198,7 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this.dispatch(event.request, event)
   }
 
-  async fetch(request: Request, env?: E, executionCtx?: ExecutionContext): Promise<Response> {
+  fetch = async (request: Request, env?: E, executionCtx?: ExecutionContext) => {
     return this.dispatch(request, executionCtx, env)
   }
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -198,7 +198,7 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this.dispatch(event.request, event)
   }
 
-  async fetch(request: Request, env?: E, executionCtx?: ExecutionContext): Promise<Response> {
+  fetch = async (request: Request, env?: E, executionCtx?: ExecutionContext) => {
     return this.dispatch(request, executionCtx, env)
   }
 


### PR DESCRIPTION
On Deno, you can write like below:

```ts
import { serve } from 'https://deno.land/std/http/server.ts'
import { Hono } from 'https://deno.land/x/hono/mod.ts'

const app = new Hono()
// ...
serve(app.fetch) // <---
```
