### PR TITLE
fix(`utils/crypto`): stringify the parameter which is object in `createHash`

### DIFF
--- a/deno_dist/utils/crypto.ts
+++ b/deno_dist/utils/crypto.ts
@@ -24,6 +24,9 @@ export const md5 = async (data: Data) => {
 }
 
 export const createHash = async (data: Data, algorithm: Algorithm): Promise<string | null> => {
+  if (typeof data === 'object') {
+    data = JSON.stringify(data)
+  }
   if (crypto && crypto.subtle) {
     const buffer = await crypto.subtle.digest(
       {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -11,6 +11,9 @@ describe('Etag Middleware', () => {
   app.get('/etag/def', (c) => {
     return c.json({ message: 'Hono is cool' })
   })
+  app.get('/etag/ghi', (c) => {
+    return c.json({ message: 'Hono is ultra cool' })
+  })
 
   app.use('/etag-weak/*', etag({ weak: true }))
   app.get('/etag-weak/abc', (c) => {
@@ -24,7 +27,14 @@ describe('Etag Middleware', () => {
 
     res = await app.request('http://localhost/etag/def')
     expect(res.headers.get('ETag')).not.toBeFalsy()
-    expect(res.headers.get('ETag')).toBe('"c1d44ff03aff1372856c281854f454e2e1d15b7c"')
+    expect(res.headers.get('ETag')).toBe('"4515561204e8269cb4468d5b39288d8f2482dcfe"')
+  })
+
+  it('Should not be the same values', async () => {
+    let res = await app.request('http://localhost/etag/def')
+    const hash = res.headers.get('Etag')
+    res = await app.request('http://localhost/etag/ghi')
+    expect(res.headers.get('ETag')).not.toBe(hash)
   })
 
   it('Should return etag header - weak', async () => {

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -16,10 +16,22 @@ describe('crypto', () => {
     expect(await sha1('炎')).toBe('d56e09ae2421b2b8a0b5ee5fdceaed663c8c9472')
     expect(await sha1('abcdedf')).not.toBe('abcdef')
   })
-  
+
   it('md5', async () => {
     expect(await md5('hono')).toBe('cf22a160789a91dd5f737cd3b2640cc2')
     expect(await md5('炎')).toBe('f620d89a5a782c22b4420acb39121be3')
     expect(await md5('abcdedf')).not.toBe('abcdef')
+  })
+
+  it('Should not be the same values - compare difference objects', async () => {
+    expect(await sha256({ foo: 'bar' })).not.toEqual(
+      await sha256({
+        bar: 'foo',
+      })
+    )
+  })
+
+  it('Should not be same value - compare true with false', async () => {
+    expect(await sha256(true)).not.toEqual(await sha256(false))
   })
 })

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -24,6 +24,9 @@ export const md5 = async (data: Data) => {
 }
 
 export const createHash = async (data: Data, algorithm: Algorithm): Promise<string | null> => {
+  if (typeof data === 'object') {
+    data = JSON.stringify(data)
+  }
   if (crypto && crypto.subtle) {
     const buffer = await crypto.subtle.digest(
       {


### PR DESCRIPTION
If an object type was passed as a parameter, the values would all be the same.

I've fixed it by making the object a different value by JSON.stringiy.

If the output values from the "object" and the "string" value are the same, the hash value will be the same. This is a specification.

Fix #451