### PR TITLE
fix(compose): fix for error handling with `async`

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -55,12 +55,21 @@ export const compose = <C extends ComposeContext, E extends Partial<Environment>
         }
         return context
       } else {
-        return res.then((res) => {
-          if (res && context.finalized === false) {
-            context.res = res
-          }
-          return context
-        })
+        return res
+          .then((res) => {
+            if (res && context.finalized === false) {
+              context.res = res
+            }
+            return context
+          })
+          .catch((err) => {
+            if (err instanceof Error && context instanceof HonoContext && onError) {
+              context.error = err
+              context.res = onError(err, context)
+              return context
+            }
+            throw err
+          })
       }
     }
   }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -55,12 +55,21 @@ export const compose = <C extends ComposeContext, E extends Partial<Environment>
         }
         return context
       } else {
-        return res.then((res) => {
-          if (res && context.finalized === false) {
-            context.res = res
-          }
-          return context
-        })
+        return res
+          .then((res) => {
+            if (res && context.finalized === false) {
+              context.res = res
+            }
+            return context
+          })
+          .catch((err) => {
+            if (err instanceof Error && context instanceof HonoContext && onError) {
+              context.error = err
+              context.res = onError(err, context)
+              return context
+            }
+            throw err
+          })
       }
     }
   }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -570,7 +570,22 @@ describe('Error handling in middleware', () => {
     }
   })
 
+  app.get('/handle-error-in-middleware-async', async (c, next) => {
+    await next()
+    if (c.error) {
+      const message = c.error.message
+      c.res = c.text(
+        `Handle the error in middleware with async, original message is ${message}`,
+        500
+      )
+    }
+  })
+
   app.get('/handle-error-in-middleware', () => {
+    throw new Error('Error message')
+  })
+
+  app.get('/handle-error-in-middleware-async', async () => {
     throw new Error('Error message')
   })
 
@@ -579,6 +594,14 @@ describe('Error handling in middleware', () => {
     expect(res.status).toBe(500)
     expect(await res.text()).toBe(
       'Handle the error in middleware, original message is Error message'
+    )
+  })
+
+  it('Should handle the error in middleware - async', async () => {
+    const res = await app.request('https://example.com/handle-error-in-middleware-async')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe(
+      'Handle the error in middleware with async, original message is Error message'
     )
   })
 })


### PR DESCRIPTION
The following PR did not support `async`.

https://github.com/honojs/hono/pull/576

This PR will support `async`. Will fix https://github.com/honojs/hono/issues/575