### PR TITLE
perf(req): improve `c.req.query` performance

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -1,6 +1,7 @@
 import { parseBody } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
+import { getQueryStringFromURL } from './utils/url.ts'
 
 declare global {
   interface Request<ParamKeyType extends string = string> {
@@ -62,26 +63,28 @@ export function extendRequestPrototype() {
   } as InstanceType<typeof Request>['header']
 
   Request.prototype.query = function (this: Request, key?: string) {
-    const url = new URL(this.url)
+    const queryString = getQueryStringFromURL(this.url)
+    const searchParams = new URLSearchParams(queryString)
     if (key) {
-      return url.searchParams.get(key)
+      return searchParams.get(key)
     } else {
       const result: Record<string, string> = {}
-      for (const key of url.searchParams.keys()) {
-        result[key] = url.searchParams.get(key) || ''
+      for (const key of searchParams.keys()) {
+        result[key] = searchParams.get(key) || ''
       }
       return result
     }
   } as InstanceType<typeof Request>['query']
 
   Request.prototype.queries = function (this: Request, key?: string) {
-    const url = new URL(this.url)
+    const queryString = getQueryStringFromURL(this.url)
+    const searchParams = new URLSearchParams(queryString)
     if (key) {
-      return url.searchParams.getAll(key)
+      return searchParams.getAll(key)
     } else {
       const result: Record<string, string[]> = {}
-      for (const key of url.searchParams.keys()) {
-        result[key] = url.searchParams.getAll(key)
+      for (const key of searchParams.keys()) {
+        result[key] = searchParams.getAll(key)
       }
       return result
     }

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -52,11 +52,7 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
 
 export const getQueryStringFromURL = (url: string): string => {
   const queryIndex = url.indexOf('?')
-  const fragmentIndex = url.indexOf('#')
-  const result =
-    queryIndex !== -1
-      ? url.substring(queryIndex, fragmentIndex !== -1 ? fragmentIndex : undefined)
-      : ''
+  const result = queryIndex !== -1 ? url.substring(queryIndex) : ''
   return result
 }
 

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -50,6 +50,16 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
   return result
 }
 
+export const getQueryStringFromURL = (url: string): string => {
+  const queryIndex = url.indexOf('?')
+  const fragmentIndex = url.indexOf('#')
+  const result =
+    queryIndex !== -1
+      ? url.substring(queryIndex, fragmentIndex !== -1 ? fragmentIndex : undefined)
+      : ''
+  return result
+}
+
 export const isAbsoluteURL = (url: string): boolean => {
   const match = url.match(URL_REGEXP)
   if (match) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,7 @@
 import { parseBody } from './utils/body'
 import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
+import { getQueryStringFromURL } from './utils/url'
 
 declare global {
   interface Request<ParamKeyType extends string = string> {
@@ -62,26 +63,28 @@ export function extendRequestPrototype() {
   } as InstanceType<typeof Request>['header']
 
   Request.prototype.query = function (this: Request, key?: string) {
-    const url = new URL(this.url)
+    const queryString = getQueryStringFromURL(this.url)
+    const searchParams = new URLSearchParams(queryString)
     if (key) {
-      return url.searchParams.get(key)
+      return searchParams.get(key)
     } else {
       const result: Record<string, string> = {}
-      for (const key of url.searchParams.keys()) {
-        result[key] = url.searchParams.get(key) || ''
+      for (const key of searchParams.keys()) {
+        result[key] = searchParams.get(key) || ''
       }
       return result
     }
   } as InstanceType<typeof Request>['query']
 
   Request.prototype.queries = function (this: Request, key?: string) {
-    const url = new URL(this.url)
+    const queryString = getQueryStringFromURL(this.url)
+    const searchParams = new URLSearchParams(queryString)
     if (key) {
-      return url.searchParams.getAll(key)
+      return searchParams.getAll(key)
     } else {
       const result: Record<string, string[]> = {}
-      for (const key of url.searchParams.keys()) {
-        result[key] = url.searchParams.getAll(key)
+      for (const key of searchParams.keys()) {
+        result[key] = searchParams.getAll(key)
       }
       return result
     }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,4 +1,11 @@
-import { splitPath, getPattern, getPathFromURL, isAbsoluteURL, mergePath } from './url'
+import {
+  splitPath,
+  getPattern,
+  getPathFromURL,
+  isAbsoluteURL,
+  mergePath,
+  getQueryStringFromURL,
+} from './url'
 
 describe('url', () => {
   it('splitPath', () => {
@@ -58,6 +65,22 @@ describe('url', () => {
       expect(path).toBe('/hello')
       path = getPathFromURL('https://example.com/hello/hey/', false)
       expect(path).toBe('/hello/hey')
+    })
+  })
+
+  describe('getQueryStringFromURL', () => {
+    it('should return strings of query params', () => {
+      let queryString = getQueryStringFromURL('https://example.com/?foo=bar')
+      expect(queryString).toBe('?foo=bar')
+      queryString = getQueryStringFromURL('https://example.com/?foo=bar&foo2=bar2')
+      expect(queryString).toBe('?foo=bar&foo2=bar2')
+      queryString = getQueryStringFromURL('https://example.com/')
+      expect(queryString).toBe('')
+      queryString = getQueryStringFromURL('https://example.com/?foo=bar#fragment')
+      expect(queryString).toBe('?foo=bar')
+      // This specification allows that the string includes two `?` or more
+      queryString = getQueryStringFromURL('https://example.com/?foo=bar?foo2=bar2')
+      expect(queryString).toBe('?foo=bar?foo2=bar2')
     })
   })
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -76,8 +76,9 @@ describe('url', () => {
       expect(queryString).toBe('?foo=bar&foo2=bar2')
       queryString = getQueryStringFromURL('https://example.com/')
       expect(queryString).toBe('')
-      queryString = getQueryStringFromURL('https://example.com/?foo=bar#fragment')
-      expect(queryString).toBe('?foo=bar')
+      // This specification allows the fragments as query strings
+      queryString = getQueryStringFromURL('https://example.com/?#foo=#bar&#foo2=#bar2')
+      expect(queryString).toBe('?#foo=#bar&#foo2=#bar2')
       // This specification allows that the string includes two `?` or more
       queryString = getQueryStringFromURL('https://example.com/?foo=bar?foo2=bar2')
       expect(queryString).toBe('?foo=bar?foo2=bar2')

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -52,11 +52,7 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
 
 export const getQueryStringFromURL = (url: string): string => {
   const queryIndex = url.indexOf('?')
-  const fragmentIndex = url.indexOf('#')
-  const result =
-    queryIndex !== -1
-      ? url.substring(queryIndex, fragmentIndex !== -1 ? fragmentIndex : undefined)
-      : ''
+  const result = queryIndex !== -1 ? url.substring(queryIndex) : ''
   return result
 }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -50,6 +50,16 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
   return result
 }
 
+export const getQueryStringFromURL = (url: string): string => {
+  const queryIndex = url.indexOf('?')
+  const fragmentIndex = url.indexOf('#')
+  const result =
+    queryIndex !== -1
+      ? url.substring(queryIndex, fragmentIndex !== -1 ? fragmentIndex : undefined)
+      : ''
+  return result
+}
+
 export const isAbsoluteURL = (url: string): boolean => {
   const match = url.match(URL_REGEXP)
   if (match) {


### PR DESCRIPTION
I've improved `c.req.query` performance. Currently, `c.req.query` uses `new URL` for parsing query parameters strings. It is inefficient. In this PR, `c.req.query` uses just `URLSearchParams`, it becomes to be faster.

## Benchmarks

Scripts:

```ts
import { run, bench } from 'mitata'
import { getQueryStringFromURL } from '../../src/utils/url'

const urlString = 'http://localhost?foo=bar&foo2=bar2&foo3=bar3'

{
  bench('URL', () => {
    const url = new URL(urlString)
    url.searchParams.get('foo')
  })
}

{
  bench('getQueryStringFromURL + URLSearchParams', () => {
    const queryStirng = getQueryStringFromURL(urlString)
    const searchParams = new URLSearchParams(queryStirng)
    searchParams.get('foo')
  })
}

await run()
```

Results:

```plain
MacBook@yusuke $ bun run ./url-params.ts
cpu: Apple M1 Pro
runtime: bun 0.1.11 (arm64-darwin)

benchmark                                    time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------------------- -----------------------------
URL                                        1.18 µs/iter   (933.55 ns … 3.21 µs)   1.14 µs   3.21 µs   3.21 µs
getQueryStringFromURL + URLSearchParams  802.39 ns/iter   (696.65 ns … 2.35 µs) 795.49 ns   2.35 µs   2.35 µs

---

MacBook@yusuke $ deno run -A ./deno.ts
cpu: Apple M1 Pro
runtime: deno 1.25.1 (aarch64-apple-darwin)

benchmark                                    time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------------------- -----------------------------
URL                                        2.62 µs/iter     (2.53 µs … 2.67 µs)   2.64 µs   2.67 µs   2.67 µs
getQueryStringFromURL + URLSearchParams    1.33 µs/iter      (1.3 µs … 1.34 µs)   1.33 µs   1.34 µs   1.34 µs
```

In the real world:

```ts
import { Hono } from '../../src/hono'

const app = new Hono()

app.get('/', (c) => {
  const q = c.req.query('q')
  return c.text(q)
})

export default app
```

Results:

Bun

```plain
---
v2.1.3

MacBook@yusuke $ bombardier -c 200 -d 10s 'http://localhost:3000/?q=search-query&foo=bar&foo2=bar2'
Bombarding http://localhost:3000/?q=search-query&foo=bar&foo2=bar2 for 10s using 200 connection(s)
[=======================================================================================================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     93868.04   25880.52  119351.49
  Latency        2.13ms     1.26ms    26.70ms
  HTTP codes:
    1xx - 0, 2xx - 938298, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    16.73MB/s

After

MacBook@yusuke $ bombardier -c 200 -d 10s 'http://localhost:3000/?q=search-query&foo=bar&foo2=bar2'
Bombarding http://localhost:3000/?q=search-query&foo=bar&foo2=bar2 for 10s using 200 connection(s)
[=======================================================================================================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec    123577.17   30821.98  148889.77
  Latency        1.62ms     1.45ms    44.68ms
  HTTP codes:
    1xx - 0, 2xx - 1235784, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    22.04MB/s
```

Deno

```plain
---
v2.1.3

MacBook@yusuke $ bombardier -c 200 -d 10s 'http://localhost:9000/?q=search-query&foo=bar&foo2=bar2'
Bombarding http://localhost:9000/?q=search-query&foo=bar&foo2=bar2 for 10s using 200 connection(s)
[=======================================================================================================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec    105378.02    8459.58  117360.28
  Latency        1.90ms   229.71us    22.57ms
  HTTP codes:
    1xx - 0, 2xx - 1053922, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    22.51MB/s
  
---
  
After

MacBook@yusuke $ bombardier -c 200 -d 10s 'http://localhost:9000/?q=search-query&foo=bar&foo2=bar2'
Bombarding http://localhost:9000/?q=search-query&foo=bar&foo2=bar2 for 10s using 200 connection(s)
[=======================================================================================================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec    136321.87   29600.10  168217.67
  Latency        1.47ms   165.65us    21.77ms
  HTTP codes:
    1xx - 0, 2xx - 1363227, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    29.12MB/s
```