### PR TITLE
feat(context): Introducing c.runtime

### DIFF
--- a/bun_test/index.test.tsx
+++ b/bun_test/index.test.tsx
@@ -25,9 +25,9 @@ describe('Basic', () => {
     expect(res.headers.get('x-query')).toBe('bar')
   })
 
-  it('returns current platform (bun)', async () => {
+  it('returns current runtime (bun)', async () => {
     const c = new HonoContext(new Request('http://localhost/'))
-    expect(c.platform).toBe('bun')
+    expect(c.runtime).toBe('bun')
   })
 })
 

--- a/bun_test/index.test.tsx
+++ b/bun_test/index.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { HonoContext } from '../src/context'
 import { Hono } from '../src/index'
 import { basicAuth } from '../src/middleware/basic-auth'
 import { jwt } from '../src/middleware/jwt'
@@ -22,6 +23,11 @@ describe('Basic', () => {
     expect(await res.text()).toBe('Hello Deno!')
     expect(res.headers.get('x-param')).toBe('foo')
     expect(res.headers.get('x-query')).toBe('bar')
+  })
+
+  it('returns current platform (bun)', async () => {
+    const c = new HonoContext(new Request('http://localhost/'))
+    expect(c.platform).toBe('bun')
   })
 })
 

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -6,8 +6,8 @@ import type { Schema, SchemaToProp } from './validator/schema.ts'
 
 type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
+type Runtime = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 export type Data = string | ArrayBuffer | ReadableStream
-export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 
 export interface Context<
   P extends string = string,
@@ -44,7 +44,7 @@ export interface Context<
   redirect: (location: string, status?: StatusCode) => Response
   cookie: (name: string, value: string, options?: CookieOptions) => void
   notFound: () => Response | Promise<Response>
-  get platform(): Platform
+  get runtime(): Runtime
 }
 
 export class HonoContext<
@@ -233,7 +233,7 @@ export class HonoContext<
     return this.notFoundHandler(this)
   }
 
-  get platform(): Platform {
+  get runtime(): Runtime {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const global = globalThis as any
 

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -7,7 +7,7 @@ import type { Schema, SchemaToProp } from './validator/schema.ts'
 type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
-export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly'
+export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 
 export interface Context<
   P extends string = string,
@@ -253,6 +253,14 @@ export class HonoContext<
       return 'cloudflare'
     }
 
-    return 'fastly'
+    if (global?.fastly !== undefined) {
+      return 'fastly'
+    }
+
+    if (typeof global?.EdgeRuntime !== 'string') {
+      return 'vercel'
+    }
+
+    return 'other'
   }
 }

--- a/deno_test/hono.test.ts
+++ b/deno_test/hono.test.ts
@@ -20,7 +20,7 @@ Deno.test('Hello World', async () => {
 })
 
 
-Deno.test('platform', async () => {
+Deno.test('runtime', async () => {
   const c = new HonoContext(new Request('http://localhost/'))
-  assertEquals(c.platform, 'deno')
+  assertEquals(c.runtime, 'deno')
 })

--- a/deno_test/hono.test.ts
+++ b/deno_test/hono.test.ts
@@ -1,3 +1,4 @@
+import { HonoContext } from '../deno_dist/context.ts'
 import { Hono } from '../deno_dist/mod.ts'
 import { assertEquals } from './deps.ts'
 
@@ -16,4 +17,10 @@ Deno.test('Hello World', async () => {
   assertEquals(await res.text(), 'Hello Deno!')
   assertEquals(res.headers.get('x-param'), 'foo')
   assertEquals(res.headers.get('x-query'), 'bar')
+})
+
+
+Deno.test('platform', async () => {
+  const c = new HonoContext(new Request('http://localhost/'))
+  assertEquals(c.platform, 'deno')
 })

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -159,6 +159,11 @@ describe('Context', () => {
     expect(res.headers.get('foo')).not.toBeNull()
     expect(res.headers.get('foo')).toBe('bar')
   })
+
+  it('returns current platform (node)', async () => {
+    c = new HonoContext(req)
+    expect(c.platform).toBe('node')
+  })
 })
 
 describe('Context header', () => {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -160,9 +160,9 @@ describe('Context', () => {
     expect(res.headers.get('foo')).toBe('bar')
   })
 
-  it('returns current platform (node)', async () => {
+  it('returns current runtime (node)', async () => {
     c = new HonoContext(req)
-    expect(c.platform).toBe('node')
+    expect(c.runtime).toBe('node')
   })
 })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,6 +7,7 @@ import type { Schema, SchemaToProp } from './validator/schema'
 type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
+export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly'
 
 export interface Context<
   P extends string = string,
@@ -43,6 +44,7 @@ export interface Context<
   redirect: (location: string, status?: StatusCode) => Response
   cookie: (name: string, value: string, options?: CookieOptions) => void
   notFound: () => Response | Promise<Response>
+  get platform(): Platform
 }
 
 export class HonoContext<
@@ -229,5 +231,28 @@ export class HonoContext<
 
   notFound(): Response | Promise<Response> {
     return this.notFoundHandler(this)
+  }
+
+  get platform(): Platform {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const global = globalThis as any
+
+    if (global?.process?.title === 'node') {
+      return 'node'
+    }
+
+    if (global?.Deno !== undefined) {
+      return 'deno'
+    }
+
+    if (global?.Bun !== undefined) {
+      return 'bun'
+    }
+
+    if (typeof global?.WebSocketPair === 'function') {
+      return 'cloudflare'
+    }
+
+    return 'fastly'
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -257,6 +257,10 @@ export class HonoContext<
       return 'fastly'
     }
 
+    if (typeof global?.EdgeRuntime !== 'string') {
+      return 'vercel'
+    }
+
     return 'other'
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,8 +6,8 @@ import type { Schema, SchemaToProp } from './validator/schema'
 
 type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
+type Runtime = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 export type Data = string | ArrayBuffer | ReadableStream
-export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 
 export interface Context<
   P extends string = string,
@@ -44,7 +44,7 @@ export interface Context<
   redirect: (location: string, status?: StatusCode) => Response
   cookie: (name: string, value: string, options?: CookieOptions) => void
   notFound: () => Response | Promise<Response>
-  get platform(): Platform
+  get runtime(): Runtime
 }
 
 export class HonoContext<
@@ -233,7 +233,7 @@ export class HonoContext<
     return this.notFoundHandler(this)
   }
 
-  get platform(): Platform {
+  get runtime(): Runtime {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const global = globalThis as any
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,7 +7,7 @@ import type { Schema, SchemaToProp } from './validator/schema'
 type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
-export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly'
+export type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 
 export interface Context<
   P extends string = string,
@@ -253,6 +253,10 @@ export class HonoContext<
       return 'cloudflare'
     }
 
-    return 'fastly'
+    if (global?.fastly !== undefined) {
+      return 'fastly'
+    }
+
+    return 'other'
   }
 }


### PR DESCRIPTION
As mentioned in #413, it might be useful to have way to know on which platform the code is running. This PR introduces `c.runtime`, which is getter of `Context` interface.

# Node, Deno, and Bun
```ts
const global = globalThis as any

if (global?.process?.title === 'node') {
  return 'node'
}

if (global?.Deno !== undefined) {
  return 'deno'
}

if (global?.Bun !== undefined) {
  return 'bun' 
}
```
This is straightforward. 

For `Deno`, `global?.process?.title === 'deno'` is possible,  but I just used shorter one.

# Cloudflare and Fastly
```ts
if (typeof global?.WebSocketPair === 'function') {
  return 'cloudflare'
}

return 'fastly'
```

[WebSocketPair](https://developers.cloudflare.com/workers/runtime-apis/websockets/) is Cloudflare Worker's runtime API. I picked this because this is only available in CF. (For example, [cache](https://developers.cloudflare.com/workers/runtime-apis/cache/) exists in other platform with similar API.)

For `Fastly`, I don't know good way to determine it at runtime yet. (Resources: [1](https://github.com/honojs/compute-starter-kit), [2](https://developer.fastly.com/reference/compute/ecp-env/))

But it is almost safe to say it is `Fastly` if it is not others.
```ts
type Platform = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly'
``` 