### PR TITLE
fix(compose): don't throw Error; set error response into `c.res`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -23,6 +23,7 @@ export interface Context<
   event: FetchEvent
   executionCtx: ExecutionContext
   finalized: boolean
+  error: Error | undefined
 
   get res(): Response
   set res(_res: Response)
@@ -58,6 +59,7 @@ export class HonoContext<
   req: Request<RequestParamKeyType, D>
   env: E['Bindings']
   finalized: boolean
+  error: Error | undefined = undefined
 
   _status: StatusCode = 200
   private _executionCtx: FetchEvent | ExecutionContext | undefined

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -249,7 +249,11 @@ export class Hono<
     }
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
-    const composed = compose<HonoContext<string, E>, E>(handlers, this.notFoundHandler)
+    const composed = compose<HonoContext<string, E>, E>(
+      handlers,
+      this.notFoundHandler,
+      this.errorHandler
+    )
 
     return (async () => {
       try {

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -230,17 +230,16 @@ describe('compose with Context - 500 error', () => {
     }
 
     const mHandler = async (_c: Context, next: Function) => {
-      try {
-        await next()
-      } catch {
-        return c.text('onError', 500)
-      }
+      await next()
     }
 
     middleware.push(mHandler)
     middleware.push(handler)
 
-    const composed = compose<Context>(middleware)
+    const onNotFound = (c: Context) => c.text('NotFound', 404)
+    const onError = (_error: Error, c: Context) => c.text('onError', 500)
+
+    const composed = compose<Context>(middleware, onNotFound, onError)
     const context = await composed(c)
     expect(context.res).not.toBeNull()
     expect(context.res.status).toBe(500)

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,5 @@
 import { HonoContext } from './context'
-import type { Environment, NotFoundHandler } from './hono'
+import type { Environment, NotFoundHandler, ErrorHandler } from './hono'
 
 interface ComposeContext {
   finalized: boolean
@@ -9,7 +9,8 @@ interface ComposeContext {
 // Based on the code in the MIT licensed `koa-compose` package.
 export const compose = <C extends ComposeContext, E extends Partial<Environment> = Environment>(
   middleware: Function[],
-  onNotFound?: NotFoundHandler<E>
+  onNotFound?: NotFoundHandler<E>,
+  onError?: ErrorHandler<E>
 ) => {
   const middlewareLength = middleware.length
   return (context: C, next?: Function) => {
@@ -25,20 +26,31 @@ export const compose = <C extends ComposeContext, E extends Partial<Environment>
       if (i === middlewareLength && next) handler = next
 
       let res
+      let isError = false
 
       if (!handler) {
         if (context instanceof HonoContext && context.finalized === false && onNotFound) {
           res = onNotFound(context)
         }
       } else {
-        res = handler(context, () => {
-          const dispatchRes = dispatch(i + 1)
-          return dispatchRes instanceof Promise ? dispatchRes : Promise.resolve(dispatchRes)
-        })
+        try {
+          res = handler(context, () => {
+            const dispatchRes = dispatch(i + 1)
+            return dispatchRes instanceof Promise ? dispatchRes : Promise.resolve(dispatchRes)
+          })
+        } catch (err) {
+          if (err instanceof Error && context instanceof HonoContext && onError) {
+            context.error = err
+            res = onError(err, context)
+            isError = true
+          } else {
+            throw err
+          }
+        }
       }
 
       if (!(res instanceof Promise)) {
-        if (res && context.finalized === false) {
+        if (res && (context.finalized === false || isError)) {
           context.res = res
         }
         return context

--- a/src/context.ts
+++ b/src/context.ts
@@ -23,6 +23,7 @@ export interface Context<
   event: FetchEvent
   executionCtx: ExecutionContext
   finalized: boolean
+  error: Error | undefined
 
   get res(): Response
   set res(_res: Response)
@@ -58,6 +59,7 @@ export class HonoContext<
   req: Request<RequestParamKeyType, D>
   env: E['Bindings']
   finalized: boolean
+  error: Error | undefined = undefined
 
   _status: StatusCode = 200
   private _executionCtx: FetchEvent | ExecutionContext | undefined

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -563,22 +563,23 @@ describe('Error handling in middleware', () => {
   const app = new Hono()
 
   app.get('/handle-error-in-middleware', async (c, next) => {
-    try {
-      await next()
-    } catch {
-      c.res = c.text('Handle the error in middleware', 500)
+    await next()
+    if (c.error) {
+      const message = c.error.message
+      c.res = c.text(`Handle the error in middleware, original message is ${message}`, 500)
     }
   })
 
   app.get('/handle-error-in-middleware', () => {
-    console.log('throw new Error')
-    throw new Error('This is Error')
+    throw new Error('Error message')
   })
 
   it('Should handle the error in middleware', async () => {
     const res = await app.request('https://example.com/handle-error-in-middleware')
     expect(res.status).toBe(500)
-    expect(await res.text()).toBe('Handle the error in middleware')
+    expect(await res.text()).toBe(
+      'Handle the error in middleware, original message is Error message'
+    )
   })
 })
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -249,7 +249,11 @@ export class Hono<
     }
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
-    const composed = compose<HonoContext<string, E>, E>(handlers, this.notFoundHandler)
+    const composed = compose<HonoContext<string, E>, E>(
+      handlers,
+      this.notFoundHandler,
+      this.errorHandler
+    )
 
     return (async () => {
       try {


### PR DESCRIPTION
**This PR has a small breaking change**

Currently, if an error occurred in the Handler, it would immediately throw an Error. Therefore, the Middleware process after `await next()` will not be executed. When handling errors in Middleware, it was necessary to wrap them in try-catch.

```ts
app.use('*', async (c, next) => {
  try {
    await next()
  } catch (_) {
    //...
  }
})
```

This works well for Sentry Middleware, but has a bad effect on Logger Middleware and CORS. This is mentioned #575 

This way of error handling was introduced in #491.

However, referring above, it is not so good, so in this PR, reverting back to the way and makinging it possible to handle Error objects in the Middleware.

If the Handler throws an error, there is no need to try-catch in the Middleware, and the error resopnse is passed into `c.res`.

```ts
app.use('*', async (c, next) => {
  await next()
  // c.res is error reponse
})

app.get('/error', () => {
  throw new Error('Test error')
})
```

If you wanted to handle the original Error object in the Middleware, it would be in `c.error`.

```ts
app.use('*', async (c, next) => {
  await next()
  const originalMessage = c.error.message
  //...
})
```

For example, for Sentry Middleware, the following:

https://github.com/honojs/sentry/blob/ca742a2ea35808cf2b70a19407a93481b4fbe8a0/src/index.ts#L51-L56

Write like this:

```ts
await next()
if (c.error) {
  sentry.captureException(c.error)
  throw error
}
```