### PR TITLE
fix(cache): export cache middleware for Deno

### DIFF
--- a/deno_dist/middleware.ts
+++ b/deno_dist/middleware.ts
@@ -1,6 +1,7 @@
 // Middleware
 export * from './middleware/basic-auth/index.ts'
 export * from './middleware/bearer-auth/index.ts'
+export * from './middleware/cache/index.ts'
 export * from './middleware/compress/index.ts'
 export * from './middleware/cors/index.ts'
 export * from './middleware/etag/index.ts'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 // Middleware
 export * from './middleware/basic-auth'
 export * from './middleware/bearer-auth'
+export * from './middleware/cache'
 export * from './middleware/compress'
 export * from './middleware/cors'
 export * from './middleware/etag'

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -43,7 +43,7 @@ describe('JWT', () => {
 
   it('JwtTokenNotBefore', async () => {
     const tok =
-      'eyJraWQiOiJFemF7bVZWbnd0TUpUNEFveFVtT0dILWJ0Y2VUVFM3djBYcEJuMm5ZZ2VjIiwiYWxnIjoiSFMyNTYifQ.eyJyb2xlIjoiYXBpX3JvbGUiLCJuYmYiOjE2NjQ1ODI0MDB9.BatadbUj5e41OZ33odEFTAndQFzX0w9aAgpQPgO-zaQ'
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjQ2MDYzMzQsImV4cCI6MTY2NDYwOTkzNCwibmJmIjoiMzEwNDYwNjI2NCJ9.hpSDT_cfkxeiLWEpWVT8TDxFP3dFi27q1K7CcMcLXHc'
     const secret = 'a-secret'
     let err: JwtTokenNotBefore
     let authorized = false


### PR DESCRIPTION
We should export the Cache middleware for the Deno distribution so that we can use it in Deno 1.26+ now that it is available.