### PR TITLE
feat(types): introduce `CustomHandler` interface

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -1,5 +1,5 @@
 import { HonoContext } from './context.ts'
-import type { Environment, NotFoundHandler, ErrorHandler } from './hono.ts'
+import type { Environment, NotFoundHandler, ErrorHandler } from './types.ts'
 import type { Schema } from './validator/schema.ts'
 
 interface ComposeContext {

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,4 +1,4 @@
-import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono.ts'
+import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'

--- a/deno_dist/deno/serve-static.ts
+++ b/deno_dist/deno/serve-static.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../context.ts'
-import type { Next } from '../hono.ts'
+import type { Next } from '../types.ts'
 import { getFilePath } from '../utils/filepath.ts'
 import { getMimeType } from '../utils/mime.ts'
 

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -3,62 +3,14 @@ import type { Context } from './context.ts'
 import { HonoContext } from './context.ts'
 import { extendRequestPrototype } from './request.ts'
 import type { Router } from './router.ts'
-import { METHODS } from './router.ts'
-import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router.ts'
+import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE, METHODS } from './router.ts'
 import { RegExpRouter } from './router/reg-exp-router/index.ts'
 import { SmartRouter } from './router/smart-router/index.ts'
 import { StaticRouter } from './router/static-router/index.ts'
 import { TrieRouter } from './router/trie-router/index.ts'
+import type { Handler, Environment, ParamKeys, ErrorHandler, NotFoundHandler } from './types.ts'
 import { getPathFromURL, mergePath } from './utils/url.ts'
 import type { Schema } from './validator/schema.ts'
-
-export interface ContextVariableMap {}
-
-export type Bindings = Record<string, any> // For Cloudflare Workers
-export type Variables = Record<string, any> // For c.set/c.get functions
-export type Environment = {
-  Bindings: Bindings
-  Variables: Variables
-}
-
-export type Handler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
-
-export type MiddlewareHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
-
-export type NotFoundHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>) => Response | Promise<Response>
-
-export type ErrorHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (err: Error, c: Context<P, E, S>) => Response
-
-export type Next = () => Promise<void>
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
-  ? Name
-  : NameWithPattern
-
-type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
-  ? ParamKeyName<NameWithPattern>
-  : never
-
-type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
-  ? ParamKey<Component> | ParamKeys<Rest>
-  : ParamKey<Path>
 
 interface HandlerInterface<
   P extends string,
@@ -198,7 +150,7 @@ export class Hono<
     return this
   }
 
-  private addRoute(method: string, path: string, handler: Handler<P, E, S>): void {
+  private addRoute(method: string, path: string, handler: Handler<P, E, S>) {
     method = method.toUpperCase()
     if (this._tempPath) {
       path = mergePath(this._tempPath, path)

--- a/deno_dist/middleware/basic-auth/index.ts
+++ b/deno_dist/middleware/basic-auth/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 import { timingSafeEqual } from '../../utils/buffer.ts'
 import { decodeBase64 } from '../../utils/encode.ts'
 

--- a/deno_dist/middleware/bearer-auth/index.ts
+++ b/deno_dist/middleware/bearer-auth/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 import { timingSafeEqual } from '../../utils/buffer.ts'
 
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'

--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 
 export const cache = (options: {
   cacheName: string

--- a/deno_dist/middleware/compress/index.ts
+++ b/deno_dist/middleware/compress/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 
 type EncodingType = 'gzip' | 'deflate'
 

--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 
 type CORSOptions = {
   origin: string | string[] | ((origin: string) => string | undefined | null)

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 import { sha1 } from '../../utils/crypto.ts'
 
 type ETagOptions = {

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
 

--- a/deno_dist/middleware/logger/index.ts
+++ b/deno_dist/middleware/logger/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 import { getPathFromURL } from '../../utils/url.ts'
 
 enum LogPrefix {

--- a/deno_dist/middleware/powered-by/index.ts
+++ b/deno_dist/middleware/powered-by/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 
 export const poweredBy = (): MiddlewareHandler => {
   return async (c, next) => {

--- a/deno_dist/middleware/pretty-json/index.ts
+++ b/deno_dist/middleware/pretty-json/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 
 type prettyOptions = {
   space: number

--- a/deno_dist/middleware/serve-static/serve-static.ts
+++ b/deno_dist/middleware/serve-static/serve-static.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono.ts'
+import type { MiddlewareHandler } from '../../types.ts'
 import { getContentFromKVAsset } from '../../utils/cloudflare.ts'
 import { getFilePath } from '../../utils/filepath.ts'
 import { getMimeType } from '../../utils/mime.ts'

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../../context.ts'
-import type { Environment, MiddlewareHandler } from '../../hono.ts'
+import type { Environment, MiddlewareHandler } from '../../types.ts'
 import { getStatusText } from '../../utils/http-status.ts'
 import { mergeObjects } from '../../utils/object.ts'
 import type { Schema } from '../../validator/schema.ts'

--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -16,7 +16,9 @@ declare global {
   }
 }
 
-export type { Handler, Next, ContextVariableMap } from './hono.ts'
+export type { Next, ContextVariableMap, MiddlewareHandler } from './types.ts'
+import type { CustomHandler } from './types.ts'
+export type { CustomHandler as Handler }
 export type { Context } from './context.ts'
 export { Hono }
 

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1,0 +1,89 @@
+import type { Context } from './context.ts'
+import type { Schema } from './validator/schema.ts'
+
+export interface ContextVariableMap {}
+
+export type Bindings = Record<string, any> // For Cloudflare Workers
+export type Variables = Record<string, any> // For c.set/c.get functions
+export type Environment = {
+  Bindings: Bindings
+  Variables: Variables
+}
+
+export type Handler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
+
+export type MiddlewareHandler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
+
+export type NotFoundHandler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (c: Context<P, E, S>) => Response | Promise<Response>
+
+export type ErrorHandler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (err: Error, c: Context<P, E, S>) => Response
+
+export type Next = () => Promise<void>
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
+  ? Name
+  : NameWithPattern
+
+type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
+  ? ParamKeyName<NameWithPattern>
+  : never
+
+export type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
+  ? ParamKey<Component> | ParamKeys<Rest>
+  : ParamKey<Path>
+
+// This is not used for internally
+// Will be used by users as `Handler`
+export interface CustomHandler<
+  P extends string | Partial<Environment> | Partial<Schema> = string,
+  E = Partial<Environment> | Partial<Schema>,
+  S = Partial<Schema>
+> {
+  (
+    c: Context<
+      P extends string
+        ? P
+        : P extends Partial<Environment>
+        ? string
+        : P extends Partial<Schema>
+        ? string
+        : never,
+      P extends Partial<Environment>
+        ? P
+        : E extends Partial<Environment>
+        ? E
+        : E extends Partial<Schema>
+        ? Partial<Environment>
+        : never,
+      P extends Partial<Schema>
+        ? P
+        : E extends Partial<Schema>
+        ? P extends Partial<Environment>
+          ? E extends Partial<Environment>
+            ? never
+            : E
+          : never
+        : S extends Partial<Schema>
+        ? S
+        : never
+    >,
+    next: Next
+  ): Response | Promise<Response | undefined | void>
+}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,5 @@
 import { HonoContext } from './context'
-import type { Environment, NotFoundHandler, ErrorHandler } from './hono'
+import type { Environment, NotFoundHandler, ErrorHandler } from './types'
 import type { Schema } from './validator/schema'
 
 interface ComposeContext {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './hono'
+import type { Environment, NotFoundHandler, ContextVariableMap, Bindings } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'

--- a/src/deno/serve-static.ts
+++ b/src/deno/serve-static.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../context'
-import type { Next } from '../hono'
+import type { Next } from '../types'
 import { getFilePath } from '../utils/filepath'
 import { getMimeType } from '../utils/mime'
 

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { Context } from './context'
-import type { Handler, Next } from './hono'
 import { Hono } from './hono'
 import { logger } from './middleware/logger'
 import { poweredBy } from './middleware/powered-by'
+import type { Handler, Next } from './types'
 import type { Expect, Equal } from './utils/types'
 
 describe('GET Request', () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -3,62 +3,14 @@ import type { Context } from './context'
 import { HonoContext } from './context'
 import { extendRequestPrototype } from './request'
 import type { Router } from './router'
-import { METHODS } from './router'
-import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router'
+import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE, METHODS } from './router'
 import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { StaticRouter } from './router/static-router'
 import { TrieRouter } from './router/trie-router'
+import type { Handler, Environment, ParamKeys, ErrorHandler, NotFoundHandler } from './types'
 import { getPathFromURL, mergePath } from './utils/url'
 import type { Schema } from './validator/schema'
-
-export interface ContextVariableMap {}
-
-export type Bindings = Record<string, any> // For Cloudflare Workers
-export type Variables = Record<string, any> // For c.set/c.get functions
-export type Environment = {
-  Bindings: Bindings
-  Variables: Variables
-}
-
-export type Handler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
-
-export type MiddlewareHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
-
-export type NotFoundHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>) => Response | Promise<Response>
-
-export type ErrorHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (err: Error, c: Context<P, E, S>) => Response
-
-export type Next = () => Promise<void>
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
-  ? Name
-  : NameWithPattern
-
-type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
-  ? ParamKeyName<NameWithPattern>
-  : never
-
-type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
-  ? ParamKey<Component> | ParamKeys<Rest>
-  : ParamKey<Path>
 
 interface HandlerInterface<
   P extends string,
@@ -198,7 +150,7 @@ export class Hono<
     return this
   }
 
-  private addRoute(method: string, path: string, handler: Handler<P, E, S>): void {
+  private addRoute(method: string, path: string, handler: Handler<P, E, S>) {
     method = method.toUpperCase()
     if (this._tempPath) {
       path = mergePath(this._tempPath, path)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,11 @@
 /// <reference path="./request.ts" /> Import "declare global" for the Request interface.
 
 import { Hono } from './hono'
-export type { Handler, Next, ContextVariableMap } from './hono'
+export type { Next, ContextVariableMap, MiddlewareHandler } from './types'
 export type { Context } from './context'
 export type { Validator } from './validator/validator'
+import type { CustomHandler } from './types'
+export type { CustomHandler as Handler }
 
 declare module './hono' {
   interface Hono {

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
 import { decodeBase64 } from '../../utils/encode'
 

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
 
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 
 export const cache = (options: {
   cacheName: string

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 
 type EncodingType = 'gzip' | 'deflate'
 

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 
 type CORSOptions = {
   origin: string | string[] | ((origin: string) => string | undefined | null)

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 import { sha1 } from '../../utils/crypto'
 
 type ETagOptions = {

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
 import type { AlgorithmTypes } from '../../utils/jwt/types'
 

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 import { getPathFromURL } from '../../utils/url'
 
 enum LogPrefix {

--- a/src/middleware/powered-by/index.ts
+++ b/src/middleware/powered-by/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 
 export const poweredBy = (): MiddlewareHandler => {
   return async (c, next) => {

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 
 type prettyOptions = {
   space: number

--- a/src/middleware/serve-static/bun.ts
+++ b/src/middleware/serve-static/bun.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { existsSync } from 'fs'
 import type { Context } from '../../context'
-import type { Next } from '../../hono'
+import type { Next } from '../../types'
 import { getFilePath } from '../../utils/filepath'
 import { getMimeType } from '../../utils/mime'
 

--- a/src/middleware/serve-static/serve-static.test.ts
+++ b/src/middleware/serve-static/serve-static.test.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../../context'
-import type { Next } from '../../hono'
 import { Hono } from '../../hono'
+import type { Next } from '../../types'
 import { serveStatic } from '.'
 
 // Mock

--- a/src/middleware/serve-static/serve-static.ts
+++ b/src/middleware/serve-static/serve-static.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
 import { getContentFromKVAsset } from '../../utils/cloudflare'
 import { getFilePath } from '../../utils/filepath'
 import { getMimeType } from '../../utils/mime'

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../../context'
-import type { Environment, MiddlewareHandler } from '../../hono'
+import type { Environment, MiddlewareHandler } from '../../types'
 import { getStatusText } from '../../utils/http-status'
 import { mergeObjects } from '../../utils/object'
 import type { Schema } from '../../validator/schema'

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,7 +16,9 @@ declare global {
   }
 }
 
-export type { Handler, Next, ContextVariableMap } from './hono'
+export type { Next, ContextVariableMap, MiddlewareHandler } from './types'
+import type { CustomHandler } from './types'
+export type { CustomHandler as Handler }
 export type { Context } from './context'
 export { Hono }
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Hono } from './hono'
+import { validator } from './middleware/validator'
+import type { CustomHandler as Handler } from './types'
+import type { Expect, Equal, NotEqual } from './utils/types'
+import type { Validator } from './validator/validator'
+
+describe('Test types of CustomHandler', () => {
+  type Env = {
+    Variables: {
+      foo: string
+    }
+  }
+
+  let app: Hono
+
+  beforeEach(() => {
+    app = new Hono()
+  })
+
+  const schema = (v: Validator) => ({
+    query: v.query('q').isRequired(),
+  })
+  type Schema = ReturnType<typeof schema>
+  const url = 'http://localhost/'
+
+  test('No arguments', async () => {
+    const handler: Handler = (c) => {
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Path', async () => {
+    const handler: Handler<'id'> = (c) => {
+      const id = c.req.param('id')
+      type verify = Expect<Equal<typeof id, string>>
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Path, Env', async () => {
+    const handler: Handler<'id', Env> = (c) => {
+      const id = c.req.param('id')
+      type verifyPath = Expect<Equal<typeof id, string>>
+      const foo = c.get('foo')
+      type verifyEnv = Expect<Equal<typeof foo, string>>
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Path, Env, Schema', async () => {
+    const handler: Handler<'id', Env, Schema> = (c) => {
+      const id = c.req.param('id')
+      type verifyPath = Expect<Equal<typeof id, string>>
+      const foo = c.get('foo')
+      type verifyEnv = Expect<Equal<typeof foo, string>>
+      const { query } = c.req.valid()
+      type verifySchema = Expect<Equal<typeof query, string>>
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Env', async () => {
+    const handler: Handler<Env> = (c) => {
+      const foo = c.get('foo')
+      type verifyEnv = Expect<Equal<typeof foo, string>>
+      const { query } = c.req.valid()
+      type verifySchema = Expect<NotEqual<typeof query, string>>
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Env, Schema', async () => {
+    const handler: Handler<Env, Schema> = (c) => {
+      const foo = c.get('foo')
+      type verifyEnv = Expect<Equal<typeof foo, string>>
+      const { query } = c.req.valid()
+      type verifySchema = Expect<Equal<typeof query, string>>
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Schema', async () => {
+    const handler: Handler<Schema> = (c) => {
+      const { query } = c.req.valid()
+      type verifySchema = Expect<Equal<typeof query, string>>
+      return c.text('Hi')
+    }
+    app.get('/', handler)
+    const res = await app.request(url)
+    expect(res.status).toBe(200)
+  })
+
+  test('Complex', async () => {
+    const app = new Hono<Env>()
+    const handler: Handler<Env> = (c) => {
+      const foo = c.get('foo')
+      type verify = Expect<Equal<typeof foo, string>>
+      return c.text(foo)
+    }
+    app.get(
+      '/',
+      async (c, next) => {
+        c.set('foo', 'bar')
+        await next()
+      },
+      handler
+    )
+    app.get('/v', validator(schema), (c) => {
+      const { query } = c.req.valid()
+      type verify = Expect<Equal<typeof query, string>>
+      return c.text(query)
+    })
+    let res = await app.request(url)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('bar')
+
+    res = await app.request('http://localhost/?q=bar')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('bar')
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,91 @@
+import type { Context } from './context'
+import type { Schema } from './validator/schema'
+
+export interface ContextVariableMap {}
+
+export type Bindings = Record<string, any> // For Cloudflare Workers
+export type Variables = Record<string, any> // For c.set/c.get functions
+export type Environment = {
+  Bindings: Bindings
+  Variables: Variables
+}
+
+export type Handler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
+
+export type MiddlewareHandler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
+
+export type NotFoundHandler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (c: Context<P, E, S>) => Response | Promise<Response>
+
+export type ErrorHandler<
+  P extends string = string,
+  E extends Partial<Environment> = Environment,
+  S extends Partial<Schema> = Schema
+> = (err: Error, c: Context<P, E, S>) => Response
+
+export type Next = () => Promise<void>
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
+  ? Name
+  : NameWithPattern
+
+type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
+  ? ParamKeyName<NameWithPattern>
+  : never
+
+export type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
+  ? ParamKey<Component> | ParamKeys<Rest>
+  : ParamKey<Path>
+
+// This is not used for internally
+// Will be used by users as `Handler`
+export interface CustomHandler<
+  P extends string | Partial<Environment> | Partial<Schema> = string,
+  E = Partial<Environment> | Partial<Schema>,
+  S = Partial<Schema>
+> {
+  (
+    c: Context<
+      P extends string
+        ? P
+        : P extends Partial<Environment>
+        ? string
+        : P extends Partial<Schema>
+        ? string
+        : never,
+      P extends Partial<Environment>
+        ? P
+        : P extends Partial<Schema>
+        ? Partial<Environment>
+        : E extends Partial<Environment>
+        ? E
+        : E extends Partial<Schema>
+        ? Partial<Environment>
+        : never,
+      P extends Partial<Schema>
+        ? P
+        : E extends Partial<Schema>
+        ? P extends Partial<Environment>
+          ? E extends Partial<Environment>
+            ? never
+            : E
+          : never
+        : S extends Partial<Schema>
+        ? S
+        : never
+    >,
+    next: Next
+  ): Response | Promise<Response | undefined | void>
+}


### PR DESCRIPTION
In this PR, introduce `CustomHandler` interface that is exported for the users as `Handler`.

If we want to declare a handler outside of `app.get()`, we write it such like this:

```ts
const handler: Handler = (c) => {
  return c.text('Hi!')
}
```

Then, in this `handler`, how can we make `c.env` or `c.get('foo')` have a type? Pass `string` as the first argument of the Generics for `Handler` and write the following:

```ts
type Env = {
  Bindings: { TOKEN: string }
  Variables: { post: Post }
}

const handler: Handler<string, Env> = (c) => { // <---
  const post = c.get('post')
  return c.json(post)
}
```

This is redundant to write `string` on purpose. So, in this PR, we can write just like this:

```ts
const handler: Handler<Env> = (c) => {
  const post = c.get('post')
  return c.json(post)
}
```

Of course, it keep to have the types:

<img width="386" alt="SS" src="https://user-images.githubusercontent.com/10682/198859014-126412d8-908f-44f9-abd8-805e0909ef84.png">

In actually, we can do something similar for Validator schema:

```ts
const schema = (v: Validator) => ({
  query: v.query('q'),
})

type Schema = ReturnType<typeof schema>

const handler: Handler<Schema> = (c) => {
  const { query } = c.req.valid()
  return c.json({ query: query })
}
```

<img width="446" alt="SS" src="https://user-images.githubusercontent.com/10682/198859081-bfb2d031-59b7-48ca-9e9a-a26d59bcd80e.png">

I think this is helpful to declare the handler independently for the user.