### PR TITLE
fix(validator): Malformed JSON body now returns HTTP 400 Bad Request

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -9,6 +9,8 @@ import { RegExpRouter } from './router/reg-exp-router/index.ts'
 import { SmartRouter } from './router/smart-router/index.ts'
 import { StaticRouter } from './router/static-router/index.ts'
 import { TrieRouter } from './router/trie-router/index.ts'
+import { getStatusText, HttpError } from './utils/http-status.ts'
+import type { StatusCode } from './utils/http-status.ts'
 import { getPathFromURL, mergePath } from './utils/url.ts'
 
 export interface ContextVariableMap {}
@@ -139,10 +141,18 @@ export class Hono<
     return c.text('404 Not Found', 404)
   }
 
+  // ErrorTranslator
+  // registerErrorTranslation
+  // translateInternalError
   private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {
     console.trace(err.message)
-    const message = 'Internal Server Error'
-    return c.text(message, 500)
+    let message = getStatusText(500)
+    let statusCode: StatusCode = 500
+    if (err instanceof HttpError) {
+      message = err.message
+      statusCode = err.statusCode
+    }
+    return c.text(message, statusCode)
   }
 
   route(path: string, app?: Hono<any>): Hono<E, P, D> {

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -1,3 +1,4 @@
+import { HttpError } from '../../utils/http-status.ts'
 import { JSONPath } from '../../utils/json.ts'
 import type { JSONObject, JSONPrimitive, JSONArray } from '../../utils/json.ts'
 import { rule } from './rule.ts'
@@ -118,8 +119,12 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
-      const obj = (await req.json()) as JSONObject
-      value = JSONPath(obj, this.key)
+      try {
+        const obj = (await req.json()) as JSONObject
+        value = JSONPath(obj, this.key)
+      } catch (e) {
+        throw new HttpError(400)
+      }
     }
 
     result.value = value

--- a/deno_dist/utils/http-status.ts
+++ b/deno_dist/utils/http-status.ts
@@ -118,3 +118,12 @@ const statuses: Record<StatusCode | number, string> = {
   505: 'HTTP Version Not Supported',
   507: 'Insufficient Storage',
 }
+
+export class HttpError extends Error {
+  statusCode: StatusCode
+  constructor(statusCode: StatusCode) {
+    super(getStatusText(statusCode))
+    this.name = getStatusText(statusCode)
+    this.statusCode = statusCode
+  }
+}

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -9,6 +9,8 @@ import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { StaticRouter } from './router/static-router'
 import { TrieRouter } from './router/trie-router'
+import { getStatusText, HttpError } from './utils/http-status'
+import type { StatusCode } from './utils/http-status'
 import { getPathFromURL, mergePath } from './utils/url'
 
 export interface ContextVariableMap {}
@@ -139,10 +141,18 @@ export class Hono<
     return c.text('404 Not Found', 404)
   }
 
+  // ErrorTranslator
+  // registerErrorTranslation
+  // translateInternalError
   private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {
     console.trace(err.message)
-    const message = 'Internal Server Error'
-    return c.text(message, 500)
+    let message = getStatusText(500)
+    let statusCode: StatusCode = 500
+    if (err instanceof HttpError) {
+      message = err.message
+      statusCode = err.statusCode
+    }
+    return c.text(message, statusCode)
   }
 
   route(path: string, app?: Hono<any>): Hono<E, P, D> {

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -1,3 +1,4 @@
+import { HttpError } from '../../utils/http-status'
 import { JSONPath } from '../../utils/json'
 import type { JSONObject, JSONPrimitive, JSONArray } from '../../utils/json'
 import { rule } from './rule'
@@ -118,8 +119,12 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
-      const obj = (await req.json()) as JSONObject
-      value = JSONPath(obj, this.key)
+      try {
+        const obj = (await req.json()) as JSONObject
+        value = JSONPath(obj, this.key)
+      } catch (e) {
+        throw new HttpError(400)
+      }
     }
 
     result.value = value

--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -118,3 +118,12 @@ const statuses: Record<StatusCode | number, string> = {
   505: 'HTTP Version Not Supported',
   507: 'Insufficient Storage',
 }
+
+export class HttpError extends Error {
+  statusCode: StatusCode
+  constructor(statusCode: StatusCode) {
+    super(getStatusText(statusCode))
+    this.name = getStatusText(statusCode)
+    this.statusCode = statusCode
+  }
+}


### PR DESCRIPTION
This PR adds a new type of error that will be caught by the default error handler: `HTTPError`. It can be passed any valid `StatusCode` and it will return this code along with the `StatusText` from `getStatusText()` as the response body. 

The validator middleware now catches when `Request.json()` fails and throws `new HTTPError(400)` to be caught and returned to the client. This should probably close #562 if I'm not mistaken.