### PR TITLE
fix(`parseBody`): return blank object when JSON body is nothing

### DIFF
--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -41,7 +41,14 @@ describe('Parse Body Middleware', () => {
         'Content-Type': 'text/plain',
       },
     })
-    console.log(res.headers.get('Content-Type'))
     expect(await parseBody(res)).toEqual(payload)
+  })
+
+  it('should return blank object if JSON body is nothing', async () => {
+    const req = new Request('http://localhost/json', {
+      method: 'POST',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+    })
+    expect(await parseBody(req)).toEqual({})
   })
 })

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -4,7 +4,11 @@ export const parseBody = async (
   const contentType = r.headers.get('Content-Type') || ''
 
   if (contentType.includes('application/json')) {
-    return await r.json()
+    let body = {}
+    try {
+      body = await r.json()
+    } catch {} // Do nothing
+    return body
   } else if (contentType.includes('application/text')) {
     return await r.text()
   } else if (contentType.startsWith('text')) {


### PR DESCRIPTION
If incomming request content-header is `application/json`, but the body is nothing, it was throwing 500 internal server error. It's better to return bank object `{}` if this situation.

Fix #428