### PR TITLE
[BREAKING] fix: make that `c.req.parseBody` parses only `FormData`

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -25,9 +25,9 @@ declare global {
       (name: string): string
       (): Cookie
     }
-    parsedBody?: Promise<any>
+    parsedBody?: Promise<Record<string, string | File>>
     parseBody: {
-      <T = any>(): Promise<T>
+      (): Promise<Record<string, string | File>>
     }
   }
 }
@@ -98,10 +98,10 @@ export function extendRequestPrototype() {
     }
   } as InstanceType<typeof Request>['cookie']
 
-  Request.prototype.parseBody = function <T = any>(this: Request): Promise<T> {
-    let body: Promise<T>
+  Request.prototype.parseBody = function (this: Request): Promise<Record<string, string | File>> {
+    let body: Promise<Record<string, string | File>>
     if (!this.parsedBody) {
-      body = parseBody<T>(this)
+      body = parseBody(this)
       this.parsedBody = body
     } else {
       body = this.parsedBody

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,28 +1,16 @@
-export async function parseBody<T = any>(r: Request | Response): Promise<T> {
-  let body: any
-
-  const contentType = r.headers.get('Content-Type') || ''
-
-  if (contentType.includes('application/json')) {
-    let jsonBody = {}
-    try {
-      jsonBody = await r.json()
-    } catch {} // Do nothing
-    body = jsonBody
-  } else if (contentType.includes('application/text')) {
-    body = await r.text()
-  } else if (contentType.startsWith('text')) {
-    body = await r.text()
-  } else if (contentType.includes('form')) {
+export async function parseBody(r: Request | Response): Promise<Record<string, string | File>> {
+  let body: Record<string, string | File> = {}
+  const contentType = r.headers.get('Content-Type')
+  if (
+    contentType &&
+    (contentType.startsWith('multipart/form-data') ||
+      contentType === 'application/x-www-form-urlencoded')
+  ) {
     const form: Record<string, string | File> = {}
-    const data = [...(await r.formData())].reduce((acc, cur) => {
+    body = [...(await r.formData())].reduce((acc, cur) => {
       acc[cur[0]] = cur[1]
       return acc
     }, form)
-    body = data
-  } else {
-    body = await r.arrayBuffer()
   }
-
-  return body as T
+  return body
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -25,9 +25,9 @@ declare global {
       (name: string): string
       (): Cookie
     }
-    parsedBody?: Promise<any>
+    parsedBody?: Promise<Record<string, string | File>>
     parseBody: {
-      <T = any>(): Promise<T>
+      (): Promise<Record<string, string | File>>
     }
   }
 }
@@ -98,10 +98,10 @@ export function extendRequestPrototype() {
     }
   } as InstanceType<typeof Request>['cookie']
 
-  Request.prototype.parseBody = function <T = any>(this: Request): Promise<T> {
-    let body: Promise<T>
+  Request.prototype.parseBody = function (this: Request): Promise<Record<string, string | File>> {
+    let body: Promise<Record<string, string | File>>
     if (!this.parsedBody) {
-      body = parseBody<T>(this)
+      body = parseBody(this)
       this.parsedBody = body
     } else {
       body = this.parsedBody

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -1,32 +1,23 @@
 import { parseBody } from './body'
 
-describe('Parse Body Middleware', () => {
-  it('should parse JSON', async () => {
-    const payload = { message: 'hello hono' }
-    const req = new Request('http://localhost/json', {
-      method: 'POST',
-      body: JSON.stringify(payload),
-      headers: new Headers({ 'Content-Type': 'application/json' }),
-    })
-    expect(await parseBody(req)).toEqual(payload)
-  })
-
-  it('should parse Text', async () => {
-    const payload = 'hello'
-    const req = new Request('http://localhost/text', {
-      method: 'POST',
-      body: 'hello',
-      headers: new Headers({ 'Content-Type': 'application/text' }),
-    })
-    expect(await parseBody(req)).toEqual(payload)
-  })
-
-  it('should parse Form', async () => {
-    const formData = new URLSearchParams()
-    formData.append('message', 'hello')
+describe('Parse Body Util', () => {
+  it('should parse `multipart/form-data`', async () => {
+    const data = new FormData()
+    data.append('message', 'hello')
     const req = new Request('https://localhost/form', {
       method: 'POST',
-      body: formData,
+      body: data,
+      // `Content-Type` header must not be set.
+    })
+    expect(await parseBody(req)).toEqual({ message: 'hello' })
+  })
+
+  it('should parse `x-www-form-urlencoded`', async () => {
+    const searchParams = new URLSearchParams()
+    searchParams.append('message', 'hello')
+    const req = new Request('https://localhost/search', {
+      method: 'POST',
+      body: searchParams,
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
@@ -34,19 +25,11 @@ describe('Parse Body Middleware', () => {
     expect(await parseBody(req)).toEqual({ message: 'hello' })
   })
 
-  it('should parse Response body ', async () => {
-    const payload = 'hello'
-    const res = new Response(payload, {
-      headers: {
-        'Content-Type': 'text/plain',
-      },
-    })
-    expect(await parseBody(res)).toEqual(payload)
-  })
-
-  it('should return blank object if JSON body is nothing', async () => {
+  it('should return blank object if body is JSON', async () => {
+    const payload = { message: 'hello hono' }
     const req = new Request('http://localhost/json', {
       method: 'POST',
+      body: JSON.stringify(payload),
       headers: new Headers({ 'Content-Type': 'application/json' }),
     })
     expect(await parseBody(req)).toEqual({})

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,28 +1,16 @@
-export async function parseBody<T = any>(r: Request | Response): Promise<T> {
-  let body: any
-
-  const contentType = r.headers.get('Content-Type') || ''
-
-  if (contentType.includes('application/json')) {
-    let jsonBody = {}
-    try {
-      jsonBody = await r.json()
-    } catch {} // Do nothing
-    body = jsonBody
-  } else if (contentType.includes('application/text')) {
-    body = await r.text()
-  } else if (contentType.startsWith('text')) {
-    body = await r.text()
-  } else if (contentType.includes('form')) {
+export async function parseBody(r: Request | Response): Promise<Record<string, string | File>> {
+  let body: Record<string, string | File> = {}
+  const contentType = r.headers.get('Content-Type')
+  if (
+    contentType &&
+    (contentType.startsWith('multipart/form-data') ||
+      contentType === 'application/x-www-form-urlencoded')
+  ) {
     const form: Record<string, string | File> = {}
-    const data = [...(await r.formData())].reduce((acc, cur) => {
+    body = [...(await r.formData())].reduce((acc, cur) => {
       acc[cur[0]] = cur[1]
       return acc
     }, form)
-    body = data
-  } else {
-    body = await r.arrayBuffer()
   }
-
-  return body as T
+  return body
 }


### PR DESCRIPTION
Make that `c.req.parseBody` parses only FormData and does not parse JSON, text, and arrayBuffer. This fix includes breaking changes.

Before this PR, this function returns the parsed body according to Content-Type, despite the type of body. And, it will be `any`:

```ts
parseBody<T = any>(r: Request | Response): Promise<T>
```

Even though the user was expecting a `Record<string, string>`, this may return `Object`. This behavior could potentially cause a security vulnerability. See #484 

In this PR, `c.req.parseBody` only parse `FormData`. If the user wants to parse others than FormData, then the user should explicitly use `json()`, `text()`, and `arrayBuffer()`.

```ts
const data = c.req.json()
```

`parseBody` will only return `Record<string, string | File>`.

```ts
parseBody(r: Request | Response): Promise<Record<string, string | File>>
```

Fix #484 