### PR TITLE
Introduce StaticRouter and SmartRouter

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -3,8 +3,12 @@ import type { Context } from './context.ts'
 import { HonoContext } from './context.ts'
 import { extendRequestPrototype } from './request.ts'
 import type { Router } from './router.ts'
+import { METHODS } from './router.ts'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router.ts'
-import { TrieRouter } from './router/trie-router/index.ts' // Default Router
+import { RegExpRouter } from './router/reg-exp-router/index.ts'
+import { SmartRouter } from './router/smart-router/index.ts'
+import { StaticRouter } from './router/static-router/index.ts'
+import { TrieRouter } from './router/trie-router/index.ts'
 import { getPathFromURL, mergePath } from './utils/url.ts'
 
 export interface ContextVariableMap {}
@@ -68,8 +72,7 @@ interface HandlerInterface<
   (path: string, ...handlers: Handler<string, E>[]): U
 }
 
-const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
-type Methods = typeof methods[number] | typeof METHOD_NAME_ALL_LOWERCASE
+type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
 
 function defineDynamicClass(): {
   new <E extends Partial<Environment> = Environment, T extends string = string, U = Hono>(): {
@@ -89,7 +92,9 @@ export class Hono<
   E extends Partial<Environment> = Environment,
   P extends string = '/'
 > extends defineDynamicClass()<E, P, Hono<E, P>> {
-  readonly router: Router<Handler<string, E>> = new TrieRouter()
+  readonly router: Router<Handler<string, E>> = new SmartRouter({
+    routers: [new StaticRouter(), new RegExpRouter({ allowAmbiguous: false }), new TrieRouter()],
+  })
   readonly strict: boolean = true // strict routing - default is true
   private _tempPath: string = ''
   private path: string = '/'
@@ -101,7 +106,7 @@ export class Hono<
 
     extendRequestPrototype()
 
-    const allMethods = [...methods, METHOD_NAME_ALL_LOWERCASE]
+    const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
       this[method] = <Path extends string = ''>(
         args1: Path | Handler<ParamKeys<Path>, E>,

--- a/deno_dist/router.ts
+++ b/deno_dist/router.ts
@@ -1,5 +1,6 @@
 export const METHOD_NAME_ALL = 'ALL' as const
 export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
+export const METHODS = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
 
 export interface Router<T> {
   add(method: string, path: string, handler: T): void
@@ -10,3 +11,5 @@ export interface Result<T> {
   handlers: T[]
   params: Record<string, string>
 }
+
+export class UnsupportedPathError extends Error {}

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Router, Result } from '../../router.ts'
-import { METHOD_NAME_ALL } from '../../router.ts'
+import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router.ts'
 import type { ParamMap } from './trie.ts'
 import { Trie } from './trie.ts'
 
@@ -200,11 +200,16 @@ function verifyDuplicateParam<T>(routes: Route<T>[]): boolean {
 }
 
 export class RegExpRouter<T> implements Router<T> {
+  allowAmbiguous: boolean = true
   routeData?: {
     index: number
     routes: Route<T>[]
     methods: Set<string>
   } = { index: 0, routes: [], methods: new Set() }
+
+  constructor(init: Partial<Pick<RegExpRouter<T>, 'allowAmbiguous'>> = {}) {
+    Object.assign(this, init)
+  }
 
   add(method: string, path: string, handler: T) {
     if (!this.routeData) {
@@ -424,6 +429,9 @@ export class RegExpRouter<T> implements Router<T> {
 
           routes[i].hint.maybeHandler = false
         } else if (compareResult === 2) {
+          if (!this.allowAmbiguous) {
+            throw new UnsupportedPathError(routes[i].path)
+          }
           // ambiguous
           hasAmbiguous = true
 

--- a/deno_dist/router/smart-router/index.ts
+++ b/deno_dist/router/smart-router/index.ts
@@ -1,0 +1,1 @@
+export { SmartRouter } from './router.ts'

--- a/deno_dist/router/smart-router/router.ts
+++ b/deno_dist/router/smart-router/router.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { Router, Result } from '../../router.ts'
+import { UnsupportedPathError } from '../../router.ts'
+
+export class SmartRouter<T> implements Router<T> {
+  routers: Router<T>[] = []
+  routes?: [string, string, T][] = []
+
+  constructor(init: Pick<SmartRouter<T>, 'routers'>) {
+    Object.assign(this, init)
+  }
+
+  add(method: string, path: string, handler: T) {
+    if (!this.routes) {
+      throw new Error('Can not add a route since the matcher is already built.')
+    }
+
+    this.routes.push([method, path, handler])
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    if (!this.routes) {
+      throw new Error('Fatal error')
+    }
+
+    const { routers, routes } = this
+    const len = routers.length
+    let i = 0
+    let res
+    for (; i < len; i++) {
+      const router = routers[i]
+      try {
+        routes.forEach((args) => {
+          router.add(...args)
+        })
+        res = router.match(method, path)
+      } catch (e) {
+        if (e instanceof UnsupportedPathError) {
+          continue
+        }
+        throw e
+      }
+
+      this.match = router.match.bind(router)
+      this.routers = [router]
+      this.routes = undefined
+      break
+    }
+
+    if (i === len) {
+      // not found
+      throw new Error('Fatal error')
+    }
+
+    return res || null
+  }
+
+  get activeRouter() {
+    if (this.routes || this.routers.length !== 1) {
+      throw new Error('No active router has been determined yet.')
+    }
+
+    return this.routers[0]
+  }
+}

--- a/deno_dist/router/static-router/index.ts
+++ b/deno_dist/router/static-router/index.ts
@@ -1,0 +1,1 @@
+export { StaticRouter } from './router.ts'

--- a/deno_dist/router/static-router/router.ts
+++ b/deno_dist/router/static-router/router.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { Router, Result } from '../../router.ts'
+import { METHOD_NAME_ALL, METHODS, UnsupportedPathError } from '../../router.ts'
+
+export class StaticRouter<T> implements Router<T> {
+  middleware: Record<string, Result<T>>
+  routes: Record<string, Record<string, Result<T>>>
+
+  constructor() {
+    this.middleware = {}
+
+    this.routes = {} as StaticRouter<T>['routes']
+    ;[METHOD_NAME_ALL, ...METHODS].forEach((method) => {
+      this.routes[method.toUpperCase()] = {}
+    })
+  }
+
+  add(method: string, path: string, handler: T) {
+    const { middleware, routes } = this
+
+    if (path === '/*') {
+      path = '*'
+    }
+
+    if (path === '*') {
+      if (method === METHOD_NAME_ALL) {
+        middleware[METHOD_NAME_ALL] ||= { handlers: [], params: {} }
+        Object.keys(middleware).forEach((m) => {
+          middleware[m].handlers.push(handler)
+        })
+        Object.keys(routes).forEach((m) => {
+          Object.values(routes[m]).forEach((matchRes) => matchRes.handlers.push(handler))
+        })
+      } else {
+        middleware[method] ||= {
+          handlers: [...(middleware[METHOD_NAME_ALL]?.handlers || [])],
+          params: {},
+        }
+        middleware[method].handlers.push(handler)
+        if (routes[method]) {
+          Object.values(routes[method]).forEach((matchRes) => matchRes.handlers.push(handler))
+        }
+      }
+      return
+    }
+
+    if (/\*|\/:/.test(path)) {
+      throw new UnsupportedPathError(path)
+    }
+
+    routes[method][path] ||= {
+      handlers: [
+        ...(routes[METHOD_NAME_ALL][path]?.handlers ||
+          middleware[method]?.handlers ||
+          middleware[METHOD_NAME_ALL]?.handlers ||
+          []),
+      ],
+      params: {},
+    }
+    if (method === METHOD_NAME_ALL) {
+      Object.keys(routes).forEach((m) => {
+        routes[m][path]?.handlers?.push(handler)
+      })
+    } else {
+      routes[method][path].handlers.push(handler)
+    }
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    const { routes, middleware } = this
+
+    this.match = (method, path) =>
+      routes[method][path] ||
+      routes[METHOD_NAME_ALL][path] ||
+      middleware[method] ||
+      middleware[METHOD_NAME_ALL] ||
+      null
+
+    return this.match(method, path)
+  }
+}

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -98,9 +98,9 @@ describe('strict parameter', () => {
 })
 
 describe('Routing', () => {
-  const app = new Hono()
-
   it('Return it self', async () => {
+    const app = new Hono()
+
     const app2 = app.get('/', () => new Response('get /'))
     expect(app2).not.toBeUndefined()
     app2.delete('/', () => new Response('delete /'))
@@ -117,6 +117,8 @@ describe('Routing', () => {
   })
 
   it('Nested route', async () => {
+    const app = new Hono()
+
     const book = app.route('/book')
     book.get('/', (c) => c.text('get /book'))
     book.get('/:id', (c) => {
@@ -153,6 +155,8 @@ describe('Routing', () => {
   })
 
   describe('Chained route', () => {
+    const app = new Hono()
+
     app
       .get('/chained/:abc', (c) => {
         const abc = c.req.param('abc')
@@ -775,40 +779,43 @@ describe('Multiple handler', () => {
   })
 
   describe('Duplicate param name', () => {
-    it('self', () => {
+    it('self', async () => {
       const app = new Hono()
-      expect(() => {
-        app.get('/:id/:id', (c) => {
-          const id = c.req.param('id')
-          return c.text(`id is ${id}`)
-        })
-      }).toThrowError(/Duplicate param name/)
+      app.get('/:id/:id', (c) => {
+        const id = c.req.param('id')
+        return c.text(`id is ${id}`)
+      })
+      await expect(async () => {
+        await app.request('http://localhost/')
+      }).rejects.toThrowError(/Duplicate param name/)
     })
 
-    it('parent', () => {
+    it('parent', async () => {
       const app = new Hono()
       app.get('/:id/:action', (c) => {
         return c.text('foo')
       })
-      expect(() => {
-        app.get('/posts/:id', (c) => {
-          const id = c.req.param('id')
-          return c.text(`id is ${id}`)
-        })
-      }).toThrowError(/Duplicate param name/)
+      app.get('/posts/:id', (c) => {
+        const id = c.req.param('id')
+        return c.text(`id is ${id}`)
+      })
+      await expect(async () => {
+        await app.request('http://localhost/')
+      }).rejects.toThrowError(/Duplicate param name/)
     })
 
-    it('child', () => {
+    it('child', async () => {
       const app = new Hono()
       app.get('/posts/:id', (c) => {
         return c.text('foo')
       })
-      expect(() => {
-        app.get('/:id/:action', (c) => {
-          const id = c.req.param('id')
-          return c.text(`id is ${id}`)
-        })
-      }).toThrowError(/Duplicate param name/)
+      app.get('/:id/:action', (c) => {
+        const id = c.req.param('id')
+        return c.text(`id is ${id}`)
+      })
+      await expect(async () => {
+        await app.request('http://localhost/')
+      }).rejects.toThrowError(/Duplicate param name/)
     })
 
     it('hierarchy', () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -5,7 +5,10 @@ import { extendRequestPrototype } from './request'
 import type { Router } from './router'
 import { METHODS } from './router'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router'
-import { TrieRouter } from './router/trie-router' // Default Router
+import { RegExpRouter } from './router/reg-exp-router'
+import { SmartRouter } from './router/smart-router'
+import { StaticRouter } from './router/static-router'
+import { TrieRouter } from './router/trie-router'
 import { getPathFromURL, mergePath } from './utils/url'
 
 export interface ContextVariableMap {}
@@ -89,7 +92,9 @@ export class Hono<
   E extends Partial<Environment> = Environment,
   P extends string = '/'
 > extends defineDynamicClass()<E, P, Hono<E, P>> {
-  readonly router: Router<Handler<string, E>> = new TrieRouter()
+  readonly router: Router<Handler<string, E>> = new SmartRouter({
+    routers: [new StaticRouter(), new RegExpRouter({ allowAmbiguous: false }), new TrieRouter()],
+  })
   readonly strict: boolean = true // strict routing - default is true
   private _tempPath: string = ''
   private path: string = '/'

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -3,6 +3,7 @@ import type { Context } from './context'
 import { HonoContext } from './context'
 import { extendRequestPrototype } from './request'
 import type { Router } from './router'
+import { METHODS } from './router'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router'
 import { TrieRouter } from './router/trie-router' // Default Router
 import { getPathFromURL, mergePath } from './utils/url'
@@ -68,8 +69,7 @@ interface HandlerInterface<
   (path: string, ...handlers: Handler<string, E>[]): U
 }
 
-const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
-type Methods = typeof methods[number] | typeof METHOD_NAME_ALL_LOWERCASE
+type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
 
 function defineDynamicClass(): {
   new <E extends Partial<Environment> = Environment, T extends string = string, U = Hono>(): {
@@ -101,7 +101,7 @@ export class Hono<
 
     extendRequestPrototype()
 
-    const allMethods = [...methods, METHOD_NAME_ALL_LOWERCASE]
+    const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
       this[method] = <Path extends string = ''>(
         args1: Path | Handler<ParamKeys<Path>, E>,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 export const METHOD_NAME_ALL = 'ALL' as const
 export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
+export const METHODS = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
 
 export interface Router<T> {
   add(method: string, path: string, handler: T): void

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,3 +11,5 @@ export interface Result<T> {
   handlers: T[]
   params: Record<string, string>
 }
+
+export class UnsupportedPathError extends Error {}

--- a/src/router/smart-router/index.ts
+++ b/src/router/smart-router/index.ts
@@ -1,0 +1,1 @@
+export { SmartRouter } from './router'

--- a/src/router/smart-router/router.test.ts
+++ b/src/router/smart-router/router.test.ts
@@ -1,0 +1,144 @@
+import { RegExpRouter } from '../reg-exp-router'
+import { StaticRouter } from '../static-router'
+import { TrieRouter } from '../trie-router'
+import { SmartRouter } from './router'
+
+describe('StaticRouter', () => {
+  describe('Basic Usage', () => {
+    const router = new SmartRouter<string>({
+      routers: [new StaticRouter(), new RegExpRouter({ allowAmbiguous: false }), new TrieRouter()],
+    })
+
+    router.add('GET', '/hello', 'get hello')
+    router.add('POST', '/hello', 'post hello')
+
+    it('get, post hello', async () => {
+      let res = router.match('GET', '/hello')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['get hello'])
+
+      res = router.match('POST', '/hello')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['post hello'])
+
+      res = router.match('PUT', '/hello')
+      expect(res).toBeNull()
+
+      res = router.match('GET', '/')
+      expect(res).toBeNull()
+
+      expect(router.activeRouter).toBeInstanceOf(StaticRouter)
+    })
+  })
+
+  describe('Multi match', () => {
+    describe('Blog', () => {
+      const router = new SmartRouter<string>({
+        routers: [new StaticRouter(), new RegExpRouter({ allowAmbiguous: false }), new TrieRouter()],
+      })
+
+      router.add('ALL', '*', 'middleware a')
+      router.add('GET', '*', 'middleware b')
+      router.add('GET', '/entry', 'get entries')
+      it('GET /', async () => {
+        const res = router.match('GET', '/')
+        expect(res).not.toBeNull()
+        expect(res?.handlers).toEqual(['middleware a', 'middleware b'])
+        expect(router.activeRouter).toBeInstanceOf(StaticRouter)
+      })
+      it('GET /entry', async () => {
+        const res = router.match('GET', '/entry')
+        expect(res).not.toBeNull()
+        expect(res?.handlers).toEqual(['middleware a', 'middleware b', 'get entries'])
+      })
+      it('DELETE /entry', async () => {
+        const res = router.match('DELETE', '/entry')
+        expect(res).not.toBeNull()
+        expect(res?.handlers).toEqual(['middleware a'])
+      })
+    })
+  })
+})
+
+describe('RegExpRouter', () => {
+  describe('Complex', () => {
+    let router: SmartRouter<string>
+    beforeEach(() => {
+      router = new SmartRouter<string>({
+        routers: [new StaticRouter(), new RegExpRouter({ allowAmbiguous: false }), new TrieRouter()],
+      })
+    })
+  
+    it('Named Param', async () => {
+      router.add('GET', '/entry/:id', 'get entry')
+      const res = router.match('GET', '/entry/123')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['get entry'])
+      expect(res?.params['id']).toBe('123')
+      expect(router.activeRouter).toBeInstanceOf(RegExpRouter)
+    })
+  
+    it('Wildcard', async () => {
+      router.add('GET', '/wild/*/card', 'get wildcard')
+      const res = router.match('GET', '/wild/xxx/card')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['get wildcard'])
+    })
+  
+    it('Default', async () => {
+      router.add('GET', '/api/abc', 'get api')
+      router.add('GET', '/api/*', 'fallback')
+      let res = router.match('GET', '/api/abc')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['get api', 'fallback'])
+      res = router.match('GET', '/api/def')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['fallback'])
+    })
+  
+    it('Regexp', async () => {
+      router.add('GET', '/post/:date{[0-9]+}/:title{[a-z]+}', 'get post')
+      let res = router.match('GET', '/post/20210101/hello')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['get post'])
+      expect(res?.params['date']).toBe('20210101')
+      expect(res?.params['title']).toBe('hello')
+      res = router.match('GET', '/post/onetwothree')
+      expect(res).toBeNull()
+      res = router.match('GET', '/post/123/123')
+      expect(res).toBeNull()
+    })
+  
+    it('/*', async () => {
+      router.add('GET', '/api/*', 'auth middleware')
+      router.add('GET', '/api', 'top')
+      router.add('GET', '/api/posts', 'posts')
+      router.add('GET', '/api/*', 'fallback')
+  
+      let res = router.match('GET', '/api')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['auth middleware', 'top', 'fallback'])
+  
+      res = router.match('GET', '/api/posts')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['auth middleware', 'posts', 'fallback'])
+    })
+  })
+})
+
+describe('TrieRouter', () => {
+  const router = new SmartRouter<string>({
+    routers: [new StaticRouter(), new RegExpRouter({ allowAmbiguous: false }), new TrieRouter()],
+  })
+
+  router.add('GET', '/:user/entries', 'get user entries')
+  router.add('GET', '/entry/:name', 'get entry')
+  it('GET /entry/entry', async () => {
+    const res = router.match('GET', '/entry/entries')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get user entries', 'get entry'])
+    expect(res?.params['user']).toBe('entry')
+    expect(res?.params['name']).toBe('entries')
+    expect(router.activeRouter).toBeInstanceOf(TrieRouter)
+  })
+})

--- a/src/router/smart-router/router.ts
+++ b/src/router/smart-router/router.ts
@@ -3,7 +3,7 @@ import type { Router, Result } from '../../router'
 import { UnsupportedPathError } from '../../router'
 
 export class SmartRouter<T> implements Router<T> {
-  routers?: Router<T>[] = []
+  routers: Router<T>[] = []
   routes?: [string, string, T][] = []
 
   constructor(init: Pick<SmartRouter<T>, 'routers'>) {
@@ -19,7 +19,7 @@ export class SmartRouter<T> implements Router<T> {
   }
 
   match(method: string, path: string): Result<T> | null {
-    if (!this.routers || !this.routes) {
+    if (!this.routes) {
       throw new Error('Fatal error')
     }
 
@@ -56,7 +56,7 @@ export class SmartRouter<T> implements Router<T> {
   }
 
   get activeRouter() {
-    if (this.routes || !this.routers) {
+    if (this.routes || this.routers.length !== 1) {
       throw new Error('No active router has been determined yet.')
     }
 

--- a/src/router/smart-router/router.ts
+++ b/src/router/smart-router/router.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { Router, Result } from '../../router'
+import { UnsupportedPathError } from '../../router'
+
+export class SmartRouter<T> implements Router<T> {
+  routers?: Router<T>[] = []
+  routes?: [string, string, T][] = []
+
+  constructor(init: Pick<SmartRouter<T>, 'routers'>) {
+    Object.assign(this, init)
+  }
+
+  add(method: string, path: string, handler: T) {
+    if (!this.routes) {
+      throw new Error('Can not add a route since the matcher is already built.')
+    }
+
+    this.routes.push([method, path, handler])
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    if (!this.routers || !this.routes) {
+      throw new Error('Fatal error')
+    }
+
+    const { routers, routes } = this
+    const len = routers.length
+    let i = 0
+    let res
+    for (; i < len; i++) {
+      const router = routers[i]
+      try {
+        routes.forEach((args) => {
+          router.add(...args)
+        })
+        res = router.match(method, path)
+      } catch (e) {
+        if (e instanceof UnsupportedPathError) {
+          continue
+        }
+        throw e
+      }
+
+      this.match = router.match.bind(router)
+      this.routers = [router]
+      this.routes = undefined
+      break
+    }
+
+    if (i === len) {
+      // not found
+      throw new Error('Fatal error')
+    }
+
+    return res || null
+  }
+
+  get activeRouter() {
+    if (this.routes || !this.routers) {
+      throw new Error('No active router has been determined yet.')
+    }
+
+    return this.routers[0]
+  }
+}

--- a/src/router/static-router/index.ts
+++ b/src/router/static-router/index.ts
@@ -1,0 +1,1 @@
+export { StaticRouter } from './router'

--- a/src/router/static-router/router.test.ts
+++ b/src/router/static-router/router.test.ts
@@ -1,0 +1,49 @@
+import { StaticRouter } from './router'
+
+describe('Basic Usage', () => {
+  const router = new StaticRouter<string>()
+
+  router.add('GET', '/hello', 'get hello')
+  router.add('POST', '/hello', 'post hello')
+
+  it('get, post hello', async () => {
+    let res = router.match('GET', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get hello'])
+
+    res = router.match('POST', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['post hello'])
+
+    res = router.match('PUT', '/hello')
+    expect(res).toBeNull()
+
+    res = router.match('GET', '/')
+    expect(res).toBeNull()
+  })
+})
+
+describe('Multi match', () => {
+  describe('Blog', () => {
+    const router = new StaticRouter<string>()
+
+    router.add('ALL', '*', 'middleware a')
+    router.add('GET', '*', 'middleware b')
+    router.add('GET', '/entry', 'get entries')
+    it('GET /', async () => {
+      const res = router.match('GET', '/')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a', 'middleware b'])
+    })
+    it('GET /entry', async () => {
+      const res = router.match('GET', '/entry')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a', 'middleware b', 'get entries'])
+    })
+    it('DELETE /entry', async () => {
+      const res = router.match('DELETE', '/entry')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a'])
+    })
+  })
+})

--- a/src/router/static-router/router.ts
+++ b/src/router/static-router/router.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { Router, Result } from '../../router'
+import { METHOD_NAME_ALL, METHODS, UnsupportedPathError } from '../../router'
+
+export class StaticRouter<T> implements Router<T> {
+  middleware: Record<string, Result<T>>
+  routes: Record<string, Record<string, Result<T>>>
+
+  constructor() {
+    this.middleware = {}
+
+    this.routes = {} as StaticRouter<T>['routes']
+    ;[METHOD_NAME_ALL, ...METHODS].forEach((method) => {
+      this.routes[method.toUpperCase()] = {}
+    })
+  }
+
+  add(method: string, path: string, handler: T) {
+    const { middleware, routes } = this
+
+    if (path === '/*') {
+      path = '*'
+    }
+
+    if (path === '*') {
+      if (method === METHOD_NAME_ALL) {
+        middleware[METHOD_NAME_ALL] ||= { handlers: [], params: {} }
+        Object.keys(middleware).forEach((m) => {
+          middleware[m].handlers.push(handler)
+        })
+        Object.keys(routes).forEach((m) => {
+          Object.values(routes[m]).forEach((matchRes) => matchRes.handlers.push(handler))
+        })
+      } else {
+        middleware[method] ||= {
+          handlers: [...(middleware[METHOD_NAME_ALL]?.handlers || [])],
+          params: {},
+        }
+        middleware[method].handlers.push(handler)
+        if (routes[method]) {
+          Object.values(routes[method]).forEach((matchRes) => matchRes.handlers.push(handler))
+        }
+      }
+      return
+    }
+
+    if (/\*|\/:/.test(path)) {
+      throw new UnsupportedPathError(path)
+    }
+
+    routes[method][path] ||= {
+      handlers: [
+        ...(routes[METHOD_NAME_ALL][path]?.handlers ||
+          middleware[method]?.handlers ||
+          middleware[METHOD_NAME_ALL]?.handlers ||
+          []),
+      ],
+      params: {},
+    }
+    if (method === METHOD_NAME_ALL) {
+      Object.keys(routes).forEach((m) => {
+        routes[m][path]?.handlers?.push(handler)
+      })
+    } else {
+      routes[method][path].handlers.push(handler)
+    }
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    const { routes, middleware } = this
+
+    this.match = (method, path) =>
+      routes[method][path] ||
+      routes[METHOD_NAME_ALL][path] ||
+      middleware[method] ||
+      middleware[METHOD_NAME_ALL] ||
+      null
+
+    return this.match(method, path)
+  }
+}


### PR DESCRIPTION
### Motivation

I think it would be difficult for users to take advantage of the "hono has two routers and the optional RegExpRouter is faster."
This PR changes this to "By default, the best router is selected based on the routing of the application."


### StaticRouter

StaticRouter is a new alternative. Works fast when there is no path to receive parameters.
I think that this is not a router for benchmarking purposes, and that it could be used in the real world as follows

```ts
app.use('*', logger(), cors())
app.use(
  '/graphql',
  graphqlServer({
    schema,
    rootResolver,
  })
)
```

However, when benchmarked, there did not appear to be a significant difference with RegExpRouter in nodejs.
If it is a bun, there may be a little difference, but there may not be.

I think this StaticRouter is a good example of the use of SmartRouter, but may not be necessary for hono.


### SmartRouter

This is a router that finds the best one for routing from several possible routers and invoke it when `match` is called.


### Side effects of merging this

* All routers are bundled by default, which increases the bundle size.
* Slightly longer spinup time.
* Makes debugging routers more difficult.

### Benchmark

#### with path parameters

https://gist.github.com/usualoma/6d8db87c9f40614073b0517dc3e8cee6

```
hono - smart x 267,322 ops/sec ±5.61% (77 runs sampled)
hono - smart - trie-router x 230,474 ops/sec ±5.72% (81 runs sampled)
hono - smart - regexp-router x 267,080 ops/sec ±5.65% (68 runs sampled)
hono - trie-router x 223,486 ops/sec ±5.05% (84 runs sampled)
hono - regexp-router x 262,344 ops/sec ±6.61% (77 runs sampled)
Fastest is hono - smart,hono - smart - regexp-router,hono - regexp-router
```

#### without path parameters

https://gist.github.com/usualoma/0b86e02ee9f3a16dd8e5af77f479624c

```
hono - smart - trie-router x 276,017 ops/sec ±6.15% (77 runs sampled)
hono - smart - regexp-router x 298,234 ops/sec ±6.67% (75 runs sampled)
hono - smart - static-router x 296,272 ops/sec ±6.79% (63 runs sampled)
hono - trie-router x 267,239 ops/sec ±6.06% (81 runs sampled)
hono - regexp-router x 303,253 ops/sec ±5.80% (82 runs sampled)
Fastest is hono - regexp-router,hono - smart - regexp-router,hono - smart - static-router
```

#### bun - RegExpRouter

```ts
import { Hono } from './src/index'
import { RegExpRouter } from './src/router/reg-exp-router'

const app = new Hono({ router: new RegExpRouter() })

app.get('/posts', (c) => c.text('foo'))

export default app
```

```
$ ./bombardier -c 200 -d 20s http://10.1.0.139:3000/posts
Bombarding http://10.1.0.139:3000/posts for 20s using 200 connection(s)
[==========================================================================] 20s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     72705.89    1742.91   75809.44
  Latency        2.75ms    86.69us    10.99ms
  HTTP codes:
    1xx - 0, 2xx - 1454123, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    10.40MB/s
```


#### bun - SmartRouter - StaticRouter

```ts
import { Hono } from './src/index'
import { SmartRouter } from './src/router/smart-router'
import { StaticRouter } from './src/router/static-router'

const app = new Hono({
  router:
    new SmartRouter({
      routers: [new StaticRouter()],
    })
})

app.get('/posts', (c) => c.text('foo'))

export default app
```

```
$ ./bombardier -c 200 -d 20s http://10.1.0.139:3000/posts
Bombarding http://10.1.0.139:3000/posts for 20s using 200 connection(s)
[==========================================================================] 20s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     74691.57    1911.30   80312.78
  Latency        2.68ms    97.25us    10.77ms
  HTTP codes:
    1xx - 0, 2xx - 1493610, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    10.68MB/s
```