### PR TITLE
fix: don't use `defaultNotFoundMessage` variable

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -5,7 +5,6 @@ import type {
   Bindings,
   ValidatedData,
 } from './hono.ts'
-import { defaultNotFoundMessage } from './hono.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
@@ -100,7 +99,7 @@ export class HonoContext<
   }
 
   get res(): Response {
-    return (this._res ||= new Response(defaultNotFoundMessage, { status: 404 }))
+    return (this._res ||= new Response('404 Not Found', { status: 404 }))
   }
 
   set res(_res: Response) {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -47,8 +47,6 @@ export type ErrorHandler<E extends Partial<Environment> = Environment> = (
 
 export type Next = () => Promise<void>
 
-export const defaultNotFoundMessage = '404 Not Found'
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
   ? Name
@@ -148,8 +146,7 @@ export class Hono<
   }
 
   private notFoundHandler: NotFoundHandler<E> = (c: Context<string, E>) => {
-    const message = defaultNotFoundMessage
-    return c.text(message, 404)
+    return c.text('404 Not Found', 404)
   }
 
   private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,7 +5,6 @@ import type {
   Bindings,
   ValidatedData,
 } from './hono'
-import { defaultNotFoundMessage } from './hono'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
@@ -100,7 +99,7 @@ export class HonoContext<
   }
 
   get res(): Response {
-    return (this._res ||= new Response(defaultNotFoundMessage, { status: 404 }))
+    return (this._res ||= new Response('404 Not Found', { status: 404 }))
   }
 
   set res(_res: Response) {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -47,8 +47,6 @@ export type ErrorHandler<E extends Partial<Environment> = Environment> = (
 
 export type Next = () => Promise<void>
 
-export const defaultNotFoundMessage = '404 Not Found'
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
   ? Name
@@ -148,8 +146,7 @@ export class Hono<
   }
 
   private notFoundHandler: NotFoundHandler<E> = (c: Context<string, E>) => {
-    const message = defaultNotFoundMessage
-    return c.text(message, 404)
+    return c.text('404 Not Found', 404)
   }
 
   private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {


### PR DESCRIPTION
This PR fixes the problem when installing Hono on Bun.

Fix #548