### PR TITLE
feat(validator): introduce nested validation

### DIFF
--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -1,7 +1,8 @@
 import type { Context } from '../../context.ts'
 import type { Environment, Next, ValidatedData } from '../../hono.ts'
 import { getStatusText } from '../../utils/http-status.ts'
-import { VBase, Validator } from './validator.ts'
+import { mergeObjects } from '../../utils/object.ts'
+import { VBase, Validator, VObjectBase } from './validator.ts'
 import type {
   VString,
   VNumber,
@@ -11,18 +12,20 @@ import type {
   VStringArray,
   VBooleanArray,
   ValidateResult,
+  VArray,
 } from './validator.ts'
 
-type Schema = {
+export type Schema = {
   [key: string]:
     | VString
     | VNumber
     | VBoolean
-    | VObject
     | VStringArray
     | VNumberArray
     | VBooleanArray
     | Schema
+    | VObject<Schema>
+    | VArray<Schema>
 }
 
 type SchemaToProp<T> = {
@@ -38,11 +41,21 @@ type SchemaToProp<T> = {
     ? boolean
     : T[K] extends VString
     ? string
-    : T[K] extends VObject
-    ? object
-    : T[K] extends Schema
-    ? SchemaToProp<T[K]>
-    : never
+    : T[K] extends VObjectBase<Schema>
+    ? T[K]['container'] extends VNumber
+      ? number
+      : T[K]['container'] extends VString
+      ? string
+      : T[K]['container'] extends VBoolean
+      ? boolean
+      : T[K] extends VArray<Schema>
+      ? SchemaToProp<ReadonlyArray<T[K]['container']>>
+      : T[K] extends VObject<Schema>
+      ? SchemaToProp<T[K]['container']>
+      : T[K] extends Schema
+      ? SchemaToProp<T[K]>
+      : never
+    : SchemaToProp<T[K]>
 }
 
 type ResultSet = {
@@ -78,10 +91,12 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
       results: [],
     }
 
-    const validatorList = getValidatorList(validationFunction(v, c))
+    const schema = validationFunction(v, c)
+    const validatorList = getValidatorList(schema)
+    let data: any = {}
 
     for (const [keys, validator] of validatorList) {
-      let result
+      let result: ValidateResult
       try {
         result = await validator.validate(c.req)
       } catch (e) {
@@ -90,7 +105,13 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
       }
       if (result.isValid) {
         // Set data on request object
-        c.req.valid(keys, result.value)
+        if (result.jsonData) {
+          const dst = data
+          mergeObjects(dst, result.jsonData)
+          data = dst
+        } else {
+          c.req.valid(keys, result.value)
+        }
       } else {
         resultSet.hasError = true
         if (result.message !== undefined) {
@@ -98,6 +119,12 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
         }
       }
       resultSet.results.push(result)
+    }
+
+    if (!resultSet.hasError) {
+      Object.keys(data).map((key) => {
+        c.req.valid(key, data[key])
+      })
     }
 
     if (options && options.done) {
@@ -115,13 +142,18 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
   return handler
 }
 
-function getValidatorList<T extends Schema>(schema: T): [string[], VBase][] {
+function getValidatorList<T extends Schema>(schema: T) {
   const map: [string[], VBase][] = []
   for (const [key, value] of Object.entries(schema)) {
-    if (value instanceof VBase) {
+    if (value instanceof VObjectBase) {
+      const validators = value.getValidators()
+      for (const validator of validators) {
+        map.push([value.keys, validator])
+      }
+    } else if (value instanceof VBase) {
       map.push([[key], value])
     } else {
-      const children = getValidatorList(value)
+      const children = getValidatorList(value as Schema)
       for (const [keys, validator] of children) {
         map.push([[key, ...keys], validator])
       }

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -107,8 +107,7 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
         // Set data on request object
         if (result.jsonData) {
           const dst = data
-          mergeObjects(dst, result.jsonData)
-          data = dst
+          data = mergeObjects(dst, result.jsonData)
         } else {
           c.req.valid(keys, result.value)
         }

--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -1,5 +1,6 @@
-import { JSONPath } from '../../utils/json.ts'
+import { JSONPathCopy } from '../../utils/json.ts'
 import type { JSONObject, JSONPrimitive, JSONArray } from '../../utils/json.ts'
+import type { Schema } from './middleware.ts'
 import { rule } from './rule.ts'
 import { sanitizer } from './sanitizer.ts'
 
@@ -8,11 +9,90 @@ type Type = JSONPrimitive | JSONObject | JSONArray | File
 type Rule = (value: Type) => boolean
 type Sanitizer = (value: Type) => Type
 
+export abstract class VObjectBase<T extends Schema> {
+  container: T
+  keys: string[] = []
+  protected _isOptional: boolean = false
+  constructor(container: T, key: string) {
+    this.container = container
+    if (this instanceof VArray) {
+      this.keys.push(key, '[*]')
+    } else if (this instanceof VObject) {
+      this.keys.push(key)
+    }
+  }
+  isOptional() {
+    this._isOptional = true
+    return this
+  }
+
+  getValidators = (): VBase[] => {
+    const validators: VBase[] = []
+    const thisKeys: string[] = []
+    Object.assign(thisKeys, this.keys)
+
+    const walk = (container: T, keys: string[], isOptional: boolean) => {
+      for (const v of Object.values(container)) {
+        if (v instanceof VArray || v instanceof VObject) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          isOptional ||= v._isOptional
+          keys.push(...v.keys)
+          walk(v.container as T, keys, isOptional)
+          const tmp: string[] = []
+          Object.assign(tmp, thisKeys)
+          keys = tmp
+        } else if (v instanceof VBase) {
+          if (isOptional) v.isOptional()
+          v.baseKeys.push(...keys)
+          validators.push(v)
+        }
+      }
+    }
+
+    walk(this.container, this.keys, this._isOptional)
+
+    return validators
+  }
+}
+
+export class VObject<T extends Schema> extends VObjectBase<T> {
+  constructor(container: T, key: string) {
+    super(container, key)
+  }
+}
+
+export class VArray<T extends Schema> extends VObjectBase<T> {
+  type: 'array' = 'array'
+  constructor(container: T, key: string) {
+    super(container, key)
+  }
+}
+
 export class Validator {
+  isArray: boolean = false
+  isOptional: boolean = false
   query = (key: string): VString => new VString({ target: 'query', key: key })
   header = (key: string): VString => new VString({ target: 'header', key: key })
   body = (key: string): VString => new VString({ target: 'body', key: key })
-  json = (key: string): VString => new VString({ target: 'json', key: key })
+  json = (key: string) => {
+    if (this.isArray) {
+      return new VStringArray({ target: 'json', key: key })
+    } else {
+      return new VString({ target: 'json', key: key })
+    }
+  }
+  array = <T extends Schema>(path: string, validator: (v: Validator) => T): VArray<T> => {
+    this.isArray = true
+    const res = validator(this)
+    const arr = new VArray(res, path)
+    return arr
+  }
+  object = <T extends Schema>(path: string, validator: (v: Validator) => T): VObject<T> => {
+    const res = validator(this)
+    const obj = new VObject(res, path)
+    return obj
+  }
 }
 
 export type ValidateResult = {
@@ -21,6 +101,7 @@ export type ValidateResult = {
   target: Target
   key: string
   value: Type
+  jsonData: JSONObject | undefined
 }
 
 type VOptions = {
@@ -33,6 +114,7 @@ type VOptions = {
 export abstract class VBase {
   type: 'string' | 'number' | 'boolean' | 'object'
   target: Target
+  baseKeys: string[] = []
   key: string
   rules: Rule[]
   sanitizers: Sanitizer[]
@@ -48,6 +130,8 @@ export abstract class VBase {
     this.isArray = options.isArray || false
     this._optional = false
   }
+
+  private _nested = () => (this.baseKeys.length ? true : false)
 
   addRule = (rule: Rule) => {
     this.rules.push(rule)
@@ -87,11 +171,6 @@ export abstract class VBase {
     return newVBoolean
   }
 
-  asObject = () => {
-    const newVObject = new VObject(this)
-    return newVObject
-  }
-
   message(value: string) {
     this._message = value
     return this
@@ -104,6 +183,7 @@ export abstract class VBase {
       target: this.target,
       key: this.key,
       value: undefined,
+      jsonData: undefined,
     }
 
     let value: Type = undefined
@@ -118,16 +198,30 @@ export abstract class VBase {
       value = body[this.key]
     }
     if (this.target === 'json') {
+      if (this._nested()) {
+        this.key = `${this.baseKeys.join('.')}.${this.key}`
+      }
+      let obj = {}
       try {
-        const obj = (await req.json()) as JSONObject
-        value = JSONPath(obj, this.key)
+        obj = (await req.json()) as JSONObject
       } catch (e) {
         throw new Error('Malformed JSON in request body')
       }
+      const dst = {}
+      value = JSONPathCopy(obj, dst, this.key)
+      if (this.isArray && !Array.isArray(value)) {
+        value = [value]
+      }
+      if (this._nested()) result.jsonData = dst
     }
 
     result.value = value
-    result.isValid = this.validateValue(value)
+
+    if (this._nested() && this.target != 'json') {
+      result.isValid = false
+    } else {
+      result.isValid = this.validateValue(value)
+    }
 
     if (result.isValid === false) {
       if (this._message) {
@@ -167,16 +261,21 @@ export abstract class VBase {
       }
 
       for (const val of value) {
-        if (typeof val !== this.type) {
-          // Value is of wrong type here
-          // If not optional, or optional and not undefined, return false
-          if (!this._optional || typeof val !== 'undefined') return false
+        if (typeof val === 'undefined' && this._nested()) {
+          value.pop()
+        }
+        for (const val of value) {
+          if (typeof val !== this.type) {
+            // Value is of wrong type here
+            // If not optional, or optional and not undefined, return false
+            if (!this._optional || typeof val !== 'undefined') return false
+          }
         }
       }
 
       // Sanitize
       for (const sanitizer of this.sanitizers) {
-        value = value.map((innerVal) => sanitizer(innerVal)) as JSONArray
+        value = value.map((innerVal: any) => sanitizer(innerVal)) as JSONArray
       }
 
       for (const rule of this.rules) {
@@ -300,13 +399,6 @@ export class VBoolean extends VBase {
 
   isFalse = () => {
     return this.addRule((value) => rule.isFalse(value as boolean))
-  }
-}
-
-export class VObject extends VBase {
-  constructor(options: VOptions) {
-    super(options)
-    this.type = 'object'
   }
 }
 

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.158.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.159.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/deno_dist/utils/object.ts
+++ b/deno_dist/utils/object.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const mergeObjects = (target: any, source: any) => {
+  if (Array.isArray(source)) {
+    for (let i = 0, len = source.length; i < len; i++) {
+      if (!target) target = []
+      Object.assign(source[i], mergeObjects(target[i], source[i]))
+    }
+  } else {
+    for (const key of Object.keys(source)) {
+      if (source[key] instanceof Object) {
+        if (!target) target = {}
+        Object.assign(source[key], mergeObjects(target[key], source[key]))
+      }
+    }
+  }
+  Object.assign(target || {}, source)
+  return target
+}

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -107,8 +107,7 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
         // Set data on request object
         if (result.jsonData) {
           const dst = data
-          mergeObjects(dst, result.jsonData)
-          data = dst
+          data = mergeObjects(dst, result.jsonData)
         } else {
           c.req.valid(keys, result.value)
         }

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -402,3 +402,250 @@ describe('Invalid HTTP request handling', () => {
     expect((error as Error).message).toBe('Malformed JSON in request body')
   })
 })
+
+describe('Validate with asArray', () => {
+  const v = new Validator()
+  const json = {
+    post: {
+      title: ['Hello'],
+      flags: [true, false],
+      published: [true],
+      comments: [
+        {
+          title: 'abc',
+          author: 'John',
+          category: 'Heroes',
+          flags: [true, false],
+        },
+        {
+          title: 'def',
+          author: 'Dave',
+          flags: [false, true],
+        },
+      ],
+    },
+  }
+
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: JSON.stringify(json),
+  })
+
+  it('Should validate array values', async () => {
+    const validator = v.json('post.comments[0].title').isAlpha()
+    const res = await validator.validate(req)
+    expect(res.isValid).toBe(true)
+  })
+})
+
+describe('Nested objects', () => {
+  const json = {
+    posts: [
+      {
+        id: 123,
+        title: 'JavaScript',
+        authors: [
+          {
+            name: 'Superman',
+            age: 20,
+            like: {
+              food: 'fish',
+            },
+          },
+        ],
+        tags: [
+          {
+            name: 'Node.js',
+          },
+          {
+            name: 'Deno',
+          },
+          {
+            name: 'Bun',
+          },
+        ],
+      },
+      {
+        id: 456,
+        title: 'Framework',
+        tags: [
+          {
+            name: 'Hono',
+          },
+          {
+            name: 'Express',
+          },
+        ],
+      },
+    ],
+    pager: {
+      prev: true,
+      next: false,
+      meta: {
+        perPage: 10,
+        pages: [
+          {
+            num: 1,
+          },
+        ],
+      },
+    },
+  }
+
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: JSON.stringify(json),
+  })
+
+  it('Should validate nested array values', async () => {
+    const v = new Validator()
+    const vArray = v.array('posts', (v) => ({
+      id: v.json('id').asNumber(),
+      title: v.json('title'),
+      authors: v
+        .array('authors', (v) => ({
+          name: v.json('name'),
+          age: v.json('age').asNumber(),
+          like: v.object('like', (v) => ({
+            food: v.json('food').isRequired(),
+          })),
+        }))
+        .isOptional(),
+      tags: v
+        .array('tags', (v) => ({
+          name: v.json('name'),
+        }))
+        .isOptional(),
+    }))
+    for (const validator of vArray.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(true)
+      expect(res.message).toBeUndefined()
+    }
+  })
+
+  it('Should validate nested object values', async () => {
+    const v = new Validator()
+    const vObject = v.object('pager', (v) => ({
+      prev: v.json('prev').asBoolean(),
+      next: v.json('next').asBoolean(),
+      meta: v.object('meta', (v) => ({
+        totalCount: v.json('perPage').asNumber(),
+        pages: v.array('pages', (v) => ({
+          num: v.json('num').asNumber(),
+        })),
+      })),
+    }))
+
+    for (const validator of vObject.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(true)
+      expect(res.message).toBeUndefined()
+    }
+  })
+
+  it('Should validate nested array values', async () => {
+    let v = new Validator()
+    const vArray = v.array('posts', (v) => ({
+      id: v.json('id'),
+    }))
+
+    for (const validator of vArray.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(false)
+      const messages = ['Invalid Value: the JSON body "posts.[*].id" is invalid - [123, 456]']
+      expect(res.message).toBe(messages.join('\n'))
+    }
+
+    v = new Validator()
+    const vArray2 = v.array('posts', (v) => ({
+      optionalProperty: v.json('optional-property').isOptional(),
+    }))
+    for (const validator of vArray2.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(true)
+      expect(res.message).toBeUndefined()
+    }
+  })
+
+  it('Should validate nested array values with `isOptional`', async () => {
+    const v = new Validator()
+    const vArray = v.array('posts', (v) => ({
+      title: v.json('optional-title').isOptional(),
+      comments: v
+        .array('comments', (v) => ({
+          body: v.json('body'),
+        }))
+        .isOptional(),
+    }))
+
+    for (const validator of vArray.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(true)
+      expect(res.message).toBeUndefined()
+    }
+
+    const vArray2 = v
+      .array('posts', (v) => ({
+        title: v.json('title').asNumber(),
+      }))
+      .isOptional()
+
+    for (const validator of vArray2.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(false)
+      const messages = [
+        'Invalid Value: the JSON body "posts.[*].title" is invalid - ["JavaScript", "Framework"]',
+      ]
+      expect(res.message).toBe(messages.join('\n'))
+    }
+  })
+
+  it('Should validate nested object values with `isOptional`', async () => {
+    const v = new Validator()
+    const vObject = v.object('pager', (v) => ({
+      current: v.json('optional-value').isOptional(),
+      method: v
+        .object('method', (v) => ({
+          name: v.json('name'),
+        }))
+        .isOptional(),
+    }))
+
+    for (const validator of vObject.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(true)
+      expect(res.message).toBeUndefined()
+    }
+  })
+
+  it('Should only allow `v.json()` in nested array or object', async () => {
+    const v = new Validator()
+    const vArray = v.array('posts', (v) => ({
+      id: v.header('id').asNumber().isRequired(),
+    }))
+
+    for (const validator of vArray.getValidators()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(false)
+      const messages = ['Invalid Value: the request header "id" is invalid - undefined']
+      expect(res.message).toBe(messages.join('\n'))
+    }
+
+    const vObject = v.object('pager', (v) => ({
+      prev: v.query('prev').asBoolean(),
+      next: v.body('next').asBoolean(),
+    }))
+
+    const messages = [
+      'Invalid Value: the query parameter "prev" is invalid - undefined',
+      'Invalid Value: the request body "next" is invalid - undefined',
+    ]
+
+    for (const [i, validator] of vObject.getValidators().entries()) {
+      const res = await validator.validate(req)
+      expect(res.isValid).toBe(false)
+      expect(res.message).toBe(`${messages[i]}`)
+    }
+  })
+})

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -403,41 +403,6 @@ describe('Invalid HTTP request handling', () => {
   })
 })
 
-describe('Validate with asArray', () => {
-  const v = new Validator()
-  const json = {
-    post: {
-      title: ['Hello'],
-      flags: [true, false],
-      published: [true],
-      comments: [
-        {
-          title: 'abc',
-          author: 'John',
-          category: 'Heroes',
-          flags: [true, false],
-        },
-        {
-          title: 'def',
-          author: 'Dave',
-          flags: [false, true],
-        },
-      ],
-    },
-  }
-
-  const req = new Request('http://localhost/', {
-    method: 'POST',
-    body: JSON.stringify(json),
-  })
-
-  it('Should validate array values', async () => {
-    const validator = v.json('post.comments[0].title').isAlpha()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-  })
-})
-
 describe('Nested objects', () => {
   const json = {
     posts: [

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,7 +1,7 @@
 import type { JSONArray } from './json'
-import { JSONPath } from './json'
+import { JSONPathCopy } from './json'
 
-describe('JSONPath', () => {
+describe('JSONPathCopy', () => {
   const data = {
     post: {
       title: 'Hello',
@@ -54,46 +54,83 @@ describe('JSONPath', () => {
   }
 
   it('Should return the string or number pointed by JSON Path', () => {
-    expect(JSONPath(data, 'post.title')).toBe('Hello')
-    expect(JSONPath(data, 'post.author.name')).toBe('Superman')
-    expect(JSONPath(data, 'post.author.age')).toBe(20)
-    expect(JSONPath(data, 'post.tags.0')).toBe('foo')
-    expect(JSONPath(data, 'post.tags[0]')).toBe('foo')
-    expect(JSONPath(data, 'post.tags.1')).toBe('bar')
-    expect(JSONPath(data, 'post.tags[1]')).toBe('bar')
-    expect(JSONPath(data, 'post.tags.2.framework')).toBe('Hono')
-    expect(JSONPath(data, 'post.tags[2].framework')).toBe('Hono')
+    const dst = {}
+    expect(JSONPathCopy(data, dst, 'post.title')).toBe('Hello')
+    expect(JSONPathCopy(data, dst, 'post.author.name')).toBe('Superman')
+    expect(JSONPathCopy(data, dst, 'post.author.age')).toBe(20)
+    expect(JSONPathCopy(data, dst, 'post.tags.0')).toBe('foo')
+    expect(JSONPathCopy(data, dst, 'post.tags[0]')).toBe('foo')
+    expect(JSONPathCopy(data, dst, 'post.tags.1')).toBe('bar')
+    expect(JSONPathCopy(data, dst, 'post.tags[1]')).toBe('bar')
+    expect(JSONPathCopy(data, dst, 'post.tags.2.framework')).toBe('Hono')
+    expect(JSONPathCopy(data, dst, 'post.tags[2].framework')).toBe('Hono')
+    expect(dst).toEqual({
+      post: {
+        title: 'Hello',
+        author: {
+          name: 'Superman',
+          age: 20,
+        },
+        tags: ['foo', 'bar', { framework: 'Hono' }],
+      },
+    })
   })
 
   it('Should return undefined', () => {
-    expect(JSONPath(data, 'post.foo')).toBe(undefined)
-    expect(JSONPath(data, 'post.author.foo')).toBe(undefined)
-    expect(JSONPath(data, 'post.tags.3')).toBe(undefined)
-    expect(JSONPath(data, 'post.tags[3]')).toBe(undefined)
+    const dst = {}
+    expect(JSONPathCopy(data, dst, 'post.foo')).toBe(undefined)
+    expect(JSONPathCopy(data, dst, 'post.author.foo')).toBe(undefined)
+    expect(JSONPathCopy(data, dst, 'post.tags.3')).toBe(undefined)
+    expect(JSONPathCopy(data, dst, 'post.tags[3]')).toBe(undefined)
+    expect(dst).toEqual({ post: { author: {}, tags: [] } })
   })
 
   it('Should return objects pointed by JSON Path', () => {
-    expect(typeof JSONPath(data, 'post')).toBe('object')
-    expect(JSONPath(data, 'post.author')).toEqual({ name: 'Superman', age: 20 })
-    expect((JSONPath(data, 'post.tags') as JSONArray).length).toBe(3)
+    const dst = {}
+    expect(typeof JSONPathCopy(data, dst, 'post')).toBe('object')
+    expect(JSONPathCopy(data, dst, 'post.author')).toEqual({ name: 'Superman', age: 20 })
+    expect((JSONPathCopy(data, dst, 'post.tags') as JSONArray).length).toBe(3)
   })
 
   it('Should return values of object as array', () => {
-    expect(JSONPath(data, 'post.author[*]')).toEqual(['Superman', 20])
+    const dst = {}
+    expect(JSONPathCopy(data, dst, 'post.author[*]')).toEqual(['Superman', 20])
+    expect(dst).toEqual({
+      post: {
+        author: {
+          name: 'Superman',
+          age: 20,
+        },
+      },
+    })
+    expect(JSONPathCopy(data, dst, 'post.author.[*]')).toEqual(['Superman', 20])
   })
 
   it('Should return an array when targeting fields in arrays of objects', () => {
-    expect(Array.isArray(JSONPath(data, 'relatedPosts[*].title'))).toBe(true)
-    expect(JSONPath(data, 'relatedPosts[*].title')).toEqual([
+    const dst = {}
+    expect(Array.isArray(JSONPathCopy(data, dst, 'relatedPosts[*].title'))).toBe(true)
+    expect(JSONPathCopy(data, dst, 'relatedPosts[*].title')).toEqual([
       'HelloWorld',
       'Hello World',
       'World. Hello!',
     ])
+    expect(dst).toEqual({
+      relatedPosts: [{ title: 'HelloWorld' }, { title: 'Hello World' }, { title: 'World. Hello!' }],
+    })
   })
 
   it('Should return all deeply nested JSON path results', () => {
-    expect(Array.isArray(JSONPath(data, 'relatedPosts[*].tags[*]'))).toBe(true)
-    expect(JSONPath(data, 'relatedPosts[*].tags[*]')).toEqual([
+    let dst = {}
+    expect(Array.isArray(JSONPathCopy(data, dst, 'relatedPosts[*].tags[*]'))).toBe(true)
+    expect(dst).toEqual({
+      relatedPosts: [
+        { tags: ['flash', 'marvel'] },
+        { tags: ['spider', 'man'] },
+        { tags: ['bat', 'man'] },
+      ],
+    })
+    dst = {}
+    expect(JSONPathCopy(data, dst, 'relatedPosts[*].tags[*]')).toEqual([
       'flash',
       'marvel',
       'spider',
@@ -101,23 +138,63 @@ describe('JSONPath', () => {
       'bat',
       'man',
     ])
-    expect(JSONPath(data, 'relatedPosts[*].tags[1]')).toEqual(['marvel', 'man', 'man'])
+    dst = {}
+    expect(JSONPathCopy(data, dst, 'relatedPosts[*].tags[1]')).toEqual(['marvel', 'man', 'man'])
   })
 
   it('Should return only the data that exist if only some of the data have values.', () => {
-    expect(JSONPath(data, 'releases[*].amd64')).toEqual([true, true])
+    const dst = {}
+    expect(JSONPathCopy(data, dst, 'releases[*].amd64')).toEqual([true, true])
   })
 
   it('Should return undefined if there is no matching path.', () => {
-    expect(JSONPath(data, 'post.category')).toEqual(undefined)
+    const dst = {}
+    expect(JSONPathCopy(data, dst, 'post.category')).toEqual(undefined)
   })
 
   it('Should return array of undefined if there is no matching path within array', () => {
-    expect(JSONPath(data, 'releases[*].i386')).toEqual([undefined, undefined, undefined])
+    const dst = {}
+    expect(JSONPathCopy(data, dst, 'releases[*].i386')).toEqual([undefined, undefined, undefined])
+    expect(dst).toEqual({
+      releases: [{}, {}, {}],
+    })
+  })
+  it('Should return value from nested array', () => {
+    let dst = {}
+    expect(JSONPathCopy(data, dst, 'nestedArray.0.0.0')).toBe(1)
+    expect(dst).toEqual({
+      nestedArray: [[[1]]],
+    })
+    dst = {}
+    expect(JSONPathCopy(data, dst, 'nestedArray[0][0][0]')).toBe(1)
+    expect(dst).toEqual({
+      nestedArray: [[[1]]],
+    })
   })
 
-  it('Should return value from nested array', () => {
-    expect(JSONPath(data, 'nestedArray.0.0.0')).toBe(1)
-    expect(JSONPath(data, 'nestedArray[0][0][0]')).toBe(1)
+  it('Should merge structured data', () => {
+    const dst = {}
+    JSONPathCopy(data, dst, 'relatedPosts.0')
+    JSONPathCopy(data, dst, 'relatedPosts.1')
+    expect(dst).toEqual({
+      relatedPosts: [
+        {
+          title: 'HelloWorld',
+          author: {
+            name: 'The Flash',
+            age: 32,
+          },
+          tags: ['flash', 'marvel'],
+        },
+        {
+          title: 'Hello World',
+          author: {
+            name: 'Spiderman',
+            age: 26,
+          },
+          tags: ['spider', 'man'],
+        },
+      ],
+    })
   })
 })

--- a/src/utils/object.test.ts
+++ b/src/utils/object.test.ts
@@ -1,0 +1,25 @@
+import { mergeObjects } from './object'
+
+describe('mergeObject', () => {
+  it('Should merge two objects into one object', () => {
+    const src = { author: { name: 'superman' }, posts: [{ id: 123 }, { id: 456 }] }
+    const dst = { author: { age: 20 }, posts: [{ title: 'JavaScript' }, { title: 'Framework' }] }
+    const res = mergeObjects(dst, src)
+    expect(res).toEqual({
+      posts: [
+        {
+          id: 123,
+          title: 'JavaScript',
+        },
+        {
+          id: 456,
+          title: 'Framework',
+        },
+      ],
+      author: {
+        name: 'superman',
+        age: 20,
+      },
+    })
+  })
+})

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,18 +1,31 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+export const isObject = (val: any): boolean => val && typeof val === 'object' && !Array.isArray(val)
+
 export const mergeObjects = (target: any, source: any) => {
-  if (Array.isArray(source)) {
-    for (let i = 0, len = source.length; i < len; i++) {
-      if (!target) target = []
-      Object.assign(source[i], mergeObjects(target[i], source[i]))
-    }
-  } else {
+  const merged = Object.assign({}, target)
+  if (isObject(target) && isObject(source)) {
     for (const key of Object.keys(source)) {
-      if (source[key] instanceof Object) {
-        if (!target) target = {}
-        Object.assign(source[key], mergeObjects(target[key], source[key]))
+      if (isObject(source[key])) {
+        if (target[key] === undefined) Object.assign(merged, { [key]: source[key] })
+        else merged[key] = mergeObjects(target[key], source[key])
+      } else if (Array.isArray(source[key]) && Array.isArray(target[key])) {
+        const srcArr = source[key]
+        const tgtArr = target[key]
+        const outArr = [] as any[]
+        for (let i = 0; i < srcArr.length; i += 1) {
+          // If corresponding index for both arrays is an object, then merge them
+          // Otherwise just copy src arr index into out arr index
+          if (isObject(srcArr[i]) && isObject(tgtArr[i])) {
+            outArr[i] = mergeObjects(tgtArr[i], srcArr[i])
+          } else {
+            outArr[i] = srcArr[i]
+          }
+        }
+        Object.assign(merged, { [key]: outArr })
+      } else {
+        Object.assign(merged, { [key]: source[key] })
       }
     }
   }
-  Object.assign(target || {}, source)
-  return target
+  return merged
 }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const mergeObjects = (target: any, source: any) => {
+  if (Array.isArray(source)) {
+    for (let i = 0, len = source.length; i < len; i++) {
+      if (!target) target = []
+      Object.assign(source[i], mergeObjects(target[i], source[i]))
+    }
+  } else {
+    for (const key of Object.keys(source)) {
+      if (source[key] instanceof Object) {
+        if (!target) target = {}
+        Object.assign(source[key], mergeObjects(target[key], source[key]))
+      }
+    }
+  }
+  Object.assign(target || {}, source)
+  return target
+}


### PR DESCRIPTION
This PR introduces "nested validation" for Validator Middleware.

In this PR, we can validate nested JSON structured data using `v.array()` and `v.object()` functions. After much thought and consideration, the result is this API.

For example, there is a nested object like below:

```ts
const data = {
  posts: [
    {
      id: 123,
      title: 'JavaScript',
      tags: ['Workers', 'Deno', 'Bun'],
    },
  ],
  pager: {
    prev: true,
    next: false,
  },
}
```

It will be validated with `v.array()` and `v.object()`:

```ts
app.post(
  '/posts',
  validator((v) => ({
    posts: v.array('posts', (v) => ({
      id: v.json('id').asNumber().isRequired(),
      title: v.json('title'),
      tags: v.json('tags').asArray(),
    })),
    pager: v.object('pager', (v) => ({
      prev: v.json('prev').asBoolean(),
      next: v.json('next').asBoolean(),
    })),
  })),
  (c) => {
    return c.text('Valid!')
  }
)
```

And it also has types:

<img width="814" alt="SS" src="https://user-images.githubusercontent.com/10682/194732339-d0bee8c4-3388-42a5-b66d-f788b0ce331b.png">

Isn't it cool? I want to know your opinion.

## Implementation

It has become a little bit complex. There may be something missing or wrong points in this implementation. If you notice any, please review them.

The code for `JSONPathCopy` is based on @ThatOneBro's  and @usualoma 's code.

https://github.com/honojs/hono/pull/508/files#diff-91414c404fd51d6fb8e47ba511fd1a5c410e5fe3e732254f0f6d621175fcd647

This PR related: #584