### PR TITLE
feat: support appending values with `c.header`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -5,7 +5,8 @@ import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
 import { isAbsoluteURL } from './utils/url.ts'
 
-type Headers = Record<string, string>
+type HeaderField = [string, string]
+type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
 
 export interface Context<
@@ -20,7 +21,7 @@ export interface Context<
 
   get res(): Response
   set res(_res: Response)
-  header: (name: string, value: string) => void
+  header: (name: string, value: string, options?: { append?: boolean }) => void
   status: (status: StatusCode) => void
   set: {
     <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
@@ -57,7 +58,7 @@ export class HonoContext<
   private _pretty: boolean = false
   private _prettySpace: number = 2
   private _map: Record<string, any> | undefined
-  private _headers: Record<string, string> | undefined
+  private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
   private notFoundHandler: NotFoundHandler<E>
 
@@ -100,11 +101,30 @@ export class HonoContext<
     this.finalized = true
   }
 
-  header(name: string, value: string): void {
+  header(name: string, value: string, options?: { append?: boolean }): void {
     this._headers ||= {}
-    this._headers[name.toLowerCase()] = value
+    const key = name.toLowerCase()
+
+    let shouldAppend = false
+    if (options && options.append) {
+      const vAlreadySet = this._headers[key]
+      if (vAlreadySet && vAlreadySet.length) {
+        shouldAppend = true
+      }
+    }
+
+    if (shouldAppend) {
+      this._headers[key].push(value)
+    } else {
+      this._headers[key] = [value]
+    }
+
     if (this.finalized) {
-      this.res.headers.set(name, value)
+      if (shouldAppend) {
+        this.res.headers.append(name, value)
+      } else {
+        this.res.headers.set(name, value)
+      }
     }
   }
 
@@ -136,16 +156,39 @@ export class HonoContext<
   }
 
   newResponse(data: Data | null, status: StatusCode, headers: Headers = {}): Response {
-    const _headers = { ...this._headers }
-    if (this._res) {
-      this._res.headers.forEach((v, k) => {
-        _headers[k] = v
-      })
-    }
     return new Response(data, {
       status: status || this._status || 200,
-      headers: { ..._headers, ...headers },
+      headers: this._finalizeHeaders(headers),
     })
+  }
+
+  private _finalizeHeaders(incomingHeaders: Headers): HeaderField[] {
+    const finalizedHeaders: HeaderField[] = []
+    const headersKv = this._headers || {}
+    // If Response is already set
+    if (this._res) {
+      this._res.headers.forEach((v, k) => {
+        headersKv[k] = [v]
+      })
+    }
+    for (const key of Object.keys(incomingHeaders)) {
+      const value = incomingHeaders[key]
+      if (typeof value === 'string') {
+        finalizedHeaders.push([key, value])
+      } else {
+        for (const v of value) {
+          finalizedHeaders.push([key, v])
+        }
+      }
+      delete headersKv[key]
+    }
+    for (const key of Object.keys(headersKv)) {
+      for (const value of headersKv[key]) {
+        const kv: HeaderField = [key, value]
+        finalizedHeaders.push(kv)
+      }
+    }
+    return finalizedHeaders
   }
 
   body(data: Data | null, status: StatusCode = this._status, headers: Headers = {}): Response {
@@ -183,7 +226,7 @@ export class HonoContext<
 
   cookie(name: string, value: string, opt?: CookieOptions): void {
     const cookie = serialize(name, value, opt)
-    this.header('set-cookie', cookie)
+    this.header('set-cookie', cookie, { append: true })
   }
 
   notFound(): Response | Promise<Response> {

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.155.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.156.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -68,6 +68,22 @@ describe('Context', () => {
     expect(foo).toBe('Bar')
   })
 
+  it('c.header() - append', async () => {
+    c.header('X-Foo', 'Bar')
+    c.header('X-Foo', 'Buzz', { append: true })
+    const res = c.body('Hi')
+    const foo = res.headers.get('X-Foo')
+    expect(foo).toBe('Bar, Buzz')
+  })
+
+  it('c.body() - multiple header', async () => {
+    const res = c.body('Hi', 200, {
+      'X-Foo': ['Bar', 'Buzz'],
+    })
+    const foo = res.headers.get('X-Foo')
+    expect(foo).toBe('Bar, Buzz')
+  })
+
   it('c.status()', async () => {
     c.status(201)
     const res = c.body('Hi')

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,7 +5,8 @@ import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
 import { isAbsoluteURL } from './utils/url'
 
-type Headers = Record<string, string>
+type HeaderField = [string, string]
+type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
 
 export interface Context<
@@ -20,7 +21,7 @@ export interface Context<
 
   get res(): Response
   set res(_res: Response)
-  header: (name: string, value: string) => void
+  header: (name: string, value: string, options?: { append?: boolean }) => void
   status: (status: StatusCode) => void
   set: {
     <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
@@ -57,7 +58,7 @@ export class HonoContext<
   private _pretty: boolean = false
   private _prettySpace: number = 2
   private _map: Record<string, any> | undefined
-  private _headers: Record<string, string> | undefined
+  private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
   private notFoundHandler: NotFoundHandler<E>
 
@@ -100,11 +101,30 @@ export class HonoContext<
     this.finalized = true
   }
 
-  header(name: string, value: string): void {
+  header(name: string, value: string, options?: { append?: boolean }): void {
     this._headers ||= {}
-    this._headers[name.toLowerCase()] = value
+    const key = name.toLowerCase()
+
+    let shouldAppend = false
+    if (options && options.append) {
+      const vAlreadySet = this._headers[key]
+      if (vAlreadySet && vAlreadySet.length) {
+        shouldAppend = true
+      }
+    }
+
+    if (shouldAppend) {
+      this._headers[key].push(value)
+    } else {
+      this._headers[key] = [value]
+    }
+
     if (this.finalized) {
-      this.res.headers.set(name, value)
+      if (shouldAppend) {
+        this.res.headers.append(name, value)
+      } else {
+        this.res.headers.set(name, value)
+      }
     }
   }
 
@@ -136,16 +156,39 @@ export class HonoContext<
   }
 
   newResponse(data: Data | null, status: StatusCode, headers: Headers = {}): Response {
-    const _headers = { ...this._headers }
-    if (this._res) {
-      this._res.headers.forEach((v, k) => {
-        _headers[k] = v
-      })
-    }
     return new Response(data, {
       status: status || this._status || 200,
-      headers: { ..._headers, ...headers },
+      headers: this._finalizeHeaders(headers),
     })
+  }
+
+  private _finalizeHeaders(incomingHeaders: Headers): HeaderField[] {
+    const finalizedHeaders: HeaderField[] = []
+    const headersKv = this._headers || {}
+    // If Response is already set
+    if (this._res) {
+      this._res.headers.forEach((v, k) => {
+        headersKv[k] = [v]
+      })
+    }
+    for (const key of Object.keys(incomingHeaders)) {
+      const value = incomingHeaders[key]
+      if (typeof value === 'string') {
+        finalizedHeaders.push([key, value])
+      } else {
+        for (const v of value) {
+          finalizedHeaders.push([key, v])
+        }
+      }
+      delete headersKv[key]
+    }
+    for (const key of Object.keys(headersKv)) {
+      for (const value of headersKv[key]) {
+        const kv: HeaderField = [key, value]
+        finalizedHeaders.push(kv)
+      }
+    }
+    return finalizedHeaders
   }
 
   body(data: Data | null, status: StatusCode = this._status, headers: Headers = {}): Response {
@@ -183,7 +226,7 @@ export class HonoContext<
 
   cookie(name: string, value: string, opt?: CookieOptions): void {
     const cookie = serialize(name, value, opt)
-    this.header('set-cookie', cookie)
+    this.header('set-cookie', cookie, { append: true })
   }
 
   notFound(): Response | Promise<Response> {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -988,6 +988,19 @@ describe('Cookie', () => {
         'great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict'
       )
     })
+
+    app.get('/set-cookie-multiple', (c) => {
+      c.cookie('delicious_cookie', 'macha')
+      c.cookie('delicious_cookie', 'choco')
+      return c.text('Give cookie')
+    })
+
+    it('Multiple values', async () => {
+      const res = await app.request('http://localhost/set-cookie-multiple')
+      expect(res.status).toBe(200)
+      const header = res.headers.get('Set-Cookie')
+      expect(header).toBe('delicious_cookie=macha, delicious_cookie=choco')
+    })
   })
 })
 


### PR DESCRIPTION
This PR enables appending values into the header with `c.header` function and makes it easier to set multiple values.

```ts
c.header('x-custom', 'foo')
c.header('x-custom', 'bar', { append: true })
```

And this PR proposes setting multiple cookies.

```ts
c.cookie('delicious_cookie', 'macha')
c.cookie('delicious_cookie', 'choco')
```

Close #534 #536 
