### PR TITLE
chore: fix typo in error class name

### DIFF
--- a/deno_dist/utils/jwt/jwt.ts
+++ b/deno_dist/utils/jwt/jwt.ts
@@ -10,7 +10,7 @@ import {
   JwtTokenNotBefore,
   JwtTokenExpired,
   JwtTokenSignatureMismatched,
-  JwtAlorithmNotImplemented,
+  JwtAlgorithmNotImplemented,
 } from './types.ts'
 
 interface AlgorithmParams {
@@ -63,7 +63,7 @@ const param = (name: AlgorithmTypes): AlgorithmParams => {
         },
       }
     default:
-      throw new JwtAlorithmNotImplemented(name)
+      throw new JwtAlgorithmNotImplemented(name)
   }
 }
 

--- a/deno_dist/utils/jwt/types.ts
+++ b/deno_dist/utils/jwt/types.ts
@@ -1,9 +1,15 @@
-export class JwtAlorithmNotImplemented extends Error {
+export class JwtAlgorithmNotImplemented extends Error {
   constructor(token: string) {
     super(`invalid JWT token: ${token}`)
-    this.name = 'JwtAlorithmNotImplemented'
+    this.name = 'JwtAlgorithmNotImplemented'
   }
 }
+
+/**
+ * Export for backward compatibility
+ * @deprecated Use JwtAlgorithmNotImplemented instead
+**/
+export const JwtAlorithmNotImplemented = JwtAlgorithmNotImplemented
 
 export class JwtTokenInvalid extends Error {
   constructor(token: string) {

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -3,27 +3,27 @@ import * as JWT from './jwt'
 import {
   AlgorithmTypes,
   JwtTokenSignatureMismatched,
-  JwtAlorithmNotImplemented,
+  JwtAlgorithmNotImplemented,
   JwtTokenInvalid,
   JwtTokenNotBefore,
   JwtTokenExpired,
 } from './types'
 
 describe('JWT', () => {
-  it('JwtAlorithmNotImplemented', async () => {
+  it('JwtAlgorithmNotImplemented', async () => {
     const payload = { message: 'hello world' }
     const secret = 'a-secret'
     const alg = ''
     let tok = ''
-    let err: JwtAlorithmNotImplemented
+    let err: JwtAlgorithmNotImplemented
     try {
       tok = await JWT.sign(payload, secret, alg as AlgorithmTypes)
     } catch (e) {
-      err = e as JwtAlorithmNotImplemented
+      err = e as JwtAlgorithmNotImplemented
     }
     expect(tok).toBe('')
     // @ts-ignore
-    expect(err).toEqual(new JwtAlorithmNotImplemented(alg))
+    expect(err).toEqual(new JwtAlgorithmNotImplemented(alg))
   })
 
   it('JwtTokenInvalid', async () => {

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -10,7 +10,7 @@ import {
   JwtTokenNotBefore,
   JwtTokenExpired,
   JwtTokenSignatureMismatched,
-  JwtAlorithmNotImplemented,
+  JwtAlgorithmNotImplemented,
 } from './types'
 
 interface AlgorithmParams {
@@ -63,7 +63,7 @@ const param = (name: AlgorithmTypes): AlgorithmParams => {
         },
       }
     default:
-      throw new JwtAlorithmNotImplemented(name)
+      throw new JwtAlgorithmNotImplemented(name)
   }
 }
 

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -1,9 +1,15 @@
-export class JwtAlorithmNotImplemented extends Error {
+export class JwtAlgorithmNotImplemented extends Error {
   constructor(token: string) {
     super(`invalid JWT token: ${token}`)
-    this.name = 'JwtAlorithmNotImplemented'
+    this.name = 'JwtAlgorithmNotImplemented'
   }
 }
+
+/**
+ * Export for backward compatibility
+ * @deprecated
+**/
+export const JwtAlorithmNotImplemented = JwtAlgorithmNotImplemented;
 
 export class JwtTokenInvalid extends Error {
   constructor(token: string) {

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -7,9 +7,9 @@ export class JwtAlgorithmNotImplemented extends Error {
 
 /**
  * Export for backward compatibility
- * @deprecated
+ * @deprecated Use JwtAlgorithmNotImplemented instead
 **/
-export const JwtAlorithmNotImplemented = JwtAlgorithmNotImplemented;
+export const JwtAlorithmNotImplemented = JwtAlgorithmNotImplemented
 
 export class JwtTokenInvalid extends Error {
   constructor(token: string) {


### PR DESCRIPTION
Noticed a small typo in error class name.

Exported original name for backward-compat.

Let me know what you think.
I'll update usages of the class everywhere else in the code if you are accepting this PR.