### PR TITLE
feat(validator): has the error message per rule

### DIFF
--- a/deno_dist/middleware/validator/validator.ts
+++ b/deno_dist/middleware/validator/validator.ts
@@ -6,8 +6,25 @@ import { sanitizer } from './sanitizer.ts'
 
 type Target = 'query' | 'header' | 'body' | 'json'
 type Type = JSONPrimitive | JSONObject | JSONArray | File
-type Rule = (value: Type) => boolean
+type RuleFunc = (value: Type) => boolean
+type Rule = {
+  name: string
+  func: RuleFunc
+  customMessage?: string
+  type: 'type' | 'value'
+}
 type Sanitizer = (value: Type) => Type
+
+export type ValidateResult = {
+  isValid: boolean
+  message: string | undefined
+  target: Target
+  key: string
+  value: Type
+  ruleName: string
+  ruleType: 'type' | 'value'
+  jsonData?: JSONObject
+}
 
 export abstract class VObjectBase<T extends Schema> {
   container: T
@@ -21,6 +38,7 @@ export abstract class VObjectBase<T extends Schema> {
       this.keys.push(key)
     }
   }
+
   isOptional() {
     this._isOptional = true
     return this
@@ -71,7 +89,6 @@ export class VArray<T extends Schema> extends VObjectBase<T> {
 
 export class Validator {
   isArray: boolean = false
-  isOptional: boolean = false
   query = (key: string): VString => new VString({ target: 'query', key: key })
   header = (key: string): VString => new VString({ target: 'header', key: key })
   body = (key: string): VString => new VString({ target: 'body', key: key })
@@ -89,19 +106,11 @@ export class Validator {
     return arr
   }
   object = <T extends Schema>(path: string, validator: (v: Validator) => T): VObject<T> => {
+    this.isArray = false
     const res = validator(this)
     const obj = new VObject(res, path)
     return obj
   }
-}
-
-export type ValidateResult = {
-  isValid: boolean
-  message: string | undefined
-  target: Target
-  key: string
-  value: Type
-  jsonData: JSONObject | undefined
 }
 
 type VOptions = {
@@ -119,22 +128,33 @@ export abstract class VBase {
   rules: Rule[]
   sanitizers: Sanitizer[]
   isArray: boolean
-  private _message: string | undefined
   private _optional: boolean
   constructor(options: VOptions) {
     this.target = options.target
     this.key = options.key
     this.type = options.type || 'string'
-    this.rules = []
+    this.rules = [
+      {
+        name: this.getTypeRuleName(),
+        type: 'type',
+        func: this.validateType,
+      },
+    ]
     this.sanitizers = []
-    this.isArray = options.isArray || false
     this._optional = false
+    this.isArray = options.isArray || false
   }
 
   private _nested = () => (this.baseKeys.length ? true : false)
 
-  addRule = (rule: Rule) => {
-    this.rules.push(rule)
+  addRule(func: RuleFunc): this
+  addRule(name: string, func: RuleFunc): this
+  addRule(arg: string | RuleFunc, func?: RuleFunc) {
+    if (typeof arg === 'string' && func) {
+      this.rules.push({ name: arg, func, type: 'value' })
+    } else if (arg instanceof Function) {
+      this.rules.push({ name: arg.name, func: arg, type: 'value' })
+    }
     return this
   }
 
@@ -143,8 +163,16 @@ export abstract class VBase {
     return this
   }
 
+  message = (text: string) => {
+    const len = this.rules.length
+    if (len >= 1) {
+      this.rules[len - 1].customMessage = text
+    }
+    return this
+  }
+
   isRequired = () => {
-    return this.addRule((value: unknown) => {
+    return this.addRule('isRequired', (value: unknown) => {
       if (value !== undefined && value !== null && value !== '') return true
       return false
     })
@@ -152,41 +180,39 @@ export abstract class VBase {
 
   isOptional = () => {
     this._optional = true
-    return this.addRule(() => true)
+    return this.addRule('isOptional', () => true)
   }
 
   isEqual = (comparison: unknown) => {
-    return this.addRule((value: unknown) => {
+    return this.addRule('isEqual', (value: unknown) => {
       return value === comparison
     })
   }
 
-  asNumber = () => {
-    const newVNumber = new VNumber(this)
+  asNumber = (): VNumber | VNumberArray => {
+    const newVNumber = new VNumber({ ...this, type: 'number' })
+    if (this.isArray) return newVNumber.asArray()
     return newVNumber
   }
 
-  asBoolean = () => {
-    const newVBoolean = new VBoolean(this)
+  asBoolean = (): VBoolean | VBooleanArray => {
+    const newVBoolean = new VBoolean({ ...this, type: 'boolean' })
+    if (this.isArray) return newVBoolean.asArray()
     return newVBoolean
   }
 
-  message(value: string) {
-    this._message = value
+  get(value: string) {
+    const len = this.rules.length
+    if (len > 0) {
+      this.rules[this.rules.length - 1].customMessage = value
+    }
     return this
   }
 
-  validate = async (req: Request): Promise<ValidateResult> => {
-    const result: ValidateResult = {
-      isValid: true,
-      message: undefined,
-      target: this.target,
-      key: this.key,
-      value: undefined,
-      jsonData: undefined,
-    }
-
+  validate = async (req: Request): Promise<ValidateResult[]> => {
     let value: Type = undefined
+    let jsonData: JSONObject | undefined = undefined
+
     if (this.target === 'query') {
       value = req.query(this.key)
     }
@@ -209,57 +235,68 @@ export abstract class VBase {
       }
       const dst = {}
       value = JSONPathCopy(obj, dst, this.key)
-      if (this.isArray && !Array.isArray(value)) {
-        value = [value]
-      }
-      if (this._nested()) result.jsonData = dst
+      if (this._nested()) jsonData = dst
     }
 
-    result.value = value
+    const results: ValidateResult[] = []
+
+    let typeRule = this.rules.shift()
+
+    for (const rule of this.rules) {
+      if (rule.type === 'type') {
+        typeRule = rule
+      } else if (rule.type === 'value') {
+        const result = this.validateRule(rule, value)
+        result.jsonData ||= jsonData
+        results.push(result)
+      }
+    }
+
+    if (typeRule) {
+      const typeResult = this.validateRule(typeRule, value)
+      typeResult.jsonData ||= jsonData
+      results.unshift(typeResult)
+    }
+
+    return results
+  }
+
+  protected getTypeRuleName(): string {
+    const prefix = 'should be'
+    return this.isArray ? `${prefix} "${this.type}[]"` : `${prefix} "${this.type}"`
+  }
+
+  private validateRule(rule: Rule, value: Type): ValidateResult {
+    let isValid: boolean = false
 
     if (this._nested() && this.target != 'json') {
-      result.isValid = false
-    } else {
-      result.isValid = this.validateValue(value)
+      isValid = false
+    } else if (rule.type === 'value') {
+      isValid = this.validateValue(rule.func, value)
+    } else if (rule.type === 'type') {
+      isValid = this.validateType(value)
     }
 
-    if (result.isValid === false) {
-      if (this._message) {
-        result.message = this._message
-      } else {
-        const valToStr = Array.isArray(value)
-          ? `[${value
-              .map((val) =>
-                val === undefined ? 'undefined' : typeof val === 'string' ? `"${val}"` : val
-              )
-              .join(', ')}]`
-          : value
-        switch (this.target) {
-          case 'query':
-            result.message = `Invalid Value: the query parameter "${this.key}" is invalid - ${valToStr}`
-            break
-          case 'header':
-            result.message = `Invalid Value: the request header "${this.key}" is invalid - ${valToStr}`
-            break
-          case 'body':
-            result.message = `Invalid Value: the request body "${this.key}" is invalid - ${valToStr}`
-            break
-          case 'json':
-            result.message = `Invalid Value: the JSON body "${this.key}" is invalid - ${valToStr}`
-            break
-        }
-      }
+    const message = isValid
+      ? undefined
+      : rule.customMessage || this.getMessage({ ruleName: rule.name, value })
+    const result = {
+      isValid: isValid,
+      message: message,
+      target: this.target,
+      key: this.key,
+      value,
+      ruleName: rule.name,
+      ruleType: rule.type,
     }
     return result
   }
 
-  private validateValue = (value: Type): boolean => {
-    // Check type
+  private validateType = (value: Type): boolean => {
     if (this.isArray) {
       if (!Array.isArray(value)) {
         return false
       }
-
       for (const val of value) {
         if (typeof val === 'undefined' && this._nested()) {
           value.pop()
@@ -267,47 +304,72 @@ export abstract class VBase {
         for (const val of value) {
           if (typeof val !== this.type) {
             // Value is of wrong type here
-            // If not optional, or optional and not undefined, return false
+            // If it is not optional and not undefined, return false
             if (!this._optional || typeof val !== 'undefined') return false
           }
         }
       }
-
-      // Sanitize
-      for (const sanitizer of this.sanitizers) {
-        value = value.map((innerVal: any) => sanitizer(innerVal)) as JSONArray
-      }
-
-      for (const rule of this.rules) {
-        for (const val of value) {
-          if (!rule(val)) {
-            return false
-          }
-        }
-      }
-      return true
     } else {
       if (typeof value !== this.type) {
-        if (this._optional && typeof value === 'undefined') {
+        if (this._optional && (typeof value === 'undefined' || Array.isArray(value))) {
           // Do nothing.
-          // The value is allowed to be `undefined` if it is `optional`
+          // If it is optional it's OK to be `undefined` or Array
         } else {
           return false
         }
       }
+    }
+    return true
+  }
 
+  private validateValue = (func: (value: Type) => boolean, value: Type): boolean => {
+    if (Array.isArray(value)) {
       // Sanitize
       for (const sanitizer of this.sanitizers) {
-        value = sanitizer(value)
+        value = value.map((innerVal: any) => sanitizer(innerVal)) as JSONArray
       }
-
-      for (const rule of this.rules) {
-        if (!rule(value)) {
+      for (const val of value) {
+        if (!func(val)) {
           return false
         }
       }
       return true
+    } else {
+      // Sanitize
+      for (const sanitizer of this.sanitizers) {
+        value = sanitizer(value)
+      }
+      if (!func(value)) {
+        return false
+      }
+      return true
     }
+  }
+
+  private getMessage = (opts: { ruleName: string; value: Type }): string => {
+    let keyText: string
+    const valueText = Array.isArray(opts.value)
+      ? `${opts.value
+          .map((val) =>
+            val === undefined ? 'undefined' : typeof val === 'string' ? `"${val}"` : val
+          )
+          .join(', ')}`
+      : opts.value
+    switch (this.target) {
+      case 'query':
+        keyText = `the query parameter "${this.key}"`
+        break
+      case 'header':
+        keyText = `the request header "${this.key}"`
+        break
+      case 'body':
+        keyText = `the request body "${this.key}"`
+        break
+      case 'json':
+        keyText = `the JSON body "${this.key}"`
+        break
+    }
+    return `Invalid Value [${valueText}]: ${keyText} is invalid - ${opts.ruleName}`
   }
 }
 
@@ -326,19 +388,19 @@ export class VString extends VBase {
       ignore_whitespace: boolean
     } = { ignore_whitespace: false }
   ) => {
-    return this.addRule((value) => rule.isEmpty(value as string, options))
+    return this.addRule('isEmpty', (value) => rule.isEmpty(value as string, options))
   }
 
   isLength = (options: Partial<{ min: number; max: number }> | number, arg2?: number) => {
-    return this.addRule((value) => rule.isLength(value as string, options, arg2))
+    return this.addRule('isLength', (value) => rule.isLength(value as string, options, arg2))
   }
 
   isAlpha = () => {
-    return this.addRule((value) => rule.isAlpha(value as string))
+    return this.addRule('isAlpha', (value) => rule.isAlpha(value as string))
   }
 
   isNumeric = () => {
-    return this.addRule((value) => rule.isNumeric(value as string))
+    return this.addRule('isNumeric', (value) => rule.isNumeric(value as string))
   }
 
   contains = (
@@ -348,15 +410,15 @@ export class VString extends VBase {
       minOccurrences: 1,
     }
   ) => {
-    return this.addRule((value) => rule.contains(value as string, elem, options))
+    return this.addRule('contains', (value) => rule.contains(value as string, elem, options))
   }
 
   isIn = (options: string[]) => {
-    return this.addRule((value) => rule.isIn(value as string, options))
+    return this.addRule('isIn', (value) => rule.isIn(value as string, options))
   }
 
   match = (regExp: RegExp) => {
-    return this.addRule((value) => rule.match(value as string, regExp))
+    return this.addRule('match', (value) => rule.match(value as string, regExp))
   }
 
   trim = () => {
@@ -375,11 +437,11 @@ export class VNumber extends VBase {
   }
 
   isGte = (min: number) => {
-    return this.addRule((value) => rule.isGte(value as number, min))
+    return this.addRule('isGte', (value) => rule.isGte(value as number, min))
   }
 
   isLte = (min: number) => {
-    return this.addRule((value) => rule.isLte(value as number, min))
+    return this.addRule('isLte', (value) => rule.isLte(value as number, min))
   }
 }
 
@@ -394,11 +456,11 @@ export class VBoolean extends VBase {
   }
 
   isTrue = () => {
-    return this.addRule((value) => rule.isTrue(value as boolean))
+    return this.addRule('isTrue', (value) => rule.isTrue(value as boolean))
   }
 
   isFalse = () => {
-    return this.addRule((value) => rule.isFalse(value as boolean))
+    return this.addRule('isFalse', (value) => rule.isFalse(value as boolean))
   }
 }
 
@@ -407,6 +469,7 @@ export class VNumberArray extends VNumber {
   constructor(options: VOptions) {
     super(options)
     this.isArray = true
+    this.rules[0].name = this.getTypeRuleName()
   }
 }
 export class VStringArray extends VString {
@@ -414,6 +477,7 @@ export class VStringArray extends VString {
   constructor(options: VOptions) {
     super(options)
     this.isArray = true
+    this.rules[0].name = this.getTypeRuleName()
   }
 }
 export class VBooleanArray extends VBoolean {
@@ -421,5 +485,6 @@ export class VBooleanArray extends VBoolean {
   constructor(options: VOptions) {
     super(options)
     this.isArray = true
+    this.rules[0].name = this.getTypeRuleName()
   }
 }

--- a/deno_dist/utils/json.ts
+++ b/deno_dist/utils/json.ts
@@ -80,11 +80,12 @@ const JSONPathCopyInternal = (
 
 export const JSONPathCopy = (src: JSONObject, dst: JSONObject, path: string) => {
   const results: JSONArray = []
+  const parts = path.replace(/\.?\[(.*?)\]/g, '.$1').split(/\./)
   try {
-    JSONPathCopyInternal(src, dst, path.replace(/\.?\[(.*?)\]/g, '.$1').split(/\./), results)
+    JSONPathCopyInternal(src, dst, parts, results)
     if (results.length === 0) {
       return undefined
-    } else if (results.length === 1) {
+    } else if (results.length === 1 && !parts.includes('*')) {
       return results[0]
     }
     return results

--- a/deno_dist/utils/object.ts
+++ b/deno_dist/utils/object.ts
@@ -1,18 +1,31 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+export const isObject = (val: any): boolean => val && typeof val === 'object' && !Array.isArray(val)
+
 export const mergeObjects = (target: any, source: any) => {
-  if (Array.isArray(source)) {
-    for (let i = 0, len = source.length; i < len; i++) {
-      if (!target) target = []
-      Object.assign(source[i], mergeObjects(target[i], source[i]))
-    }
-  } else {
+  const merged = Object.assign({}, target)
+  if (isObject(target) && isObject(source)) {
     for (const key of Object.keys(source)) {
-      if (source[key] instanceof Object) {
-        if (!target) target = {}
-        Object.assign(source[key], mergeObjects(target[key], source[key]))
+      if (isObject(source[key])) {
+        if (target[key] === undefined) Object.assign(merged, { [key]: source[key] })
+        else merged[key] = mergeObjects(target[key], source[key])
+      } else if (Array.isArray(source[key]) && Array.isArray(target[key])) {
+        const srcArr = source[key]
+        const tgtArr = target[key]
+        const outArr = [] as any[]
+        for (let i = 0; i < srcArr.length; i += 1) {
+          // If corresponding index for both arrays is an object, then merge them
+          // Otherwise just copy src arr index into out arr index
+          if (isObject(srcArr[i]) && isObject(tgtArr[i])) {
+            outArr[i] = mergeObjects(tgtArr[i], srcArr[i])
+          } else {
+            outArr[i] = srcArr[i]
+          }
+        }
+        Object.assign(merged, { [key]: outArr })
+      } else {
+        Object.assign(merged, { [key]: source[key] })
       }
     }
   }
-  Object.assign(target || {}, source)
-  return target
+  return merged
 }

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -215,6 +215,56 @@ describe('Custom Validation', () => {
   })
 })
 
+describe('Result objects', () => {
+  const app = new Hono()
+
+  app.post(
+    '/posts',
+    validator(
+      (v) => ({
+        title: v.body('title').isLength({ max: 5 }),
+      }),
+      {
+        done: (res, c) => {
+          return c.json(res['results'])
+        },
+      }
+    ),
+    (c) => {
+      return c.text('Valid')
+    }
+  )
+
+  it('Should return the result objects', async () => {
+    const formData = new FormData()
+    formData.append('title', 'abcdef')
+    const req = new Request('http://localhost/posts', {
+      method: 'POST',
+      body: formData,
+    })
+    const res = await app.request(req)
+    expect(await res.json()).toEqual([
+      {
+        isValid: true,
+        key: 'title',
+        ruleName: 'should be "string"',
+        ruleType: 'type',
+        target: 'body',
+        value: 'abcdef',
+      },
+      {
+        isValid: false,
+        key: 'title',
+        message: 'Invalid Value [abcdef]: the request body "title" is invalid - isLength',
+        ruleName: 'isLength',
+        ruleType: 'value',
+        target: 'body',
+        value: 'abcdef',
+      },
+    ])
+  })
+})
+
 describe('Array parameter', () => {
   const app = new Hono()
 

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -293,7 +293,6 @@ describe('Result objects', () => {
     })
     const res = await app.request(req)
     const body1 = await res.json()
-    console.log(JSON.stringify(body1, null, 2))
     expect(body1).toEqual([
       {
         isValid: false,

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -35,8 +35,9 @@ describe('Basic - query', () => {
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(
       [
-        'Invalid Value: the query parameter "page" is invalid - undefined',
-        'Invalid Value: the query parameter "q5" is invalid - 123',
+        'Invalid Value [undefined]: the query parameter "page" is invalid - isRequired',
+        'Invalid Value [undefined]: the query parameter "page" is invalid - isNumeric',
+        'Invalid Value [123]: the query parameter "q5" is invalid - isEmpty',
       ].join('\n')
     )
   })
@@ -76,7 +77,7 @@ describe('Basic - body', () => {
     })
     const res = await app.request(req)
     expect(res.status).toBe(400)
-    const messages = ['Invalid Value: the request body "title" is invalid - undefined']
+    const messages = ['Invalid Value [undefined]: the request body "title" is invalid - isRequired']
     expect(await res.text()).toBe(messages.join('\n'))
   })
 })

--- a/src/middleware/validator/validator.test.ts
+++ b/src/middleware/validator/validator.test.ts
@@ -11,26 +11,35 @@ describe('Basic - query', () => {
   it('Should be valid - page', async () => {
     const validator = v.query('page').trim().isNumeric()
     expect(validator.type).toBe('string')
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].message).toBeUndefined()
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
   })
 
   it('Should be invalid - q', async () => {
     const validator = v.query('q').isRequired().asNumber()
     expect(validator.type).toBe('number')
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the query parameter "q" is invalid - foo']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    const messages = [
+      'Invalid Value [foo]: the query parameter "q" is invalid - should be "number"',
+    ]
+    expect(results[0].message).toBe(messages.join('\n'))
   })
 
   it('Should be invalid - q2', async () => {
     const validator = v.query('q2').isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the query parameter "q2" is invalid - undefined']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    let messages = [
+      'Invalid Value [undefined]: the query parameter "q2" is invalid - should be "string"',
+    ]
+    expect(results[0].message).toBe(messages.join('\n'))
+    expect(results[1].isValid).toBe(false)
+    messages = ['Invalid Value [undefined]: the query parameter "q2" is invalid - isRequired']
+    expect(results[1].message).toBe(messages.join('\n'))
   })
 })
 
@@ -46,17 +55,22 @@ describe('Basic - header', () => {
 
   it('Should be valid - x-message', async () => {
     const validator = v.header('x-message').isRequired().contains('Hello', { ignoreCase: true })
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].message).toBeUndefined()
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
+    expect(results[2].isValid).toBe(true)
+    expect(results[2].message).toBeUndefined()
   })
 
   it('Should be invalid - x-number', async () => {
     const validator = v.header('x-number').isEqual(12345)
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the request header "x-number" is invalid - 12345']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(false)
+    const messages = ['Invalid Value [12345]: the request header "x-number" is invalid - isEqual']
+    expect(results[1].message).toBe(messages.join('\n'))
   })
 })
 
@@ -73,17 +87,23 @@ describe('Basic - body', () => {
 
   it('Should be valid - title', async () => {
     const validator = v.body('title').trim().isLength({ max: 10 }).isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].message).toBeUndefined()
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
+    expect(results[2].isValid).toBe(true)
+    expect(results[2].message).toBeUndefined()
   })
 
   it('Should be invalid - title2', async () => {
     const validator = v.body('title2').isLength({ max: 5 })
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the request body "title2" is invalid - abcdef']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].message).toBeUndefined()
+    expect(results[1].isValid).toBe(false)
+    const messages = ['Invalid Value [abcdef]: the request body "title2" is invalid - isLength']
+    expect(results[1].message).toBe(messages.join('\n'))
   })
 })
 
@@ -106,24 +126,29 @@ describe('Basic - JSON', () => {
 
   it('Should be valid - id', async () => {
     const validator = v.json('id').asNumber().isEqual(1234)
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].message).toBeUndefined()
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
   })
 
   it('Should be valid - author.name', async () => {
     const validator = v.json('author.name').isIn(['Ultra man', 'Superman'])
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].message).toBeUndefined()
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
   })
 
   it('Should be invalid - author.age', async () => {
     const validator = v.json('author.age').asNumber().isLte(10)
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the JSON body "author.age" is invalid - 20']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(false)
+    const messages = ['Invalid Value [20]: the JSON body "author.age" is invalid - isLte']
+    expect(results[1].message).toBe(messages.join('\n'))
   })
 })
 
@@ -137,21 +162,24 @@ describe('Handle required values', () => {
 
   it('Should be valid - `name` is required', async () => {
     const validator = v.json('name').isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
   })
 
   it('Should be invalid - `comment` is required but missing', async () => {
     const validator = v.json('comment').isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    expect(results[1].isValid).toBe(false)
   })
 
-  it('Should be valid - `admin` is required and present, although falsey', async () => {
+  it('Should be valid - `admin` is required and present, although falsy', async () => {
     const validator = v.json('admin').asBoolean().isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.value).toBe(false)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].value).toBe(false)
   })
 })
 
@@ -164,8 +192,8 @@ describe('Handle optional values', () => {
 
   it('Should be valid - `comment` is optional', async () => {
     const validator = v.body('comment').isOptional()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
   })
 })
 
@@ -185,18 +213,20 @@ describe('Handling types error', () => {
 
   it('Should be invalid - "1234" is not number', async () => {
     const validator = v.json('id').asNumber().isEqual(1234)
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the JSON body "id" is invalid - 1234']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    const messages = ['Invalid Value [1234]: the JSON body "id" is invalid - should be "number"']
+    expect(results[0].message).toBe(messages.join('\n'))
   })
 
   it('Should be invalid - "true" is not boolean', async () => {
     const validator = v.json('published').asBoolean()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the JSON body "published" is invalid - true']
-    expect(res.message).toBe(messages.join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    const messages = [
+      'Invalid Value [true]: the JSON body "published" is invalid - should be "boolean"',
+    ]
+    expect(results[0].message).toBe(messages.join('\n'))
   })
 })
 
@@ -238,55 +268,58 @@ describe('Handle array paths', () => {
 
   it('Should validate targeted path in array', async () => {
     const validator = v.json('posts[*].published').asArray().asBoolean().isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
-    expect(res.value).toEqual([true, true, false])
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
+    expect(results[1].value).toEqual([true, true, false])
   })
 
   it('Should allow nested array paths', async () => {
     const validator = v.json('posts[*].rating[0]').asArray().asBoolean().isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
-    expect(res.value).toEqual([true, false, true])
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
+    expect(results[1].value).toEqual([true, false, true])
   })
 
   it('Should allow optional array paths', async () => {
     const validator = v.json('posts[*].rating[1]').asArray().isOptional()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.message).toBeUndefined()
-    expect(res.value).toEqual(['cool', undefined, 'lame'])
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
+    expect(results[1].message).toBeUndefined()
+    expect(results[1].value).toEqual(['cool', undefined, 'lame'])
   })
 
   it('Should provide error with invalid array paths', async () => {
     const validator = v.json('posts[*].rating[3]').asArray()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
     const messages = [
-      'Invalid Value: the JSON body "posts[*].rating[3]" is invalid - [undefined, undefined, undefined]',
+      'Invalid Value [undefined, undefined, undefined]: the JSON body "posts[*].rating[3]" is invalid - should be "string[]"',
     ]
-    expect(res.message).toBe(messages.join('\n'))
-    expect(res.value).toEqual([undefined, undefined, undefined])
+    expect(results[0].message).toBe(messages.join('\n'))
+    expect(results[0].value).toEqual([undefined, undefined, undefined])
   })
 
   it('Should prevent invalid types within array', async () => {
     const validator = v.json('posts[*].awesome').asArray().asBoolean()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
     const messages = [
-      'Invalid Value: the JSON body "posts[*].awesome" is invalid - [true, "true", false]',
+      'Invalid Value [true, "true", false]: the JSON body "posts[*].awesome" is invalid - should be "boolean[]"',
     ]
-    expect(res.message).toBe(messages.join('\n'))
-    expect(res.value).toEqual([true, 'true', false])
+    expect(results[0].message).toBe(messages.join('\n'))
+    expect(results[0].value).toEqual([true, 'true', false])
   })
 
   it('Should allow undefined values when optional', async () => {
     const validator = v.json('posts[*].testing').asArray().asBoolean().isOptional()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
-    expect(res.value).toEqual([false, true, undefined])
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[0].value).toEqual([false, true, undefined])
   })
 })
 
@@ -311,6 +344,9 @@ describe('Validate with asArray', () => {
         },
       ],
     },
+    pager: {
+      prev: true,
+    },
   }
 
   const req = new Request('http://localhost/', {
@@ -320,14 +356,16 @@ describe('Validate with asArray', () => {
 
   it('Should validate array values', async () => {
     const validator = v.json('post.title').asArray().isAlpha()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
   })
 
   it('Should validate array values - specify with `*`', async () => {
     const validator = v.json('post.comments[*].title').asArray().isAlpha()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
   })
 
   it('Should return the same result for `.asArray().as{Type}()` and `.as{Type}().asArray()', async () => {
@@ -336,9 +374,10 @@ describe('Validate with asArray', () => {
     const res1 = await validator1.validate(req)
     const res2 = await validator2.validate(req)
 
-    expect(res1.isValid).toBe(true)
-    expect(res1.message).toBeUndefined()
-    expect(res1.value).toEqual([true, false])
+    expect(res1[0].isValid).toBe(true)
+    expect(res1[0].message).toBeUndefined()
+    expect(res1[0].value).toEqual([true, false])
+    expect(res1[1].isValid).toBe(true)
 
     // Entire responses should be equal
     expect(res1).toEqual(res2)
@@ -346,23 +385,46 @@ describe('Validate with asArray', () => {
 
   it('Should fail validation if value is array but `.asArray()` not called', async () => {
     const validator = v.json('post.flags').asBoolean().isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
-    const messages = ['Invalid Value: the JSON body "post.flags" is invalid - [true, false]']
-    expect(res.message).toBe(messages.join('\n'))
-    expect(res.value).toEqual([true, false])
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    const messages = [
+      'Invalid Value [true, false]: the JSON body "post.flags" is invalid - should be "boolean"',
+    ]
+    expect(results[0].message).toBe(messages.join('\n'))
+    expect(results[0].value).toEqual([true, false])
+    expect(results[1].isValid).toBe(true)
   })
 
   it('Should pass validation if `isRequired` and path has no missing entries', async () => {
     const validator = v.json('post.comments[*].author').asArray().isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(true)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(true)
   })
 
   it('Should fail validation if `isRequired` and missing entry for path', async () => {
     const validator = v.json('post.comments[*].heroes').asArray().isRequired()
-    const res = await validator.validate(req)
-    expect(res.isValid).toBe(false)
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    let messages = [
+      'Invalid Value [undefined, undefined]: the JSON body "post.comments[*].heroes" is invalid - should be "string[]"',
+    ]
+    expect(results[0].message).toBe(messages.join('\n'))
+    expect(results[1].isValid).toBe(false)
+    messages = [
+      'Invalid Value [undefined, undefined]: the JSON body "post.comments[*].heroes" is invalid - isRequired',
+    ]
+    expect(results[1].message).toBe(messages.join('\n'))
+  })
+
+  it('Should fail validation if value is not array but `asArray` is set', async () => {
+    const validator = v.json('pager.prev').asBoolean().asArray()
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    const messages = [
+      'Invalid Value [true]: the JSON body "pager.prev" is invalid - should be "boolean[]"',
+    ]
+    expect(results[0].message).toBe(messages.join('\n'))
   })
 })
 
@@ -483,9 +545,9 @@ describe('Nested objects', () => {
         .isOptional(),
     }))
     for (const validator of vArray.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(true)
-      expect(res.message).toBeUndefined()
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(true)
+      expect(results[0].message).toBeUndefined()
     }
   })
 
@@ -503,9 +565,9 @@ describe('Nested objects', () => {
     }))
 
     for (const validator of vObject.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(true)
-      expect(res.message).toBeUndefined()
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(true)
+      expect(results[0].message).toBeUndefined()
     }
   })
 
@@ -516,10 +578,12 @@ describe('Nested objects', () => {
     }))
 
     for (const validator of vArray.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(false)
-      const messages = ['Invalid Value: the JSON body "posts.[*].id" is invalid - [123, 456]']
-      expect(res.message).toBe(messages.join('\n'))
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(false)
+      const messages = [
+        'Invalid Value [123, 456]: the JSON body "posts.[*].id" is invalid - should be "string[]"',
+      ]
+      expect(results[0].message).toBe(messages.join('\n'))
     }
 
     v = new Validator()
@@ -527,9 +591,9 @@ describe('Nested objects', () => {
       optionalProperty: v.json('optional-property').isOptional(),
     }))
     for (const validator of vArray2.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(true)
-      expect(res.message).toBeUndefined()
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(true)
+      expect(results[0].message).toBeUndefined()
     }
   })
 
@@ -545,9 +609,9 @@ describe('Nested objects', () => {
     }))
 
     for (const validator of vArray.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(true)
-      expect(res.message).toBeUndefined()
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(true)
+      expect(results[0].message).toBeUndefined()
     }
 
     const vArray2 = v
@@ -557,12 +621,12 @@ describe('Nested objects', () => {
       .isOptional()
 
     for (const validator of vArray2.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(false)
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(false)
       const messages = [
-        'Invalid Value: the JSON body "posts.[*].title" is invalid - ["JavaScript", "Framework"]',
+        'Invalid Value ["JavaScript", "Framework"]: the JSON body "posts.[*].title" is invalid - should be "number[]"',
       ]
-      expect(res.message).toBe(messages.join('\n'))
+      expect(results[0].message).toBe(messages.join('\n'))
     }
   })
 
@@ -578,9 +642,9 @@ describe('Nested objects', () => {
     }))
 
     for (const validator of vObject.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(true)
-      expect(res.message).toBeUndefined()
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(true)
+      expect(results[0].message).toBeUndefined()
     }
   })
 
@@ -591,10 +655,12 @@ describe('Nested objects', () => {
     }))
 
     for (const validator of vArray.getValidators()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(false)
-      const messages = ['Invalid Value: the request header "id" is invalid - undefined']
-      expect(res.message).toBe(messages.join('\n'))
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(false)
+      const messages = [
+        'Invalid Value [undefined]: the request header "id" is invalid - should be "number"',
+      ]
+      expect(results[0].message).toBe(messages.join('\n'))
     }
 
     const vObject = v.object('pager', (v) => ({
@@ -603,14 +669,57 @@ describe('Nested objects', () => {
     }))
 
     const messages = [
-      'Invalid Value: the query parameter "prev" is invalid - undefined',
-      'Invalid Value: the request body "next" is invalid - undefined',
+      'Invalid Value [undefined]: the query parameter "prev" is invalid - should be "boolean"',
+      'Invalid Value [undefined]: the request body "next" is invalid - should be "boolean"',
     ]
 
     for (const [i, validator] of vObject.getValidators().entries()) {
-      const res = await validator.validate(req)
-      expect(res.isValid).toBe(false)
-      expect(res.message).toBe(`${messages[i]}`)
+      const results = await validator.validate(req)
+      expect(results[0].isValid).toBe(false)
+      expect(results[0].message).toBe(`${messages[i]}`)
     }
+  })
+})
+
+describe('Custom message', () => {
+  const v = new Validator()
+
+  const json = {
+    title: 'foo',
+    post: [
+      {
+        id: 123,
+      },
+    ],
+  }
+
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body: JSON.stringify(json),
+  })
+
+  it('Should return custom error message - value', async () => {
+    const customMessage1 = 'Custom message: not contain!'
+    const customMessage2 = 'Custom message: not numeric!'
+    const validator = v
+      .json('title')
+      .contains('bar')
+      .message([customMessage1].join('\n'))
+      .isNumeric()
+      .message([customMessage2].join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(true)
+    expect(results[1].isValid).toBe(false)
+    expect(results[1].message).toBe([customMessage1].join('\n'))
+    expect(results[2].isValid).toBe(false)
+    expect(results[2].message).toBe([customMessage2].join('\n'))
+  })
+
+  it('Should return custom error message - validate type', async () => {
+    const customMessage = 'Custom message: not string array!'
+    const validator = v.json('post[*].id').message([customMessage].join('\n'))
+    const results = await validator.validate(req)
+    expect(results[0].isValid).toBe(false)
+    expect(results[0].message).toBe([customMessage].join('\n'))
   })
 })

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -80,11 +80,12 @@ const JSONPathCopyInternal = (
 
 export const JSONPathCopy = (src: JSONObject, dst: JSONObject, path: string) => {
   const results: JSONArray = []
+  const parts = path.replace(/\.?\[(.*?)\]/g, '.$1').split(/\./)
   try {
-    JSONPathCopyInternal(src, dst, path.replace(/\.?\[(.*?)\]/g, '.$1').split(/\./), results)
+    JSONPathCopyInternal(src, dst, parts, results)
     if (results.length === 0) {
       return undefined
-    } else if (results.length === 1) {
+    } else if (results.length === 1 && !parts.includes('*')) {
       return results[0]
     }
     return results


### PR DESCRIPTION
In this PR, the validator will have multiple result objects, so it will have an error message per rule.

For example, one error message will become more friendly.

```
'Invalid Value: the request body "title" is invalid - abcdefg'
```

will be:

```
'Invalid Value [abcdef]: the request body "title" is invalid - isLength'
```

Internally, it has error objects as follows:

```json
[
  {
      "isValid": true,
      "target": "body",
      "key": "title",
      "value": "abcdefg",
      "ruleName": "should be \"string\"",
      "ruleType": "type"
  },
  {
      "isValid": false,
      "message": "Invalid Value [abcdefg]: the request body \"title\" is invalid - isLength",
      "target": "body",
      "key": "title",
      "value": "abcdefg",
      "ruleName": "isLength",
      "ruleType": "value"
  }
]
```

If you want to do more complex error handling, you can refer to this result objects in the `done` option.

```ts
const vHandler = validator(
  (v) => ({
    title: v.body('title').isLength({ max: 5 }),
  }),
  {
    done: (res, c) => {
      if (res.hasError) {
        // ... do something
        // console.log(res.results)
      }
    },
  }
)
```

This PR is related to #561 