### PR TITLE
refactor(bun/serve-static): don't check `c.res`

### DIFF
--- a/src/middleware/serve-static/bun.ts
+++ b/src/middleware/serve-static/bun.ts
@@ -19,7 +19,7 @@ const DEFAULT_DOCUMENT = 'index.html'
 export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
   return async (c: Context, next: Next) => {
     // Do nothing if Response is already set
-    if (c.res && c.finalized) {
+    if (c.finalized) {
       await next()
     }
     const url = new URL(c.req.url)


### PR DESCRIPTION
It does not check `c.res` so that `c.res` would not be initialized.

This PR related to #510 