### PR TITLE
feat(validator): export `Validator` from 'hono'

### DIFF
--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -25,3 +25,6 @@ export { RegExpRouter } from './router/reg-exp-router/index.ts'
 export { TrieRouter } from './router/trie-router/index.ts'
 export { StaticRouter } from './router/static-router/index.ts'
 export { SmartRouter } from './router/smart-router/index.ts'
+
+// Validator
+export type { Validator } from './validator/validator.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 import { Hono } from './hono'
 export type { Handler, Next, ContextVariableMap } from './hono'
 export type { Context } from './context'
+export type { Validator } from './validator/validator'
 
 declare module './hono' {
   interface Hono {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -25,3 +25,6 @@ export { RegExpRouter } from './router/reg-exp-router'
 export { TrieRouter } from './router/trie-router'
 export { StaticRouter } from './router/static-router'
 export { SmartRouter } from './router/smart-router'
+
+// Validator
+export type { Validator } from './validator/validator'


### PR DESCRIPTION
You can write your schema definition outside the middleware handler as follows:

```ts
import type { Validator } from 'hono'
import { validator } from 'hono/validator

const schema = (v: Validator) => ({
  query: v.query('query').isRequired(),
  page: v.query('page').isNumeric().isOptional(),
})

app.get('/search', validator(schema), (c) => {
  const { query, page } = c.req.valid()
  //...
  return c.text('Result!!')
})
```

`Validator` and `validator` are similar and confusing, but if you don't like it, just use an alias.

This will fix #624 