### PR TITLE
fix(validator): return HTTP 400 on malformed JSON request

### DIFF
--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -118,8 +118,12 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
-      const obj = (await req.json()) as JSONObject
-      value = JSONPath(obj, this.key)
+      try {
+        const obj = (await req.json()) as JSONObject
+        value = JSONPath(obj, this.key)
+      } catch (e) {
+        throw new Error('Malformed JSON in request body')
+      }
     }
 
     result.value = value

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from '../../hono'
+import { getStatusText } from '../../utils/http-status'
 import { validator } from './index'
 
 describe('Basic - query', () => {
@@ -127,6 +128,24 @@ describe('Basic - JSON', () => {
     })
     const res = await app.request(req)
     expect(res.status).toBe(200)
+  })
+
+  it('Should return 400 Bad Request when given an invalid JSON body', async () => {
+    const req1 = new Request('http://localhost/json', {
+      method: 'POST',
+      body: 'Not json!',
+    })
+    const req2 = new Request('http://localhost/json', {
+      method: 'POST',
+    })
+
+    const res1 = await app.request(req1)
+    expect(res1.status).toBe(400)
+    expect(await res1.text()).toBe(getStatusText(400))
+
+    const res2 = await app.request(req2)
+    expect(res2.status).toBe(400)
+    expect(await res2.text()).toBe(getStatusText(400))
   })
 })
 

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -1,5 +1,6 @@
 import type { Context } from '../../context'
 import type { Environment, Next, ValidatedData } from '../../hono'
+import { getStatusText } from '../../utils/http-status'
 import { VBase, Validator } from './validator'
 import type {
   VString,
@@ -80,7 +81,13 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
     const validatorList = getValidatorList(validationFunction(v, c))
 
     for (const [keys, validator] of validatorList) {
-      const result = await validator.validate(c.req)
+      let result
+      try {
+        result = await validator.validate(c.req)
+      } catch (e) {
+        // Invalid JSON request
+        return c.text(getStatusText(400), 400)
+      }
       if (result.isValid) {
         // Set data on request object
         c.req.valid(keys, result.value)

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -365,3 +365,40 @@ describe('Validate with asArray', () => {
     expect(res.isValid).toBe(false)
   })
 })
+
+describe('Invalid HTTP request handling', () => {
+  const v = new Validator()
+
+  it('Should throw malformed error when JSON body absent', async () => {
+    const req = new Request('http://localhost/', {
+      method: 'POST',
+    })
+
+    let error
+    try {
+      const validator = v.json('post.title').isRequired()
+      await validator.validate(req)
+    } catch (e) {
+      error = e
+    }
+    expect(error instanceof Error).toBe(true)
+    expect((error as Error).message).toBe('Malformed JSON in request body')
+  })
+
+  it('Should throw malformed error when a JSON body is not valid JSON', async () => {
+    const req = new Request('http://localhost/', {
+      method: 'POST',
+      body: 'Not json!',
+    })
+
+    let error
+    try {
+      const validator = v.json('post.title').isRequired()
+      await validator.validate(req)
+    } catch (e) {
+      error = e
+    }
+    expect(error instanceof Error).toBe(true)
+    expect((error as Error).message).toBe('Malformed JSON in request body')
+  })
+})

--- a/src/middleware/validator/validator.ts
+++ b/src/middleware/validator/validator.ts
@@ -118,8 +118,12 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
-      const obj = (await req.json()) as JSONObject
-      value = JSONPath(obj, this.key)
+      try {
+        const obj = (await req.json()) as JSONObject
+        value = JSONPath(obj, this.key)
+      } catch (e) {
+        throw new Error('Malformed JSON in request body')
+      }
     }
 
     result.value = value


### PR DESCRIPTION
This PR should close #562. The Validator middleware will now return a HTTP 400 Bad Request response whenever JSON in the request body fails to parse, or if the body is empty.