### PR TITLE
perf(compose): Remove `await composed()` from hono.ts.

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -1,14 +1,22 @@
 import { HonoContext } from './context.ts'
 import type { NotFoundHandler } from './hono.ts'
 
+interface ComposeContext {
+  finalized: boolean
+  res: any
+}
+
 // Based on the code in the MIT licensed `koa-compose` package.
-export const compose = <C>(middleware: Function[], onNotFound?: NotFoundHandler) => {
+export const compose = <C extends ComposeContext>(
+  middleware: Function[],
+  onNotFound?: NotFoundHandler
+) => {
   const middlewareLength = middleware.length
   return (context: C, next?: Function) => {
     let index = -1
     return dispatch(0)
 
-    async function dispatch(i: number): Promise<C> {
+    function dispatch(i: number): C | Promise<C> {
       if (i <= index) {
         throw new Error('next() called multiple times')
       }
@@ -16,20 +24,29 @@ export const compose = <C>(middleware: Function[], onNotFound?: NotFoundHandler)
       index = i
       if (i === middlewareLength && next) handler = next
 
+      let res
+
       if (!handler) {
         if (context instanceof HonoContext && context.finalized === false && onNotFound) {
-          context.res = await onNotFound(context)
+          res = onNotFound(context)
+        }
+      } else {
+        res = handler(context, async () => dispatch(i + 1))
+      }
+
+      if (!(res instanceof Promise)) {
+        if (res && context.finalized === false) {
+          context.res = res
         }
         return context
+      } else {
+        return res.then((res) => {
+          if (res && context.finalized === false) {
+            context.res = res
+          }
+          return context
+        })
       }
-
-      const tmp = handler(context, () => dispatch(i + 1))
-      const res = tmp instanceof Promise ? await tmp : tmp
-
-      if (res && context instanceof HonoContext && context.finalized === false) {
-        context.res = res
-      }
-      return context
     }
   }
 }

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -226,7 +226,8 @@ export class Hono<
     const composed = compose<HonoContext<string, E>>(handlers, this.notFoundHandler)
     let context: HonoContext<string, E>
     try {
-      context = await composed(c)
+      const tmp = composed(c)
+      context = tmp instanceof Promise ? await tmp : tmp
       if (!context.finalized) {
         throw new Error(
           'Context is not finalized. You may forget returning Response object or `await next()`'

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,14 +1,22 @@
 import { HonoContext } from './context'
 import type { NotFoundHandler } from './hono'
 
+interface ComposeContext {
+  finalized: boolean
+  res: any
+}
+
 // Based on the code in the MIT licensed `koa-compose` package.
-export const compose = <C>(middleware: Function[], onNotFound?: NotFoundHandler) => {
+export const compose = <C extends ComposeContext>(
+  middleware: Function[],
+  onNotFound?: NotFoundHandler
+) => {
   const middlewareLength = middleware.length
   return (context: C, next?: Function) => {
     let index = -1
     return dispatch(0)
 
-    async function dispatch(i: number): Promise<C> {
+    function dispatch(i: number): C | Promise<C> {
       if (i <= index) {
         throw new Error('next() called multiple times')
       }
@@ -16,20 +24,29 @@ export const compose = <C>(middleware: Function[], onNotFound?: NotFoundHandler)
       index = i
       if (i === middlewareLength && next) handler = next
 
+      let res
+
       if (!handler) {
         if (context instanceof HonoContext && context.finalized === false && onNotFound) {
-          context.res = await onNotFound(context)
+          res = onNotFound(context)
+        }
+      } else {
+        res = handler(context, async () => dispatch(i + 1))
+      }
+
+      if (!(res instanceof Promise)) {
+        if (res && context.finalized === false) {
+          context.res = res
         }
         return context
+      } else {
+        return res.then((res) => {
+          if (res && context.finalized === false) {
+            context.res = res
+          }
+          return context
+        })
       }
-
-      const tmp = handler(context, () => dispatch(i + 1))
-      const res = tmp instanceof Promise ? await tmp : tmp
-
-      if (res && context instanceof HonoContext && context.finalized === false) {
-        context.res = res
-      }
-      return context
     }
   }
 }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -226,7 +226,8 @@ export class Hono<
     const composed = compose<HonoContext<string, E>>(handlers, this.notFoundHandler)
     let context: HonoContext<string, E>
     try {
-      context = await composed(c)
+      const tmp = composed(c)
+      context = tmp instanceof Promise ? await tmp : tmp
       if (!context.finalized) {
         throw new Error(
           'Context is not finalized. You may forget returning Response object or `await next()`'


### PR DESCRIPTION
### What is included?

* Reduced use of `await`
* Reduced use of `context instanceof HonoContext`
    * I think this code did not limit the type of `context` for abstraction, but since it will always be `HonoContext` in production environment, we have limited the type of `context` so that we do not have to compare.

There are many changes to the test code, but no changes to Hono's API.

### Benchmark

These are the results in my environment.
#493 reflects the results of optimization.
```
hono - trie-router(default) x 220,343 ops/sec ±5.68% (83 runs sampled)
hono - regexp-router x 261,953 ops/sec ±5.37% (82 runs sampled)
itty-router x 82,331 ops/sec ±3.38% (85 runs sampled)
sunder x 114,834 ops/sec ±2.25% (83 runs sampled)
worktop x 66,525 ops/sec ±3.41% (87 runs sampled)
Fastest is hono - regexp-router
```

Apply the following changes to this PR.

```diff
diff --git a/src/hono.ts b/src/hono.ts
index c4c0810..4a2da5e 100644
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -203,24 +203,6 @@ export class Hono<
 
     const c = new HonoContext<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
-    // Do not `compose` if it has only one handler
-    if (result && result.handlers.length === 1) {
-      const handler = result.handlers[0]
-      try {
-        const res = handler(c, async () => {})
-        if (res) {
-          const awaited = res instanceof Promise ? await res : res
-          if (awaited) return awaited
-        }
-        return this.notFoundHandler(c as Context)
-      } catch (err) {
-        if (err instanceof Error) {
-          return this.errorHandler(err, c as Context)
-        }
-        throw err
-      }
-    }
-
     const handlers = result ? result.handlers : [this.notFoundHandler]
 
     const composed = compose<HonoContext<string, E>>(handlers, this.notFoundHandler)
```

This version is a bit slower, but this is doing quite well, too.

```
hono - trie-router(default) x 218,861 ops/sec ±6.06% (79 runs sampled)
hono - regexp-router x 265,468 ops/sec ±6.16% (79 runs sampled)
itty-router x 83,826 ops/sec ±3.77% (86 runs sampled)
sunder x 120,162 ops/sec ±2.26% (85 runs sampled)
worktop x 66,387 ops/sec ±5.05% (84 runs sampled)
Fastest is hono - regexp-router
```