### PR TITLE
fix(trie-router): fix the rule for capturing named parameters

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -527,3 +527,21 @@ describe('star', () => {
     expect(res?.handlers).toEqual(['/*', '*', '/x', '/x/*'])
   })
 })
+
+describe('Routing order With named parameters', () => {
+  const node = new Node()
+  node.insert('get', '/book/a', 'no-slug')
+  node.insert('get', '/book/:slug', 'slug')
+  it('/book/a', () => {
+    const res = node.search('get', '/book/a')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['no-slug', 'slug'])
+    expect(res?.params['slug']).toBeUndefined()
+  })
+  it('/book/foo', () => {
+    const res = node.search('get', '/book/foo')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['slug'])
+    expect(res?.params['slug']).toBe('foo')
+  })
+})

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -129,3 +129,19 @@ describe('page', () => {
     expect(res?.handlers).toEqual(['page', 'fallback'])
   })
 })
+
+describe('routing order with named parameters', () => {
+  const router = new TrieRouter<string>()
+  router.add('GET', '/book/a', 'no-slug')
+  router.add('GET', '/book/:slug', 'slug')
+  it('GET /book/a', async () => {
+    const res = router.match('GET', '/book/a')
+    expect(res?.handlers).toEqual(['no-slug', 'slug'])
+    expect(res?.params['slug']).toBeUndefined()
+  })
+  it('GET /book/foo', async () => {
+    const res = router.match('GET', '/book/foo')
+    expect(res?.handlers).toEqual(['slug'])
+    expect(res?.params['slug']).toBe('foo')
+  })
+})


### PR DESCRIPTION
It should work:

```ts
app.get('/book/a', (c) => {
  return c.text(c.req.param('slug') || 'no-slug')
})

app.get('/book/:slug', (c) => {
  return c.text(c.req.param('slug') || 'no-slug-at-slug-endpoint')
})
```

```
$ curl http://localhost:8787/book/a
no-slug
$ curl http://localhost:8787/book/foo
foo
```

Close #418