### PR TITLE
Skip closing tag if it is an empty element

### DIFF
--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -27,6 +27,11 @@ describe('render to string', () => {
     expect(template.toString()).toBe('<p><span>a</span><span>b</span></p>')
   })
 
+  it('Empty elements are rended withtout closing tag', () => {
+    const template = (<input />)
+    expect(template.toString()).toBe('<input>')
+  })
+
   it('Props value is null', () => {
     const template = <span data-hello={null}>Hello</span>
     expect(template.toString()).toBe('<span>Hello</span>')

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -10,6 +10,24 @@ declare global {
   }
 }
 
+const emptyTags = [
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+];
+
 export const jsx = (
   tag: string | Function,
   props: Record<string, any>,
@@ -56,7 +74,7 @@ export const jsx = (
     }
   }
 
-  if (tag !== '') {
+  if (tag !== '' && !emptyTags.includes(taga)) {
     result += `</${tag}>`
   }
 


### PR DESCRIPTION
Hi. According to the web standard,
we should skip to render the closing tag if it is an empty tag. This pull request adds the validation for the empty element. Cheers.