### PR TITLE
fix app.HTTP_METHOD type

### DIFF
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -53,17 +53,17 @@ interface HandlerInterface<
   E extends Partial<Environment> = Environment,
   U = Hono<E, T>
 > {
+  // app.get(handler...)
+  <Path extends string, Env extends Partial<Environment> = E>(
+    ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, Env>[]
+  ): U
+  (...handlers: Handler<string, E>[]): U
   // app.get('/', handler, handler...)
   <Path extends string, Env extends Partial<Environment> = E>(
     path: Path,
     ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, Env>[]
   ): U
   (path: string, ...handlers: Handler<string, E>[]): U
-  // app.get(handler...)
-  <Path extends string, Env extends Partial<Environment> = E>(
-    ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, Env>[]
-  ): U
-  (...handlers: Handler<string, E>[]): U
 }
 
 const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const


### PR DESCRIPTION
Hi, Thank you for publishing such a good product!

This PR improve type of app.HTTP_METHOD.

If the return type of the handler function is wrong, as in the example below, an error is reported for "path".

![スクリーンショット 2022-08-29 17 34 04](https://user-images.githubusercontent.com/59350345/187159717-6762f2a7-6bef-45ff-a972-cb71733b4ee9.png)

This is not ideal. Because it should be the handler function that should report the error like below.

![スクリーンショット 2022-08-29 17 36 39](https://user-images.githubusercontent.com/59350345/187160251-673e04ad-b762-4fd6-82a0-b517df6523ce.png)



