### PR TITLE
feat(types): enable adding Types for variables used in `c.set`/`c.get`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,4 +1,4 @@
-import type { ContextVariableMap, NotFoundHandler } from './hono.ts'
+import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
@@ -6,11 +6,13 @@ import { isAbsoluteURL } from './utils/url.ts'
 
 type Headers = Record<string, string>
 export type Data = string | ArrayBuffer | ReadableStream
-type Env = Record<string, any>
 
-export interface Context<RequestParamKeyType extends string = string, E = Env> {
+export interface Context<
+  RequestParamKeyType extends string = string,
+  E extends Partial<Environment> = Environment
+> {
   req: Request<RequestParamKeyType>
-  env: E
+  env: E['Bindings'] | Bindings
   event: FetchEvent
   executionCtx: ExecutionContext
   finalized: boolean
@@ -21,10 +23,12 @@ export interface Context<RequestParamKeyType extends string = string, E = Env> {
   status: (status: StatusCode) => void
   set: {
     <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
+    <Key extends keyof E['Variables']>(key: Key, value: E['Variables'][Key]): void
     (key: string, value: any): void
   }
   get: {
     <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
+    <Key extends keyof E['Variables']>(key: Key): E['Variables'][Key]
     <T = any>(key: string): T
   }
   pretty: (prettyJSON: boolean, space?: number) => void
@@ -38,11 +42,13 @@ export interface Context<RequestParamKeyType extends string = string, E = Env> {
   notFound: () => Response | Promise<Response>
 }
 
-export class HonoContext<RequestParamKeyType extends string = string, E = Env>
-  implements Context<RequestParamKeyType, E>
+export class HonoContext<
+  RequestParamKeyType extends string = string,
+  E extends Partial<Environment> = Environment
+> implements Context<RequestParamKeyType, E>
 {
   req: Request<RequestParamKeyType>
-  env: E
+  env: Environment['Bindings']
   finalized: boolean
 
   _status: StatusCode = 200
@@ -56,13 +62,13 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
 
   constructor(
     req: Request,
-    env: E | undefined = undefined,
+    env: E['Bindings'] | undefined = undefined,
     executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
     notFoundHandler: NotFoundHandler = () => new Response()
   ) {
     this._executionCtx = executionCtx
     this.req = req
-    this.env = env ? env : ({} as E)
+    this.env = env ? env : ({} as Bindings)
 
     this.notFoundHandler = notFoundHandler
     this.finalized = false
@@ -106,6 +112,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
   }
 
   set<Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
+  set<Key extends keyof E['Variables']>(key: Key, value: E['Variables'][Key]): void
   set(key: string, value: any): void
   set(key: string, value: any): void {
     this._map ||= {}
@@ -113,6 +120,7 @@ export class HonoContext<RequestParamKeyType extends string = string, E = Env>
   }
 
   get<Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
+  get<Key extends keyof E['Variables']>(key: Key): E['Variables'][Key]
   get<T = any>(key: string): T
   get(key: string) {
     if (!this._map) {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -9,13 +9,30 @@ import { getPathFromURL, mergePath } from './utils/url.ts'
 
 export interface ContextVariableMap {}
 
-type Env = Record<string, any>
-export type Handler<RequestParamKeyType extends string = string, E = Env> = (
+export type Bindings = Record<string, any> // For Cloudflare Workers
+export type Variables = Record<string, any> // For c.set/c.get functions
+export type Environment = {
+  Bindings: Bindings
+  Variables: Variables
+}
+
+export type Handler<
+  RequestParamKeyType extends string = string,
+  E extends Partial<Environment> = Environment
+> = (
   c: Context<RequestParamKeyType, E>,
   next: Next
 ) => Response | Promise<Response> | Promise<void> | Promise<Response | undefined>
-export type NotFoundHandler<E = Env> = (c: Context<string, E>) => Response | Promise<Response>
-export type ErrorHandler<E = Env> = (err: Error, c: Context<string, E>) => Response
+
+export type NotFoundHandler<E extends Partial<Environment> = Environment> = (
+  c: Context<string, E>
+) => Response | Promise<Response>
+
+export type ErrorHandler<E extends Partial<Environment> = Environment> = (
+  err: Error,
+  c: Context<string, E>
+) => Response
+
 export type Next = () => Promise<void>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -31,7 +48,11 @@ type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
   ? ParamKey<Component> | ParamKeys<Rest>
   : ParamKey<Path>
 
-interface HandlerInterface<T extends string, E extends Env = Env, U = Hono<E, T>> {
+interface HandlerInterface<
+  T extends string,
+  E extends Partial<Environment> = Environment,
+  U = Hono<E, T>
+> {
   // app.get('/', handler, handler...)
   <Path extends string>(
     path: Path,
@@ -49,24 +70,23 @@ const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as 
 type Methods = typeof methods[number] | typeof METHOD_NAME_ALL_LOWERCASE
 
 function defineDynamicClass(): {
-  new <E extends Env, T extends string, U>(): {
+  new <E extends Partial<Environment> = Environment, T extends string = string, U = Hono>(): {
     [K in Methods]: HandlerInterface<T, E, U>
   }
 } {
   return class {} as any
 }
 
-interface Route<E extends Env> {
+interface Route<E extends Partial<Environment> = Environment> {
   path: string
   method: string
   handler: Handler<string, E>
 }
 
-export class Hono<E extends Env = Env, P extends string = '/'> extends defineDynamicClass()<
-  E,
-  P,
-  Hono<E, P>
-> {
+export class Hono<
+  E extends { Bindings?: Bindings; Variables?: Variables } = Environment,
+  P extends string = '/'
+> extends defineDynamicClass()<E, P, Hono<E, P>> {
   readonly router: Router<Handler<string, E>> = new TrieRouter()
   readonly strict: boolean = true // strict routing - default is true
   private _tempPath: string = ''
@@ -139,13 +159,13 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this
   }
 
-  onError(handler: ErrorHandler<E>): Hono<E, P> {
+  onError(handler: ErrorHandler): Hono<E, P> {
     this.errorHandler = handler as ErrorHandler
     return this
   }
 
-  notFound(handler: NotFoundHandler<E>): Hono<E, P> {
-    this.notFoundHandler = handler as NotFoundHandler
+  notFound(handler: NotFoundHandler): Hono<E, P> {
+    this.notFoundHandler = handler
     return this
   }
 
@@ -166,7 +186,7 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
   private async dispatch(
     request: Request,
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
-    env?: E
+    Environment?: E['Bindings']
   ): Promise<Response> {
     const path = getPathFromURL(request.url, this.strict)
     const method = request.method
@@ -176,10 +196,19 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
 
-    const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
+    const c = new HonoContext<string, E>(
+      request,
+      Environment,
+      eventOrExecutionCtx,
+      this.notFoundHandler
+    )
 
-    const composed = compose<HonoContext>(handlers, this.errorHandler, this.notFoundHandler)
-    let context: HonoContext
+    const composed = compose<HonoContext<string, E>>(
+      handlers,
+      this.errorHandler,
+      this.notFoundHandler
+    )
+    let context: HonoContext<string, E>
     try {
       context = await composed(c)
       if (!context.finalized) {
@@ -201,8 +230,8 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this.dispatch(event.request, event)
   }
 
-  fetch = (request: Request, env?: E, executionCtx?: ExecutionContext) => {
-    return this.dispatch(request, executionCtx, env)
+  fetch = (request: Request, Environment?: E['Bindings'], executionCtx?: ExecutionContext) => {
+    return this.dispatch(request, executionCtx, Environment)
   }
 
   request(input: RequestInfo, requestInit?: RequestInit): Promise<Response> {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -186,7 +186,7 @@ export class Hono<
   private async dispatch(
     request: Request,
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
-    Environment?: E['Bindings']
+    env?: E['Bindings']
   ): Promise<Response> {
     const path = getPathFromURL(request.url, this.strict)
     const method = request.method
@@ -196,12 +196,7 @@ export class Hono<
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
 
-    const c = new HonoContext<string, E>(
-      request,
-      Environment,
-      eventOrExecutionCtx,
-      this.notFoundHandler
-    )
+    const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
     const composed = compose<HonoContext<string, E>>(
       handlers,

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -186,7 +186,7 @@ export class Hono<
   private async dispatch(
     request: Request,
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
-    Environment?: E['Bindings']
+    env?: E['Bindings']
   ): Promise<Response> {
     const path = getPathFromURL(request.url, this.strict)
     const method = request.method
@@ -196,12 +196,7 @@ export class Hono<
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
 
-    const c = new HonoContext<string, E>(
-      request,
-      Environment,
-      eventOrExecutionCtx,
-      this.notFoundHandler
-    )
+    const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
     const composed = compose<HonoContext<string, E>>(
       handlers,

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -9,13 +9,30 @@ import { getPathFromURL, mergePath } from './utils/url'
 
 export interface ContextVariableMap {}
 
-type Env = Record<string, any>
-export type Handler<RequestParamKeyType extends string = string, E = Env> = (
+export type Bindings = Record<string, any> // For Cloudflare Workers
+export type Variables = Record<string, any> // For c.set/c.get functions
+export type Environment = {
+  Bindings: Bindings
+  Variables: Variables
+}
+
+export type Handler<
+  RequestParamKeyType extends string = string,
+  E extends Partial<Environment> = Environment
+> = (
   c: Context<RequestParamKeyType, E>,
   next: Next
 ) => Response | Promise<Response> | Promise<void> | Promise<Response | undefined>
-export type NotFoundHandler<E = Env> = (c: Context<string, E>) => Response | Promise<Response>
-export type ErrorHandler<E = Env> = (err: Error, c: Context<string, E>) => Response
+
+export type NotFoundHandler<E extends Partial<Environment> = Environment> = (
+  c: Context<string, E>
+) => Response | Promise<Response>
+
+export type ErrorHandler<E extends Partial<Environment> = Environment> = (
+  err: Error,
+  c: Context<string, E>
+) => Response
+
 export type Next = () => Promise<void>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -31,7 +48,11 @@ type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
   ? ParamKey<Component> | ParamKeys<Rest>
   : ParamKey<Path>
 
-interface HandlerInterface<T extends string, E extends Env = Env, U = Hono<E, T>> {
+interface HandlerInterface<
+  T extends string,
+  E extends Partial<Environment> = Environment,
+  U = Hono<E, T>
+> {
   // app.get('/', handler, handler...)
   <Path extends string>(
     path: Path,
@@ -49,24 +70,23 @@ const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as 
 type Methods = typeof methods[number] | typeof METHOD_NAME_ALL_LOWERCASE
 
 function defineDynamicClass(): {
-  new <E extends Env, T extends string, U>(): {
+  new <E extends Partial<Environment> = Environment, T extends string = string, U = Hono>(): {
     [K in Methods]: HandlerInterface<T, E, U>
   }
 } {
   return class {} as any
 }
 
-interface Route<E extends Env> {
+interface Route<E extends Partial<Environment> = Environment> {
   path: string
   method: string
   handler: Handler<string, E>
 }
 
-export class Hono<E extends Env = Env, P extends string = '/'> extends defineDynamicClass()<
-  E,
-  P,
-  Hono<E, P>
-> {
+export class Hono<
+  E extends { Bindings?: Bindings; Variables?: Variables } = Environment,
+  P extends string = '/'
+> extends defineDynamicClass()<E, P, Hono<E, P>> {
   readonly router: Router<Handler<string, E>> = new TrieRouter()
   readonly strict: boolean = true // strict routing - default is true
   private _tempPath: string = ''
@@ -139,13 +159,13 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this
   }
 
-  onError(handler: ErrorHandler<E>): Hono<E, P> {
+  onError(handler: ErrorHandler): Hono<E, P> {
     this.errorHandler = handler as ErrorHandler
     return this
   }
 
-  notFound(handler: NotFoundHandler<E>): Hono<E, P> {
-    this.notFoundHandler = handler as NotFoundHandler
+  notFound(handler: NotFoundHandler): Hono<E, P> {
+    this.notFoundHandler = handler
     return this
   }
 
@@ -166,7 +186,7 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
   private async dispatch(
     request: Request,
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
-    env?: E
+    Environment?: E['Bindings']
   ): Promise<Response> {
     const path = getPathFromURL(request.url, this.strict)
     const method = request.method
@@ -176,10 +196,19 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
 
-    const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
+    const c = new HonoContext<string, E>(
+      request,
+      Environment,
+      eventOrExecutionCtx,
+      this.notFoundHandler
+    )
 
-    const composed = compose<HonoContext>(handlers, this.errorHandler, this.notFoundHandler)
-    let context: HonoContext
+    const composed = compose<HonoContext<string, E>>(
+      handlers,
+      this.errorHandler,
+      this.notFoundHandler
+    )
+    let context: HonoContext<string, E>
     try {
       context = await composed(c)
       if (!context.finalized) {
@@ -201,8 +230,8 @@ export class Hono<E extends Env = Env, P extends string = '/'> extends defineDyn
     return this.dispatch(event.request, event)
   }
 
-  fetch = (request: Request, env?: E, executionCtx?: ExecutionContext) => {
-    return this.dispatch(request, executionCtx, env)
+  fetch = (request: Request, Environment?: E['Bindings'], executionCtx?: ExecutionContext) => {
+    return this.dispatch(request, executionCtx, Environment)
   }
 
   request(input: RequestInfo, requestInit?: RequestInit): Promise<Response> {


### PR DESCRIPTION
This PR is for enabling adding Types for variables used in `c.set` and `c.get`. Related to #472 

`c.set()` and `c.get()` are useful to store variables for middleware and handlers. For example, you can set the "client" object in middleware and use it later in a handler. But, these key-value do not have Types.

![SS](https://user-images.githubusercontent.com/10682/186123114-1e8793cd-fcd8-4cef-8c68-40b18cf74d06.png)

In this PR, Types will be available for `c.set` and `c.get` by passing the Types as generics into Hono class.

![SS](https://user-images.githubusercontent.com/10682/186121412-46ee880f-f6a4-4d00-b581-5d6de81c9af2.png)

![SS](https://user-images.githubusercontent.com/10682/186123398-25f9e035-30e6-4e48-b542-4b7b9ea1bd2a.png)

Before this PR, the generics is used for "bindings" on Cloudflare Workers.

```ts
type Bindings = {
  KV: KVNamespace
  Storage: R2Bucket
}

const app = new Hono<Bindings>()
```

After this PR, the generics will be used for "bindings" and "variables":

```ts
type Bindings = {
  KV: KVNamespace
  Storage: R2Bucket
}

type WebClient = {
  user: string
  pass: string
}

type Variables = {
  client: WebClient
}

const app = new Hono<{ Variables: Variables; Bindings: Bindings }>()

app.get('/foo', (c) => {
  const client = c.get('client') // client is WebClient
  const kv = c.env.KV // kv is KVNamespace
  //...
})
```

I think this is a cool feature for fine DX, but it has a small breaking change that is should be told the user well.