### PR TITLE
feat: another idea of Validator Middleware

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,4 +1,10 @@
-import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono.ts'
+import type {
+  Environment,
+  NotFoundHandler,
+  ContextVariableMap,
+  Bindings,
+  ValidatedData,
+} from './hono.ts'
 import { defaultNotFoundMessage } from './hono.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
@@ -10,9 +16,10 @@ export type Data = string | ArrayBuffer | ReadableStream
 
 export interface Context<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = any
+  E extends Partial<Environment> = any,
+  D extends ValidatedData = ValidatedData
 > {
-  req: Request<RequestParamKeyType>
+  req: Request<RequestParamKeyType, D>
   env: E['Bindings']
   event: FetchEvent
   executionCtx: ExecutionContext
@@ -45,10 +52,11 @@ export interface Context<
 
 export class HonoContext<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = Environment
-> implements Context<RequestParamKeyType, E>
+  E extends Partial<Environment> = Environment,
+  D extends ValidatedData = ValidatedData
+> implements Context<RequestParamKeyType, E, D>
 {
-  req: Request<RequestParamKeyType>
+  req: Request<RequestParamKeyType, D>
   env: E['Bindings']
   finalized: boolean
 
@@ -62,13 +70,13 @@ export class HonoContext<
   private notFoundHandler: NotFoundHandler<E>
 
   constructor(
-    req: Request,
+    req: Request<RequestParamKeyType>,
     env: E['Bindings'] | undefined = undefined,
     executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
     notFoundHandler: NotFoundHandler<E> = () => new Response()
   ) {
     this._executionCtx = executionCtx
-    this.req = req
+    this.req = req as Request<RequestParamKeyType, D>
     this.env = env || ({} as Bindings)
 
     this.notFoundHandler = notFoundHandler

--- a/deno_dist/middleware/validator/index.ts
+++ b/deno_dist/middleware/validator/index.ts
@@ -1,5 +1,2 @@
 import { validatorMiddleware } from './middleware.ts'
-import { validator } from './validator.ts'
-
-const validation = validatorMiddleware<typeof validator>(validator)
-export { validation }
+export { validatorMiddleware as validator }

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -1,214 +1,72 @@
 import type { Context } from '../../context.ts'
-import type { MiddlewareHandler } from '../../hono.ts'
-import { JSONPathCopy } from '../../utils/json.ts'
+import type { Environment, Handler } from '../../hono.ts'
+import { Validator } from './validator.ts'
+import type { VBase, VString, VNumber, VBoolean, VObject, ValidateResult } from './validator.ts'
 
-type Param =
-  | string
-  | number
-  | string[]
-  | number[]
-  | Record<string, string | number>
-  | ValidatorMessage
-type Rule = Function | [Function, ...Param[]]
-type Rules = Rule | Rule[]
-type Done = (resultSet: ResultSet, context: Context) => Response | void
+type ValidationFunction<T> = (v: Validator, c: Context) => T
 
-type RuleSet = {
-  body: Record<string, Rules>
-  json: Record<string, Rules>
-  header: Record<string, Rules>
-  query: Record<string, Rules>
-  done: Done
-  removeAdditional: boolean
+type Schema = Record<string, VString | VNumber | VBoolean | VObject>
+type SchemaToProp<T> = {
+  [K in keyof T]: T[K] extends VBase
+    ? T[K]['type'] extends 'number'
+      ? number
+      : T[K]['type'] extends 'boolean'
+      ? boolean
+      : T[K]['type'] extends 'string'
+      ? string
+      : never
+    : never
 }
 
 type ResultSet = {
   hasError: boolean
   messages: string[]
+  results: ValidateResult[]
 }
 
-type Result = {
-  rule: Function
-  params: Param[]
-  message?: string
-}
+type Done = (resultSet: ResultSet, context: Context) => Response | void
 
-export class ValidatorMessage {
-  value: string
-  constructor(value: string) {
-    this.value = value
-  }
-  getMessage(): string {
-    return this.value
-  }
-}
+export const validatorMiddleware = <T extends Schema>(
+  validationFunction: ValidationFunction<T>,
+  options?: { done?: Done }
+) => {
+  const v = new Validator()
 
-const message = (value: string): ValidatorMessage => {
-  return new ValidatorMessage(value)
-}
-
-export const validatorMiddleware = <Validator>(validator: Validator) => {
-  return (
-    validatorFunction: (
-      validator: Validator,
-      message: (value: string) => ValidatorMessage,
-      context: Context
-    ) => Partial<RuleSet>
-  ): MiddlewareHandler => {
-    return async (c, next) => {
-      const validations = validatorFunction(validator, message, c)
-
-      const result: ResultSet = {
-        hasError: false,
-        messages: [],
-      }
-
-      const v = validations
-      v.removeAdditional = v.removeAdditional === undefined ? true : v.removeAdditional // default value is `true`
-
-      function validate(rules: Rules, value: string, messageFunc: (ruleName: string) => string) {
-        value ||= ''
-
-        let count = 0
-        const results: Result[] = []
-
-        const check = (rules: Rules) => {
-          if (!Array.isArray(rules)) {
-            if (rules instanceof ValidatorMessage) {
-              if (results[count - 1]) {
-                results[count - 1].message = rules.getMessage()
-              }
-            } else if (typeof rules === 'function') {
-              results[count] = {
-                rule: rules,
-                params: [],
-              }
-              count++
-            } else {
-              results[count - 1].params.push(rules)
-            }
-          } else {
-            if (typeof rules[0] === ('string' || 'number')) {
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              results[count - 1].params.push(rules)
-            } else {
-              for (const rule of rules) {
-                check(rule as Rules)
-              }
-            }
-          }
-        }
-        check(rules)
-
-        let invalid = false
-        results.map((r) => {
-          const ok = r.rule(value, ...r.params)
-          if (!invalid && ok === false) {
-            invalid = true
-            if (r.message) {
-              result.messages.push(r.message)
-            } else {
-              result.messages.push(messageFunc(r.rule.name))
-            }
-          }
-          if (typeof ok !== 'boolean') {
-            // ok is sanitized string
-            value = ok
-          }
-        })
-
-        if (invalid) {
-          result.hasError = true
-          return
-        }
-      }
-
-      if (v.query) {
-        const query = v.query
-        const realQueries = c.req.query()
-        const validatedQueries: Record<string, string> = {}
-
-        Object.keys(query).map((key) => {
-          validatedQueries[key] = realQueries[key] || ''
-          const message = (name: string) =>
-            `Invalid Value: the query parameter "${key}" is invalid - ${name}`
-          validate(query[key], validatedQueries[key], message)
-        })
-        if (!result.hasError && v.removeAdditional) {
-          c.req.queryData = validatedQueries
-        }
-      }
-
-      if (v.header) {
-        const header = v.header
-        const realHeaders: Record<string, string> = {}
-        for (const key of c.req.headers.keys()) {
-          realHeaders[key] = c.req.headers.get(key) || ''
-        }
-        const validatedHeaders: Record<string, string> = {}
-
-        Object.keys(header).map((key) => {
-          validatedHeaders[key] = realHeaders[key] || ''
-          const message = (name: string) =>
-            `Invalid Value: the request header "${key}" is invalid - ${name}`
-          validate(header[key], validatedHeaders[key], message)
-        })
-        if (!result.hasError && v.removeAdditional) {
-          c.req.headerData = validatedHeaders
-        }
-      }
-
-      if (v.body) {
-        const field = v.body
-        const parsedBody = (await c.req.parseBody()) as Record<string, string>
-        const kv = { ...parsedBody }
-        const validatedKv: Record<string, string> = {}
-
-        Object.keys(field).map(async (key) => {
-          validatedKv[key] = kv[key] || ''
-          const message = (name: string) =>
-            `Invalid Value: the request body "${key}" is invalid - ${name}`
-          validate(field[key], validatedKv[key], message)
-        })
-        if (!result.hasError && v.removeAdditional) {
-          c.req.bodyData = validatedKv
-        }
-      }
-
-      if (v.json) {
-        const field = v.json
-        let json: object
-        try {
-          json = await c.req.json()
-        } catch {
-          json = {}
-        }
-        const validatedJson: object = new (json as any).constructor()
-
-        Object.keys(field).map(async (key) => {
-          const value = JSONPathCopy(json, validatedJson, key)
-          const message = (name: string) =>
-            `Invalid Value: the JSON body "${key}" is invalid - ${name}`
-          validate(field[key], value, message)
-        })
-
-        if (!result.hasError && v.removeAdditional) {
-          c.req.jsonData = validatedJson
-        }
-      }
-
-      if (v.done) {
-        const res = v.done(result, c)
-        if (res) {
-          return res
-        }
-      }
-
-      if (result.hasError) {
-        return c.text(result.messages.join('\n'), 400)
-      }
-      await next()
+  const handler: Handler<string, Environment, SchemaToProp<T>> = async (c, next) => {
+    const resultSet: ResultSet = {
+      hasError: false,
+      messages: [],
+      results: [],
     }
+
+    const schema = validationFunction(v, c)
+
+    for (const key of Object.keys(schema)) {
+      const validator = schema[key]
+      const result = await validator.validate(c.req)
+      if (result.isValid) {
+        // Set data on request object
+        c.req.valid(key, result.value)
+      } else {
+        resultSet.hasError = true
+        if (result.message !== undefined) {
+          resultSet.messages.push(result.message)
+        }
+      }
+      resultSet.results.push(result)
+    }
+
+    if (options && options.done) {
+      const res = options.done(resultSet, c)
+      if (res) {
+        return res
+      }
+    }
+
+    if (resultSet.hasError) {
+      return c.text(resultSet.messages.join('\n'), 400)
+    }
+    await next()
   }
+  return handler
 }

--- a/deno_dist/middleware/validator/rule.ts
+++ b/deno_dist/middleware/validator/rule.ts
@@ -1,0 +1,83 @@
+// Some validation rules is are based on Validator.js
+// Validator.js
+// License (MIT)
+// Copyright (c) 2018 Chris O'Hara <cohara87@gmail.com>
+// https://github.com/validatorjs/validator.js
+
+export const rule = {
+  // string
+  isEmpty(
+    value: string,
+    options: {
+      ignore_whitespace: boolean
+    } = { ignore_whitespace: false }
+  ): boolean {
+    return (options.ignore_whitespace ? value.trim().length : value.length) === 0
+  },
+
+  isLength: (
+    value: string,
+    options: Partial<{ min: number; max: number }> | number,
+    arg2?: number
+  ) => {
+    let min: number
+    let max: number | undefined
+    if (typeof options === 'object') {
+      min = options.min || 0
+      max = options.max
+    } else {
+      // backwards compatibility: isLength(str, min [, max])
+      min = options || 0
+      max = arg2
+    }
+    const presentationSequences = value.match(/(\uFE0F|\uFE0E)/g) || []
+    const surrogatePairs = value.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || []
+    const len = value.length - presentationSequences.length - surrogatePairs.length
+    return len >= min && (typeof max === 'undefined' || len <= max)
+  },
+
+  isAlpha: (value: string): boolean => {
+    return value.match(/^[A-Z]+$/i) ? true : false
+  },
+
+  isNumeric: (value: string): boolean => {
+    return value.match(/^[0-9]+$/) ? true : false
+  },
+
+  contains: (
+    value: string,
+    elem: string,
+    options: Partial<{ ignoreCase: boolean; minOccurrences: number }> = {
+      ignoreCase: false,
+      minOccurrences: 1,
+    }
+  ): boolean => {
+    options.ignoreCase ||= false
+    options.minOccurrences ||= 1
+    if (options.ignoreCase) {
+      return value.toLowerCase().split(elem.toLowerCase()).length > options.minOccurrences
+    }
+    return value.split(elem).length > options.minOccurrences
+  },
+
+  isIn: (value: string, options: string[]): boolean => {
+    if (typeof options === 'object') {
+      for (const elem of options) {
+        if (elem === value) return true
+      }
+    }
+    return false
+  },
+
+  match: (value: string, regExp: RegExp): boolean => {
+    return value.match(regExp) ? true : false
+  },
+
+  // number
+  isGte: (value: number, min: number) => min <= value,
+  isLte: (value: number, max: number) => value <= max,
+
+  // boolean
+  isTrue: (value: boolean) => value === true,
+  isFalse: (value: boolean) => value === false,
+}

--- a/deno_dist/middleware/validator/rule.ts
+++ b/deno_dist/middleware/validator/rule.ts
@@ -37,11 +37,11 @@ export const rule = {
   },
 
   isAlpha: (value: string): boolean => {
-    return value.match(/^[A-Z]+$/i) ? true : false
+    return /^[A-Z]+$/i.test(value)
   },
 
   isNumeric: (value: string): boolean => {
-    return value.match(/^[0-9]+$/) ? true : false
+    return /^[0-9]+$/.test(value)
   },
 
   contains: (
@@ -70,7 +70,7 @@ export const rule = {
   },
 
   match: (value: string, regExp: RegExp): boolean => {
-    return value.match(regExp) ? true : false
+    return regExp.test(value)
   },
 
   // number

--- a/deno_dist/middleware/validator/sanitizer.ts
+++ b/deno_dist/middleware/validator/sanitizer.ts
@@ -1,0 +1,3 @@
+export const sanitizer = {
+  trim: (value: string) => value.trim(),
+}

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -22,6 +22,12 @@ export type ValidateResult = {
   value: Type
 }
 
+type VOption = {
+  target: Target
+  key: string
+  type?: 'string' | 'number' | 'boolean' | 'object'
+}
+
 export abstract class VBase {
   type: 'string' | 'number' | 'boolean' | 'object'
   target: Target
@@ -30,11 +36,7 @@ export abstract class VBase {
   sanitizers: Sanitizer[]
   private _message: string | undefined
 
-  constructor(option: {
-    target: Target
-    key: string
-    type?: 'string' | 'number' | 'boolean' | 'object'
-  }) {
+  constructor(option: VOption) {
     this.target = option.target
     this.key = option.key
     this.type = option.type || 'string'
@@ -71,19 +73,16 @@ export abstract class VBase {
 
   asNumber = () => {
     const newVNumber = new VNumber(this)
-    newVNumber.type = 'number'
     return newVNumber
   }
 
   asBoolean = () => {
     const newVBoolean = new VBoolean(this)
-    newVBoolean.type = 'boolean'
     return newVBoolean
   }
 
   asObject = () => {
     const newVObject = new VObject(this)
-    newVObject.type = 'object'
     return newVObject
   }
 
@@ -164,7 +163,10 @@ export abstract class VBase {
 }
 
 export class VString extends VBase {
-  type!: 'string'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'string'
+  }
 
   isEmpty = (
     options: {
@@ -210,7 +212,10 @@ export class VString extends VBase {
 }
 
 export class VNumber extends VBase {
-  type!: 'number'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'number'
+  }
 
   isGte = (min: number) => {
     return this.addRule((value) => rule.isGte(value as number, min))
@@ -222,7 +227,10 @@ export class VNumber extends VBase {
 }
 
 export class VBoolean extends VBase {
-  type!: 'boolean'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'boolean'
+  }
 
   isTrue = () => {
     return this.addRule((value) => rule.isTrue(value as boolean))
@@ -234,5 +242,8 @@ export class VBoolean extends VBase {
 }
 
 export class VObject extends VBase {
-  type!: 'object'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'object'
+  }
 }

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -22,7 +22,7 @@ export type ValidateResult = {
   value: Type
 }
 
-type VOption = {
+type VOptions = {
   target: Target
   key: string
   type?: 'string' | 'number' | 'boolean' | 'object'
@@ -36,10 +36,10 @@ export abstract class VBase {
   sanitizers: Sanitizer[]
   private _message: string | undefined
 
-  constructor(option: VOption) {
-    this.target = option.target
-    this.key = option.key
-    this.type = option.type || 'string'
+  constructor(options: VOptions) {
+    this.target = options.target
+    this.key = options.key
+    this.type = options.type || 'string'
     this.rules = []
     this.sanitizers = []
   }
@@ -163,8 +163,8 @@ export abstract class VBase {
 }
 
 export class VString extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'string'
   }
 
@@ -212,8 +212,8 @@ export class VString extends VBase {
 }
 
 export class VNumber extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'number'
   }
 
@@ -227,8 +227,8 @@ export class VNumber extends VBase {
 }
 
 export class VBoolean extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'boolean'
   }
 
@@ -242,8 +242,8 @@ export class VBoolean extends VBase {
 }
 
 export class VObject extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'object'
   }
 }

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -1,107 +1,238 @@
-// Some validation rules is are based on Validator.js
-// Validator.js
-// License (MIT)
-// Copyright (c) 2018 Chris O'Hara <cohara87@gmail.com>
-// https://github.com/validatorjs/validator.js
+import { JSONPath } from '../../utils/json.ts'
+import { rule } from './rule.ts'
+import { sanitizer } from './sanitizer.ts'
 
-const isString = (value: any) => {
-  return typeof value === 'string'
+type Target = 'query' | 'header' | 'body' | 'json'
+type Type = string | number | boolean | object | undefined
+type Rule = (value: Type) => boolean
+type Sanitizer = (value: Type) => Type
+
+export class Validator {
+  query = (key: string): VString => new VString({ target: 'query', key: key })
+  header = (key: string): VString => new VString({ target: 'header', key: key })
+  body = (key: string): VString => new VString({ target: 'body', key: key })
+  json = (key: string): VString => new VString({ target: 'json', key: key })
 }
 
-export const validator = {
-  required(value: unknown): boolean {
-    if (value === undefined) return false
-    if (isString(value) && value === '') return false
+export type ValidateResult = {
+  isValid: boolean
+  message: string | undefined
+  target: Target
+  key: string
+  value: Type
+}
+
+export abstract class VBase {
+  type: 'string' | 'number' | 'boolean' | 'object'
+  target: Target
+  key: string
+  rules: Rule[]
+  sanitizers: Sanitizer[]
+  private _message: string | undefined
+
+  constructor(option: {
+    target: Target
+    key: string
+    type?: 'string' | 'number' | 'boolean' | 'object'
+  }) {
+    this.target = option.target
+    this.key = option.key
+    this.type = option.type || 'string'
+    this.rules = []
+    this.sanitizers = []
+  }
+
+  addRule = (rule: Rule) => {
+    this.rules.push(rule)
+    return this
+  }
+
+  addSanitizer = (sanitizer: Sanitizer) => {
+    this.sanitizers.push(sanitizer)
+    return this
+  }
+
+  isRequired = () => {
+    return this.addRule((value: unknown) => {
+      if (value) return true
+      return false
+    })
+  }
+
+  isOptional = () => {
+    return this.addRule(() => true)
+  }
+
+  isEqual = (comparison: unknown) => {
+    return this.addRule((value: unknown) => {
+      return value === comparison
+    })
+  }
+
+  asNumber = () => {
+    const newVNumber = new VNumber(this)
+    newVNumber.type = 'number'
+    return newVNumber
+  }
+
+  asBoolean = () => {
+    const newVBoolean = new VBoolean(this)
+    newVBoolean.type = 'boolean'
+    return newVBoolean
+  }
+
+  asObject = () => {
+    const newVObject = new VObject(this)
+    newVObject.type = 'object'
+    return newVObject
+  }
+
+  message(value: string) {
+    this._message = value
+    return this
+  }
+
+  validate = async (req: Request): Promise<ValidateResult> => {
+    const result: ValidateResult = {
+      isValid: true,
+      message: undefined,
+      target: this.target,
+      key: this.key,
+      value: undefined,
+    }
+
+    let value: Type = undefined
+    if (this.target === 'query') {
+      value = req.query(this.key)
+    }
+    if (this.target === 'header') {
+      value = req.header(this.key)
+    }
+    if (this.target === 'body') {
+      const body = await req.parseBody()
+      value = body[this.key]
+    }
+    if (this.target === 'json') {
+      const obj = await req.json()
+      value = JSONPath(obj, this.key)
+    }
+
+    result.value = value
+    result.isValid = this.validateValue(value)
+
+    if (result.isValid == false) {
+      if (this._message) {
+        result.message = this._message
+      } else {
+        switch (this.target) {
+          case 'query':
+            result.message = `Invalid Value: the query parameter "${this.key}" is invalid - ${value}`
+            break
+          case 'header':
+            result.message = `Invalid Value: the request header "${this.key}" is invalid - ${value}`
+            break
+          case 'body':
+            result.message = `Invalid Value: the request body "${this.key}" is invalid - ${value}`
+            break
+          case 'json':
+            result.message = `Invalid Value: the JSON body "${this.key}" is invalid - ${value}`
+            break
+        }
+      }
+    }
+    return result
+  }
+
+  private validateValue = (value: Type): boolean => {
+    // Check type
+    if (typeof value !== this.type) {
+      return false
+    }
+
+    // Sanitize
+    for (const sanitizer of this.sanitizers) {
+      value = sanitizer(value)
+    }
+
+    for (const rule of this.rules) {
+      if (!rule(value)) {
+        return false
+      }
+    }
     return true
-  },
+  }
+}
 
-  optional(): boolean {
-    return true
-  },
+export class VString extends VBase {
+  type!: 'string'
 
-  isBoolean(value: unknown): boolean {
-    return typeof value === 'boolean'
-  },
-
-  isNumber(value: unknown): boolean {
-    return typeof value === 'number'
-  },
-
-  isFalsy(value: unknown): boolean {
-    return !value
-  },
-
-  isNotFalsy(value: unknown): boolean {
-    return !!value
-  },
-
-  isAlpha(value: string): boolean {
-    return isString(value) && value.match(/^[A-Z]+$/i) ? true : false
-  },
-
-  isNumeric(value: string): boolean {
-    return isString(value) && value.match(/^[0-9]+$/) ? true : false
-  },
-
-  isEmpty(
-    value: string,
+  isEmpty = (
     options: {
       ignore_whitespace: boolean
     } = { ignore_whitespace: false }
-  ): boolean {
-    return (isString(value) && options.ignore_whitespace ? value.trim().length : value.length) === 0
-  },
+  ) => {
+    return this.addRule((value) => rule.isEmpty(value as string, options))
+  }
 
-  isLength(value: string, options: Partial<{ min: number; max: number }> | number, arg2?: number) {
-    if (!isString(value)) return false
-    let min: number
-    let max: number | undefined
-    if (typeof options === 'object') {
-      min = options.min || 0
-      max = options.max
-    } else {
-      // backwards compatibility: isLength(str, min [, max])
-      min = options || 0
-      max = arg2
-    }
-    const presentationSequences = value.match(/(\uFE0F|\uFE0E)/g) || []
-    const surrogatePairs = value.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || []
-    const len = value.length - presentationSequences.length - surrogatePairs.length
-    return len >= min && (typeof max === 'undefined' || len <= max)
-  },
+  isLength = (options: Partial<{ min: number; max: number }> | number, arg2?: number) => {
+    return this.addRule((value) => rule.isLength(value as string, options, arg2))
+  }
 
-  contains(
-    value: string,
+  isAlpha = () => {
+    return this.addRule((value) => rule.isAlpha(value as string))
+  }
+
+  isNumeric = () => {
+    return this.addRule((value) => rule.isNumeric(value as string))
+  }
+
+  contains = (
     elem: string,
     options: Partial<{ ignoreCase: boolean; minOccurrences: number }> = {
       ignoreCase: false,
       minOccurrences: 1,
     }
-  ): boolean {
-    options.ignoreCase ||= false
-    options.minOccurrences ||= 1
-    if (!isString(value) || !isString(elem)) return false
-    if (options.ignoreCase) {
-      return value.toLowerCase().split(elem.toLowerCase()).length > options.minOccurrences
-    }
-    return value.split(elem).length > options.minOccurrences
-  },
+  ) => {
+    return this.addRule((value) => rule.contains(value as string, elem, options))
+  }
 
-  equals(value: unknown, comparison: unknown): boolean {
-    return value === comparison
-  },
+  isIn = (options: string[]) => {
+    return this.addRule((value) => rule.isIn(value as string, options))
+  }
 
-  isIn(value: string, options: string[]): boolean {
-    if (!isString(value)) return false
-    if (typeof options === 'object') {
-      for (const elem of options) {
-        if (elem === value) return true
-      }
-    }
-    return false
-  },
+  match = (regExp: RegExp) => {
+    return this.addRule((value) => rule.match(value as string, regExp))
+  }
 
-  trim(value: string): string {
-    return isString(value) ? value.trim() : value
-  },
+  trim = () => {
+    return this.addSanitizer((value) => sanitizer.trim(value as string))
+  }
+}
+
+export class VNumber extends VBase {
+  type!: 'number'
+
+  isGte = (min: number) => {
+    return this.addRule((value) => rule.isGte(value as number, min))
+  }
+
+  isLte = (min: number) => {
+    return this.addRule((value) => rule.isLte(value as number, min))
+  }
+}
+
+export class VBoolean extends VBase {
+  type!: 'boolean'
+
+  isTrue = () => {
+    return this.addRule((value) => rule.isTrue(value as boolean))
+  }
+
+  isFalse = () => {
+    return this.addRule((value) => rule.isFalse(value as boolean))
+  }
+}
+
+export class VObject extends VBase {
+  type!: 'object'
 }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -3,8 +3,13 @@ import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 import { getQueryStringFromURL } from './utils/url.ts'
 
+type ValidatedData = Record<string, any>
+
 declare global {
-  interface Request<ParamKeyType extends string = string> {
+  interface Request<
+    ParamKeyType extends string = string,
+    Data extends ValidatedData = ValidatedData
+  > {
     paramData?: Record<ParamKeyType, string>
     param: {
       (key: ParamKeyType): string
@@ -35,6 +40,11 @@ declare global {
     jsonData?: any
     json: {
       (): Promise<any>
+    }
+    data: Data
+    valid: {
+      (key: string, value: any): Data
+      (): Data
     }
   }
 }
@@ -136,4 +146,14 @@ export function extendRequestPrototype() {
     }
     return jsonData
   } as InstanceType<typeof Request>['jsonData']
+
+  Request.prototype.valid = function (this: Request, key?: string, value?: any) {
+    if (!this.data) {
+      this.data = {}
+    }
+    if (key && value) {
+      this.data[key] = value
+    }
+    return this.data
+  } as InstanceType<typeof Request>['valid']
 }

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.155.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.156.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/deno_dist/utils/json.ts
+++ b/deno_dist/utils/json.ts
@@ -1,33 +1,17 @@
-export const JSONPathCopy = (src: object, dst: object, path: string) => {
+export const JSONPath = (data: object, path: string) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let srcVal: any = src
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let dstVal: any = dst
+  let val: any = data
   const parts = path.split('.')
   const length = parts.length
-  for (let i = 0; i < length && srcVal !== undefined; i++) {
+  for (let i = 0; i < length && val !== undefined; i++) {
     const p = parts[i]
     if (p !== '') {
-      if (typeof srcVal === 'object') {
-        if (typeof srcVal[p] === 'object') {
-          dstVal[p] ||= new srcVal[p].constructor()
-        }
-        else if (p in srcVal) {
-          dstVal[p] = srcVal[p]
-        }
-        else {
-          return undefined
-        }
-        srcVal = srcVal[p]
-        dstVal = dstVal[p]
+      if (typeof val === 'object') {
+        val = val[p]
       } else {
-        return undefined
+        val = undefined
       }
     }
   }
-
-  if (typeof srcVal === 'object') {
-    Object.assign(dstVal, srcVal)
-  }
-  return srcVal
+  return val
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,10 @@
-import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono'
+import type {
+  Environment,
+  NotFoundHandler,
+  ContextVariableMap,
+  Bindings,
+  ValidatedData,
+} from './hono'
 import { defaultNotFoundMessage } from './hono'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
@@ -10,9 +16,10 @@ export type Data = string | ArrayBuffer | ReadableStream
 
 export interface Context<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = any
+  E extends Partial<Environment> = any,
+  D extends ValidatedData = ValidatedData
 > {
-  req: Request<RequestParamKeyType>
+  req: Request<RequestParamKeyType, D>
   env: E['Bindings']
   event: FetchEvent
   executionCtx: ExecutionContext
@@ -45,10 +52,11 @@ export interface Context<
 
 export class HonoContext<
   RequestParamKeyType extends string = string,
-  E extends Partial<Environment> = Environment
-> implements Context<RequestParamKeyType, E>
+  E extends Partial<Environment> = Environment,
+  D extends ValidatedData = ValidatedData
+> implements Context<RequestParamKeyType, E, D>
 {
-  req: Request<RequestParamKeyType>
+  req: Request<RequestParamKeyType, D>
   env: E['Bindings']
   finalized: boolean
 
@@ -62,13 +70,13 @@ export class HonoContext<
   private notFoundHandler: NotFoundHandler<E>
 
   constructor(
-    req: Request,
+    req: Request<RequestParamKeyType>,
     env: E['Bindings'] | undefined = undefined,
     executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
     notFoundHandler: NotFoundHandler<E> = () => new Response()
   ) {
     this._executionCtx = executionCtx
-    this.req = req
+    this.req = req as Request<RequestParamKeyType, D>
     this.env = env || ({} as Bindings)
 
     this.notFoundHandler = notFoundHandler

--- a/src/middleware/validator/index.ts
+++ b/src/middleware/validator/index.ts
@@ -1,5 +1,2 @@
 import { validatorMiddleware } from './middleware'
-import { validator } from './validator'
-
-const validation = validatorMiddleware<typeof validator>(validator)
-export { validation }
+export { validatorMiddleware as validator }

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -1,214 +1,72 @@
 import type { Context } from '../../context'
-import type { MiddlewareHandler } from '../../hono'
-import { JSONPathCopy } from '../../utils/json'
+import type { Environment, Handler } from '../../hono'
+import { Validator } from './validator'
+import type { VBase, VString, VNumber, VBoolean, VObject, ValidateResult } from './validator'
 
-type Param =
-  | string
-  | number
-  | string[]
-  | number[]
-  | Record<string, string | number>
-  | ValidatorMessage
-type Rule = Function | [Function, ...Param[]]
-type Rules = Rule | Rule[]
-type Done = (resultSet: ResultSet, context: Context) => Response | void
+type ValidationFunction<T> = (v: Validator, c: Context) => T
 
-type RuleSet = {
-  body: Record<string, Rules>
-  json: Record<string, Rules>
-  header: Record<string, Rules>
-  query: Record<string, Rules>
-  done: Done
-  removeAdditional: boolean
+type Schema = Record<string, VString | VNumber | VBoolean | VObject>
+type SchemaToProp<T> = {
+  [K in keyof T]: T[K] extends VBase
+    ? T[K]['type'] extends 'number'
+      ? number
+      : T[K]['type'] extends 'boolean'
+      ? boolean
+      : T[K]['type'] extends 'string'
+      ? string
+      : never
+    : never
 }
 
 type ResultSet = {
   hasError: boolean
   messages: string[]
+  results: ValidateResult[]
 }
 
-type Result = {
-  rule: Function
-  params: Param[]
-  message?: string
-}
+type Done = (resultSet: ResultSet, context: Context) => Response | void
 
-export class ValidatorMessage {
-  value: string
-  constructor(value: string) {
-    this.value = value
-  }
-  getMessage(): string {
-    return this.value
-  }
-}
+export const validatorMiddleware = <T extends Schema>(
+  validationFunction: ValidationFunction<T>,
+  options?: { done?: Done }
+) => {
+  const v = new Validator()
 
-const message = (value: string): ValidatorMessage => {
-  return new ValidatorMessage(value)
-}
-
-export const validatorMiddleware = <Validator>(validator: Validator) => {
-  return (
-    validatorFunction: (
-      validator: Validator,
-      message: (value: string) => ValidatorMessage,
-      context: Context
-    ) => Partial<RuleSet>
-  ): MiddlewareHandler => {
-    return async (c, next) => {
-      const validations = validatorFunction(validator, message, c)
-
-      const result: ResultSet = {
-        hasError: false,
-        messages: [],
-      }
-
-      const v = validations
-      v.removeAdditional = v.removeAdditional === undefined ? true : v.removeAdditional // default value is `true`
-
-      function validate(rules: Rules, value: string, messageFunc: (ruleName: string) => string) {
-        value ||= ''
-
-        let count = 0
-        const results: Result[] = []
-
-        const check = (rules: Rules) => {
-          if (!Array.isArray(rules)) {
-            if (rules instanceof ValidatorMessage) {
-              if (results[count - 1]) {
-                results[count - 1].message = rules.getMessage()
-              }
-            } else if (typeof rules === 'function') {
-              results[count] = {
-                rule: rules,
-                params: [],
-              }
-              count++
-            } else {
-              results[count - 1].params.push(rules)
-            }
-          } else {
-            if (typeof rules[0] === ('string' || 'number')) {
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              results[count - 1].params.push(rules)
-            } else {
-              for (const rule of rules) {
-                check(rule as Rules)
-              }
-            }
-          }
-        }
-        check(rules)
-
-        let invalid = false
-        results.map((r) => {
-          const ok = r.rule(value, ...r.params)
-          if (!invalid && ok === false) {
-            invalid = true
-            if (r.message) {
-              result.messages.push(r.message)
-            } else {
-              result.messages.push(messageFunc(r.rule.name))
-            }
-          }
-          if (typeof ok !== 'boolean') {
-            // ok is sanitized string
-            value = ok
-          }
-        })
-
-        if (invalid) {
-          result.hasError = true
-          return
-        }
-      }
-
-      if (v.query) {
-        const query = v.query
-        const realQueries = c.req.query()
-        const validatedQueries: Record<string, string> = {}
-
-        Object.keys(query).map((key) => {
-          validatedQueries[key] = realQueries[key] || ''
-          const message = (name: string) =>
-            `Invalid Value: the query parameter "${key}" is invalid - ${name}`
-          validate(query[key], validatedQueries[key], message)
-        })
-        if (!result.hasError && v.removeAdditional) {
-          c.req.queryData = validatedQueries
-        }
-      }
-
-      if (v.header) {
-        const header = v.header
-        const realHeaders: Record<string, string> = {}
-        for (const key of c.req.headers.keys()) {
-          realHeaders[key] = c.req.headers.get(key) || ''
-        }
-        const validatedHeaders: Record<string, string> = {}
-
-        Object.keys(header).map((key) => {
-          validatedHeaders[key] = realHeaders[key] || ''
-          const message = (name: string) =>
-            `Invalid Value: the request header "${key}" is invalid - ${name}`
-          validate(header[key], validatedHeaders[key], message)
-        })
-        if (!result.hasError && v.removeAdditional) {
-          c.req.headerData = validatedHeaders
-        }
-      }
-
-      if (v.body) {
-        const field = v.body
-        const parsedBody = (await c.req.parseBody()) as Record<string, string>
-        const kv = { ...parsedBody }
-        const validatedKv: Record<string, string> = {}
-
-        Object.keys(field).map(async (key) => {
-          validatedKv[key] = kv[key] || ''
-          const message = (name: string) =>
-            `Invalid Value: the request body "${key}" is invalid - ${name}`
-          validate(field[key], validatedKv[key], message)
-        })
-        if (!result.hasError && v.removeAdditional) {
-          c.req.bodyData = validatedKv
-        }
-      }
-
-      if (v.json) {
-        const field = v.json
-        let json: object
-        try {
-          json = await c.req.json()
-        } catch {
-          json = {}
-        }
-        const validatedJson: object = new (json as any).constructor()
-
-        Object.keys(field).map(async (key) => {
-          const value = JSONPathCopy(json, validatedJson, key)
-          const message = (name: string) =>
-            `Invalid Value: the JSON body "${key}" is invalid - ${name}`
-          validate(field[key], value, message)
-        })
-
-        if (!result.hasError && v.removeAdditional) {
-          c.req.jsonData = validatedJson
-        }
-      }
-
-      if (v.done) {
-        const res = v.done(result, c)
-        if (res) {
-          return res
-        }
-      }
-
-      if (result.hasError) {
-        return c.text(result.messages.join('\n'), 400)
-      }
-      await next()
+  const handler: Handler<string, Environment, SchemaToProp<T>> = async (c, next) => {
+    const resultSet: ResultSet = {
+      hasError: false,
+      messages: [],
+      results: [],
     }
+
+    const schema = validationFunction(v, c)
+
+    for (const key of Object.keys(schema)) {
+      const validator = schema[key]
+      const result = await validator.validate(c.req)
+      if (result.isValid) {
+        // Set data on request object
+        c.req.valid(key, result.value)
+      } else {
+        resultSet.hasError = true
+        if (result.message !== undefined) {
+          resultSet.messages.push(result.message)
+        }
+      }
+      resultSet.results.push(result)
+    }
+
+    if (options && options.done) {
+      const res = options.done(resultSet, c)
+      if (res) {
+        return res
+      }
+    }
+
+    if (resultSet.hasError) {
+      return c.text(resultSet.messages.join('\n'), 400)
+    }
+    await next()
   }
+  return handler
 }

--- a/src/middleware/validator/rule.test.ts
+++ b/src/middleware/validator/rule.test.ts
@@ -1,0 +1,55 @@
+import { rule } from './rule'
+
+describe('Rules', () => {
+  // string
+  test('isEmpty', () => {
+    expect(rule.isEmpty('')).toBeTruthy()
+    expect(rule.isEmpty('abcdef')).toBeFalsy()
+    expect(rule.isEmpty('')).toBeTruthy()
+    expect(rule.isEmpty(' ')).toBeFalsy()
+    expect(rule.isEmpty(' ', { ignore_whitespace: true })).toBeTruthy()
+  })
+  test('isLength', () => {
+    expect(rule.isLength('abcde', { min: 1, max: 10 })).toBeTruthy()
+    expect(rule.isLength('abcde', { min: 1, max: 4 })).toBeFalsy()
+    expect(rule.isLength('abcde', { max: 10 })).toBeTruthy()
+    expect(rule.isLength('abcde', { max: 4 })).toBeFalsy()
+    expect(rule.isLength('abcde', { min: 10 })).toBeFalsy()
+    expect(rule.isLength('abcde', { min: 4 })).toBeTruthy()
+    expect(rule.isLength('abcde', 1, 10)).toBeTruthy()
+    expect(rule.isLength('abcde', 1, 4)).toBeFalsy()
+  })
+  test('isAlpha', () => {
+    expect(rule.isAlpha('abcdef')).toBeTruthy()
+    expect(rule.isAlpha('abc123')).toBeFalsy()
+  })
+  test('isNumeric', () => {
+    expect(rule.isNumeric('01234')).toBeTruthy()
+    expect(rule.isNumeric('012abc')).toBeFalsy()
+  })
+  test('contains', () => {
+    expect(rule.contains('barfoobaz', 'foo')).toBeTruthy()
+    expect(rule.contains('barfoobaz', 'fooo')).toBeFalsy()
+    expect(rule.contains('barfoobaz', 'Foo')).toBeFalsy()
+    expect(rule.contains('barfoobaz', 'Foo', { ignoreCase: true })).toBeTruthy()
+  })
+  test('isIn', () => {
+    expect(rule.isIn('foo', ['foo', 'bar'])).toBeTruthy()
+    expect(rule.isIn('foo', ['zzz', 'yyy'])).toBeFalsy()
+  })
+  test('match', () => {
+    expect(rule.match('abcdef', /def$/)).toBeTruthy()
+    expect(rule.match('abcdef', /^def$/)).toBeFalsy()
+  })
+  // number
+  test('isGte', () => {
+    expect(rule.isGte(20, 10)).toBeTruthy()
+    expect(rule.isGte(10, 20)).toBeFalsy()
+    expect(rule.isGte(10, 10)).toBeTruthy()
+  })
+  test('isLte', () => {
+    expect(rule.isLte(10, 20)).toBeTruthy()
+    expect(rule.isLte(20, 10)).toBeFalsy()
+    expect(rule.isLte(10, 10)).toBeTruthy()
+  })
+})

--- a/src/middleware/validator/rule.ts
+++ b/src/middleware/validator/rule.ts
@@ -1,0 +1,83 @@
+// Some validation rules is are based on Validator.js
+// Validator.js
+// License (MIT)
+// Copyright (c) 2018 Chris O'Hara <cohara87@gmail.com>
+// https://github.com/validatorjs/validator.js
+
+export const rule = {
+  // string
+  isEmpty(
+    value: string,
+    options: {
+      ignore_whitespace: boolean
+    } = { ignore_whitespace: false }
+  ): boolean {
+    return (options.ignore_whitespace ? value.trim().length : value.length) === 0
+  },
+
+  isLength: (
+    value: string,
+    options: Partial<{ min: number; max: number }> | number,
+    arg2?: number
+  ) => {
+    let min: number
+    let max: number | undefined
+    if (typeof options === 'object') {
+      min = options.min || 0
+      max = options.max
+    } else {
+      // backwards compatibility: isLength(str, min [, max])
+      min = options || 0
+      max = arg2
+    }
+    const presentationSequences = value.match(/(\uFE0F|\uFE0E)/g) || []
+    const surrogatePairs = value.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || []
+    const len = value.length - presentationSequences.length - surrogatePairs.length
+    return len >= min && (typeof max === 'undefined' || len <= max)
+  },
+
+  isAlpha: (value: string): boolean => {
+    return value.match(/^[A-Z]+$/i) ? true : false
+  },
+
+  isNumeric: (value: string): boolean => {
+    return value.match(/^[0-9]+$/) ? true : false
+  },
+
+  contains: (
+    value: string,
+    elem: string,
+    options: Partial<{ ignoreCase: boolean; minOccurrences: number }> = {
+      ignoreCase: false,
+      minOccurrences: 1,
+    }
+  ): boolean => {
+    options.ignoreCase ||= false
+    options.minOccurrences ||= 1
+    if (options.ignoreCase) {
+      return value.toLowerCase().split(elem.toLowerCase()).length > options.minOccurrences
+    }
+    return value.split(elem).length > options.minOccurrences
+  },
+
+  isIn: (value: string, options: string[]): boolean => {
+    if (typeof options === 'object') {
+      for (const elem of options) {
+        if (elem === value) return true
+      }
+    }
+    return false
+  },
+
+  match: (value: string, regExp: RegExp): boolean => {
+    return value.match(regExp) ? true : false
+  },
+
+  // number
+  isGte: (value: number, min: number) => min <= value,
+  isLte: (value: number, max: number) => value <= max,
+
+  // boolean
+  isTrue: (value: boolean) => value === true,
+  isFalse: (value: boolean) => value === false,
+}

--- a/src/middleware/validator/rule.ts
+++ b/src/middleware/validator/rule.ts
@@ -37,11 +37,11 @@ export const rule = {
   },
 
   isAlpha: (value: string): boolean => {
-    return value.match(/^[A-Z]+$/i) ? true : false
+    return /^[A-Z]+$/i.test(value)
   },
 
   isNumeric: (value: string): boolean => {
-    return value.match(/^[0-9]+$/) ? true : false
+    return /^[0-9]+$/.test(value)
   },
 
   contains: (
@@ -70,7 +70,7 @@ export const rule = {
   },
 
   match: (value: string, regExp: RegExp): boolean => {
-    return value.match(regExp) ? true : false
+    return regExp.test(value)
   },
 
   // number

--- a/src/middleware/validator/sanitizer.test.ts
+++ b/src/middleware/validator/sanitizer.test.ts
@@ -1,0 +1,7 @@
+import { sanitizer } from './sanitizer'
+
+describe('Sanitizers', () => {
+  test('trim', () => {
+    expect(sanitizer.trim(' abc  ')).toBe('abc')
+  })
+})

--- a/src/middleware/validator/sanitizer.ts
+++ b/src/middleware/validator/sanitizer.ts
@@ -1,0 +1,3 @@
+export const sanitizer = {
+  trim: (value: string) => value.trim(),
+}

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -1,109 +1,128 @@
-import { validator } from './validator'
+import { extendRequestPrototype } from '../../request'
+import { Validator } from './validator'
 
-describe('Test the validator rules', () => {
-  test('required', () => {
-    expect(validator.required('a')).toBeTruthy()
-    expect(validator.required(0)).toBeTruthy()
-    expect(validator.required(undefined)).toBeFalsy()
-    expect(validator.required('')).toBeFalsy()
+extendRequestPrototype()
+
+describe('Basic - query', () => {
+  const v = new Validator()
+
+  const req = new Request('http://localhost/?q=foo&page=3')
+
+  it('Should be valid - page', async () => {
+    const validator = v.query('page').trim().isNumeric()
+    expect(validator.type).toBe('string')
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.message).toBeUndefined()
   })
 
-  test('optional', () => {
-    expect(validator.optional).toBeTruthy()
+  it('Should be invalid - q', async () => {
+    const validator = v.query('q').isRequired().asNumber()
+    expect(validator.type).toBe('number')
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the query parameter "q" is invalid - foo']
+    expect(res.message).toBe(messages.join('\n'))
   })
 
-  test('isBoolean', () => {
-    expect(validator.isBoolean(true)).toBeTruthy()
-    expect(validator.isBoolean('abc')).toBeFalsy()
+  it('Should be invalid - q2', async () => {
+    const validator = v.query('q2').isRequired()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the query parameter "q2" is invalid - undefined']
+    expect(res.message).toBe(messages.join('\n'))
+  })
+})
+
+describe('Basic - header', () => {
+  const v = new Validator()
+
+  const req = new Request('http://localhost/', {
+    headers: {
+      'x-message': 'hello world!',
+      'x-number': '12345',
+    },
   })
 
-  test('isNumber', () => {
-    expect(validator.isNumber(123)).toBeTruthy()
-    expect(validator.isNumber('123')).toBeFalsy()
+  it('Should be valid - x-message', async () => {
+    const validator = v.header('x-message').isRequired().contains('Hello', { ignoreCase: true })
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.message).toBeUndefined()
   })
 
-  test('isFalsy', () => {
-    expect(validator.isFalsy(undefined)).toBeTruthy()
-    expect(validator.isFalsy(0)).toBeTruthy()
-    expect(validator.isFalsy('')).toBeTruthy()
-    expect(validator.isFalsy(null)).toBeTruthy()
+  it('Should be invalid - x-number', async () => {
+    const validator = v.header('x-number').isEqual(12345)
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the request header "x-number" is invalid - 12345']
+    expect(res.message).toBe(messages.join('\n'))
+  })
+})
+
+describe('Basic - body', () => {
+  const v = new Validator()
+
+  const body = new FormData()
+  body.append('title', '  abcdef ')
+  body.append('title2', 'abcdef')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: body,
   })
 
-  test('isNotFalsy', () => {
-    expect(validator.isNotFalsy('abc')).toBeTruthy()
-    expect(validator.isNotFalsy(123)).toBeTruthy()
-    expect(validator.isNotFalsy(true)).toBeTruthy()
+  it('Should be valid - title', async () => {
+    const validator = v.body('title').trim().isLength({ max: 10 }).isRequired()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.message).toBeUndefined()
   })
 
-  test('isAlpha', () => {
-    expect(validator.isAlpha('abcdef')).toBeTruthy()
-    expect(validator.isAlpha('abc123')).toBeFalsy()
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.isAlpha(123)).toBeFalsy()
+  it('Should be invalid - title2', async () => {
+    const validator = v.body('title2').isLength({ max: 5 })
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the request body "title2" is invalid - abcdef']
+    expect(res.message).toBe(messages.join('\n'))
+  })
+})
+
+describe('Basic - JSON', () => {
+  const v = new Validator()
+
+  const post = {
+    id: 1234,
+    title: 'This is title',
+    author: {
+      name: 'Superman',
+      age: 20,
+    },
+  }
+
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: JSON.stringify(post),
   })
 
-  test('isNumeric', () => {
-    expect(validator.isNumeric('01234')).toBeTruthy()
-    expect(validator.isNumeric('012abc')).toBeFalsy()
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.isAlpha(123)).toBeFalsy()
+  it('Should be valid - id', async () => {
+    const validator = v.json('id').asNumber().isEqual(1234)
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.message).toBeUndefined()
   })
 
-  test('isEmpty', () => {
-    expect(validator.isEmpty('')).toBeTruthy()
-    expect(validator.isEmpty(' ')).toBeFalsy()
-    expect(validator.isEmpty(' ', { ignore_whitespace: true })).toBeTruthy()
-    expect(validator.isEmpty('abc')).toBeFalsy()
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.isEmpty(123, { ignore_whitespace: true })).toBeFalsy()
+  it('Should be valid - author.name', async () => {
+    const validator = v.json('author.name').isIn(['Ultra man', 'Superman'])
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.message).toBeUndefined()
   })
 
-  test('isLength', () => {
-    expect(validator.isLength('abcde', { min: 1, max: 10 })).toBeTruthy()
-    expect(validator.isLength('abcde', { min: 1, max: 4 })).toBeFalsy()
-    expect(validator.isLength('abcde', { max: 10 })).toBeTruthy()
-    expect(validator.isLength('abcde', { max: 4 })).toBeFalsy()
-    expect(validator.isLength('abcde', { min: 10 })).toBeFalsy()
-    expect(validator.isLength('abcde', { min: 4 })).toBeTruthy()
-    expect(validator.isLength('abcde', 1, 10)).toBeTruthy()
-    expect(validator.isLength('abcde', 1, 4)).toBeFalsy()
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.isLength(123, { max: 10 })).toBeFalsy()
-  })
-
-  test('contains', () => {
-    expect(validator.contains('barfoobaz', 'foo')).toBeTruthy()
-    expect(validator.contains('barfoobaz', 'fooo')).toBeFalsy()
-    expect(validator.contains('barfoobaz', 'Foo')).toBeFalsy()
-    expect(validator.contains('barfoobaz', 'Foo', { ignoreCase: true })).toBeTruthy()
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.contains(12345, 123)).toBeFalsy()
-  })
-
-  test('equals', () => {
-    expect(validator.equals('foo', 'foo')).toBeTruthy()
-    expect(validator.equals('foo', 'bar')).toBeFalsy()
-    expect(validator.equals(123, 123)).toBeTruthy()
-    expect(validator.equals(123, '123')).toBeFalsy()
-  })
-
-  test('isIn', () => {
-    expect(validator.isIn('foo', ['foo', 'bar'])).toBeTruthy()
-    expect(validator.isIn('foo', ['zzz', 'yyy'])).toBeFalsy()
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.isIn(123, [123, 456])).toBeFalsy()
-  })
-
-  test('trim', () => {
-    expect(validator.trim(' foo ')).toBe('foo')
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    expect(validator.trim(123)).toBe(123)
+  it('Should be invalid - author.age', async () => {
+    const validator = v.json('author.age').asNumber().isLte(10)
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the JSON body "author.age" is invalid - 20']
+    expect(res.message).toBe(messages.join('\n'))
   })
 })

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -126,3 +126,34 @@ describe('Basic - JSON', () => {
     expect(res.message).toBe(messages.join('\n'))
   })
 })
+
+describe('Handling types error', () => {
+  const v = new Validator()
+
+  const post = {
+    id: '1234',
+    title: 'This is title',
+    published: 'true',
+  }
+
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: JSON.stringify(post),
+  })
+
+  it('Should be invalid - "1234" is not number', async () => {
+    const validator = v.json('id').asNumber().isEqual(1234)
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the JSON body "id" is invalid - 1234']
+    expect(res.message).toBe(messages.join('\n'))
+  })
+
+  it('Should be invalid - "true" is not boolean', async () => {
+    const validator = v.json('published').asBoolean()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = ['Invalid Value: the JSON body "published" is invalid - true']
+    expect(res.message).toBe(messages.join('\n'))
+  })
+})

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -22,6 +22,12 @@ export type ValidateResult = {
   value: Type
 }
 
+type VOption = {
+  target: Target
+  key: string
+  type?: 'string' | 'number' | 'boolean' | 'object'
+}
+
 export abstract class VBase {
   type: 'string' | 'number' | 'boolean' | 'object'
   target: Target
@@ -30,11 +36,7 @@ export abstract class VBase {
   sanitizers: Sanitizer[]
   private _message: string | undefined
 
-  constructor(option: {
-    target: Target
-    key: string
-    type?: 'string' | 'number' | 'boolean' | 'object'
-  }) {
+  constructor(option: VOption) {
     this.target = option.target
     this.key = option.key
     this.type = option.type || 'string'
@@ -71,19 +73,16 @@ export abstract class VBase {
 
   asNumber = () => {
     const newVNumber = new VNumber(this)
-    newVNumber.type = 'number'
     return newVNumber
   }
 
   asBoolean = () => {
     const newVBoolean = new VBoolean(this)
-    newVBoolean.type = 'boolean'
     return newVBoolean
   }
 
   asObject = () => {
     const newVObject = new VObject(this)
-    newVObject.type = 'object'
     return newVObject
   }
 
@@ -164,7 +163,10 @@ export abstract class VBase {
 }
 
 export class VString extends VBase {
-  type!: 'string'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'string'
+  }
 
   isEmpty = (
     options: {
@@ -210,7 +212,10 @@ export class VString extends VBase {
 }
 
 export class VNumber extends VBase {
-  type!: 'number'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'number'
+  }
 
   isGte = (min: number) => {
     return this.addRule((value) => rule.isGte(value as number, min))
@@ -222,7 +227,10 @@ export class VNumber extends VBase {
 }
 
 export class VBoolean extends VBase {
-  type!: 'boolean'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'boolean'
+  }
 
   isTrue = () => {
     return this.addRule((value) => rule.isTrue(value as boolean))
@@ -234,5 +242,8 @@ export class VBoolean extends VBase {
 }
 
 export class VObject extends VBase {
-  type!: 'object'
+  constructor(option: VOption) {
+    super(option)
+    this.type = 'object'
+  }
 }

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -22,7 +22,7 @@ export type ValidateResult = {
   value: Type
 }
 
-type VOption = {
+type VOptions = {
   target: Target
   key: string
   type?: 'string' | 'number' | 'boolean' | 'object'
@@ -36,10 +36,10 @@ export abstract class VBase {
   sanitizers: Sanitizer[]
   private _message: string | undefined
 
-  constructor(option: VOption) {
-    this.target = option.target
-    this.key = option.key
-    this.type = option.type || 'string'
+  constructor(options: VOptions) {
+    this.target = options.target
+    this.key = options.key
+    this.type = options.type || 'string'
     this.rules = []
     this.sanitizers = []
   }
@@ -163,8 +163,8 @@ export abstract class VBase {
 }
 
 export class VString extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'string'
   }
 
@@ -212,8 +212,8 @@ export class VString extends VBase {
 }
 
 export class VNumber extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'number'
   }
 
@@ -227,8 +227,8 @@ export class VNumber extends VBase {
 }
 
 export class VBoolean extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'boolean'
   }
 
@@ -242,8 +242,8 @@ export class VBoolean extends VBase {
 }
 
 export class VObject extends VBase {
-  constructor(option: VOption) {
-    super(option)
+  constructor(options: VOptions) {
+    super(options)
     this.type = 'object'
   }
 }

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -1,107 +1,238 @@
-// Some validation rules is are based on Validator.js
-// Validator.js
-// License (MIT)
-// Copyright (c) 2018 Chris O'Hara <cohara87@gmail.com>
-// https://github.com/validatorjs/validator.js
+import { JSONPath } from '../../utils/json'
+import { rule } from './rule'
+import { sanitizer } from './sanitizer'
 
-const isString = (value: any) => {
-  return typeof value === 'string'
+type Target = 'query' | 'header' | 'body' | 'json'
+type Type = string | number | boolean | object | undefined
+type Rule = (value: Type) => boolean
+type Sanitizer = (value: Type) => Type
+
+export class Validator {
+  query = (key: string): VString => new VString({ target: 'query', key: key })
+  header = (key: string): VString => new VString({ target: 'header', key: key })
+  body = (key: string): VString => new VString({ target: 'body', key: key })
+  json = (key: string): VString => new VString({ target: 'json', key: key })
 }
 
-export const validator = {
-  required(value: unknown): boolean {
-    if (value === undefined) return false
-    if (isString(value) && value === '') return false
+export type ValidateResult = {
+  isValid: boolean
+  message: string | undefined
+  target: Target
+  key: string
+  value: Type
+}
+
+export abstract class VBase {
+  type: 'string' | 'number' | 'boolean' | 'object'
+  target: Target
+  key: string
+  rules: Rule[]
+  sanitizers: Sanitizer[]
+  private _message: string | undefined
+
+  constructor(option: {
+    target: Target
+    key: string
+    type?: 'string' | 'number' | 'boolean' | 'object'
+  }) {
+    this.target = option.target
+    this.key = option.key
+    this.type = option.type || 'string'
+    this.rules = []
+    this.sanitizers = []
+  }
+
+  addRule = (rule: Rule) => {
+    this.rules.push(rule)
+    return this
+  }
+
+  addSanitizer = (sanitizer: Sanitizer) => {
+    this.sanitizers.push(sanitizer)
+    return this
+  }
+
+  isRequired = () => {
+    return this.addRule((value: unknown) => {
+      if (value) return true
+      return false
+    })
+  }
+
+  isOptional = () => {
+    return this.addRule(() => true)
+  }
+
+  isEqual = (comparison: unknown) => {
+    return this.addRule((value: unknown) => {
+      return value === comparison
+    })
+  }
+
+  asNumber = () => {
+    const newVNumber = new VNumber(this)
+    newVNumber.type = 'number'
+    return newVNumber
+  }
+
+  asBoolean = () => {
+    const newVBoolean = new VBoolean(this)
+    newVBoolean.type = 'boolean'
+    return newVBoolean
+  }
+
+  asObject = () => {
+    const newVObject = new VObject(this)
+    newVObject.type = 'object'
+    return newVObject
+  }
+
+  message(value: string) {
+    this._message = value
+    return this
+  }
+
+  validate = async (req: Request): Promise<ValidateResult> => {
+    const result: ValidateResult = {
+      isValid: true,
+      message: undefined,
+      target: this.target,
+      key: this.key,
+      value: undefined,
+    }
+
+    let value: Type = undefined
+    if (this.target === 'query') {
+      value = req.query(this.key)
+    }
+    if (this.target === 'header') {
+      value = req.header(this.key)
+    }
+    if (this.target === 'body') {
+      const body = await req.parseBody()
+      value = body[this.key]
+    }
+    if (this.target === 'json') {
+      const obj = await req.json()
+      value = JSONPath(obj, this.key)
+    }
+
+    result.value = value
+    result.isValid = this.validateValue(value)
+
+    if (result.isValid == false) {
+      if (this._message) {
+        result.message = this._message
+      } else {
+        switch (this.target) {
+          case 'query':
+            result.message = `Invalid Value: the query parameter "${this.key}" is invalid - ${value}`
+            break
+          case 'header':
+            result.message = `Invalid Value: the request header "${this.key}" is invalid - ${value}`
+            break
+          case 'body':
+            result.message = `Invalid Value: the request body "${this.key}" is invalid - ${value}`
+            break
+          case 'json':
+            result.message = `Invalid Value: the JSON body "${this.key}" is invalid - ${value}`
+            break
+        }
+      }
+    }
+    return result
+  }
+
+  private validateValue = (value: Type): boolean => {
+    // Check type
+    if (typeof value !== this.type) {
+      return false
+    }
+
+    // Sanitize
+    for (const sanitizer of this.sanitizers) {
+      value = sanitizer(value)
+    }
+
+    for (const rule of this.rules) {
+      if (!rule(value)) {
+        return false
+      }
+    }
     return true
-  },
+  }
+}
 
-  optional(): boolean {
-    return true
-  },
+export class VString extends VBase {
+  type!: 'string'
 
-  isBoolean(value: unknown): boolean {
-    return typeof value === 'boolean'
-  },
-
-  isNumber(value: unknown): boolean {
-    return typeof value === 'number'
-  },
-
-  isFalsy(value: unknown): boolean {
-    return !value
-  },
-
-  isNotFalsy(value: unknown): boolean {
-    return !!value
-  },
-
-  isAlpha(value: string): boolean {
-    return isString(value) && value.match(/^[A-Z]+$/i) ? true : false
-  },
-
-  isNumeric(value: string): boolean {
-    return isString(value) && value.match(/^[0-9]+$/) ? true : false
-  },
-
-  isEmpty(
-    value: string,
+  isEmpty = (
     options: {
       ignore_whitespace: boolean
     } = { ignore_whitespace: false }
-  ): boolean {
-    return (isString(value) && options.ignore_whitespace ? value.trim().length : value.length) === 0
-  },
+  ) => {
+    return this.addRule((value) => rule.isEmpty(value as string, options))
+  }
 
-  isLength(value: string, options: Partial<{ min: number; max: number }> | number, arg2?: number) {
-    if (!isString(value)) return false
-    let min: number
-    let max: number | undefined
-    if (typeof options === 'object') {
-      min = options.min || 0
-      max = options.max
-    } else {
-      // backwards compatibility: isLength(str, min [, max])
-      min = options || 0
-      max = arg2
-    }
-    const presentationSequences = value.match(/(\uFE0F|\uFE0E)/g) || []
-    const surrogatePairs = value.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || []
-    const len = value.length - presentationSequences.length - surrogatePairs.length
-    return len >= min && (typeof max === 'undefined' || len <= max)
-  },
+  isLength = (options: Partial<{ min: number; max: number }> | number, arg2?: number) => {
+    return this.addRule((value) => rule.isLength(value as string, options, arg2))
+  }
 
-  contains(
-    value: string,
+  isAlpha = () => {
+    return this.addRule((value) => rule.isAlpha(value as string))
+  }
+
+  isNumeric = () => {
+    return this.addRule((value) => rule.isNumeric(value as string))
+  }
+
+  contains = (
     elem: string,
     options: Partial<{ ignoreCase: boolean; minOccurrences: number }> = {
       ignoreCase: false,
       minOccurrences: 1,
     }
-  ): boolean {
-    options.ignoreCase ||= false
-    options.minOccurrences ||= 1
-    if (!isString(value) || !isString(elem)) return false
-    if (options.ignoreCase) {
-      return value.toLowerCase().split(elem.toLowerCase()).length > options.minOccurrences
-    }
-    return value.split(elem).length > options.minOccurrences
-  },
+  ) => {
+    return this.addRule((value) => rule.contains(value as string, elem, options))
+  }
 
-  equals(value: unknown, comparison: unknown): boolean {
-    return value === comparison
-  },
+  isIn = (options: string[]) => {
+    return this.addRule((value) => rule.isIn(value as string, options))
+  }
 
-  isIn(value: string, options: string[]): boolean {
-    if (!isString(value)) return false
-    if (typeof options === 'object') {
-      for (const elem of options) {
-        if (elem === value) return true
-      }
-    }
-    return false
-  },
+  match = (regExp: RegExp) => {
+    return this.addRule((value) => rule.match(value as string, regExp))
+  }
 
-  trim(value: string): string {
-    return isString(value) ? value.trim() : value
-  },
+  trim = () => {
+    return this.addSanitizer((value) => sanitizer.trim(value as string))
+  }
+}
+
+export class VNumber extends VBase {
+  type!: 'number'
+
+  isGte = (min: number) => {
+    return this.addRule((value) => rule.isGte(value as number, min))
+  }
+
+  isLte = (min: number) => {
+    return this.addRule((value) => rule.isLte(value as number, min))
+  }
+}
+
+export class VBoolean extends VBase {
+  type!: 'boolean'
+
+  isTrue = () => {
+    return this.addRule((value) => rule.isTrue(value as boolean))
+  }
+
+  isFalse = () => {
+    return this.addRule((value) => rule.isFalse(value as boolean))
+  }
+}
+
+export class VObject extends VBase {
+  type!: 'object'
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -3,8 +3,13 @@ import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
 import { getQueryStringFromURL } from './utils/url'
 
+type ValidatedData = Record<string, any>
+
 declare global {
-  interface Request<ParamKeyType extends string = string> {
+  interface Request<
+    ParamKeyType extends string = string,
+    Data extends ValidatedData = ValidatedData
+  > {
     paramData?: Record<ParamKeyType, string>
     param: {
       (key: ParamKeyType): string
@@ -35,6 +40,11 @@ declare global {
     jsonData?: any
     json: {
       (): Promise<any>
+    }
+    data: Data
+    valid: {
+      (key: string, value: any): Data
+      (): Data
     }
   }
 }
@@ -136,4 +146,14 @@ export function extendRequestPrototype() {
     }
     return jsonData
   } as InstanceType<typeof Request>['jsonData']
+
+  Request.prototype.valid = function (this: Request, key?: string, value?: any) {
+    if (!this.data) {
+      this.data = {}
+    }
+    if (key && value) {
+      this.data[key] = value
+    }
+    return this.data
+  } as InstanceType<typeof Request>['valid']
 }

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,6 +1,6 @@
-import { JSONPathCopy } from './json'
+import { JSONPath } from './json'
 
-describe('JSONPathCopy', () => {
+describe('JSONPath', () => {
   const data = {
     post: {
       title: 'Hello',
@@ -13,65 +13,23 @@ describe('JSONPathCopy', () => {
   }
 
   it('Should return the string or number pointed by JSON Path', () => {
-    const dst = {}
-
-    expect(JSONPathCopy(data, dst, 'post.title')).toBe('Hello')
-    expect(dst).toEqual({ post: { title: 'Hello' } })
-    expect(JSONPathCopy(data, dst, 'post.author.name')).toBe('Superman')
-    expect(dst).toEqual({ post: { title: 'Hello', author: { name: 'Superman' } } })
-    expect(JSONPathCopy(data, dst, 'post.author.age')).toBe(20)
-    expect(dst).toEqual({ post: { title: 'Hello', author: { name: 'Superman', age: 20 } } })
-    expect(JSONPathCopy(data, dst, 'post.tags.0')).toBe('foo')
-    expect(dst).toEqual({
-      post: {
-        title: 'Hello',
-        author: { name: 'Superman', age: 20 },
-        tags: ['foo'],
-      },
-    })
-    expect(JSONPathCopy(data, dst, 'post.tags.1')).toBe('bar')
-    expect(dst).toEqual({
-      post: {
-        title: 'Hello',
-        author: { name: 'Superman', age: 20 },
-        tags: ['foo', 'bar'],
-      },
-    })
-    expect(JSONPathCopy(data, dst, 'post.tags.2.framework')).toBe('Hono')
-    expect(dst).toEqual({
-      post: {
-        title: 'Hello',
-        author: { name: 'Superman', age: 20 },
-        tags: ['foo', 'bar', { framework: 'Hono' }],
-      },
-    })
+    expect(JSONPath(data, 'post.title')).toBe('Hello')
+    expect(JSONPath(data, 'post.author.name')).toBe('Superman')
+    expect(JSONPath(data, 'post.author.age')).toBe(20)
+    expect(JSONPath(data, 'post.tags.0')).toBe('foo')
+    expect(JSONPath(data, 'post.tags.1')).toBe('bar')
+    expect(JSONPath(data, 'post.tags.2.framework')).toBe('Hono')
   })
 
   it('Should return undefined', () => {
-    const dst = {}
-
-    expect(JSONPathCopy(data, dst, 'post.foo')).toBe(undefined)
-    expect(JSONPathCopy(data, dst, 'post.author.foo')).toBe(undefined)
-    expect(JSONPathCopy(data, dst, 'post.tags.3')).toBe(undefined)
-    expect(dst).toEqual({ post: { author: {}, tags: [] } })
+    expect(JSONPath(data, 'post.foo')).toBe(undefined)
+    expect(JSONPath(data, 'post.author.foo')).toBe(undefined)
+    expect(JSONPath(data, 'post.tags.3')).toBe(undefined)
   })
 
   it('Should return objects pointed by JSON Path', () => {
-    const [dstPost, dstPostAuthor, dstPostTags] = [{}, {}, {}]
-
-    expect(typeof JSONPathCopy(data, dstPost, 'post')).toBe('object')
-    expect(dstPost).toEqual({
-      post: {
-        title: 'Hello',
-        author: { name: 'Superman', age: 20 },
-        tags: ['foo', 'bar', { framework: 'Hono' }],
-      },
-    })
-    expect(JSONPathCopy(data, dstPostAuthor, 'post.author')).toEqual({ name: 'Superman', age: 20 })
-    expect(dstPostAuthor).toEqual({ post: { author: { name: 'Superman', age: 20 } } })
-    expect(JSONPathCopy(data, dstPostTags, 'post.tags').length).toBe(3)
-    expect(dstPostTags).toEqual({
-      post: { tags: ['foo', 'bar', { framework: 'Hono' }] },
-    })
+    expect(typeof JSONPath(data, 'post')).toBe('object')
+    expect(JSONPath(data, 'post.author')).toEqual({ name: 'Superman', age: 20 })
+    expect(JSONPath(data, 'post.tags').length).toBe(3)
   })
 })

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,33 +1,17 @@
-export const JSONPathCopy = (src: object, dst: object, path: string) => {
+export const JSONPath = (data: object, path: string) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let srcVal: any = src
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let dstVal: any = dst
+  let val: any = data
   const parts = path.split('.')
   const length = parts.length
-  for (let i = 0; i < length && srcVal !== undefined; i++) {
+  for (let i = 0; i < length && val !== undefined; i++) {
     const p = parts[i]
     if (p !== '') {
-      if (typeof srcVal === 'object') {
-        if (typeof srcVal[p] === 'object') {
-          dstVal[p] ||= new srcVal[p].constructor()
-        }
-        else if (p in srcVal) {
-          dstVal[p] = srcVal[p]
-        }
-        else {
-          return undefined
-        }
-        srcVal = srcVal[p]
-        dstVal = dstVal[p]
+      if (typeof val === 'object') {
+        val = val[p]
       } else {
-        return undefined
+        val = undefined
       }
     }
   }
-
-  if (typeof srcVal === 'object') {
-    Object.assign(dstVal, srcVal)
-  }
-  return srcVal
+  return val
 }


### PR DESCRIPTION
I like the current validator middleware API:

```ts
app.post(
  '/json',
  validation((v) => ({
    json: {
      'post.author.name': v.isAlpha,
    },
  })),
  (c) => {
    return c.text('Valid')
  }
)
```

But there are times when I want "Types":

```ts
  async (c) => {
    const data = await c.req.json()
    // How can I access `post.author.name` ?
    return c.text('Valid')
  }
```

So I implemented the new idea of Validator Middleware that support "Types". This is the approach of "declaring the keys of properties first".

```ts
app.post(
  '/posts',
  validator((v) => ({
    id: v.json('post.id').asNumber().isRequired(),
    title: v.json('post.title').isRequired().isLength(400),
    body: v.json('post.body').isOptional(),
  })),
  (c) => {
    const data = c.req.valid()
    return c.text(`ID is ${data.id}, Title is ${data.title}`)
  }
)
```

![SS](https://user-images.githubusercontent.com/10682/190910186-60efc2db-c1c8-426f-bab2-da038ddbb6d5.png)

Wow, we got "Types"!

There are other good points to this approach as well.

* Easy to understand the result data because "declaring property name first".
* Easy to writing rules. `v.isLength(400)` is better than `[v.isLength, 400]` .
* Getting only "declared properties". Additional properties are always ignored. It's safe.

I liked the current Validator Middleware, but I like this one even better.

One thing that bothers me is the implementation of `hono.ts` has become more complex.

How do you think about this?
