### PR TITLE
fix: fixed the issue logger called twice

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,4 +1,5 @@
 import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono.ts'
+import { defaultNotFoundMessage } from './hono.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
@@ -91,7 +92,7 @@ export class HonoContext<
   }
 
   get res(): Response {
-    return (this._res ||= new Response())
+    return (this._res ||= new Response(defaultNotFoundMessage, { status: 404 }))
   }
 
   set res(_res: Response) {

--- a/deno_dist/deno/serve-static.ts
+++ b/deno_dist/deno/serve-static.ts
@@ -13,7 +13,7 @@ const DEFAULT_DOCUMENT = 'index.html'
 export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
   return async (c: Context, next: Next): Promise<Response | undefined> => {
     // Do nothing if Response is already set
-    if (c.res && c.finalized) {
+    if (c.finalized) {
       await next()
     }
 

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -35,6 +35,8 @@ export type ErrorHandler<E extends Partial<Environment> = Environment> = (
 
 export type Next = () => Promise<void>
 
+export const defaultNotFoundMessage = '404 Not Found'
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
   ? Name
@@ -123,7 +125,7 @@ export class Hono<
   }
 
   private notFoundHandler: NotFoundHandler = (c: Context) => {
-    const message = '404 Not Found'
+    const message = defaultNotFoundMessage
     return c.text(message, 404)
   }
 
@@ -214,6 +216,7 @@ export class Hono<
             return response
           }
         }
+        return this.notFoundHandler(c as Context)
         // Do nothing
       } catch {}
     }

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -207,18 +207,18 @@ export class Hono<
     if (result && result.handlers.length === 1) {
       const handler = result.handlers[0]
       try {
-        const response = handler(c, async () => {})
-        if (response) {
-          if (response instanceof Promise) {
-            const awaited = await response
-            if (awaited) return awaited
-          } else {
-            return response
-          }
+        const res = handler(c, async () => {})
+        if (res) {
+          const awaited = res instanceof Promise ? await res : res
+          if (awaited) return awaited
         }
         return this.notFoundHandler(c as Context)
-        // Do nothing
-      } catch {}
+      } catch (err) {
+        if (err instanceof Error) {
+          return this.errorHandler(err, c as Context)
+        }
+        throw err
+      }
     }
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
@@ -234,7 +234,7 @@ export class Hono<
       }
     } catch (err) {
       if (err instanceof Error) {
-        return this.errorHandler(err, c as Context<string, Environment>)
+        return this.errorHandler(err, c as Context)
       }
       throw err
     }

--- a/deno_dist/middleware/serve-static/serve-static.ts
+++ b/deno_dist/middleware/serve-static/serve-static.ts
@@ -17,7 +17,7 @@ const DEFAULT_DOCUMENT = 'index.html'
 export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
   return async (c: Context, next: Next): Promise<Response | undefined> => {
     // Do nothing if Response is already set
-    if (c.res && c.finalized) {
+    if (c.finalized) {
       await next()
     }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono'
+import { defaultNotFoundMessage } from './hono'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
@@ -91,7 +92,7 @@ export class HonoContext<
   }
 
   get res(): Response {
-    return (this._res ||= new Response())
+    return (this._res ||= new Response(defaultNotFoundMessage, { status: 404 }))
   }
 
   set res(_res: Response) {

--- a/src/deno/serve-static.ts
+++ b/src/deno/serve-static.ts
@@ -13,7 +13,7 @@ const DEFAULT_DOCUMENT = 'index.html'
 export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
   return async (c: Context, next: Next): Promise<Response | undefined> => {
     // Do nothing if Response is already set
-    if (c.res && c.finalized) {
+    if (c.finalized) {
       await next()
     }
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -35,6 +35,8 @@ export type ErrorHandler<E extends Partial<Environment> = Environment> = (
 
 export type Next = () => Promise<void>
 
+export const defaultNotFoundMessage = '404 Not Found'
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
   ? Name
@@ -123,7 +125,7 @@ export class Hono<
   }
 
   private notFoundHandler: NotFoundHandler = (c: Context) => {
-    const message = '404 Not Found'
+    const message = defaultNotFoundMessage
     return c.text(message, 404)
   }
 
@@ -214,6 +216,7 @@ export class Hono<
             return response
           }
         }
+        return this.notFoundHandler(c as Context)
         // Do nothing
       } catch {}
     }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -207,18 +207,18 @@ export class Hono<
     if (result && result.handlers.length === 1) {
       const handler = result.handlers[0]
       try {
-        const response = handler(c, async () => {})
-        if (response) {
-          if (response instanceof Promise) {
-            const awaited = await response
-            if (awaited) return awaited
-          } else {
-            return response
-          }
+        const res = handler(c, async () => {})
+        if (res) {
+          const awaited = res instanceof Promise ? await res : res
+          if (awaited) return awaited
         }
         return this.notFoundHandler(c as Context)
-        // Do nothing
-      } catch {}
+      } catch (err) {
+        if (err instanceof Error) {
+          return this.errorHandler(err, c as Context)
+        }
+        throw err
+      }
     }
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
@@ -234,7 +234,7 @@ export class Hono<
       }
     } catch (err) {
       if (err instanceof Error) {
-        return this.errorHandler(err, c as Context<string, Environment>)
+        return this.errorHandler(err, c as Context)
       }
       throw err
     }

--- a/src/middleware/serve-static/serve-static.ts
+++ b/src/middleware/serve-static/serve-static.ts
@@ -17,7 +17,7 @@ const DEFAULT_DOCUMENT = 'index.html'
 export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
   return async (c: Context, next: Next): Promise<Response | undefined> => {
     // Do nothing if Response is already set
-    if (c.res && c.finalized) {
+    if (c.finalized) {
       await next()
     }
 


### PR DESCRIPTION
By this PR #493 , the logger is called twice if it's not found. And the first log shows "200". The following case:

```ts
app.use('*', logger())
app.get('/', (c) => c.text('Hono!!'))
```

```
GET /not-found
```

![SS](https://user-images.githubusercontent.com/10682/188030412-b8158620-e3a4-48a8-91e6-590b366bcb56.png)

This problem is caused by two reasons.

1. It did not return 404 response immediately If the response is undefined. 
2. Default `c.res` is 200 response. It should be 404 response.

This PR fixed this problem.

This is the issue pointed out in the comments of this PR.
https://github.com/honojs/hono/pull/493#issuecomment-1234769263
