### PR TITLE
fix(compose): do not handle the error in `compose`

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -1,12 +1,8 @@
 import { HonoContext } from './context.ts'
-import type { ErrorHandler, NotFoundHandler } from './hono.ts'
+import type { NotFoundHandler } from './hono.ts'
 
 // Based on the code in the MIT licensed `koa-compose` package.
-export const compose = <C>(
-  middleware: Function[],
-  onError?: ErrorHandler,
-  onNotFound?: NotFoundHandler
-) => {
+export const compose = <C>(middleware: Function[], onNotFound?: NotFoundHandler) => {
   const middlewareLength = middleware.length
   return (context: C, next?: Function) => {
     let index = -1
@@ -27,25 +23,10 @@ export const compose = <C>(
         return context
       }
 
-      let res!: Response
-      let isError: boolean = false
+      const tmp = handler(context, () => dispatch(i + 1))
+      const res = tmp instanceof Promise ? await tmp : tmp
 
-      try {
-        const tmp = handler(context, () => dispatch(i + 1))
-        res = tmp instanceof Promise ? await tmp : tmp
-      } catch (err) {
-        if (context instanceof HonoContext && onError) {
-          if (err instanceof Error) {
-            isError = true
-            res = onError(err, context)
-          }
-        }
-        if (!res) {
-          throw err
-        }
-      }
-
-      if (res && context instanceof HonoContext && (!context.finalized || isError)) {
+      if (res && context instanceof HonoContext && !context.finalized) {
         context.res = res
       }
       return context

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -203,11 +203,7 @@ export class Hono<
 
     const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
-    const composed = compose<HonoContext<string, E>>(
-      handlers,
-      this.errorHandler,
-      this.notFoundHandler
-    )
+    const composed = compose<HonoContext<string, E>>(handlers, this.notFoundHandler)
     let context: HonoContext<string, E>
     try {
       context = await composed(c)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -554,6 +554,29 @@ describe('Error handle', () => {
   })
 })
 
+describe('Error handling in middleware', () => {
+  const app = new Hono()
+
+  app.get('/handle-error-in-middleware', async (c, next) => {
+    try {
+      await next()
+    } catch {
+      c.res = c.text('Handle the error in middleware', 500)
+    }
+  })
+
+  app.get('/handle-error-in-middleware', () => {
+    console.log('throw new Error')
+    throw new Error('This is Error')
+  })
+
+  it('Should handle the error in middleware', async () => {
+    const res = await app.request('https://example.com/handle-error-in-middleware')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('Handle the error in middleware')
+  })
+})
+
 describe('Request methods with custom middleware', () => {
   const app = new Hono()
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -203,11 +203,7 @@ export class Hono<
 
     const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
-    const composed = compose<HonoContext<string, E>>(
-      handlers,
-      this.errorHandler,
-      this.notFoundHandler
-    )
+    const composed = compose<HonoContext<string, E>>(handlers, this.notFoundHandler)
     let context: HonoContext<string, E>
     try {
       context = await composed(c)


### PR DESCRIPTION
This is fixing and refactoring things.

We refactored `compose` in v2.0.9. Since this version, it does not throw the Error in `compose`, just adding the 500 error response into `c.res`. But it should throw the error as it should. Otherwise, middleware can't catch the error. We want to do like below:


```ts
app.use('*', async (c, next) => {
  try {
    await next()
  } catch (err) {
    return c.text('Catch the Error in middleware!!', 500)
  }
})
```

So we don't have to do error handling in `compose`, just handling in the outer `dispatch` method.

https://github.com/honojs/hono/blob/543fdbaaa6cd489c671157641d3b49e25287eee3/src/hono.ts#L219-L222

And this fix will make the code simpler and less.

This fix related to https://github.com/honojs/sentry/issues/3