### PR TITLE
fix(context): fixed `ContextVariableMap` is not enabled in built code

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -105,11 +105,15 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
     this._status = status
   }
 
+  set<Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
+  set(key: string, value: any): void
   set(key: string, value: any): void {
     this._map ||= {}
     this._map[key] = value
   }
 
+  get<Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
+  get<T = any>(key: string): T
   get(key: string) {
     if (!this._map) {
       return undefined

--- a/src/context.ts
+++ b/src/context.ts
@@ -105,11 +105,15 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
     this._status = status
   }
 
+  set<Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
+  set(key: string, value: any): void
   set(key: string, value: any): void {
     this._map ||= {}
     this._map[key] = value
   }
 
+  get<Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
+  get<T = any>(key: string): T
   get(key: string) {
     if (!this._map) {
       return undefined


### PR DESCRIPTION
`ContextVariableMap` was not available on the built code for the npm library. We have to write the lines in this PR.