### PR TITLE
fix(validator): enable handling "Bad Request" in validator

### DIFF
--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -49,7 +49,15 @@ export const validatorMiddleware = <
         results = await validator.validate(c.req as Request)
       } catch (e) {
         // Invalid JSON request
-        return c.text(getStatusText(400), 400)
+        if (e instanceof Error) {
+          const result = getErrorResult(e)
+          resultSet.hasError = true
+          resultSet.messages = [result.message || '']
+          resultSet.results = [result]
+          break
+        } else {
+          return c.text(getStatusText(400), 400)
+        }
       }
 
       let isValid = true
@@ -128,4 +136,17 @@ function getValidatorList<T extends Schema>(schema: T) {
     }
   }
   return map
+}
+
+const getErrorResult = (e: Error) => {
+  const result: ValidateResult = {
+    isValid: false,
+    message: e.message,
+    target: 'unknown',
+    key: null,
+    value: null,
+    ruleName: e.message,
+    ruleType: 'value',
+  }
+  return result
 }

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -18,9 +18,9 @@ type Sanitizer = (value: Type) => Type
 export type ValidateResult = {
   isValid: boolean
   message: string | undefined
-  target: Target
-  key: string
-  value: Type
+  target: Target | 'unknown'
+  key: string | null
+  value: Type | null
   ruleName: string
   ruleType: 'type' | 'value'
   jsonData?: JSONObject

--- a/src/middleware/validator/middleware.test.ts
+++ b/src/middleware/validator/middleware.test.ts
@@ -148,13 +148,15 @@ describe('Basic - JSON with type check', () => {
       method: 'POST',
     })
 
+    const messages = ['Malformed JSON in request body']
+
     const res1 = await app.request(req1)
     expect(res1.status).toBe(400)
-    expect(await res1.text()).toBe(getStatusText(400))
+    expect(await res1.text()).toBe(messages.join('\n'))
 
     const res2 = await app.request(req2)
     expect(res2.status).toBe(400)
-    expect(await res2.text()).toBe(getStatusText(400))
+    expect(await res2.text()).toBe(messages.join('\n'))
   })
 })
 

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -49,7 +49,15 @@ export const validatorMiddleware = <
         results = await validator.validate(c.req as Request)
       } catch (e) {
         // Invalid JSON request
-        return c.text(getStatusText(400), 400)
+        if (e instanceof Error) {
+          const result = getErrorResult(e)
+          resultSet.hasError = true
+          resultSet.messages = [result.message || '']
+          resultSet.results = [result]
+          break
+        } else {
+          return c.text(getStatusText(400), 400)
+        }
       }
 
       let isValid = true
@@ -128,4 +136,17 @@ function getValidatorList<T extends Schema>(schema: T) {
     }
   }
   return map
+}
+
+const getErrorResult = (e: Error) => {
+  const result: ValidateResult = {
+    isValid: false,
+    message: e.message,
+    target: 'unknown',
+    key: null,
+    value: null,
+    ruleName: e.message,
+    ruleType: 'value',
+  }
+  return result
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -18,9 +18,9 @@ type Sanitizer = (value: Type) => Type
 export type ValidateResult = {
   isValid: boolean
   message: string | undefined
-  target: Target
-  key: string
-  value: Type
+  target: Target | 'unknown'
+  key: string | null
+  value: Type | null
   ruleName: string
   ruleType: 'type' | 'value'
   jsonData?: JSONObject


### PR DESCRIPTION
Currently, with Validator middleware, if the JSON body is empty, it will return "Malformed JSON in request body" response error immediately. This behavior is good but it's not possible to handle in the validator middleware `done` method. This is mentioned in #561.

To handle "Malformed JSON in request body" error we have to write another middleware to get an error object. It's very verbose. So, in this PR, I made it we can handle "Malformed JSON in request body" in validator middleware.

If we have handler like below:

```ts

app.post(
  '/posts',
  validator(
    (v) => ({
      title: v.json('title'),
    }),
    {
      done: (results, c) => {
        return c.json(results, 400)
      },
    }
  ),
  (c) => {
    return c.json({
      message: 'Valid!',
    })
  }
)
```

Then, post the empty body to the endpoint, the result response will be this:

```json
{
  "hasError": true,
  "messages": [
    "Malformed JSON in request body"
  ],
  "results": [
    {
      "isValid": false,
      "message": "Malformed JSON in request body",
      "target": "unknown",
      "key": null,
      "value": null,
      "ruleName": "Malformed JSON in request body",
      "ruleType": "value"
    }
  ]
}
```

This will make it easier to handle cases where the JSON body content is empty.