### PR TITLE
fix(jsx): Fix for JSX checked and selected props

### DIFF
--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -75,19 +75,49 @@ describe('render to string', () => {
     })
   })
 
-  describe('Special case for input "checked" and "selected" params', () => {
+  describe('Special case for input boolean params', () => {
     it('default prop value for checked', () => {
       const template = <input type='checkbox' checked />
-      expect(template.toString()).toBe('<input type="checkbox" checked="checked"/>')
+      expect(template.toString()).toBe('<input type="checkbox" checked=""/>')
     })
 
     it('default prop value for checked={true}', () => {
       const template = <input type='checkbox' checked={true} />
-      expect(template.toString()).toBe('<input type="checkbox" checked="checked"/>')
+      expect(template.toString()).toBe('<input type="checkbox" checked=""/>')
     })
 
     it('no prop for checked={false}', () => {
       const template = <input type='checkbox' checked={false} />
+      expect(template.toString()).toBe('<input type="checkbox"/>')
+    })
+
+    it('default prop value for disabled', () => {
+      const template = <input type='checkbox' disabled />
+      expect(template.toString()).toBe('<input type="checkbox" disabled=""/>')
+    })
+
+    it('default prop value for disabled={true}', () => {
+      const template = <input type='checkbox' disabled={true} />
+      expect(template.toString()).toBe('<input type="checkbox" disabled=""/>')
+    })
+
+    it('no prop for disabled={false}', () => {
+      const template = <input type='checkbox' disabled={false} />
+      expect(template.toString()).toBe('<input type="checkbox"/>')
+    })
+
+    it('default prop value for readonly', () => {
+      const template = <input type='checkbox' readonly />
+      expect(template.toString()).toBe('<input type="checkbox" readonly=""/>')
+    })
+
+    it('default prop value for readonly={true}', () => {
+      const template = <input type='checkbox' readonly={true} />
+      expect(template.toString()).toBe('<input type="checkbox" readonly=""/>')
+    })
+
+    it('no prop for readonly={false}', () => {
+      const template = <input type='checkbox' readonly={false} />
       expect(template.toString()).toBe('<input type="checkbox"/>')
     })
 
@@ -97,7 +127,7 @@ describe('render to string', () => {
           Test
         </option>
       )
-      expect(template.toString()).toBe('<option value="test" selected="selected">Test</option>')
+      expect(template.toString()).toBe('<option value="test" selected="">Test</option>')
     })
 
     it('default prop value for selected={true}', () => {
@@ -106,7 +136,7 @@ describe('render to string', () => {
           Test
         </option>
       )
-      expect(template.toString()).toBe('<option value="test" selected="selected">Test</option>')
+      expect(template.toString()).toBe('<option value="test" selected="">Test</option>')
     })
 
     it('no prop for selected={false}', () => {
@@ -116,6 +146,38 @@ describe('render to string', () => {
         </option>
       )
       expect(template.toString()).toBe('<option value="test">Test</option>')
+    })
+
+    it('default prop value for multiple select', () => {
+      const template = (
+        <select multiple>
+          <option>test</option>
+        </select>
+      )
+      expect(template.toString()).toBe('<select multiple=""><option>test</option></select>')
+    })
+
+    it('default prop value for select multiple={true}', () => {
+      const template = (
+        <select multiple={true}>
+          <option>test</option>
+        </select>
+      )
+      expect(template.toString()).toBe('<select multiple=""><option>test</option></select>')
+    })
+
+    it('no prop for select multiple={false}', () => {
+      const template = (
+        <select multiple={false}>
+          <option>test</option>
+        </select>
+      )
+      expect(template.toString()).toBe('<select><option>test</option></select>')
+    })
+
+    it('should render "false" value properly for other non-defined keys', () => {
+      const template = <input type='checkbox' testkey={false} />
+      expect(template.toString()).toBe('<input type="checkbox" testkey="false"/>')
     })
   })
 

--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -75,6 +75,50 @@ describe('render to string', () => {
     })
   })
 
+  describe('Special case for input "checked" and "selected" params', () => {
+    it('default prop value for checked', () => {
+      const template = <input type='checkbox' checked />
+      expect(template.toString()).toBe('<input type="checkbox" checked="checked"/>')
+    })
+
+    it('default prop value for checked={true}', () => {
+      const template = <input type='checkbox' checked={true} />
+      expect(template.toString()).toBe('<input type="checkbox" checked="checked"/>')
+    })
+
+    it('no prop for checked={false}', () => {
+      const template = <input type='checkbox' checked={false} />
+      expect(template.toString()).toBe('<input type="checkbox"/>')
+    })
+
+    it('default prop value for selected', () => {
+      const template = (
+        <option value='test' selected>
+          Test
+        </option>
+      )
+      expect(template.toString()).toBe('<option value="test" selected="selected">Test</option>')
+    })
+
+    it('default prop value for selected={true}', () => {
+      const template = (
+        <option value='test' selected={true}>
+          Test
+        </option>
+      )
+      expect(template.toString()).toBe('<option value="test" selected="selected">Test</option>')
+    })
+
+    it('no prop for selected={false}', () => {
+      const template = (
+        <option value='test' selected={false}>
+          Test
+        </option>
+      )
+      expect(template.toString()).toBe('<option value="test">Test</option>')
+    })
+  })
+
   // https://en.reactjs.org/docs/jsx-in-depth.html#functions-as-children
   describe('Functions as Children', () => {
     it('Function', () => {

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -41,6 +41,8 @@ const jsxFn = (
   let result = tag !== '' ? `<${tag}` : ''
 
   const propsKeys = Object.keys(props || {})
+  const booleanKeys = ['checked', 'selected', 'disabled', 'readonly', 'multiple']
+
   for (let i = 0, len = propsKeys.length; i < len; i++) {
     const v = props[propsKeys[i]]
     if (propsKeys[i] === 'dangerouslySetInnerHTML') {
@@ -54,10 +56,10 @@ const jsxFn = (
       continue
     } else if (v === null || v === undefined) {
       continue
-    } else if (['checked', 'selected'].includes(propsKeys[i]) && v === false) {
+    } else if (booleanKeys.includes(propsKeys[i]) && v === false) {
       continue
-    } else if (['checked', 'selected'].includes(propsKeys[i]) && (!v || v === true)) {
-      result += ` ${propsKeys[i]}="${propsKeys[i].toString().toLowerCase()}"`
+    } else if (booleanKeys.includes(propsKeys[i]) && (!v || v === true)) {
+      result += ` ${propsKeys[i]}=""`
       continue
     }
 

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -54,6 +54,11 @@ const jsxFn = (
       continue
     } else if (v === null || v === undefined) {
       continue
+    } else if (['checked', 'selected'].includes(propsKeys[i]) && v === false) {
+      continue
+    } else if (['checked', 'selected'].includes(propsKeys[i]) && (!v || v === true)) {
+      result += ` ${propsKeys[i]}="${propsKeys[i].toString().toLowerCase()}"`
+      continue
     }
 
     result += ` ${propsKeys[i]}="${escape(v.toString())}"`


### PR DESCRIPTION
Fixes #427:
- `checked` and `selected` will not be rendered when set to false
- `checked="checked"` and `selected="selected"` will be rendered when no value set or set to `true`