### PR TITLE
fix(context): fix header values shifting

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -95,7 +95,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
 
   header(name: string, value: string): void {
     this._headers ||= {}
-    this._headers[name] = value
+    this._headers[name.toLowerCase()] = value
     if (this.finalized) {
       this.res.headers.set(name, value)
     }
@@ -123,7 +123,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
   }
 
   newResponse(data: Data | null, status: StatusCode, headers: Headers = {}): Response {
-    const _headers = { ...this._headers, ...headers }
+    const _headers = { ...this._headers }
     if (this._res) {
       this._res.headers.forEach((v, k) => {
         _headers[k] = v
@@ -131,7 +131,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
     }
     return new Response(data, {
       status: status || this._status || 200,
-      headers: _headers,
+      headers: { ..._headers, ...headers },
     })
   }
 
@@ -140,7 +140,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
   }
 
   text(text: string, status: StatusCode = this._status, headers: Headers = {}): Response {
-    headers['Content-Type'] ||= 'text/plain; charset=UTF-8'
+    headers['content-type'] = 'text/plain; charset=UTF-8'
     return this.body(text, status, headers)
   }
 
@@ -148,12 +148,12 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
     const body = this._pretty
       ? JSON.stringify(object, null, this._prettySpace)
       : JSON.stringify(object)
-    headers['Content-Type'] ||= 'application/json; charset=UTF-8'
+    headers['content-type'] = 'application/json; charset=UTF-8'
     return this.body(body, status, headers)
   }
 
   html(html: string, status: StatusCode = this._status, headers: Headers = {}): Response {
-    headers['Content-Type'] ||= 'text/html; charset=UTF-8'
+    headers['content-type'] = 'text/html; charset=UTF-8'
     return this.body(html, status, headers)
   }
 
@@ -170,7 +170,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
 
   cookie(name: string, value: string, opt?: CookieOptions): void {
     const cookie = serialize(name, value, opt)
-    this.header('Set-Cookie', cookie)
+    this.header('set-cookie', cookie)
   }
 
   notFound(): Response | Promise<Response> {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -144,3 +144,23 @@ describe('Context', () => {
     expect(res.headers.get('foo')).toBe('bar')
   })
 })
+
+describe('Context header', () => {
+  const req = new Request('http://localhost/')
+  let c: Context
+  beforeEach(() => {
+    c = new HonoContext(req)
+  })
+  it('Should return only one content-type value', async () => {
+    c.header('Content-Type', 'foo')
+    c.header('content-type', 'foo')
+    const res = c.html('foo')
+    expect(res.headers.get('Content-Type')).toBe('text/html; charset=UTF-8')
+    expect(res.headers.get('content-type')).toBe('text/html; charset=UTF-8')
+  })
+  it('Should rewrite header values correctly', async () => {
+    c.res = c.html('foo')
+    const res = c.text('foo')
+    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=UTF-8')
+  })
+})

--- a/src/context.ts
+++ b/src/context.ts
@@ -95,7 +95,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
 
   header(name: string, value: string): void {
     this._headers ||= {}
-    this._headers[name] = value
+    this._headers[name.toLowerCase()] = value
     if (this.finalized) {
       this.res.headers.set(name, value)
     }
@@ -123,7 +123,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
   }
 
   newResponse(data: Data | null, status: StatusCode, headers: Headers = {}): Response {
-    const _headers = { ...this._headers, ...headers }
+    const _headers = { ...this._headers }
     if (this._res) {
       this._res.headers.forEach((v, k) => {
         _headers[k] = v
@@ -131,7 +131,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
     }
     return new Response(data, {
       status: status || this._status || 200,
-      headers: _headers,
+      headers: { ..._headers, ...headers },
     })
   }
 
@@ -140,7 +140,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
   }
 
   text(text: string, status: StatusCode = this._status, headers: Headers = {}): Response {
-    headers['Content-Type'] ||= 'text/plain; charset=UTF-8'
+    headers['content-type'] = 'text/plain; charset=UTF-8'
     return this.body(text, status, headers)
   }
 
@@ -148,12 +148,12 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
     const body = this._pretty
       ? JSON.stringify(object, null, this._prettySpace)
       : JSON.stringify(object)
-    headers['Content-Type'] ||= 'application/json; charset=UTF-8'
+    headers['content-type'] = 'application/json; charset=UTF-8'
     return this.body(body, status, headers)
   }
 
   html(html: string, status: StatusCode = this._status, headers: Headers = {}): Response {
-    headers['Content-Type'] ||= 'text/html; charset=UTF-8'
+    headers['content-type'] = 'text/html; charset=UTF-8'
     return this.body(html, status, headers)
   }
 
@@ -170,7 +170,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
 
   cookie(name: string, value: string, opt?: CookieOptions): void {
     const cookie = serialize(name, value, opt)
-    this.header('Set-Cookie', cookie)
+    this.header('set-cookie', cookie)
   }
 
   notFound(): Response | Promise<Response> {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1019,3 +1019,21 @@ describe('Parse Body', () => {
     expect(await res.json()).toEqual({ message: 'hello' })
   })
 })
+
+describe('Both two middleware returning response', () => {
+  it('Should return correct Content-Type`', async () => {
+    const app = new Hono()
+    app.use('*', async (c, next) => {
+      await next()
+      return c.html('Foo')
+    })
+    app.get('/', (c) => {
+      return c.text('Bar')
+    })
+    const res = await app.request('http://localhost/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Foo')
+    expect(res.headers.get('content-type')).toBe('text/html; charset=UTF-8')
+  })
+})


### PR DESCRIPTION
Header values in Context may sometimes be "shifting" This PR does:

* Handle header values as lowercase.
* Fix the order of setting headers.