### PR TITLE
feat(jsx): support `jsxImportSource`

### DIFF
--- a/bun_test/index.test.tsx
+++ b/bun_test/index.test.tsx
@@ -83,3 +83,19 @@ describe('JWT Middleware (Not supported yet)', () => {
     expect(t).toBe(true)
   })
 })
+
+// To enable JSX middleware,
+// set "jsxImportSource": "hono/jsx" in the tsconfig.json
+describe('JSX Middleware', () => {
+  const app = new Hono()
+  app.get('/', (c) => {
+    return c.html(<h1>Hello</h1>)
+  })
+
+  it('Should return rendered HTML', async () => {
+    const res = await app.request(new Request('http://localhost/'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/html; charset=UTF-8')
+    expect(await res.text()).toBe('<h1>Hello</h1>')
+  })
+})

--- a/deno_dist/middleware/jsx/index.test.tsx
+++ b/deno_dist/middleware/jsx/index.test.tsx
@@ -28,7 +28,7 @@ describe('render to string', () => {
   })
 
   it('Empty elements are rended withtout closing tag', () => {
-    const template = (<input/>)
+    const template = <input />
     expect(template.toString()).toBe('<input/>')
   })
 

--- a/deno_dist/middleware/jsx/index.ts
+++ b/deno_dist/middleware/jsx/index.ts
@@ -28,7 +28,8 @@ const emptyTags = [
   'wbr',
 ]
 
-export const jsx = (
+export { jsxFn as jsx }
+const jsxFn = (
   tag: string | Function,
   props: Record<string, any>,
   ...children: (string | HtmlEscapedString)[]
@@ -125,5 +126,5 @@ export const memo = <T>(
 }
 
 export const Fragment = (props: { key?: string; children?: any }): HtmlEscapedString => {
-  return jsx('', {}, ...(props.children || []))
+  return jsxFn('', {}, ...(props.children || []))
 }

--- a/deno_dist/middleware/jsx/jsx-dev-runtime.ts
+++ b/deno_dist/middleware/jsx/jsx-dev-runtime.ts
@@ -1,0 +1,7 @@
+import { jsx } from './index.ts'
+
+export function jsxDEV(tag: string | Function, props: Record<string, any>) {
+  const children = props.children ?? []
+  delete props['children']
+  return jsx(tag, props, ...children)
+}

--- a/deno_dist/middleware/jsx/jsx-dev-runtime.ts
+++ b/deno_dist/middleware/jsx/jsx-dev-runtime.ts
@@ -1,6 +1,7 @@
+import type { HtmlEscapedString } from '../html/index.ts'
 import { jsx } from './index.ts'
 
-export function jsxDEV(tag: string | Function, props: Record<string, any>) {
+export function jsxDEV(tag: string | Function, props: Record<string, any>): HtmlEscapedString {
   const children = props.children ?? []
   delete props['children']
   return jsx(tag, props, ...children)

--- a/deno_dist/middleware/jsx/jsx-runtime.ts
+++ b/deno_dist/middleware/jsx/jsx-runtime.ts
@@ -1,0 +1,2 @@
+export { jsxDEV as jsx } from './jsx-dev-runtime.ts'
+export { jsxDEV as jsxs } from './jsx-dev-runtime.ts'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "jest",
     "test:deno": "deno test --allow-read deno_test",
-    "test:bun": "bun wiptest bun_test/index.test.ts",
+    "test:bun": "bun wiptest --jsx-import-source ../src/middleware/jsx/jsx-dev-runtime bun_test/index.test.tsx",
+    "test:all": "yarn test && yarn test:deno && yarn test:bun",
     "lint": "eslint --ext js,ts src .eslintrc.js",
     "lint:fix": "eslint --ext js,ts src .eslintrc.js --fix",
     "denoify": "rimraf deno_dist && denoify && rimraf 'deno_dist/**/*.test.ts'",
@@ -29,6 +30,8 @@
     "./etag": "./dist/middleware/etag/index.js",
     "./html": "./dist/middleware/html/index.js",
     "./jsx": "./dist/middleware/jsx/index.js",
+    "./jsx/jsx-dev-runtime": "./dist/middleware/jsx/jsx-dev-runtime.js",
+    "./jsx/jsx-runtime": "./dist/middleware/jsx/jsx-runtime.js",
     "./jwt": "./dist/middleware/jwt/index.js",
     "./logger": "./dist/middleware/logger/index.js",
     "./powered-by": "./dist/middleware/powered-by/index.js",
@@ -66,6 +69,12 @@
       ],
       "jsx": [
         "./dist/middleware/jsx"
+      ],
+      "jsx-runtime": [
+        "./dist/middleware/jsx/jsx-runtime"
+      ],
+      "jsx-dev-runtime": [
+        "./dist/middleware/jsx/jsx-dev-runtime"
       ],
       "jwt": [
         "./dist/middleware/jwt"

--- a/package.json
+++ b/package.json
@@ -71,10 +71,10 @@
         "./dist/middleware/jsx"
       ],
       "jsx-runtime": [
-        "./dist/middleware/jsx/jsx-runtime"
+        "./dist/middleware/jsx/jsx-runtime.d.ts"
       ],
       "jsx-dev-runtime": [
-        "./dist/middleware/jsx/jsx-dev-runtime"
+        "./dist/middleware/jsx/jsx-dev-runtime.d.ts"
       ],
       "jwt": [
         "./dist/middleware/jwt"

--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { jsx, memo, Fragment } from '.'
+import { jsx, memo, Fragment } from './index'
 
 describe('JSX middleware', () => {
   const app = new Hono()
@@ -28,7 +28,7 @@ describe('render to string', () => {
   })
 
   it('Empty elements are rended withtout closing tag', () => {
-    const template = (<input/>)
+    const template = <input />
     expect(template.toString()).toBe('<input/>')
   })
 

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -28,7 +28,8 @@ const emptyTags = [
   'wbr',
 ]
 
-export const jsx = (
+export { jsxFn as jsx }
+const jsxFn = (
   tag: string | Function,
   props: Record<string, any>,
   ...children: (string | HtmlEscapedString)[]
@@ -125,5 +126,5 @@ export const memo = <T>(
 }
 
 export const Fragment = (props: { key?: string; children?: any }): HtmlEscapedString => {
-  return jsx('', {}, ...(props.children || []))
+  return jsxFn('', {}, ...(props.children || []))
 }

--- a/src/middleware/jsx/jsx-dev-runtime.ts
+++ b/src/middleware/jsx/jsx-dev-runtime.ts
@@ -1,6 +1,7 @@
+import type { HtmlEscapedString } from '../html'
 import { jsx } from '.'
 
-export function jsxDEV(tag: string | Function, props: Record<string, any>) {
+export function jsxDEV(tag: string | Function, props: Record<string, any>): HtmlEscapedString {
   const children = props.children ?? []
   delete props['children']
   return jsx(tag, props, ...children)

--- a/src/middleware/jsx/jsx-dev-runtime.ts
+++ b/src/middleware/jsx/jsx-dev-runtime.ts
@@ -1,0 +1,7 @@
+import { jsx } from '.'
+
+export function jsxDEV(tag: string | Function, props: Record<string, any>) {
+  const children = props.children ?? []
+  delete props['children']
+  return jsx(tag, props, ...children)
+}

--- a/src/middleware/jsx/jsx-runtime.ts
+++ b/src/middleware/jsx/jsx-runtime.ts
@@ -1,0 +1,2 @@
+export { jsxDEV as jsx } from './jsx-dev-runtime'
+export { jsxDEV as jsxs } from './jsx-dev-runtime'


### PR DESCRIPTION
Support `jsxImportSource`.
You can use this option on Bun and Deno (Wrangler does not support it).
if you write tsconfig as below, JSX middleware will be enabled without `import { jsx } from 'hono/jsx'`.

```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxFragmentFactory": "Fragment",
    "jsxImportSource": "hono/jsx"
  }
}
```