### PR TITLE
fix: enable passing Generics to c.req.parseBody, default is any

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -1,5 +1,4 @@
 import { parseBody } from './utils/body.ts'
-import type { Body } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 
@@ -26,9 +25,9 @@ declare global {
       (name: string): string
       (): Cookie
     }
-    parsedBody?: Promise<Body>
+    parsedBody?: Promise<any>
     parseBody: {
-      (): Promise<Body>
+      <T = any>(): Promise<T>
     }
   }
 }
@@ -99,10 +98,14 @@ export function extendRequestPrototype() {
     }
   } as InstanceType<typeof Request>['cookie']
 
-  Request.prototype.parseBody = function (this: Request) {
+  Request.prototype.parseBody = function <T = any>(this: Request): Promise<T> {
+    let body: Promise<T>
     if (!this.parsedBody) {
-      this.parsedBody = parseBody(this)
+      body = parseBody<T>(this)
+      this.parsedBody = body
+    } else {
+      body = this.parsedBody
     }
-    return this.parsedBody
+    return body
   } as InstanceType<typeof Request>['parseBody']
 }

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,27 +1,28 @@
-export type Body = string | object | Record<string, string | File> | ArrayBuffer
+export async function parseBody<T = any>(r: Request | Response): Promise<T> {
+  let body: any
 
-export const parseBody = async (r: Request | Response): Promise<Body> => {
   const contentType = r.headers.get('Content-Type') || ''
 
   if (contentType.includes('application/json')) {
-    let body = {}
+    let jsonBody = {}
     try {
-      body = await r.json()
+      jsonBody = await r.json()
     } catch {} // Do nothing
-    return body
+    body = jsonBody
   } else if (contentType.includes('application/text')) {
-    return await r.text()
+    body = await r.text()
   } else if (contentType.startsWith('text')) {
-    return await r.text()
+    body = await r.text()
   } else if (contentType.includes('form')) {
     const form: Record<string, string | File> = {}
     const data = [...(await r.formData())].reduce((acc, cur) => {
       acc[cur[0]] = cur[1]
       return acc
     }, form)
-    return data
+    body = data
+  } else {
+    body = await r.arrayBuffer()
   }
 
-  const arrayBuffer = await r.arrayBuffer()
-  return arrayBuffer
+  return body as T
 }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -963,6 +963,10 @@ describe('Cookie', () => {
 describe('Parse Body', () => {
   const app = new Hono()
 
+  type Payload = {
+    message: string
+  }
+
   app.post('/json', async (c) => {
     return c.json(await c.req.parseBody(), 200)
   })
@@ -974,7 +978,7 @@ describe('Parse Body', () => {
   })
 
   it('POST with JSON', async () => {
-    const payload = { message: 'hello hono' }
+    const payload: Payload = { message: 'hello hono' }
     const req = new Request('http://localhost/json', {
       method: 'POST',
       body: JSON.stringify(payload),
@@ -983,8 +987,9 @@ describe('Parse Body', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(await req.parseBody()).toEqual(payload)
-    expect(await res.json()).toEqual(payload)
+    const body = await req.parseBody<Payload>()
+    expect(body.message).toBe('hello hono')
+    expect(body).toEqual(payload)
   })
 
   it('POST with text', async () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,4 @@
 import { parseBody } from './utils/body'
-import type { Body } from './utils/body'
 import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
 
@@ -26,9 +25,9 @@ declare global {
       (name: string): string
       (): Cookie
     }
-    parsedBody?: Promise<Body>
+    parsedBody?: Promise<any>
     parseBody: {
-      (): Promise<Body>
+      <T = any>(): Promise<T>
     }
   }
 }
@@ -99,10 +98,14 @@ export function extendRequestPrototype() {
     }
   } as InstanceType<typeof Request>['cookie']
 
-  Request.prototype.parseBody = function (this: Request) {
+  Request.prototype.parseBody = function <T = any>(this: Request): Promise<T> {
+    let body: Promise<T>
     if (!this.parsedBody) {
-      this.parsedBody = parseBody(this)
+      body = parseBody<T>(this)
+      this.parsedBody = body
+    } else {
+      body = this.parsedBody
     }
-    return this.parsedBody
+    return body
   } as InstanceType<typeof Request>['parseBody']
 }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,27 +1,28 @@
-export type Body = string | object | Record<string, string | File> | ArrayBuffer
+export async function parseBody<T = any>(r: Request | Response): Promise<T> {
+  let body: any
 
-export const parseBody = async (r: Request | Response): Promise<Body> => {
   const contentType = r.headers.get('Content-Type') || ''
 
   if (contentType.includes('application/json')) {
-    let body = {}
+    let jsonBody = {}
     try {
-      body = await r.json()
+      jsonBody = await r.json()
     } catch {} // Do nothing
-    return body
+    body = jsonBody
   } else if (contentType.includes('application/text')) {
-    return await r.text()
+    body = await r.text()
   } else if (contentType.startsWith('text')) {
-    return await r.text()
+    body = await r.text()
   } else if (contentType.includes('form')) {
     const form: Record<string, string | File> = {}
     const data = [...(await r.formData())].reduce((acc, cur) => {
       acc[cur[0]] = cur[1]
       return acc
     }, form)
-    return data
+    body = data
+  } else {
+    body = await r.arrayBuffer()
   }
 
-  const arrayBuffer = await r.arrayBuffer()
-  return arrayBuffer
+  return body as T
 }


### PR DESCRIPTION
Fix #479 #341 

In this PR, we can pass the Generics to `c.req.parseBody()`. If we do not it, type will be `any`.

```ts
const body = await c.req.parseBody() // body is any

type Post = { message: string }
const postBody = await c.req.parseBody<Post>() // postBody is Post
```