### PR TITLE
perf: remove unrequired cloning of ctx.res

### DIFF
--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -17,7 +17,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     }
     const encoding = match[0]
     const stream = new CompressionStream(encoding as EncodingType)
-    ctx.res = new Response(ctx.res.body.pipeThrough(stream), ctx.res.clone())
+    ctx.res = new Response(ctx.res.body.pipeThrough(stream), ctx.res)
     ctx.res.headers.set('Content-Encoding', encoding)
   }
 }


### PR DESCRIPTION
Response constructor's 2nd argument does not require a cloned response as all it does is read these fields and does not modify anything:
- status
- statusText
- headers

> https://fetch.spec.whatwg.org/#initialize-a-response