### PR TITLE
fix(validator): show "type" error messages if does not have "value" errors

### DIFF
--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -119,6 +119,16 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
         resultSet.results.push(result)
       }
 
+      // If it's invalid but it has no "value" messages, have to set the "type" messages.
+      // This approach is verbose, but if do not so, the response body will be empty.
+      if (!isValid && resultSet.messages.length === 0) {
+        resultSet.results.map((r) => {
+          if (!r.isValid && r.ruleType === 'type' && r.message) {
+            resultSet.messages.push(r.message)
+          }
+        })
+      }
+
       // Set data on request object
       if (isValid) {
         // Set data on request object

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -707,3 +707,26 @@ describe('Nested structured data', () => {
     expect(res.status).toBe(400)
   })
 })
+
+describe('Special case', () => {
+  const app = new Hono()
+  app.get(
+    '/search',
+    validator((v) => ({
+      q: v.query('q').isRequired(),
+      page: v.query('page').asNumber(),
+    })),
+    (c) => {
+      return c.text('Valid')
+    }
+  )
+  it('Should show the type message error if it does not have "value" errors', async () => {
+    const res = await app.request('http://localhost/search?q=foo')
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe(
+      [
+        'Invalid Value [undefined]: the query parameter "page" is invalid - should be "number"',
+      ].join('\n')
+    )
+  })
+})

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -119,6 +119,16 @@ export const validatorMiddleware = <T extends Schema, Env extends Partial<Enviro
         resultSet.results.push(result)
       }
 
+      // If it's invalid but it has no "value" messages, have to set the "type" messages.
+      // This approach is verbose, but if do not so, the response body will be empty.
+      if (!isValid && resultSet.messages.length === 0) {
+        resultSet.results.map((r) => {
+          if (!r.isValid && r.ruleType === 'type' && r.message) {
+            resultSet.messages.push(r.message)
+          }
+        })
+      }
+
       // Set data on request object
       if (isValid) {
         // Set data on request object


### PR DESCRIPTION
Fixed the bug returning an empty body if the results don't have "value" errors.