### PR TITLE
feat(cors): allow multiple origins

### DIFF
--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -21,7 +21,7 @@
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/honojs/hono)](https://github.com/honojs/hono/pulse)
 [![GitHub last commit](https://img.shields.io/github/last-commit/honojs/hono)](https://github.com/honojs/hono/commits/main)
 [![Deno badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fhono%2Fmod.ts)](https://doc.deno.land/https/deno.land/x/hono/mod.ts)
-[![Discord badge](https://img.shields.io/discord/1011308539819597844?label=Discord&logo=Discord)](https://discord.gg/KVYKWmfD)
+[![Discord badge](https://img.shields.io/discord/1011308539819597844?label=Discord&logo=Discord)](https://discord.gg/KMh2eNSdxV)
 
 Hono - _**[炎] means flame🔥 in Japanese**_ - is a small, simple, and ultrafast web framework for Cloudflare Workers, Deno, Bun, and others.
 
@@ -66,7 +66,7 @@ Migration guide is available on [docs/MIGRATION.md](docs/MIGRATION.md).
 
 ## Communication
 
-[Twitter](https://twitter.com/honojs) and [Discord channel](https://discord.gg/KVYKWmfD) are available.
+[Twitter](https://twitter.com/honojs) and [Discord channel](https://discord.gg/KMh2eNSdxV) are available.
 
 ## Contributing
 

--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -1,7 +1,8 @@
 import type { MiddlewareHandler } from '../../hono.ts'
+import { getDomainFromURL } from '../../utils/url.ts'
 
 type CORSOptions = {
-  origin: string
+  origin: string | string[]
   allowMethods?: string[]
   allowHeaders?: string[]
   maxAge?: number
@@ -28,7 +29,28 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       c.res.headers.append(key, value)
     }
 
-    set('Access-Control-Allow-Origin', opts.origin)
+    if (typeof opts.origin === 'string') {
+      set('Access-Control-Allow-Origin', opts.origin)
+    } else {
+      const length = opts.origin.length
+      if (length) {
+        let origin = opts.origin[0]
+        const referer = c.req.headers.get('referer')
+        if (referer) {
+          const domain = getDomainFromURL(referer)
+          if (domain) {
+            for (let i = 0; i < length; i++) {
+              const optDomain = getDomainFromURL(opts.origin[i])
+              if (optDomain && optDomain === domain) {
+                origin = opts.origin[i]
+                break
+              }
+            }
+          }
+        }
+        set('Access-Control-Allow-Origin', origin)
+      }
+    }
 
     // Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard).
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -19,6 +19,14 @@ export const validator = {
     return true
   },
 
+  isBoolean(value: unknown): boolean {
+    return typeof value === 'boolean'
+  },
+
+  isNumber(value: unknown): boolean {
+    return typeof value === 'number'
+  },
+
   isFalsy(value: unknown): boolean {
     return !value
   },
@@ -79,7 +87,7 @@ export const validator = {
     return value.split(elem).length > options.minOccurrences
   },
 
-  equals(value: string, comparison: string): boolean {
+  equals(value: unknown, comparison: unknown): boolean {
     return value === comparison
   },
 

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -50,6 +50,14 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
   return result
 }
 
+export const getDomainFromURL = (url: string): string | null => {
+  const match = url.match(/^https?:\/\/([a-zA-Z0-9\-\.:]+)(:?\/|\#)?/)
+  if (match) {
+    return match[1]
+  }
+  return null
+}
+
 export const getQueryStringFromURL = (url: string): string => {
   const queryIndex = url.indexOf('?')
   const result = queryIndex !== -1 ? url.substring(queryIndex) : ''

--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -17,10 +17,20 @@ describe('CORS by Middleware', () => {
     })
   )
 
+  app.use(
+    '/api3/*',
+    cors({
+      origin: ['http://example.com', 'http://example.org', 'http://example.dev'],
+    })
+  )
+
   app.all('/api/abc', (c) => {
     return c.json({ success: true })
   })
   app.all('/api2/abc', (c) => {
+    return c.json({ success: true })
+  })
+  app.all('/api3/abc', (c) => {
     return c.json({ success: true })
   })
 
@@ -65,5 +75,27 @@ describe('CORS by Middleware', () => {
     ])
     expect(res.headers.get('Access-Control-Max-Age')).toBe('600')
     expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+  })
+
+  it('Allow multiple origins', async () => {
+    let req = new Request('http://localhost/api3/abc', {
+      headers: {
+        Referer: 'http://example.org/',
+      },
+    })
+    let res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.org')
+
+    req = new Request('http://localhost/api3/abc')
+    res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+
+    req = new Request('http://localhost/api3/abc', {
+      headers: {
+        Referer: 'http://example.net/',
+      },
+    })
+    res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
   })
 })

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -12,6 +12,16 @@ describe('Test the validator rules', () => {
     expect(validator.optional).toBeTruthy()
   })
 
+  test('isBoolean', () => {
+    expect(validator.isBoolean(true)).toBeTruthy()
+    expect(validator.isBoolean('abc')).toBeFalsy()
+  })
+
+  test('isNumber', () => {
+    expect(validator.isNumber(123)).toBeTruthy()
+    expect(validator.isNumber('123')).toBeFalsy()
+  })
+
   test('isFalsy', () => {
     expect(validator.isFalsy(undefined)).toBeTruthy()
     expect(validator.isFalsy(0)).toBeTruthy()
@@ -78,6 +88,8 @@ describe('Test the validator rules', () => {
   test('equals', () => {
     expect(validator.equals('foo', 'foo')).toBeTruthy()
     expect(validator.equals('foo', 'bar')).toBeFalsy()
+    expect(validator.equals(123, 123)).toBeTruthy()
+    expect(validator.equals(123, '123')).toBeFalsy()
   })
 
   test('isIn', () => {

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -19,6 +19,14 @@ export const validator = {
     return true
   },
 
+  isBoolean(value: unknown): boolean {
+    return typeof value === 'boolean'
+  },
+
+  isNumber(value: unknown): boolean {
+    return typeof value === 'number'
+  },
+
   isFalsy(value: unknown): boolean {
     return !value
   },
@@ -79,7 +87,7 @@ export const validator = {
     return value.split(elem).length > options.minOccurrences
   },
 
-  equals(value: string, comparison: string): boolean {
+  equals(value: unknown, comparison: unknown): boolean {
     return value === comparison
   },
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -5,6 +5,7 @@ import {
   isAbsoluteURL,
   mergePath,
   getQueryStringFromURL,
+  getDomainFromURL,
 } from './url'
 
 describe('url', () => {
@@ -65,6 +66,17 @@ describe('url', () => {
       expect(path).toBe('/hello')
       path = getPathFromURL('https://example.com/hello/hey/', false)
       expect(path).toBe('/hello/hey')
+    })
+
+    it('getDomainFromURL', () => {
+      let domain = getDomainFromURL('https://example.com/hello/')
+      expect(domain).toBe('example.com')
+      domain = getDomainFromURL('https://example.com/')
+      expect(domain).toBe('example.com')
+      domain = getDomainFromURL('https://example.com')
+      expect(domain).toBe('example.com')
+      domain = getDomainFromURL('https://example.com#fragment')
+      expect(domain).toBe('example.com')
     })
   })
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -50,6 +50,14 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
   return result
 }
 
+export const getDomainFromURL = (url: string): string | null => {
+  const match = url.match(/^https?:\/\/([a-zA-Z0-9\-\.:]+)(:?\/|\#)?/)
+  if (match) {
+    return match[1]
+  }
+  return null
+}
+
 export const getQueryStringFromURL = (url: string): string => {
   const queryIndex = url.indexOf('?')
   const result = queryIndex !== -1 ? url.substring(queryIndex) : ''


### PR DESCRIPTION
In this RP, it allows multiple origins on CORS middleware.

```ts
app.use(
 '*',
 cors({
   origin: ['https://example.com', 'https://example.org'],
   //...
 })
)
```

This middleware responds with the correct origin based on the `Referer` header. Falling back to origin[0] if it is empty or none.

Close #503