### PR TITLE
refactor(jsx): Support all the boolean attributes.

### DIFF
--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -125,7 +125,8 @@ describe('render to string', () => {
     })
   })
 
-  describe('Special case for input boolean params', () => {
+  // https://html.spec.whatwg.org/#attributes-3
+  describe('Boolean attribute', () => {
     it('default prop value for checked', () => {
       const template = <input type='checkbox' checked />
       expect(template.toString()).toBe('<input type="checkbox" checked=""/>')
@@ -228,6 +229,17 @@ describe('render to string', () => {
     it('should render "false" value properly for other non-defined keys', () => {
       const template = <input type='checkbox' testkey={false} />
       expect(template.toString()).toBe('<input type="checkbox" testkey="false"/>')
+    })
+
+    it('should support attributes for elements other than input', () => {
+      const template = (
+        <video controls autoplay>
+          <source src='movie.mp4' type='video/mp4' />
+        </video>
+      )
+      expect(template.toString()).toBe(
+        '<video controls="" autoplay=""><source src="movie.mp4" type="video/mp4"/></video>'
+      )
     })
   })
 

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -27,7 +27,33 @@ const emptyTags = [
   'track',
   'wbr',
 ]
-const booleanAttributes = ['checked', 'selected', 'disabled', 'readonly', 'multiple']
+const booleanAttributes = [
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+]
 
 const childrenToStringToBuffer = (children: Child[], buffer: Buffer): void => {
   for (let i = 0, len = children.length; i < len; i++) {


### PR DESCRIPTION
I think it is better to support all boolean attirbutes listed in the table below.
https://html.spec.whatwg.org/#attributes-3

And, supporting all of them will not affect performance.