### PR TITLE
Feat: data passing in context

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -143,6 +143,11 @@ describe('Context', () => {
     expect(res.headers.get('foo')).not.toBeNull()
     expect(res.headers.get('foo')).toBe('bar')
   })
+
+  it('should support data passing', async () => {
+    c = new HonoContext(req, undefined, undefined, undefined, { foo: 'bar' })
+    expect(c.data.foo).toBe('bar')
+  })
 })
 
 describe('Context header', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,13 +10,15 @@ export type Data = string | ArrayBuffer | ReadableStream
 
 export interface Context<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = any
+  E extends Partial<Environment> = any,
+  CustomData extends Record<string, any> = Record<string, any>
 > {
   req: Request<RequestParamKeyType>
   env: E['Bindings']
   event: FetchEvent
   executionCtx: ExecutionContext
   finalized: boolean
+  data: CustomData
 
   get res(): Response
   set res(_res: Response)
@@ -45,12 +47,14 @@ export interface Context<
 
 export class HonoContext<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = Environment
+  E extends Partial<Environment> = Environment,
+  CustomData extends Record<string, any> = Record<string, any>
 > implements Context<RequestParamKeyType, E>
 {
   req: Request<RequestParamKeyType>
   env: E['Bindings']
   finalized: boolean
+  data: CustomData
 
   _status: StatusCode = 200
   private _executionCtx: FetchEvent | ExecutionContext | undefined
@@ -65,11 +69,13 @@ export class HonoContext<
     req: Request,
     env: E['Bindings'] | undefined = undefined,
     executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
-    notFoundHandler: NotFoundHandler = () => new Response()
+    notFoundHandler: NotFoundHandler = () => new Response(),
+    data: CustomData = {} as CustomData
   ) {
     this._executionCtx = executionCtx
     this.req = req
     this.env = env || ({} as Bindings)
+    this.data = data
 
     this.notFoundHandler = notFoundHandler
     this.finalized = false

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -18,9 +18,10 @@ export type Environment = {
 
 export type Handler<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = Environment
+  E extends Partial<Environment> = Environment,
+  CustomData extends Record<string, any> = Record<string, any>
 > = (
-  c: Context<RequestParamKeyType, E>,
+  c: Context<RequestParamKeyType, E, CustomData>,
   next: Next
 ) => Response | Promise<Response> | Promise<void> | Promise<Response | undefined>
 


### PR DESCRIPTION
This allows users to type and create their own data, which is passed through middleware. This can be useful for things like https://npmjs.com/package/d1-orm, where the library is initialised in the first middleware, and then can't be used as easily in routes past that without doing something like editing the Env object.