### PR TITLE
fix(utils/crypto): make Binary and JSON object crypto correct

### DIFF
--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,4 +1,4 @@
-export type Body = string | object | Record<string, string | File>
+export type Body = string | object | Record<string, string | File> | ArrayBuffer
 
 export const parseBody = async (r: Request | Response): Promise<Body> => {
   const contentType = r.headers.get('Content-Type') || ''
@@ -22,5 +22,6 @@ export const parseBody = async (r: Request | Response): Promise<Body> => {
     return data
   }
 
-  return r.arrayBuffer()
+  const arrayBuffer = await r.arrayBuffer()
+  return arrayBuffer
 }

--- a/deno_dist/utils/crypto.ts
+++ b/deno_dist/utils/crypto.ts
@@ -3,7 +3,7 @@ type Algorithm = {
   alias: string
 }
 
-type Data = string | object | boolean
+type Data = string | boolean | number | object | ArrayBufferView | ArrayBuffer
 
 export const sha256 = async (data: Data) => {
   const algorithm: Algorithm = { name: 'SHA-256', alias: 'sha256' }
@@ -24,12 +24,23 @@ export const md5 = async (data: Data) => {
 }
 
 export const createHash = async (data: Data, algorithm: Algorithm): Promise<string | null> => {
+  let sourceBuffer: ArrayBufferView | ArrayBuffer
+
+  if (ArrayBuffer.isView(data) || data instanceof ArrayBuffer) {
+    sourceBuffer = data
+  } else {
+    if (typeof data === 'object') {
+      data = JSON.stringify(data)
+    }
+    sourceBuffer = new TextEncoder().encode(String(data))
+  }
+
   if (crypto && crypto.subtle) {
     const buffer = await crypto.subtle.digest(
       {
         name: algorithm.name,
       },
-      new TextEncoder().encode(String(data))
+      sourceBuffer
     )
     const hash = Array.prototype.map
       .call(new Uint8Array(buffer), (x) => ('00' + x.toString(16)).slice(-2))

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,4 +1,4 @@
-export type Body = string | object | Record<string, string | File>
+export type Body = string | object | Record<string, string | File> | ArrayBuffer
 
 export const parseBody = async (r: Request | Response): Promise<Body> => {
   const contentType = r.headers.get('Content-Type') || ''
@@ -22,5 +22,6 @@ export const parseBody = async (r: Request | Response): Promise<Body> => {
     return data
   }
 
-  return r.arrayBuffer()
+  const arrayBuffer = await r.arrayBuffer()
+  return arrayBuffer
 }

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { sha256, sha1, md5 } from './crypto'
 
 describe('crypto', () => {
@@ -16,10 +17,24 @@ describe('crypto', () => {
     expect(await sha1('炎')).toBe('d56e09ae2421b2b8a0b5ee5fdceaed663c8c9472')
     expect(await sha1('abcdedf')).not.toBe('abcdef')
   })
-  
+
   it('md5', async () => {
     expect(await md5('hono')).toBe('cf22a160789a91dd5f737cd3b2640cc2')
     expect(await md5('炎')).toBe('f620d89a5a782c22b4420acb39121be3')
     expect(await md5('abcdedf')).not.toBe('abcdef')
+  })
+
+  it('Should not be the same values - compare difference objects', async () => {
+    expect(await sha256({ foo: 'bar' })).not.toEqual(
+      await sha256({
+        bar: 'foo',
+      })
+    )
+  })
+
+  it('Should create hash for Buffer', async () => {
+    const hash = createHash('sha256').update(new Uint8Array(1)).digest('hex')
+    expect(await sha256(new Uint8Array(1))).toBe(hash)
+    expect(await sha256(new Uint8Array(1))).not.toEqual(await sha256(new Uint8Array(2)))
   })
 })

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -3,7 +3,7 @@ type Algorithm = {
   alias: string
 }
 
-type Data = string | object | boolean
+type Data = string | boolean | number | object | ArrayBufferView | ArrayBuffer
 
 export const sha256 = async (data: Data) => {
   const algorithm: Algorithm = { name: 'SHA-256', alias: 'sha256' }
@@ -24,12 +24,23 @@ export const md5 = async (data: Data) => {
 }
 
 export const createHash = async (data: Data, algorithm: Algorithm): Promise<string | null> => {
+  let sourceBuffer: ArrayBufferView | ArrayBuffer
+
+  if (ArrayBuffer.isView(data) || data instanceof ArrayBuffer) {
+    sourceBuffer = data
+  } else {
+    if (typeof data === 'object') {
+      data = JSON.stringify(data)
+    }
+    sourceBuffer = new TextEncoder().encode(String(data))
+  }
+
   if (crypto && crypto.subtle) {
     const buffer = await crypto.subtle.digest(
       {
         name: algorithm.name,
       },
-      new TextEncoder().encode(String(data))
+      sourceBuffer
     )
     const hash = Array.prototype.map
       .call(new Uint8Array(buffer), (x) => ('00' + x.toString(16)).slice(-2))


### PR DESCRIPTION
JSON object and Binary such ArrayBuffer or Uint8Array are not cryptos correctly.
In this PR, make a crypto hash according to the type of parameters.

Fix #451