### PR TITLE
fix(typo) package.cjs.json target to type

### DIFF
--- a/package.cjs.json
+++ b/package.cjs.json
@@ -1,3 +1,3 @@
 {
-  "target": "CommonJS"
+  "type": "commonjs"
 }


### PR DESCRIPTION
The "type" in package.cjs.json was set to "target".
The bug did not occur because the default "type" in package.json is "commonjs".
I have not checked another property but it may have been overridden by default.

This package.cjs.json also worked
```
{}
```