### PR TITLE
Pass path to serve-static middleware when using cloudflare module workers

### DIFF
--- a/src/middleware/serve-static/module.mts
+++ b/src/middleware/serve-static/module.mts
@@ -8,6 +8,7 @@ import { serveStatic } from './serve-static'
 const module = (options: ServeStaticOptions = { root: '' }) => {
   return serveStatic({
     root: options.root,
+    path: options.path,
     manifest: options.manifest ? options.manifest : manifest,
   })
 }


### PR DESCRIPTION
I had a problem using the `{path: "..."}` option with the serve-static middleware when using cloudflare module workers. This should hopefully fix it.