### PR TITLE
perf(jsx): JSX performance improvement

### DIFF
--- a/benchmarks/jsx/index.tsx
+++ b/benchmarks/jsx/index.tsx
@@ -25,11 +25,11 @@ const buildPage = ({ jsx, Fragment }: { jsx: any; Fragment: any }) => {
 
   const Form = () => (
     <form>
-      <input type='text' value='a' readonly tabindex={1} />
-      <input type='checkbox' value='b' checked={true} tabindex={2} />
-      <input type='checkbox' value='c' checked={true} tabindex={3} />
-      <input type='checkbox' value='d' checked={false} tabindex={4} />
-      <input type='checkbox' value='e' checked={false} tabindex={5} />
+      <input type='text' value='1234567890 < 1234567891' readonly tabindex={1} />
+      <input type='checkbox' value='1234567890 < 1234567891' checked={true} tabindex={2} />
+      <input type='checkbox' value='1234567890 < 1234567891' checked={true} tabindex={3} />
+      <input type='checkbox' value='1234567890 < 1234567891' checked={false} tabindex={4} />
+      <input type='checkbox' value='1234567890 < 1234567891' checked={false} tabindex={5} />
     </form>
   )
 

--- a/src/middleware/html/index.ts
+++ b/src/middleware/html/index.ts
@@ -1,6 +1,5 @@
-import { escape } from '../../utils/html'
-
-export type HtmlEscapedString = string & { isEscaped: true }
+import { escapeToBuffer } from '../../utils/html'
+import type { Buffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html'
 
 export const raw = (value: any): HtmlEscapedString => {
   const escapedString = new String(value) as HtmlEscapedString
@@ -10,24 +9,29 @@ export const raw = (value: any): HtmlEscapedString => {
 }
 
 export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscapedString => {
-  let result = ''
+  const buffer: Buffer = ['']
 
   for (let i = 0, len = strings.length - 1; i < len; i++) {
-    result += strings[i]
+    buffer[0] += strings[i]
 
     const children = values[i] instanceof Array ? values[i].flat(Infinity) : [values[i]]
     for (let i = 0, len = children.length; i < len; i++) {
       const child = children[i]
-      if (typeof child === 'boolean' || child === null || child === undefined) {
+      if (typeof child === 'string') {
+        escapeToBuffer(child, buffer)
+      } else if (typeof child === 'boolean' || child === null || child === undefined) {
         continue
-      } else if (typeof child === 'object' && (child as any).isEscaped) {
-        result += child
+      } else if (
+        (typeof child === 'object' && (child as HtmlEscaped).isEscaped) ||
+        typeof child === 'number'
+      ) {
+        buffer[0] += child
       } else {
-        result += escape(child.toString())
+        escapeToBuffer(child.toString(), buffer)
       }
     }
   }
-  result += strings[strings.length - 1]
+  buffer[0] += strings[strings.length - 1]
 
-  return raw(result)
+  return raw(buffer[0])
 }

--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -1,8 +1,18 @@
 import { Hono } from '../../hono'
+import { html } from '../html/index'
 import { jsx, memo, Fragment } from './index'
 
+interface SiteData {
+  title: string
+  children?: any
+}
+
 describe('JSX middleware', () => {
-  const app = new Hono()
+  let app: Hono
+
+  beforeEach(() => {
+    app = new Hono()
+  })
 
   it('Should render HTML strings', async () => {
     app.get('/', (c) => {
@@ -12,6 +22,46 @@ describe('JSX middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('text/html; charset=UTF-8')
     expect(await res.text()).toBe('<h1>Hello</h1>')
+  })
+
+  it('Should be able to be used with html middleware', async () => {
+    const Layout = (props: SiteData) => html`<!DOCTYPE html>
+      <html>
+        <head>
+          <title>${props.title}</title>
+        </head>
+        <body>
+          ${props.children}
+        </body>
+      </html>`
+
+    const Content = (props: { siteData: SiteData; name: string }) => (
+      <Layout {...props.siteData}>
+        <h1>{props.name}</h1>
+      </Layout>
+    )
+
+    app.get('/', (c) => {
+      const props = {
+        name: 'JSX',
+        siteData: {
+          title: 'with html middleware',
+        },
+      }
+      return c.html(<Content {...props} />)
+    })
+    const res = await app.request('http://localhost/')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/html; charset=UTF-8')
+    expect(await res.text()).toBe(`<!DOCTYPE html>
+      <html>
+        <head>
+          <title>with html middleware</title>
+        </head>
+        <body>
+          <h1>JSX</h1>
+        </body>
+      </html>`)
   })
 })
 
@@ -49,9 +99,9 @@ describe('render to string', () => {
     })
 
     it('Should get an error if both dangerouslySetInnerHTML and children are specified', () => {
-      expect(() => (
-        <span dangerouslySetInnerHTML={{ __html: '" is allowed here' }}>Hello</span>
-      )).toThrow()
+      expect(() =>
+        (<span dangerouslySetInnerHTML={{ __html: '" is allowed here' }}>Hello</span>).toString()
+      ).toThrow()
     })
   })
 

--- a/src/middleware/jsx/jsx-dev-runtime.ts
+++ b/src/middleware/jsx/jsx-dev-runtime.ts
@@ -1,7 +1,7 @@
-import type { HtmlEscapedString } from '../html'
 import { jsx } from '.'
+import type { JSXNode } from '.'
 
-export function jsxDEV(tag: string | Function, props: Record<string, any>): HtmlEscapedString {
+export function jsxDEV(tag: string | Function, props: Record<string, any>): JSXNode {
   const children = props.children ?? []
   delete props['children']
   return jsx(tag, props, children)

--- a/src/utils/html.test.ts
+++ b/src/utils/html.test.ts
@@ -1,8 +1,23 @@
-import { escape } from './html'
+import { escape, escapeToBuffer } from './html'
+import type { Buffer } from './html'
 
-describe('HTML escape', () => {
-  it('Should escape special characters', () => {
-    expect(escape('I <b>think</b> this is good.')).toBe('I &lt;b&gt;think&lt;/b&gt; this is good.')
-    expect(escape('John "Johnny" Smith')).toBe('John &quot;Johnny&quot; Smith')
+describe('HTML utilities', () => {
+  describe('escape', () => {
+    it('Should escape special characters', () => {
+      expect(escape('I <b>think</b> this is good.')).toBe('I &lt;b&gt;think&lt;/b&gt; this is good.')
+      expect(escape('John "Johnny" Smith')).toBe('John &quot;Johnny&quot; Smith')
+    })
+  })
+
+  describe('escapeToBuffer', () => {
+    it('Should escape special characters', () => {
+      let buffer: Buffer = ['']
+      escapeToBuffer('I <b>think</b> this is good.', buffer)
+      expect(buffer[0]).toBe('I &lt;b&gt;think&lt;/b&gt; this is good.')
+
+      buffer = ['']
+      escapeToBuffer('John "Johnny" Smith', buffer)
+      expect(buffer[0]).toBe('John &quot;Johnny&quot; Smith')
+    })
   })
 })

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,4 +1,5 @@
-export type HtmlEscapedString = string & { isEscaped: true }
+export type HtmlEscaped = { isEscaped: true }
+export type HtmlEscapedString = string & HtmlEscaped
 export type Buffer = [string]
 
 // The `escape` and `escapeToBuffer` implementations are based on code from the MIT licensed `react-dom` package.

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,13 +1,56 @@
 export type HtmlEscapedString = string & { isEscaped: true }
+export type Buffer = [string]
 
-const entityMap: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-}
-const escapeRe = new RegExp(`[${Object.keys(entityMap).join('')}]`, 'g')
-const replaceFn = (m: string) => entityMap[m]
+// The `escape` and `escapeToBuffer` implementations are based on code from the MIT licensed `react-dom` package.
+// https://github.com/facebook/react/blob/main/packages/react-dom/src/server/escapeTextForBrowser.js
+
+const escapeRe = /[&<>"]/
+
 export const escape = (str: string): string => {
-  return str.replace(escapeRe, replaceFn)
+  // This function is an alias for `escapeToBuffer`,
+  // but returns immediately if `str` does not contain the character to be escaped.
+  const match = str.search(escapeRe)
+  if (match === -1) {
+    return str
+  }
+
+  const buffer: Buffer = ['']
+  escapeToBuffer(str, buffer)
+  return buffer[0]
+}
+
+export const escapeToBuffer = (str: string, buffer: Buffer): void => {
+  const match = str.search(escapeRe)
+  if (match === -1) {
+    buffer[0] += str
+    return
+  }
+
+  let escape
+  let index
+  let lastIndex = 0
+
+  for (index = match; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = '&quot;'
+        break
+      case 38: // &
+        escape = '&amp;'
+        break
+      case 60: // <
+        escape = '&lt;'
+        break
+      case 62: // >
+        escape = '&gt;'
+        break
+      default:
+        continue
+    }
+
+    buffer[0] += str.substring(lastIndex, index) + escape
+    lastIndex = index + 1
+  }
+
+  buffer[0] += str.substring(lastIndex, index)
 }


### PR DESCRIPTION
This PR fixes #439.

### Changes

There are no changes to the external specification in this PR, and we can continue to stringify templates with `(<p>text</p>).toString()`. However, there are some changes in the internal structure.

#### `jsx` returns `JSXNode` instead of `HtmlEscapedString`

Previously, upon calling `jsx`, basic stringification was completed and an `HtmlEscapedString` object was returned, but with this PR, a data-wrapped `JSXNode` is returned upon calling `jsx`. The stringification is done at `toString()` call.

### Discussion

With this PR, `escape` defined in utils/html is no longer used inside the hono repository. (Only `escapeToBuffer` is used.)

The `escape` function is fast enough and convenient for hono users to use in their applications, but depending on policy, it could be removed as unnecessary.

### Benchmark

```
Hono x 173,197 ops/sec ±2.16% (93 runs sampled)
React x 84,569 ops/sec ±2.81% (91 runs sampled)
Preact x 61,307 ops/sec ±3.21% (86 runs sampled)
Nano x 16,871 ops/sec ±5.46% (78 runs sampled)
Fastest is Hono
```