### PR TITLE
refactor(bun): throw error when using `jwt` middleware

### DIFF
--- a/bun_test/index.test.ts
+++ b/bun_test/index.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import { Hono } from '../src/index'
 import { basicAuth } from '../src/middleware/basic-auth'
+import { jwt } from '../src/middleware/jwt'
 import { serveStatic } from '../src/middleware/serve-static/bun'
 
 // Test just only minimal patterns.
@@ -52,3 +53,9 @@ const resStatic = await app.request(new Request('http://localhost/favicon.ico'))
 await resStatic.arrayBuffer()
 assert.strictEqual(resStatic.status, 200)
 assert.strictEqual(resStatic.headers.get('Content-Type'), 'image/vnd.microsoft.icon')
+
+// JWT is not available for Bun
+// It throw the Error
+assert.throws(() => {
+  app.use('/jwt/*', jwt({ secret: 'a-secret' }))
+})

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -8,6 +8,10 @@ export const jwt = (options: { secret: string; alg?: string }) => {
     throw new Error('JWT auth middleware requires options for "secret')
   }
 
+  if (!crypto.subtle || !crypto.subtle.importKey) {
+    throw new Error('`crypto.subtle.importKey` is undefined. JWT auth middleware requires it.')
+  }
+
   return async (ctx: Context, next: Next) => {
     const credentials = ctx.req.headers.get('Authorization')
 

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -72,6 +72,10 @@ const signing = async (
   secret: string,
   alg: AlgorithmTypes = AlgorithmTypes.HS256
 ): Promise<ArrayBuffer> => {
+  if (!crypto.subtle || !crypto.subtle.importKey) {
+    throw new Error('`crypto.subtle.importKey` is undefined. JWT auth middleware requires it.')
+  }
+
   const cryptoKey = await crypto.subtle.importKey(
     CryptoKeyFormat.RAW,
     utf8ToUint8Array(secret),


### PR DESCRIPTION
`jwt` middleware is not supported on Bun, yet.

Close #381