### PR TITLE
perf: remove `async` from dispatch; will be 16% faster

### DIFF
--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.156.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.157.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')


### PR DESCRIPTION
Remove `async` from `dispatch` function in `hono.ts`. A single handler that does not use `async` will be about 16% faster on Bun:

v2.2.1:

```
Reqs/sec    158951.18   43864.54  202188.36
Latency        1.26ms     1.39ms    41.26ms
HTTP codes:
1xx - 0, 2xx - 1589211, 3xx - 0, 4xx - 0, 5xx - 0
others - 0
Throughput:    21.67MB/s
```

This PR:

```
Reqs/sec    188225.08   24307.40  218436.45
Latency        1.06ms   109.58us    12.83ms
HTTP codes:
1xx - 0, 2xx - 1880915, 3xx - 0, 4xx - 0, 5xx - 0
others - 0
Throughput:    25.65MB/s
```
<img width="802" alt="SS" src="https://user-images.githubusercontent.com/10682/192086832-cde1bed7-6bf1-4b1e-be79-3eab4ad31cfc.png">

<img width="862" alt="SS" src="https://user-images.githubusercontent.com/10682/192086840-d5ecd000-c637-4d80-b003-2ac2e4955f09.png">

This benchmark using: https://github.com/SaltyAom/bun-http-framework-benchmark