### PR TITLE
feat(validator): add support for JSON array path validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,6 @@
 {
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "deno.enable": false,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   }

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -1,14 +1,37 @@
 import type { Context } from '../../context.ts'
 import type { Environment, Next, ValidatedData } from '../../hono.ts'
 import { VBase, Validator } from './validator.ts'
-import type { VString, VNumber, VBoolean, VObject, ValidateResult } from './validator.ts'
+import type {
+  VString,
+  VNumber,
+  VBoolean,
+  VObject,
+  VNumberArray,
+  VStringArray,
+  VBooleanArray,
+  ValidateResult,
+} from './validator.ts'
 
 type Schema = {
-  [key: string]: VString | VNumber | VBoolean | VObject | Schema
+  [key: string]:
+    | VString
+    | VNumber
+    | VBoolean
+    | VObject
+    | VStringArray
+    | VNumberArray
+    | VBooleanArray
+    | Schema
 }
 
 type SchemaToProp<T> = {
-  [K in keyof T]: T[K] extends VNumber
+  [K in keyof T]: T[K] extends VNumberArray
+    ? number[]
+    : T[K] extends VBooleanArray
+    ? boolean[]
+    : T[K] extends VStringArray
+    ? string[]
+    : T[K] extends VNumber
     ? number
     : T[K] extends VBoolean
     ? boolean

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -128,7 +128,11 @@ export abstract class VBase {
         result.message = this._message
       } else {
         const valToStr = Array.isArray(value)
-          ? `[${value.map((val) => (val === undefined ? 'undefined' : val)).join(', ')}]`
+          ? `[${value
+              .map((val) =>
+                val === undefined ? 'undefined' : typeof val === 'string' ? `"${val}"` : val
+              )
+              .join(', ')}]`
           : value
         switch (this.target) {
           case 'query':

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -1,10 +1,10 @@
 import { JSONPath } from '../../utils/json.ts'
-import type { JSONObject, JSONPrimative, JSONArray } from '../../utils/json.ts'
+import type { JSONObject, JSONPrimitive, JSONArray } from '../../utils/json.ts'
 import { rule } from './rule.ts'
 import { sanitizer } from './sanitizer.ts'
 
 type Target = 'query' | 'header' | 'body' | 'json'
-type Type = JSONPrimative | JSONObject | JSONArray | File
+type Type = JSONPrimitive | JSONObject | JSONArray | File
 type Rule = (value: Type) => boolean
 type Sanitizer = (value: Type) => Type
 

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -1,9 +1,10 @@
 import { JSONPath } from '../../utils/json.ts'
+import type { JSONObject, JSONPrimative, JSONArray } from '../../utils/json.ts'
 import { rule } from './rule.ts'
 import { sanitizer } from './sanitizer.ts'
 
 type Target = 'query' | 'header' | 'body' | 'json'
-type Type = string | number | boolean | object | undefined
+type Type = JSONPrimative | JSONObject | JSONArray | File
 type Rule = (value: Type) => boolean
 type Sanitizer = (value: Type) => Type
 
@@ -58,7 +59,7 @@ export abstract class VBase {
 
   isRequired = () => {
     return this.addRule((value: unknown) => {
-      if (value) return true
+      if (value !== undefined && value !== null && value !== '') return true
       return false
     })
   }
@@ -115,7 +116,7 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
-      const obj = await req.json()
+      const obj = (await req.json()) as JSONObject
       value = JSONPath(obj, this.key)
     }
 
@@ -126,18 +127,21 @@ export abstract class VBase {
       if (this._message) {
         result.message = this._message
       } else {
+        const valToStr = Array.isArray(value)
+          ? `[${value.map((val) => (val === undefined ? 'undefined' : val)).join(', ')}]`
+          : value
         switch (this.target) {
           case 'query':
-            result.message = `Invalid Value: the query parameter "${this.key}" is invalid - ${value}`
+            result.message = `Invalid Value: the query parameter "${this.key}" is invalid - ${valToStr}`
             break
           case 'header':
-            result.message = `Invalid Value: the request header "${this.key}" is invalid - ${value}`
+            result.message = `Invalid Value: the request header "${this.key}" is invalid - ${valToStr}`
             break
           case 'body':
-            result.message = `Invalid Value: the request body "${this.key}" is invalid - ${value}`
+            result.message = `Invalid Value: the request body "${this.key}" is invalid - ${valToStr}`
             break
           case 'json':
-            result.message = `Invalid Value: the JSON body "${this.key}" is invalid - ${value}`
+            result.message = `Invalid Value: the JSON body "${this.key}" is invalid - ${valToStr}`
             break
         }
       }
@@ -147,26 +151,51 @@ export abstract class VBase {
 
   private validateValue = (value: Type): boolean => {
     // Check type
-    if (typeof value !== this.type) {
-      if (this._optional && typeof value === 'undefined') {
-        // Do nothing.
-        // The value is allowed to be `undefined` if it is `optional`
-      } else {
-        return false
+    if (Array.isArray(value)) {
+      if (!value[0] || typeof value[0] !== this.type) {
+        if (this._optional && typeof value[0] === 'undefined') {
+          // Do nothing.
+          // The value is allowed to be `undefined` if it is `optional`
+        } else {
+          return false
+        }
       }
-    }
 
-    // Sanitize
-    for (const sanitizer of this.sanitizers) {
-      value = sanitizer(value)
-    }
-
-    for (const rule of this.rules) {
-      if (!rule(value)) {
-        return false
+      // Sanitize
+      for (const sanitizer of this.sanitizers) {
+        value = value.map((innerVal) => sanitizer(innerVal)) as JSONArray
       }
+
+      for (const rule of this.rules) {
+        for (const val of value) {
+          if (!rule(val)) {
+            return false
+          }
+        }
+      }
+      return true
+    } else {
+      if (typeof value !== this.type) {
+        if (this._optional && typeof value === 'undefined') {
+          // Do nothing.
+          // The value is allowed to be `undefined` if it is `optional`
+        } else {
+          return false
+        }
+      }
+
+      // Sanitize
+      for (const sanitizer of this.sanitizers) {
+        value = sanitizer(value)
+      }
+
+      for (const rule of this.rules) {
+        if (!rule(value)) {
+          return false
+        }
+      }
+      return true
     }
-    return true
   }
 }
 

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -152,12 +152,11 @@ export abstract class VBase {
   private validateValue = (value: Type): boolean => {
     // Check type
     if (Array.isArray(value)) {
-      if (!value[0] || typeof value[0] !== this.type) {
-        if (this._optional && typeof value[0] === 'undefined') {
-          // Do nothing.
-          // The value is allowed to be `undefined` if it is `optional`
-        } else {
-          return false
+      for (const val of value) {
+        if (typeof val !== this.type) {
+          // Value is of wrong type here
+          // If not optional, or optional and not undefined, return false
+          if (!this._optional || typeof val !== 'undefined') return false
         }
       }
 

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.157.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.158.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/deno_dist/utils/json.ts
+++ b/deno_dist/utils/json.ts
@@ -1,78 +1,35 @@
-const ARRAY_NOTATION_REGEX = /\[([0-9\*])\]/
-const ANY_INDEX = '*'
-
 export type JSONPrimitive = string | boolean | number | null | undefined
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
 export type JSONValue = JSONObject | JSONArray | JSONPrimitive
 
-export type AnyIndex = typeof ANY_INDEX
-
-export const isArraySubpath = (subpath: string): boolean => {
-  const match = subpath.match(ARRAY_NOTATION_REGEX)
-  return Boolean(match ? match.length : false)
-}
-export const getArrSubpathIndex = (subpath: string): number | AnyIndex | undefined => {
-  const match = subpath.match(ARRAY_NOTATION_REGEX)
-  if (!match?.length) return undefined
-  // This works because only * and 0-9 should pass regex
-  if (match[1] === '*') {
-    return match[1]
-  } else {
-    const asInt = parseInt(match[1])
-    if (isNaN(asInt)) return undefined
-    else return asInt
-  }
-}
-
-const fromPath = (data: JSONObject, parts: string[]): JSONValue | undefined => {
-  let val: JSONValue | undefined = data
+const JSONPathInternal = (data: JSONValue, parts: string[]): JSONValue => {
   const length = parts.length
-  for (let i = 0; i < length && val !== undefined; i++) {
+  for (let i = 0; i < length && data !== undefined; i++) {
     const p = parts[i]
-    if (p !== '') {
-      if (isArraySubpath(p)) {
-        const arrName = p.replace(ARRAY_NOTATION_REGEX, '')
-        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimitive[]
-        if (Array.isArray(arr)) {
-          const subIdx = getArrSubpathIndex(p)
-          if (typeof subIdx === 'number') {
-            val = arr[subIdx]
-          } else if (subIdx === '*') {
-            // Get rest of path
-            if (Array.isArray(arr[0])) {
-              throw new Error('Directly nested arrays not supported!')
-            }
-            val = arr.flatMap((curr) =>
-              curr && typeof curr === 'object' ? fromPath(curr, parts.slice(i + 1)) : curr
-            )
-            break
-          } else {
-            val = undefined
-          }
-        } else {
-          // This is an error, return undefined
-          val = undefined
-        }
-      } else if (Array.isArray(val)) {
-        // Val is an array, but we weren't marked as an array subpath
-        // Also, we know we shouldn't be here if this array was the last subpath part
-        // So this is invalid
-        val = undefined
-      } else if (typeof val === 'object') {
-        // Type coercion because type validator thinks val can be null past the if check
-        val = (val as JSONObject)[p]
-      } else {
-        val = undefined
-      }
+    if (p === '') {
+      continue
+    }
+
+    if (typeof data !== 'object' || data === null) {
+      return undefined
+    }
+
+    if (p === '*') {
+      const restParts = parts.slice(i + 1)
+      const values = Object.values(data).map((v) => JSONPathInternal(v, restParts))
+      return restParts.indexOf('*') === -1 ? values : values.flat()
+    } else {
+      data = (data as JSONObject)[p] // `data` may be an array, but accessing it as an object yields the same result.
     }
   }
-  return val
+  return data
 }
 
 export const JSONPath = (data: JSONObject, path: string) => {
-  let val: JSONValue | undefined = data
-  const parts = path.split('.')
-  val = fromPath(data, parts)
-  return val
+  try {
+    return JSONPathInternal(data, path.replace(/\[(.*?)\]/g, '.$1').split(/\./))
+  } catch (e) {
+    return undefined
+  }
 }

--- a/deno_dist/utils/json.ts
+++ b/deno_dist/utils/json.ts
@@ -1,17 +1,78 @@
-export const JSONPath = (data: object, path: string) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let val: any = data
-  const parts = path.split('.')
+const ARRAY_NOTATION_REGEX = /\[([0-9\*])\]/
+const ANY_INDEX = '*'
+
+export type JSONPrimative = string | boolean | number | null | undefined
+export type JSONArray = (JSONPrimative | JSONObject | JSONArray)[]
+export type JSONObject = { [key: string]: JSONPrimative | JSONArray | JSONObject }
+export type JSONValue = JSONObject | JSONArray | JSONPrimative
+
+export type AnyIndex = typeof ANY_INDEX
+
+export const isArraySubpath = (subpath: string): boolean => {
+  const match = subpath.match(ARRAY_NOTATION_REGEX)
+  return Boolean(match ? match.length : false)
+}
+export const getArrSubpathIndex = (subpath: string): number | AnyIndex | undefined => {
+  const match = subpath.match(ARRAY_NOTATION_REGEX)
+  if (!match?.length) return undefined
+  // This works because only * and 0-9 should pass regex
+  if (match[1] === '*') {
+    return match[1]
+  } else {
+    const asInt = parseInt(match[1])
+    if (isNaN(asInt)) return undefined
+    else return asInt
+  }
+}
+
+const fromPath = (data: JSONObject, parts: string[]): JSONValue | undefined => {
+  let val: JSONValue | undefined = data
   const length = parts.length
   for (let i = 0; i < length && val !== undefined; i++) {
     const p = parts[i]
     if (p !== '') {
-      if (typeof val === 'object') {
-        val = val[p]
+      if (isArraySubpath(p)) {
+        const arrName = p.replace(ARRAY_NOTATION_REGEX, '')
+        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimative[]
+        if (Array.isArray(arr)) {
+          const subIdx = getArrSubpathIndex(p)
+          if (typeof subIdx === 'number') {
+            val = arr[subIdx]
+          } else if (subIdx === '*') {
+            // Get rest of path
+            if (Array.isArray(arr[0])) {
+              throw new Error('Directly nested arrays not supported!')
+            }
+            val = arr.flatMap((curr) =>
+              curr && typeof curr === 'object' ? fromPath(curr, parts.slice(i + 1)) : curr
+            )
+            break
+          } else {
+            val = undefined
+          }
+        } else {
+          // This is an error, return undefined
+          val = undefined
+        }
+      } else if (Array.isArray(val)) {
+        // Val is an array, but we weren't marked as an array subpath
+        // Also, we know we shouldn't be here if this array was the last subpath part
+        // So this is invalid
+        val = undefined
+      } else if (typeof val === 'object') {
+        // Type coercion because type validator thinks val can be null past the if check
+        val = (val as JSONObject)[p]
       } else {
         val = undefined
       }
     }
   }
+  return val
+}
+
+export const JSONPath = (data: JSONObject, path: string) => {
+  let val: JSONValue | undefined = data
+  const parts = path.split('.')
+  val = fromPath(data, parts)
   return val
 }

--- a/deno_dist/utils/json.ts
+++ b/deno_dist/utils/json.ts
@@ -1,10 +1,10 @@
 const ARRAY_NOTATION_REGEX = /\[([0-9\*])\]/
 const ANY_INDEX = '*'
 
-export type JSONPrimative = string | boolean | number | null | undefined
-export type JSONArray = (JSONPrimative | JSONObject | JSONArray)[]
-export type JSONObject = { [key: string]: JSONPrimative | JSONArray | JSONObject }
-export type JSONValue = JSONObject | JSONArray | JSONPrimative
+export type JSONPrimitive = string | boolean | number | null | undefined
+export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
+export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
+export type JSONValue = JSONObject | JSONArray | JSONPrimitive
 
 export type AnyIndex = typeof ANY_INDEX
 
@@ -33,7 +33,7 @@ const fromPath = (data: JSONObject, parts: string[]): JSONValue | undefined => {
     if (p !== '') {
       if (isArraySubpath(p)) {
         const arrName = p.replace(ARRAY_NOTATION_REGEX, '')
-        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimative[]
+        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimitive[]
         if (Array.isArray(arr)) {
           const subIdx = getArrSubpathIndex(p)
           if (typeof subIdx === 'number') {

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -432,7 +432,7 @@ describe('Structured data', () => {
   })
 })
 
-describe('', () => {
+describe('Array values', () => {
   const app = new Hono()
   app.post(
     '/post',

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -25,7 +25,13 @@ type Schema = {
 }
 
 type SchemaToProp<T> = {
-  [K in keyof T]: T[K] extends VNumber
+  [K in keyof T]: T[K] extends VNumberArray
+    ? number[]
+    : T[K] extends VBooleanArray
+    ? boolean[]
+    : T[K] extends VStringArray
+    ? string[]
+    : T[K] extends VNumber
     ? number
     : T[K] extends VBoolean
     ? boolean
@@ -33,12 +39,6 @@ type SchemaToProp<T> = {
     ? string
     : T[K] extends VObject
     ? object
-    : T[K] extends VNumberArray
-    ? number[]
-    : T[K] extends VBooleanArray
-    ? boolean[]
-    : T[K] extends VStringArray
-    ? string[]
     : T[K] extends Schema
     ? SchemaToProp<T[K]>
     : never

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -25,13 +25,7 @@ type Schema = {
 }
 
 type SchemaToProp<T> = {
-  [K in keyof T]: T[K] extends VNumberArray
-    ? number[]
-    : T[K] extends VBooleanArray
-    ? boolean[]
-    : T[K] extends VStringArray
-    ? string[]
-    : T[K] extends VNumber
+  [K in keyof T]: T[K] extends VNumber
     ? number
     : T[K] extends VBoolean
     ? boolean
@@ -39,6 +33,12 @@ type SchemaToProp<T> = {
     ? string
     : T[K] extends VObject
     ? object
+    : T[K] extends VNumberArray
+    ? number[]
+    : T[K] extends VBooleanArray
+    ? boolean[]
+    : T[K] extends VStringArray
+    ? string[]
     : T[K] extends Schema
     ? SchemaToProp<T[K]>
     : never

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -127,6 +127,34 @@ describe('Basic - JSON', () => {
   })
 })
 
+describe('Handle required values', () => {
+  const v = new Validator()
+
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: JSON.stringify({ comment: null, name: 'John', admin: false }),
+  })
+
+  it('Should be valid - `name` is required', async () => {
+    const validator = v.json('name').isRequired()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+  })
+
+  it('Should be invalid - `comment` is required but missing', async () => {
+    const validator = v.json('comment').isRequired()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+  })
+
+  it('Should be valid - `admin` is required and present, although falsey', async () => {
+    const validator = v.json('admin').asBoolean().isRequired()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.value).toBe(false)
+  })
+})
+
 describe('Handle optional values', () => {
   const v = new Validator()
 

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -210,18 +210,23 @@ describe('Handle array paths', () => {
         title: 'This is title #1',
         published: true,
         rating: [true, 'cool'],
+        awesome: true,
+        testing: false,
       },
       {
         id: 12412,
         title: 'This is title #2',
         published: true,
         rating: [false],
+        awesome: 'true',
+        testing: true,
       },
       {
         id: 12413,
         title: 'This is title #3',
         published: false,
         rating: [true, 'lame'],
+        awesome: false,
       },
     ],
   }
@@ -255,7 +260,7 @@ describe('Handle array paths', () => {
     expect(res.value).toEqual(['cool', undefined, 'lame'])
   })
 
-  it('Should allow error with invalid array paths', async () => {
+  it('Should provide error with invalid array paths', async () => {
     const validator = v.json('posts[*].rating[3]')
     const res = await validator.validate(req)
     expect(res.isValid).toBe(false)
@@ -264,5 +269,23 @@ describe('Handle array paths', () => {
     ]
     expect(res.message).toBe(messages.join('\n'))
     expect(res.value).toEqual([undefined, undefined, undefined])
+  })
+
+  it('Should prevent invalid types within array', async () => {
+    const validator = v.json('posts[*].awesome').asBoolean()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(false)
+    const messages = [
+      'Invalid Value: the JSON body "posts[*].awesome" is invalid - [true, "true", false]',
+    ]
+    expect(res.message).toBe(messages.join('\n'))
+    expect(res.value).toEqual([true, 'true', false])
+  })
+
+  it('Should allow undefined values when optional', async () => {
+    const validator = v.json('posts[*].testing').asBoolean().isOptional()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+    expect(res.value).toEqual([false, true, undefined])
   })
 })

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -128,7 +128,11 @@ export abstract class VBase {
         result.message = this._message
       } else {
         const valToStr = Array.isArray(value)
-          ? `[${value.map((val) => (val === undefined ? 'undefined' : val)).join(', ')}]`
+          ? `[${value
+              .map((val) =>
+                val === undefined ? 'undefined' : typeof val === 'string' ? `"${val}"` : val
+              )
+              .join(', ')}]`
           : value
         switch (this.target) {
           case 'query':

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -307,18 +307,21 @@ export class VObject extends VBase {
 }
 
 export class VNumberArray extends VNumber {
+  isArray: true
   constructor(options: VOptions) {
     super(options)
     this.isArray = true
   }
 }
 export class VStringArray extends VString {
+  isArray: true
   constructor(options: VOptions) {
     super(options)
     this.isArray = true
   }
 }
 export class VBooleanArray extends VBoolean {
+  isArray: true
   constructor(options: VOptions) {
     super(options)
     this.isArray = true

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -58,7 +58,7 @@ export abstract class VBase {
 
   isRequired = () => {
     return this.addRule((value: unknown) => {
-      if (value) return true
+      if (value !== undefined && value !== null && value !== '') return true
       return false
     })
   }
@@ -115,7 +115,7 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
-      const obj = await req.json()
+      const obj = (await req.json()) as JSONObject
       value = JSONPath(obj, this.key)
     }
 

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -1,10 +1,10 @@
 import { JSONPath } from '../../utils/json'
-import type { JSONObject, JSONPrimative, JSONArray } from '../../utils/json'
+import type { JSONObject, JSONPrimitive, JSONArray } from '../../utils/json'
 import { rule } from './rule'
 import { sanitizer } from './sanitizer'
 
 type Target = 'query' | 'header' | 'body' | 'json'
-type Type = JSONPrimative | JSONObject | JSONArray | File
+type Type = JSONPrimitive | JSONObject | JSONArray | File
 type Rule = (value: Type) => boolean
 type Sanitizer = (value: Type) => Type
 

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -3,7 +3,7 @@ import { rule } from './rule'
 import { sanitizer } from './sanitizer'
 
 type Target = 'query' | 'header' | 'body' | 'json'
-type Type = string | number | boolean | object | undefined
+type Type = string | number | boolean | object | null | undefined
 type Rule = (value: Type) => boolean
 type Sanitizer = (value: Type) => Type
 

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -152,12 +152,11 @@ export abstract class VBase {
   private validateValue = (value: Type): boolean => {
     // Check type
     if (Array.isArray(value)) {
-      if (!value[0] || typeof value[0] !== this.type) {
-        if (this._optional && typeof value[0] === 'undefined') {
-          // Do nothing.
-          // The value is allowed to be `undefined` if it is `optional`
-        } else {
-          return false
+      for (const val of value) {
+        if (typeof val !== this.type) {
+          // Value is of wrong type here
+          // If not optional, or optional and not undefined, return false
+          if (!this._optional || typeof val !== 'undefined') return false
         }
       }
 

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -27,6 +27,7 @@ type VOptions = {
   target: Target
   key: string
   type?: 'string' | 'number' | 'boolean' | 'object'
+  isArray?: boolean
 }
 
 export abstract class VBase {
@@ -35,6 +36,7 @@ export abstract class VBase {
   key: string
   rules: Rule[]
   sanitizers: Sanitizer[]
+  isArray: boolean
   private _message: string | undefined
   private _optional: boolean
   constructor(options: VOptions) {
@@ -43,6 +45,7 @@ export abstract class VBase {
     this.type = options.type || 'string'
     this.rules = []
     this.sanitizers = []
+    this.isArray = options.isArray || false
     this._optional = false
   }
 
@@ -122,7 +125,7 @@ export abstract class VBase {
     result.value = value
     result.isValid = this.validateValue(value)
 
-    if (result.isValid == false) {
+    if (result.isValid === false) {
       if (this._message) {
         result.message = this._message
       } else {
@@ -154,7 +157,11 @@ export abstract class VBase {
 
   private validateValue = (value: Type): boolean => {
     // Check type
-    if (Array.isArray(value)) {
+    if (this.isArray) {
+      if (!Array.isArray(value)) {
+        return false
+      }
+
       for (const val of value) {
         if (typeof val !== this.type) {
           // Value is of wrong type here
@@ -300,11 +307,20 @@ export class VObject extends VBase {
 }
 
 export class VNumberArray extends VNumber {
-  isArray = true
+  constructor(options: VOptions) {
+    super(options)
+    this.isArray = true
+  }
 }
 export class VStringArray extends VString {
-  isArray = true
+  constructor(options: VOptions) {
+    super(options)
+    this.isArray = true
+  }
 }
 export class VBooleanArray extends VBoolean {
-  isArray = true
+  constructor(options: VOptions) {
+    super(options)
+    this.isArray = true
+  }
 }

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,3 +1,4 @@
+import type { JSONArray } from './json'
 import { JSONPath } from './json'
 
 describe('JSONPath', () => {
@@ -10,26 +11,74 @@ describe('JSONPath', () => {
       },
       tags: ['foo', 'bar', { framework: 'Hono' }],
     },
+    relatedPosts: [
+      {
+        title: 'HelloWorld',
+        author: {
+          name: 'The Flash',
+          age: 32,
+        },
+        tags: ['flash', 'marvel'],
+      },
+      {
+        title: 'Hello World',
+        author: {
+          name: 'Spiderman',
+          age: 26,
+        },
+        tags: ['spider', 'man'],
+      },
+      {
+        title: 'World. Hello!',
+        author: {
+          name: 'Batman',
+          age: 45,
+        },
+        tags: ['bat', 'man'],
+      },
+    ],
   }
 
   it('Should return the string or number pointed by JSON Path', () => {
     expect(JSONPath(data, 'post.title')).toBe('Hello')
     expect(JSONPath(data, 'post.author.name')).toBe('Superman')
     expect(JSONPath(data, 'post.author.age')).toBe(20)
-    expect(JSONPath(data, 'post.tags.0')).toBe('foo')
-    expect(JSONPath(data, 'post.tags.1')).toBe('bar')
-    expect(JSONPath(data, 'post.tags.2.framework')).toBe('Hono')
+    expect(JSONPath(data, 'post.tags[0]')).toBe('foo')
+    expect(JSONPath(data, 'post.tags[1]')).toBe('bar')
+    expect(JSONPath(data, 'post.tags[2].framework')).toBe('Hono')
   })
 
   it('Should return undefined', () => {
     expect(JSONPath(data, 'post.foo')).toBe(undefined)
     expect(JSONPath(data, 'post.author.foo')).toBe(undefined)
-    expect(JSONPath(data, 'post.tags.3')).toBe(undefined)
+    expect(JSONPath(data, 'post.tags[3]')).toBe(undefined)
   })
 
   it('Should return objects pointed by JSON Path', () => {
     expect(typeof JSONPath(data, 'post')).toBe('object')
     expect(JSONPath(data, 'post.author')).toEqual({ name: 'Superman', age: 20 })
-    expect(JSONPath(data, 'post.tags').length).toBe(3)
+    expect((JSONPath(data, 'post.tags') as JSONArray).length).toBe(3)
+  })
+
+  it('Should return an array when targeting fields in arrays of objects', () => {
+    expect(Array.isArray(JSONPath(data, 'relatedPosts[*].title'))).toBe(true)
+    expect(JSONPath(data, 'relatedPosts[*].title')).toEqual([
+      'HelloWorld',
+      'Hello World',
+      'World. Hello!',
+    ])
+  })
+
+  it('Should return all deeply nested JSON path results', () => {
+    expect(Array.isArray(JSONPath(data, 'relatedPosts[*].tags[*]'))).toBe(true)
+    expect(JSONPath(data, 'relatedPosts[*].tags[*]')).toEqual([
+      'flash',
+      'marvel',
+      'spider',
+      'man',
+      'bat',
+      'man',
+    ])
+    expect(JSONPath(data, 'relatedPosts[*].tags[1]')).toEqual(['marvel', 'man', 'man'])
   })
 })

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -109,7 +109,11 @@ describe('JSONPath', () => {
   })
 
   it('Should return undefined if there is no matching path.', () => {
-    expect(JSONPath(data, 'releases[*].i386')).toBe(undefined)
+    expect(JSONPath(data, 'post.category')).toEqual(undefined)
+  })
+
+  it('Should return array of undefined if there is no matching path within array', () => {
+    expect(JSONPath(data, 'releases[*].i386')).toEqual([undefined, undefined, undefined])
   })
 
   it('Should return value from nested array', () => {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -3,8 +3,6 @@ export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
 export type JSONValue = JSONObject | JSONArray | JSONPrimitive
 
-const noMatch = Symbol('no match')
-
 const JSONPathInternal = (data: JSONValue, parts: string[]): JSONValue => {
   const length = parts.length
   for (let i = 0; i < length && data !== undefined; i++) {
@@ -14,31 +12,15 @@ const JSONPathInternal = (data: JSONValue, parts: string[]): JSONValue => {
     }
 
     if (typeof data !== 'object' || data === null) {
-      throw noMatch
+      return undefined
     }
 
     if (p === '*') {
       const restParts = parts.slice(i + 1)
-      const values = Object.values<JSONValue>(data).map((v): JSONValue | typeof noMatch => {
-        try {
-          return JSONPathInternal(v, restParts)
-        } catch (e) {
-          if (e === noMatch) {
-            return noMatch
-          } else {
-            throw e
-          }
-        }
-      })
-      if (values.every((v) => v === noMatch)) {
-        throw noMatch
-      }
-      const matches = values.filter((v): v is JSONValue => v !== noMatch)
-      return restParts.indexOf('*') === -1 ? matches : matches.flat()
-    } else if (p in data) {
-      data = (data as JSONObject)[p] // `data` may be an array, but accessing it as an object yields the same result.
+      const values = Object.values(data).map((v) => JSONPathInternal(v, restParts))
+      return restParts.indexOf('*') === -1 ? values : values.flat()
     } else {
-      throw noMatch
+      data = (data as JSONObject)[p] // `data` may be an array, but accessing it as an object yields the same result.
     }
   }
   return data

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,20 +1,78 @@
-export type JSONPrimative = string | boolean | number | null
-export type JSONObject = { [key: string]: JSONPrimative }
-export type JSONValue = JSONObject | JSONPrimative
+const ARRAY_NOTATION_REGEX = /\[([0-9\*])\]/
+const ANY_INDEX = '*'
 
-export const JSONPath = (data: JSONObject, path: string) => {
+export type JSONPrimative = string | boolean | number | null | undefined
+export type JSONArray = (JSONPrimative | JSONObject | JSONArray)[]
+export type JSONObject = { [key: string]: JSONPrimative | JSONArray | JSONObject }
+export type JSONValue = JSONObject | JSONArray | JSONPrimative
+
+export type AnyIndex = typeof ANY_INDEX
+
+export const isArraySubpath = (subpath: string): boolean => {
+  const match = subpath.match(ARRAY_NOTATION_REGEX)
+  return Boolean(match ? match.length : false)
+}
+export const getArrSubpathIndex = (subpath: string): number | AnyIndex | undefined => {
+  const match = subpath.match(ARRAY_NOTATION_REGEX)
+  if (!match?.length) return undefined
+  // This works because only * and 0-9 should pass regex
+  if (match[1] === '*') {
+    return match[1]
+  } else {
+    const asInt = parseInt(match[1])
+    if (isNaN(asInt)) return undefined
+    else return asInt
+  }
+}
+
+const fromPath = (data: JSONObject, parts: string[]): JSONValue | undefined => {
   let val: JSONValue | undefined = data
-  const parts = path.split('.')
   const length = parts.length
-  for (let i = 0; i < length && val !== undefined && val !== null; i++) {
+  for (let i = 0; i < length && val !== undefined; i++) {
     const p = parts[i]
     if (p !== '') {
-      if (typeof val === 'object') {
-        val = val[p]
+      if (isArraySubpath(p)) {
+        const arrName = p.replace(ARRAY_NOTATION_REGEX, '')
+        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimative[]
+        if (Array.isArray(arr)) {
+          const subIdx = getArrSubpathIndex(p)
+          if (typeof subIdx === 'number') {
+            val = arr[subIdx]
+          } else if (subIdx === '*') {
+            // Get rest of path
+            if (Array.isArray(arr[0])) {
+              throw new Error('Directly nested arrays not supported!')
+            }
+            val = arr.flatMap((curr) =>
+              curr && typeof curr === 'object' ? fromPath(curr, parts.slice(i + 1)) : curr
+            )
+            break
+          } else {
+            val = undefined
+          }
+        } else {
+          // This is an error, return undefined
+          val = undefined
+        }
+      } else if (Array.isArray(val)) {
+        // Val is an array, but we weren't marked as an array subpath
+        // Also, we know we shouldn't be here if this array was the last subpath part
+        // So this is invalid
+        val = undefined
+      } else if (typeof val === 'object') {
+        // Type coercion because type validator thinks val can be null past the if check
+        val = (val as JSONObject)[p]
       } else {
         val = undefined
       }
     }
   }
+  return val
+}
+
+export const JSONPath = (data: JSONObject, path: string) => {
+  let val: JSONValue | undefined = data
+  const parts = path.split('.')
+  val = fromPath(data, parts)
   return val
 }

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,9 +1,12 @@
-export const JSONPath = (data: object, path: string) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let val: any = data
+export type JSONPrimative = string | boolean | number | null
+export type JSONObject = { [key: string]: JSONPrimative }
+export type JSONValue = JSONObject | JSONPrimative
+
+export const JSONPath = (data: JSONObject, path: string) => {
+  let val: JSONValue | undefined = data
   const parts = path.split('.')
   const length = parts.length
-  for (let i = 0; i < length && val !== undefined; i++) {
+  for (let i = 0; i < length && val !== undefined && val !== null; i++) {
     const p = parts[i]
     if (p !== '') {
       if (typeof val === 'object') {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,10 +1,10 @@
 const ARRAY_NOTATION_REGEX = /\[([0-9\*])\]/
 const ANY_INDEX = '*'
 
-export type JSONPrimative = string | boolean | number | null | undefined
-export type JSONArray = (JSONPrimative | JSONObject | JSONArray)[]
-export type JSONObject = { [key: string]: JSONPrimative | JSONArray | JSONObject }
-export type JSONValue = JSONObject | JSONArray | JSONPrimative
+export type JSONPrimitive = string | boolean | number | null | undefined
+export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
+export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
+export type JSONValue = JSONObject | JSONArray | JSONPrimitive
 
 export type AnyIndex = typeof ANY_INDEX
 
@@ -33,7 +33,7 @@ const fromPath = (data: JSONObject, parts: string[]): JSONValue | undefined => {
     if (p !== '') {
       if (isArraySubpath(p)) {
         const arrName = p.replace(ARRAY_NOTATION_REGEX, '')
-        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimative[]
+        const arr = (val as JSONObject)[arrName] as JSONObject[] | JSONPrimitive[]
         if (Array.isArray(arr)) {
           const subIdx = getArrSubpathIndex(p)
           if (typeof subIdx === 'number') {


### PR DESCRIPTION
This PR adds support for JSON array paths in the JSONPath util, and also support for validating JSON array paths from a validator context.

The update doesn't break backwards compatibility with the current API (besides the previous less standard `.i` syntax, eg. `posts.4` instead of `posts[4]`) and provides the ability to validate arbitrary array paths, including complex paths of nested arrays and objects.

For example this:
```ts
const jsonBody = {
  posts: [
    {
       title: 'New Post 1',
       tags: ['new-ish', false],
    },
    {
       title: 'New Post 2',
       tags: ['newest', true],
    },
  ],
}
```
Can have arbitrary validations like this:
```ts
validator((v) => ({
  title: v.json('posts[*].title').isRequired(),
  secondTag: v.json('posts[*].tags[1]').asBoolean().isRequired(),
}))
```

One thing I would like to do in the future is to provide messages to the API consumer about which specific values in an array path failed validation, eg. `posts[2].title is required -- undefined`. I have a working version of this in a patch for the old middleware using `validator.js`, but it would need to be modified, as mentioned in #561. However, that is for another time. As of now, I think I am ready for comment on this PR.

Let me know if there is anything that needs to be changed with this PR before merge, or if you think this is a good approach at all.