### PR TITLE
fix(context): export `ContextVariableMap` correctly

### DIFF
--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-export type { Handler, Next } from './hono.ts'
+export type { Handler, Next, ContextVariableMap } from './hono.ts'
 export type { Context } from './context.ts'
 export { Hono }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 /// <reference path="./request.ts" /> Import "declare global" for the Request interface.
 
 import { Hono } from './hono'
-export type { Handler, Next } from './hono'
+export type { Handler, Next, ContextVariableMap } from './hono'
 export type { Context } from './context'
 
 declare module './hono' {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-export type { Handler, Next } from './hono'
+export type { Handler, Next, ContextVariableMap } from './hono'
 export type { Context } from './context'
 export { Hono }
 


### PR DESCRIPTION
`ContextVariableMap` is not working in the npm package because it's not exported from 'dist/hono/index`. In this PR, I've made that export correctly.