### PR TITLE
docs(readme): update discord invite url

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/honojs/hono)](https://github.com/honojs/hono/pulse)
 [![GitHub last commit](https://img.shields.io/github/last-commit/honojs/hono)](https://github.com/honojs/hono/commits/main)
 [![Deno badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fhono%2Fmod.ts)](https://doc.deno.land/https/deno.land/x/hono/mod.ts)
-[![Discord badge](https://img.shields.io/discord/1011308539819597844?label=Discord&logo=Discord)](https://discord.gg/KVYKWmfD)
+[![Discord badge](https://img.shields.io/discord/1011308539819597844?label=Discord&logo=Discord)](https://discord.gg/KMh2eNSdxV)
 
 Hono - _**[炎] means flame🔥 in Japanese**_ - is a small, simple, and ultrafast web framework for Cloudflare Workers, Deno, Bun, and others.
 
@@ -66,7 +66,7 @@ Migration guide is available on [docs/MIGRATION.md](docs/MIGRATION.md).
 
 ## Communication
 
-[Twitter](https://twitter.com/honojs) and [Discord channel](https://discord.gg/KVYKWmfD) are available.
+[Twitter](https://twitter.com/honojs) and [Discord channel](https://discord.gg/KMh2eNSdxV) are available.
 
 ## Contributing
 


### PR DESCRIPTION
The Discord invite url in the readme.md is invalid.

valid invite url: https://discord.gg/KMh2eNSdxV
invalid invite url in the readme.md: https://discord.gg/KVYKWmfD
![image](https://user-images.githubusercontent.com/1294640/190174440-0cab20af-8ea3-478b-a588-4c566a06026e.png)

I found the valid url from the comment [here](https://github.com/honojs/hono/issues/483#issuecomment-1227848565).
https://github.com/honojs/hono/issues/483#issuecomment-1227848565