### PR TITLE
fix(bearer-auth, basic-auth): handler should not be executed when unauthorized

### DIFF
--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -53,12 +53,11 @@ export const basicAuth = (
         }
       }
     }
-    ctx.res = new Response('Unauthorized', {
+    return new Response('Unauthorized', {
       status: 401,
       headers: {
         'WWW-Authenticate': 'Basic realm="' + options.realm?.replace(/"/g, '\\"') + '"',
       },
     })
-    await next()
   }
 }

--- a/src/middleware/bearer-auth/index.test.ts
+++ b/src/middleware/bearer-auth/index.test.ts
@@ -2,19 +2,30 @@ import { Hono } from '../../hono'
 import { bearerAuth } from '.'
 
 describe('Bearer Auth by Middleware', () => {
-  const app = new Hono()
+  let app: Hono
+  let handlerExecuted: boolean
+  let token: string
 
-  const token = 'abcdefg12345-._~+/='
+  beforeEach(async () => {
+    app = new Hono()
+    handlerExecuted = false
+    token = 'abcdefg12345-._~+/='
+    app.use('/auth/*', bearerAuth({ token }))
+    app.use('/auth/*', async (c, next) => {
+      c.header('x-custom', 'foo')
+      await next()
+    })
+    app.get('/auth/*', (c) => {
+      handlerExecuted = true
+      return c.text('auth')
+    })
 
-  app.use('/auth/*', bearerAuth({ token }))
-  app.use('/auth/*', async (c, next) => {
-    c.header('x-custom', 'foo')
-    await next()
+    app.use('/authBot/*', bearerAuth({ token, prefix: 'Bot' }))
+    app.get('/authBot/*', (c) => {
+      handlerExecuted = true
+      return c.text('auth bot')
+    })
   })
-  app.get('/auth/*', (c) => c.text('auth'))
-
-  app.use('/authBot/*', bearerAuth({ token, prefix: 'Bot' }))
-  app.get('/authBot/*', (c) => c.text('auth bot'))
 
   it('Should authorize', async () => {
     const req = new Request('http://localhost/auth/a')
@@ -22,6 +33,7 @@ describe('Bearer Auth by Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
+    expect(handlerExecuted).toBeTruthy()
     expect(await res.text()).toBe('auth')
     expect(res.headers.get('x-custom')).toBe('foo')
   })
@@ -31,8 +43,9 @@ describe('Bearer Auth by Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
+    expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('Unauthorized')
-    expect(res.headers.get('x-custom')).toBe('foo')
+    expect(res.headers.get('x-custom')).toBeNull()
   })
 
   it('Should not authorize - invalid request', async () => {
@@ -40,9 +53,10 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Beare abcdefg12345-._~+/=')
     const res = await app.request(req)
     expect(res).not.toBeNull()
+    expect(handlerExecuted).toBeFalsy()
     expect(res.status).toBe(400)
     expect(await res.text()).toBe('Bad Request')
-    expect(res.headers.get('x-custom')).toBe('foo')
+    expect(res.headers.get('x-custom')).toBeNull()
   })
 
   it('Should not authorize - invalid token', async () => {
@@ -52,7 +66,7 @@ describe('Bearer Auth by Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
     expect(await res.text()).toBe('Unauthorized')
-    expect(res.headers.get('x-custom')).toBe('foo')
+    expect(res.headers.get('x-custom')).toBeNull()
   })
 
   it('Should authorize', async () => {
@@ -61,6 +75,7 @@ describe('Bearer Auth by Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
+    expect(handlerExecuted).toBeTruthy()
     expect(await res.text()).toBe('auth bot')
   })
 
@@ -69,6 +84,7 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Bearer abcdefg12345-._~+/=')
     const res = await app.request(req)
     expect(res).not.toBeNull()
+    expect(handlerExecuted).toBeFalsy()
     expect(res.status).toBe(400)
     expect(await res.text()).toBe('Bad Request')
   })

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -27,7 +27,7 @@ export const bearerAuth = (options: {
 
     if (!headerToken) {
       // No Authorization header
-      c.res = new Response('Unauthorized', {
+      return new Response('Unauthorized', {
         status: 401,
         headers: {
           'WWW-Authenticate': `${options.prefix} realm="` + realm + '"',
@@ -38,7 +38,7 @@ export const bearerAuth = (options: {
       const match = regexp.exec(headerToken)
       if (!match) {
         // Invalid Request
-        c.res = new Response('Bad Request', {
+        return new Response('Bad Request', {
           status: 400,
           headers: {
             'WWW-Authenticate': `${options.prefix} error="invalid_request"`,
@@ -48,7 +48,7 @@ export const bearerAuth = (options: {
         const equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
         if (!equal) {
           // Invalid Token
-          c.res = new Response('Unauthorized', {
+          return new Response('Unauthorized', {
             status: 401,
             headers: {
               'WWW-Authenticate': `${options.prefix} error="invalid_token"`,


### PR DESCRIPTION
This is a huge security concern. Imagine securing a nuclear launch handler with it :scream: 

I would suggest yanking all previous versions with this middleware