### PR TITLE
perf(compose): Always return a Promise without async.

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -31,7 +31,10 @@ export const compose = <C extends ComposeContext>(
           res = onNotFound(context)
         }
       } else {
-        res = handler(context, async () => dispatch(i + 1))
+        res = handler(context, () => {
+          const dispatchRes = dispatch(i + 1)
+          return dispatchRes instanceof Promise ? dispatchRes : Promise.resolve(dispatchRes)
+        })
       }
 
       if (!(res instanceof Promise)) {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -31,7 +31,10 @@ export const compose = <C extends ComposeContext>(
           res = onNotFound(context)
         }
       } else {
-        res = handler(context, async () => dispatch(i + 1))
+        res = handler(context, () => {
+          const dispatchRes = dispatch(i + 1)
+          return dispatchRes instanceof Promise ? dispatchRes : Promise.resolve(dispatchRes)
+        })
       }
 
       if (!(res instanceof Promise)) {


### PR DESCRIPTION
This PR will improve the poor performance noted in the following comment.
https://github.com/honojs/hono/pull/495#issuecomment-1236125012

This branch is the fastest in my environment.

#### perf-reduce-async-compose branch

```
% bombardier -c 200 -d 20s http://127.0.0.1:3000/with-middleware
Bombarding http://127.0.0.1:3000/with-middleware for 20s using 200 connection(s)
[==========================================================================================] 20s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     28673.49    2688.43   35743.89
  Latency        6.97ms   306.34us    24.17ms
  HTTP codes:
    1xx - 0, 2xx - 573631, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     4.87MB/s
```

#### main branch

```
% bombardier -c 200 -d 20s http://127.0.0.1:3000/with-middleware
Bombarding http://127.0.0.1:3000/with-middleware for 20s using 200 connection(s)
[==========================================================================================] 20s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     27164.11    2934.39   32670.21
  Latency        7.36ms   339.90us    22.79ms
  HTTP codes:
    1xx - 0, 2xx - 543455, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     4.61MB/s
```

#### v2.1.3

```
% bombardier -c 200 -d 20s http://127.0.0.1:3000/with-middleware
Bombarding http://127.0.0.1:3000/with-middleware for 20s using 200 connection(s)
[==========================================================================================] 20s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     27380.01    2801.29   32083.21
  Latency        7.30ms   457.61us    28.43ms
  HTTP codes:
    1xx - 0, 2xx - 547572, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     4.65MB/s
```


#### Less middleware

The comparison of the following conditions also showed little difference between v2.1.3 and v2.1.3, but still not worse than v2.1.3.

```ts
import { RegExpRouter } from 'hono/router/reg-exp-router'
import { Hono } from '../../src/index'

const app = new Hono({ router: new RegExpRouter() })

for (let i = 0; i < 1; i++) {
  app.use('/with-middleware', async (c, next) => {
    c.set('count', i)
    await next()
    c.get('foo')
  })
}
app.get('/with-middleware', (c) => c.text('GET(/with-middleware)'))
export default app
```