### PR TITLE
Fix documentation : Add proper casting to `Post` object using `json()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ api.post(
     await auth(c, next)
   },
   async (c) => {
-    const post = await c.req.json<Post>()
+    const post = await c.req.json() as Post
     const ok = createPost({ post })
     return c.json({ ok })
   }

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -743,7 +743,7 @@ api.post(
     await auth(c, next)
   },
   async (c) => {
-    const post = await c.req.json<Post>()
+    const post = await c.req.json() as Post;
     const ok = createPost({ post })
     return c.json({ ok })
   }


### PR DESCRIPTION
### Problem

Using the code is causing build error as below.
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/497812/179224141-b5687eab-6c31-48d0-8acc-b6bbf4fa357d.png">



### Reason
In the definition, we can see the `.json` method don't take any type nor any parameter. Instead it is needed to cast the response object manually.

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/497812/179223053-3202f4d9-ea20-42ba-a2c4-112541473315.png">

`json(): Promise<JSON>;`

### Solution 

Manually cast the response object as `Post` like below

`const post = await c.req.json() as Post`

It will solve the build error.

### Special note

We also need to create the `model` file and implement methods to properly solve the other build errors. 