### PR TITLE
perf(trie-router): fine tuning, 9~10% faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ export default app
 **Hono is fastest**, compared to other routers for Cloudflare Workers.
 
 ```plain
-hono - trie-router(default) x 424,449 ops/sec ±4.98% (77 runs sampled)
-hono - regexp-router x 516,228 ops/sec ±4.79% (81 runs sampled)
-itty-router x 206,641 ops/sec ±3.59% (87 runs sampled)
-sunder x 319,500 ops/sec ±1.33% (93 runs sampled)
-worktop x 187,280 ops/sec ±3.09% (87 runs sampled)
+hono - trie-router(default) x 437,354 ops/sec ±4.58% (83 runs sampled)
+hono - regexp-router x 535,157 ops/sec ±3.46% (83 runs sampled)
+itty-router x 203,092 ops/sec ±3.64% (89 runs sampled)
+sunder x 308,252 ops/sec ±2.17% (91 runs sampled)
+worktop x 190,764 ops/sec ±3.11% (86 runs sampled)
 Fastest is hono - regexp-router
-✨  Done in 38.32s.
+✨  Done in 38.26s.
 ```
 
 ## Documentation

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -46,13 +46,13 @@ export default app
 **Hono is fastest**, compared to other routers for Cloudflare Workers.
 
 ```plain
-hono - trie-router(default) x 424,449 ops/sec ±4.98% (77 runs sampled)
-hono - regexp-router x 516,228 ops/sec ±4.79% (81 runs sampled)
-itty-router x 206,641 ops/sec ±3.59% (87 runs sampled)
-sunder x 319,500 ops/sec ±1.33% (93 runs sampled)
-worktop x 187,280 ops/sec ±3.09% (87 runs sampled)
+hono - trie-router(default) x 437,354 ops/sec ±4.58% (83 runs sampled)
+hono - regexp-router x 535,157 ops/sec ±3.46% (83 runs sampled)
+itty-router x 203,092 ops/sec ±3.64% (89 runs sampled)
+sunder x 308,252 ops/sec ±2.17% (91 runs sampled)
+worktop x 190,764 ops/sec ±3.11% (86 runs sampled)
 Fastest is hono - regexp-router
-✨  Done in 38.32s.
+✨  Done in 38.26s.
 ```
 
 ## Documentation


### PR DESCRIPTION
I did some minor tweaking of the TrieRouter and made it 9-10% faster.

```
hono - trie-router(default) x 434,571 ops/sec ±4.82% (81 runs sampled)
hono - [Optimized] trie-router(default) x 465,051 ops/sec ±3.45% (87 runs sampled)
hono - regexp-router x 528,354 ops/sec ±4.34% (84 runs sampled)
itty-router x 201,821 ops/sec ±4.02% (88 runs sampled)
sunder x 320,189 ops/sec ±2.17% (88 runs sampled)
worktop x 191,326 ops/sec ±2.88% (83 runs sampled)
Fastest is hono - regexp-router
✨  Done in 44.36s.
```