### PR TITLE
feat(router): support optional route

### DIFF
--- a/deno_dist/router/trie-router/router.ts
+++ b/deno_dist/router/trie-router/router.ts
@@ -1,5 +1,5 @@
 import type { Result, Router } from '../../router.ts'
-import { checkOptionalRoute } from '../../utils/url.ts'
+import { checkOptionalParameter } from '../../utils/url.ts'
 import { Node } from './node.ts'
 
 export class TrieRouter<T> implements Router<T> {
@@ -10,7 +10,7 @@ export class TrieRouter<T> implements Router<T> {
   }
 
   add(method: string, path: string, handler: T) {
-    const results = checkOptionalRoute(path)
+    const results = checkOptionalParameter(path)
     if (results) {
       for (const p of results) {
         this.node.insert(method, p, handler)

--- a/deno_dist/router/trie-router/router.ts
+++ b/deno_dist/router/trie-router/router.ts
@@ -1,4 +1,5 @@
 import type { Result, Router } from '../../router.ts'
+import { checkOptionalRoute } from '../../utils/url.ts'
 import { Node } from './node.ts'
 
 export class TrieRouter<T> implements Router<T> {
@@ -9,6 +10,14 @@ export class TrieRouter<T> implements Router<T> {
   }
 
   add(method: string, path: string, handler: T) {
+    const results = checkOptionalRoute(path)
+    if (results) {
+      for (const p of results) {
+        this.node.insert(method, p, handler)
+      }
+      return
+    }
+
     this.node.insert(method, path, handler)
   }
 

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.155.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.156.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -95,3 +95,17 @@ export const mergePath = (...paths: string[]): string => {
 
   return p
 }
+
+export const checkOptionalRoute = (path: string): string[] | null => {
+  /*
+   If path is `/api/animals/:type?` it will return:
+   [`/api/animals`, `/api/animals/:type`]
+   in other cases it will return null
+   */
+  const match = path.match(/(^.+)(\/\:[^\/]+)\?$/)
+  if (!match) return null
+
+  const base = match[1]
+  const optional = base + match[2]
+  return [base, optional]
+}

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -96,7 +96,7 @@ export const mergePath = (...paths: string[]): string => {
   return p
 }
 
-export const checkOptionalRoute = (path: string): string[] | null => {
+export const checkOptionalParameter = (path: string): string[] | null => {
   /*
    If path is `/api/animals/:type?` it will return:
    [`/api/animals`, `/api/animals/:type`]

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -145,3 +145,18 @@ describe('routing order with named parameters', () => {
     expect(res?.params['slug']).toBe('foo')
   })
 })
+
+describe('Optional route', () => {
+  const router = new TrieRouter<string>()
+  router.add('GET', '/api/animals/:type?', 'animals')
+  it('GET /api/animals/dog', async () => {
+    const res = router.match('GET', '/api/animals/dog')
+    expect(res?.handlers).toEqual(['animals'])
+    expect(res?.params['type']).toBe('dog')
+  })
+  it('GET /api/animals', async () => {
+    const res = router.match('GET', '/api/animals')
+    expect(res?.handlers).toEqual(['animals'])
+    expect(res?.params['type']).toBeUndefined()
+  })
+})

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -1,4 +1,5 @@
 import type { Result, Router } from '../../router'
+import { checkOptionalRoute } from '../../utils/url'
 import { Node } from './node'
 
 export class TrieRouter<T> implements Router<T> {
@@ -9,6 +10,14 @@ export class TrieRouter<T> implements Router<T> {
   }
 
   add(method: string, path: string, handler: T) {
+    const results = checkOptionalRoute(path)
+    if (results) {
+      for (const p of results) {
+        this.node.insert(method, p, handler)
+      }
+      return
+    }
+
     this.node.insert(method, path, handler)
   }
 

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -1,5 +1,5 @@
 import type { Result, Router } from '../../router'
-import { checkOptionalRoute } from '../../utils/url'
+import { checkOptionalParameter } from '../../utils/url'
 import { Node } from './node'
 
 export class TrieRouter<T> implements Router<T> {
@@ -10,7 +10,7 @@ export class TrieRouter<T> implements Router<T> {
   }
 
   add(method: string, path: string, handler: T) {
-    const results = checkOptionalRoute(path)
+    const results = checkOptionalParameter(path)
     if (results) {
       for (const p of results) {
         this.node.insert(method, p, handler)

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -5,6 +5,7 @@ import {
   isAbsoluteURL,
   mergePath,
   getQueryStringFromURL,
+  checkOptionalRoute,
 } from './url'
 
 describe('url', () => {
@@ -123,6 +124,20 @@ describe('url', () => {
     })
     it('Should be `/`', () => {
       expect(mergePath('/', '/')).toBe('/')
+    })
+  })
+
+  describe('checkOptionalRoute', () => {
+    it('checkOptionalRoute', () => {
+      expect(checkOptionalRoute('/api/animals/:type?')).toEqual([
+        '/api/animals',
+        '/api/animals/:type',
+      ])
+      expect(checkOptionalRoute('/api/animals/type?')).toBeNull()
+      expect(checkOptionalRoute('/api/animals/:type')).toBeNull()
+      expect(checkOptionalRoute('/api/animals')).toBeNull()
+      expect(checkOptionalRoute('/api/:animals?/type')).toBeNull()
+      expect(checkOptionalRoute('/api/animals/:type?/')).toBeNull()
     })
   })
 })

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -5,7 +5,7 @@ import {
   isAbsoluteURL,
   mergePath,
   getQueryStringFromURL,
-  checkOptionalRoute,
+  checkOptionalParameter,
 } from './url'
 
 describe('url', () => {
@@ -127,17 +127,17 @@ describe('url', () => {
     })
   })
 
-  describe('checkOptionalRoute', () => {
-    it('checkOptionalRoute', () => {
-      expect(checkOptionalRoute('/api/animals/:type?')).toEqual([
+  describe('checkOptionalParameter', () => {
+    it('checkOptionalParameter', () => {
+      expect(checkOptionalParameter('/api/animals/:type?')).toEqual([
         '/api/animals',
         '/api/animals/:type',
       ])
-      expect(checkOptionalRoute('/api/animals/type?')).toBeNull()
-      expect(checkOptionalRoute('/api/animals/:type')).toBeNull()
-      expect(checkOptionalRoute('/api/animals')).toBeNull()
-      expect(checkOptionalRoute('/api/:animals?/type')).toBeNull()
-      expect(checkOptionalRoute('/api/animals/:type?/')).toBeNull()
+      expect(checkOptionalParameter('/api/animals/type?')).toBeNull()
+      expect(checkOptionalParameter('/api/animals/:type')).toBeNull()
+      expect(checkOptionalParameter('/api/animals')).toBeNull()
+      expect(checkOptionalParameter('/api/:animals?/type')).toBeNull()
+      expect(checkOptionalParameter('/api/animals/:type?/')).toBeNull()
     })
   })
 })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -95,3 +95,17 @@ export const mergePath = (...paths: string[]): string => {
 
   return p
 }
+
+export const checkOptionalRoute = (path: string): string[] | null => {
+  /*
+   If path is `/api/animals/:type?` it will return:
+   [`/api/animals`, `/api/animals/:type`]
+   in other cases it will return null
+   */
+  const match = path.match(/(^.+)(\/\:[^\/]+)\?$/)
+  if (!match) return null
+
+  const base = match[1]
+  const optional = base + match[2]
+  return [base, optional]
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -96,7 +96,7 @@ export const mergePath = (...paths: string[]): string => {
   return p
 }
 
-export const checkOptionalRoute = (path: string): string[] | null => {
+export const checkOptionalParameter = (path: string): string[] | null => {
   /*
    If path is `/api/animals/:type?` it will return:
    [`/api/animals`, `/api/animals/:type`]


### PR DESCRIPTION
This PR introduces "optional parameter":

```ts
app.get('/api/animals/:type?',() => {})
```

Will match:

```http
GET /api/animals
GET /api/animals/dog
```


Reference:
https://router.vuejs.org/guide/essentials/route-matching-syntax.html#sensitive-and-strict-route-options
