### PR TITLE
refactor(`utils/html`): rename `Buffer` to `StringBuffer`

### DIFF
--- a/deno_dist/middleware/html/index.ts
+++ b/deno_dist/middleware/html/index.ts
@@ -1,6 +1,5 @@
-import { escape } from '../../utils/html.ts'
-
-export type HtmlEscapedString = string & { isEscaped: true }
+import { escapeToBuffer } from '../../utils/html.ts'
+import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html.ts'
 
 export const raw = (value: any): HtmlEscapedString => {
   const escapedString = new String(value) as HtmlEscapedString
@@ -10,24 +9,29 @@ export const raw = (value: any): HtmlEscapedString => {
 }
 
 export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscapedString => {
-  let result = ''
+  const buffer: StringBuffer = ['']
 
   for (let i = 0, len = strings.length - 1; i < len; i++) {
-    result += strings[i]
+    buffer[0] += strings[i]
 
     const children = values[i] instanceof Array ? values[i].flat(Infinity) : [values[i]]
     for (let i = 0, len = children.length; i < len; i++) {
       const child = children[i]
-      if (typeof child === 'boolean' || child === null || child === undefined) {
+      if (typeof child === 'string') {
+        escapeToBuffer(child, buffer)
+      } else if (typeof child === 'boolean' || child === null || child === undefined) {
         continue
-      } else if (typeof child === 'object' && (child as any).isEscaped) {
-        result += child
+      } else if (
+        (typeof child === 'object' && (child as HtmlEscaped).isEscaped) ||
+        typeof child === 'number'
+      ) {
+        buffer[0] += child
       } else {
-        result += escape(child.toString())
+        escapeToBuffer(child.toString(), buffer)
       }
     }
   }
-  result += strings[strings.length - 1]
+  buffer[0] += strings[strings.length - 1]
 
-  return raw(result)
+  return raw(buffer[0])
 }

--- a/deno_dist/middleware/jsx/index.ts
+++ b/deno_dist/middleware/jsx/index.ts
@@ -1,5 +1,5 @@
-import { escape } from '../../utils/html.ts'
-import type { HtmlEscapedString } from '../../utils/html.ts'
+import { escapeToBuffer } from '../../utils/html.ts'
+import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html.ts'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -27,12 +27,144 @@ const emptyTags = [
   'track',
   'wbr',
 ]
-const booleanAttributes = ['checked', 'selected', 'disabled', 'readonly', 'multiple']
+const booleanAttributes = [
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+]
 
-const newHtmlEscapedString = (str: string): HtmlEscapedString => {
-  const escapedString = new String(str) as HtmlEscapedString
-  escapedString.isEscaped = true
-  return escapedString
+const childrenToStringToBuffer = (children: Child[], buffer: StringBuffer): void => {
+  for (let i = 0, len = children.length; i < len; i++) {
+    const child = children[i]
+    if (typeof child === 'string') {
+      escapeToBuffer(child, buffer)
+    } else if (typeof child === 'boolean' || child === null || child === undefined) {
+      continue
+    } else if (child instanceof JSXNode) {
+      child.toStringToBuffer(buffer)
+    } else if (typeof child === 'number' || (child as any).isEscaped) {
+      buffer[0] += child
+    } else {
+      // `child` type is `Child[]`, so stringify recursively
+      childrenToStringToBuffer(child, buffer)
+    }
+  }
+}
+
+type Child = string | number | JSXNode | Child[]
+export class JSXNode implements HtmlEscaped {
+  tag: string | Function
+  props: Record<string, any>
+  children: Child[]
+  isEscaped: true = true
+  constructor(tag: string | Function, props: Record<string, any>, children: Child[]) {
+    this.tag = tag
+    this.props = props
+    this.children = children
+  }
+
+  toString(): string {
+    const buffer: StringBuffer = ['']
+    this.toStringToBuffer(buffer)
+    return buffer[0]
+  }
+
+  toStringToBuffer(buffer: StringBuffer): void {
+    const tag = this.tag as string
+    const props = this.props
+    let { children } = this
+
+    buffer[0] += `<${tag}`
+
+    const propsKeys = Object.keys(props || {})
+
+    for (let i = 0, len = propsKeys.length; i < len; i++) {
+      const v = props[propsKeys[i]]
+      if (typeof v === 'string') {
+        buffer[0] += ` ${propsKeys[i]}="`
+        escapeToBuffer(v, buffer)
+        buffer[0] += '"'
+      } else if (typeof v === 'number') {
+        buffer[0] += ` ${propsKeys[i]}="${v}"`
+      } else if (v === null || v === undefined) {
+        // Do nothing
+      } else if (typeof v === 'boolean' && booleanAttributes.includes(propsKeys[i])) {
+        if (v) {
+          buffer[0] += ` ${propsKeys[i]}=""`
+        }
+      } else if (propsKeys[i] === 'dangerouslySetInnerHTML') {
+        if (children.length > 0) {
+          throw 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
+        }
+
+        const escapedString = new String(v.__html) as HtmlEscapedString
+        escapedString.isEscaped = true
+        children = [escapedString]
+      } else {
+        buffer[0] += ` ${propsKeys[i]}="`
+        escapeToBuffer(v.toString(), buffer)
+        buffer[0] += '"'
+      }
+    }
+
+    if (emptyTags.includes(tag as string)) {
+      buffer[0] += '/>'
+      return
+    }
+
+    buffer[0] += '>'
+
+    childrenToStringToBuffer(children, buffer)
+
+    buffer[0] += `</${tag}>`
+  }
+}
+
+class JSXFunctionNode extends JSXNode {
+  toStringToBuffer(buffer: StringBuffer): void {
+    const { children } = this
+
+    const res = (this.tag as Function).call(null, {
+      ...this.props,
+      children: children.length <= 1 ? children[0] : children,
+    })
+
+    if (res instanceof JSXNode) {
+      res.toStringToBuffer(buffer)
+    } else if (typeof res === 'number' || (res as HtmlEscaped).isEscaped) {
+      buffer[0] += res
+    } else {
+      escapeToBuffer(res, buffer)
+    }
+  }
+}
+
+class JSXFragmentNode extends JSXNode {
+  toStringToBuffer(buffer: StringBuffer): void {
+    childrenToStringToBuffer(this.children, buffer)
+  }
 }
 
 export { jsxFn as jsx }
@@ -40,64 +172,12 @@ const jsxFn = (
   tag: string | Function,
   props: Record<string, any>,
   ...children: (string | HtmlEscapedString)[]
-): HtmlEscapedString => {
+): JSXNode => {
   if (typeof tag === 'function') {
-    return tag.call(null, { ...props, children: children.length <= 1 ? children[0] : children })
+    return new JSXFunctionNode(tag, props, children)
+  } else {
+    return new JSXNode(tag, props, children)
   }
-
-  let result = tag !== '' ? `<${tag}` : ''
-
-  const propsKeys = Object.keys(props || {})
-
-  for (let i = 0, len = propsKeys.length; i < len; i++) {
-    const v = props[propsKeys[i]]
-    if (typeof v === 'string') {
-      result += ` ${propsKeys[i]}="${escape(v)}"`
-    } else if (typeof v === 'number') {
-      result += ` ${propsKeys[i]}="${v}"`
-    } else if (v === null || v === undefined) {
-      // Do nothing
-    } else if (typeof v === 'boolean' && booleanAttributes.includes(propsKeys[i])) {
-      if (v) {
-        result += ` ${propsKeys[i]}=""`
-      }
-    } else if (propsKeys[i] === 'dangerouslySetInnerHTML') {
-      if (children.length > 0) {
-        throw 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
-      }
-
-      children = [newHtmlEscapedString(v.__html)]
-    } else {
-      result += ` ${propsKeys[i]}="${escape(v.toString())}"`
-    }
-  }
-
-  if (emptyTags.includes(tag)) {
-    result += '/>'
-    return newHtmlEscapedString(result)
-  }
-
-  if (tag !== '') {
-    result += '>'
-  }
-
-  const flattenChildren = children.flat(Infinity)
-  for (let i = 0, len = flattenChildren.length; i < len; i++) {
-    const child = flattenChildren[i]
-    if (typeof child === 'boolean' || child === null || child === undefined) {
-      continue
-    } else if (typeof child === 'object' && (child as any).isEscaped) {
-      result += child
-    } else {
-      result += escape(child.toString())
-    }
-  }
-
-  if (tag !== '') {
-    result += `</${tag}>`
-  }
-
-  return newHtmlEscapedString(result)
 }
 
 type FC<T = Record<string, any>> = (props: T) => HtmlEscapedString
@@ -137,6 +217,6 @@ export const memo = <T>(
   }) as FC<T>
 }
 
-export const Fragment = (props: { key?: string; children?: any }): HtmlEscapedString => {
-  return jsxFn('', {}, ...(props.children || []))
+export const Fragment = (props: { key?: string; children?: any }): JSXNode => {
+  return new JSXFragmentNode('', {}, props.children || [])
 }

--- a/deno_dist/middleware/jsx/jsx-dev-runtime.ts
+++ b/deno_dist/middleware/jsx/jsx-dev-runtime.ts
@@ -1,7 +1,7 @@
-import type { HtmlEscapedString } from '../html/index.ts'
 import { jsx } from './index.ts'
+import type { JSXNode } from './index.ts'
 
-export function jsxDEV(tag: string | Function, props: Record<string, any>): HtmlEscapedString {
+export function jsxDEV(tag: string | Function, props: Record<string, any>): JSXNode {
   const children = props.children ?? []
   delete props['children']
   return jsx(tag, props, children)

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -3,7 +3,7 @@ import type { Next } from '../../hono.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
 
-export const jwt = (options: { secret: string; alg?: string }) => {
+export const jwt = (options: { secret: string; cookie?: string; alg?: string }) => {
   if (!options) {
     throw new Error('JWT auth middleware requires options for "secret')
   }
@@ -14,19 +14,25 @@ export const jwt = (options: { secret: string; alg?: string }) => {
 
   return async (ctx: Context, next: Next) => {
     const credentials = ctx.req.headers.get('Authorization')
-
-    if (!credentials) {
-      ctx.res = new Response('Unauthorized', {
-        status: 401,
-        headers: {
-          'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="no authorization included in request"`,
-        },
-      })
-      return
+    let token
+    if (credentials) {
+      const parts = credentials.split(/\s+/)
+      if (parts.length !== 2) {
+        ctx.res = new Response('Unauthorized', {
+          status: 401,
+          headers: {
+            'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="invalid credentials structure"`,
+          },
+        })
+        return
+      } else {
+        token = parts[1]
+      }
+    } else if (options.cookie) {
+      token = ctx.req.cookie(options.cookie)
     }
 
-    const parts = credentials.split(/\s+/)
-    if (parts.length !== 2) {
+    if (!token) {
       ctx.res = new Response('Unauthorized', {
         status: 401,
         headers: {
@@ -39,7 +45,7 @@ export const jwt = (options: { secret: string; alg?: string }) => {
     let authorized = false
     let msg = ''
     try {
-      authorized = await Jwt.verify(parts[1], options.secret, options.alg as AlgorithmTypes)
+      authorized = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
     } catch (e) {
       msg = `${e}`
     }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -1,4 +1,5 @@
 import { parseBody } from './utils/body.ts'
+import type { Body } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 
@@ -25,9 +26,9 @@ declare global {
       (name: string): string
       (): Cookie
     }
-    parsedBody?: Promise<any>
+    parsedBody?: Promise<Body>
     parseBody: {
-      (): Promise<any>
+      (): Promise<Body>
     }
   }
 }

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,6 +1,6 @@
-export const parseBody = async (
-  r: Request | Response
-): Promise<string | object | Record<string, string | File>> => {
+export type Body = string | object | Record<string, string | File>
+
+export const parseBody = async (r: Request | Response): Promise<Body> => {
   const contentType = r.headers.get('Content-Type') || ''
 
   if (contentType.includes('application/json')) {

--- a/deno_dist/utils/html.ts
+++ b/deno_dist/utils/html.ts
@@ -1,13 +1,57 @@
-export type HtmlEscapedString = string & { isEscaped: true }
+export type HtmlEscaped = { isEscaped: true }
+export type HtmlEscapedString = string & HtmlEscaped
+export type StringBuffer = [string]
 
-const entityMap: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-}
-const escapeRe = new RegExp(`[${Object.keys(entityMap).join('')}]`, 'g')
-const replaceFn = (m: string) => entityMap[m]
+// The `escape` and `escapeToBuffer` implementations are based on code from the MIT licensed `react-dom` package.
+// https://github.com/facebook/react/blob/main/packages/react-dom/src/server/escapeTextForBrowser.js
+
+const escapeRe = /[&<>"]/
+
 export const escape = (str: string): string => {
-  return str.replace(escapeRe, replaceFn)
+  // This function is an alias for `escapeToBuffer`,
+  // but returns immediately if `str` does not contain the character to be escaped.
+  const match = str.search(escapeRe)
+  if (match === -1) {
+    return str
+  }
+
+  const buffer: StringBuffer = ['']
+  escapeToBuffer(str, buffer)
+  return buffer[0]
+}
+
+export const escapeToBuffer = (str: string, buffer: StringBuffer): void => {
+  const match = str.search(escapeRe)
+  if (match === -1) {
+    buffer[0] += str
+    return
+  }
+
+  let escape
+  let index
+  let lastIndex = 0
+
+  for (index = match; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = '&quot;'
+        break
+      case 38: // &
+        escape = '&amp;'
+        break
+      case 60: // <
+        escape = '&lt;'
+        break
+      case 62: // >
+        escape = '&gt;'
+        break
+      default:
+        continue
+    }
+
+    buffer[0] += str.substring(lastIndex, index) + escape
+    lastIndex = index + 1
+  }
+
+  buffer[0] += str.substring(lastIndex, index)
 }

--- a/src/middleware/html/index.ts
+++ b/src/middleware/html/index.ts
@@ -1,5 +1,5 @@
 import { escapeToBuffer } from '../../utils/html'
-import type { Buffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html'
+import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html'
 
 export const raw = (value: any): HtmlEscapedString => {
   const escapedString = new String(value) as HtmlEscapedString
@@ -9,7 +9,7 @@ export const raw = (value: any): HtmlEscapedString => {
 }
 
 export const html = (strings: TemplateStringsArray, ...values: any[]): HtmlEscapedString => {
-  const buffer: Buffer = ['']
+  const buffer: StringBuffer = ['']
 
   for (let i = 0, len = strings.length - 1; i < len; i++) {
     buffer[0] += strings[i]

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -1,5 +1,5 @@
 import { escapeToBuffer } from '../../utils/html'
-import type { Buffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html'
+import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -55,7 +55,7 @@ const booleanAttributes = [
   'selected',
 ]
 
-const childrenToStringToBuffer = (children: Child[], buffer: Buffer): void => {
+const childrenToStringToBuffer = (children: Child[], buffer: StringBuffer): void => {
   for (let i = 0, len = children.length; i < len; i++) {
     const child = children[i]
     if (typeof child === 'string') {
@@ -86,12 +86,12 @@ export class JSXNode implements HtmlEscaped {
   }
 
   toString(): string {
-    const buffer: Buffer = ['']
+    const buffer: StringBuffer = ['']
     this.toStringToBuffer(buffer)
     return buffer[0]
   }
 
-  toStringToBuffer(buffer: Buffer): void {
+  toStringToBuffer(buffer: StringBuffer): void {
     const tag = this.tag as string
     const props = this.props
     let { children } = this
@@ -143,7 +143,7 @@ export class JSXNode implements HtmlEscaped {
 }
 
 class JSXFunctionNode extends JSXNode {
-  toStringToBuffer(buffer: Buffer): void {
+  toStringToBuffer(buffer: StringBuffer): void {
     const { children } = this
 
     const res = (this.tag as Function).call(null, {
@@ -162,7 +162,7 @@ class JSXFunctionNode extends JSXNode {
 }
 
 class JSXFragmentNode extends JSXNode {
-  toStringToBuffer(buffer: Buffer): void {
+  toStringToBuffer(buffer: StringBuffer): void {
     childrenToStringToBuffer(this.children, buffer)
   }
 }

--- a/src/utils/html.test.ts
+++ b/src/utils/html.test.ts
@@ -1,17 +1,19 @@
 import { escape, escapeToBuffer } from './html'
-import type { Buffer } from './html'
+import type { StringBuffer } from './html'
 
 describe('HTML utilities', () => {
   describe('escape', () => {
     it('Should escape special characters', () => {
-      expect(escape('I <b>think</b> this is good.')).toBe('I &lt;b&gt;think&lt;/b&gt; this is good.')
+      expect(escape('I <b>think</b> this is good.')).toBe(
+        'I &lt;b&gt;think&lt;/b&gt; this is good.'
+      )
       expect(escape('John "Johnny" Smith')).toBe('John &quot;Johnny&quot; Smith')
     })
   })
 
   describe('escapeToBuffer', () => {
     it('Should escape special characters', () => {
-      let buffer: Buffer = ['']
+      let buffer: StringBuffer = ['']
       escapeToBuffer('I <b>think</b> this is good.', buffer)
       expect(buffer[0]).toBe('I &lt;b&gt;think&lt;/b&gt; this is good.')
 

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,6 +1,6 @@
 export type HtmlEscaped = { isEscaped: true }
 export type HtmlEscapedString = string & HtmlEscaped
-export type Buffer = [string]
+export type StringBuffer = [string]
 
 // The `escape` and `escapeToBuffer` implementations are based on code from the MIT licensed `react-dom` package.
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/server/escapeTextForBrowser.js
@@ -15,12 +15,12 @@ export const escape = (str: string): string => {
     return str
   }
 
-  const buffer: Buffer = ['']
+  const buffer: StringBuffer = ['']
   escapeToBuffer(str, buffer)
   return buffer[0]
 }
 
-export const escapeToBuffer = (str: string, buffer: Buffer): void => {
+export const escapeToBuffer = (str: string, buffer: StringBuffer): void => {
   const match = str.search(escapeRe)
   if (match === -1) {
     buffer[0] += str


### PR DESCRIPTION
Ranamed `Buffer` to `StringBuffer` in `utils/html`.

Fixed namespace conflicts. denoify force polyfill the type named `Buffer` for [Buffer](https://nodejs.org/api/buffer.html) module.

