### PR TITLE
refactor(types): reduce type definitions

### DIFF
--- a/bun_test/index.test.tsx
+++ b/bun_test/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { HonoContext } from '../src/context'
+import { Context } from '../src/context'
 import { Hono } from '../src/index'
 import { basicAuth } from '../src/middleware/basic-auth'
 import { jwt } from '../src/middleware/jwt'
@@ -26,7 +26,7 @@ describe('Basic', () => {
   })
 
   it('returns current runtime (bun)', async () => {
-    const c = new HonoContext(new Request('http://localhost/'))
+    const c = new Context(new Request('http://localhost/'))
     expect(c.runtime).toBe('bun')
   })
 })

--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -1,6 +1,5 @@
-import { HonoContext } from './context.ts'
+import { Context } from './context.ts'
 import type { Environment, NotFoundHandler, ErrorHandler } from './types.ts'
-import type { Schema } from './validator/schema.ts'
 
 interface ComposeContext {
   finalized: boolean
@@ -8,15 +7,10 @@ interface ComposeContext {
 }
 
 // Based on the code in the MIT licensed `koa-compose` package.
-export const compose = <
-  C extends ComposeContext,
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  D extends Partial<Schema> = Schema
->(
+export const compose = <C extends ComposeContext, E extends Partial<Environment> = Environment>(
   middleware: Function[],
-  onNotFound?: NotFoundHandler<P, E, D>,
-  onError?: ErrorHandler<P, E, D>
+  onNotFound?: NotFoundHandler<E>,
+  onError?: ErrorHandler<E>
 ) => {
   const middlewareLength = middleware.length
   return (context: C, next?: Function) => {
@@ -35,7 +29,7 @@ export const compose = <
       let isError = false
 
       if (!handler) {
-        if (context instanceof HonoContext && context.finalized === false && onNotFound) {
+        if (context instanceof Context && context.finalized === false && onNotFound) {
           res = onNotFound(context)
         }
       } else {
@@ -45,7 +39,7 @@ export const compose = <
             return dispatchRes instanceof Promise ? dispatchRes : Promise.resolve(dispatchRes)
           })
         } catch (err) {
-          if (err instanceof Error && context instanceof HonoContext && onError) {
+          if (err instanceof Error && context instanceof Context && onError) {
             context.error = err
             res = onError(err, context)
             isError = true
@@ -69,7 +63,7 @@ export const compose = <
             return context
           })
           .catch((err) => {
-            if (err instanceof Error && context instanceof HonoContext && onError) {
+            if (err instanceof Error && context instanceof Context && onError) {
               context.error = err
               context.res = onError(err, context)
               return context

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -8,49 +8,11 @@ type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
 
-export interface Context<
+export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
   S extends Partial<Schema> | unknown = Schema
 > {
-  req: Request<P, S extends Schema ? SchemaToProp<S> : any>
-  env: E['Bindings']
-  event: FetchEvent
-  executionCtx: ExecutionContext
-  finalized: boolean
-  error: Error | undefined
-
-  get res(): Response
-  set res(_res: Response)
-  header: (name: string, value: string, options?: { append?: boolean }) => void
-  status: (status: StatusCode) => void
-  set: {
-    <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
-    <Key extends keyof E['Variables']>(key: Key, value: E['Variables'][Key]): void
-    (key: string, value: unknown): void
-  }
-  get: {
-    <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
-    <Key extends keyof E['Variables']>(key: Key): E['Variables'][Key]
-    <T = any>(key: string): T
-  }
-  pretty: (prettyJSON: boolean, space?: number) => void
-  newResponse: (data: Data | null, status: StatusCode, headers: Headers) => Response
-  body: (data: Data | null, status?: StatusCode, headers?: Headers) => Response
-  text: (text: string, status?: StatusCode, headers?: Headers) => Response
-  json: <T>(object: T, status?: StatusCode, headers?: Headers) => Response
-  html: (html: string, status?: StatusCode, headers?: Headers) => Response
-  redirect: (location: string, status?: StatusCode) => Response
-  cookie: (name: string, value: string, options?: CookieOptions) => void
-  notFound: () => Response | Promise<Response>
-}
-
-export class HonoContext<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> implements Context<P, E, S>
-{
   req: Request<P, S extends Schema ? SchemaToProp<S> : any>
   env: E['Bindings']
   finalized: boolean
@@ -63,13 +25,13 @@ export class HonoContext<
   private _map: Record<string, unknown> | undefined
   private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
-  private notFoundHandler: NotFoundHandler<P, E, S>
+  private notFoundHandler: NotFoundHandler<E>
 
   constructor(
     req: Request<P>,
     env: E['Bindings'] = {},
     executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
-    notFoundHandler: NotFoundHandler<P, E, S> = () => new Response()
+    notFoundHandler: NotFoundHandler<E> = () => new Response()
   ) {
     this._executionCtx = executionCtx
     this.req = req as Request<P, S extends Schema ? SchemaToProp<S> : any>
@@ -228,6 +190,6 @@ export class HonoContext<
   }
 
   notFound(): Response | Promise<Response> {
-    return this.notFoundHandler(this)
+    return this.notFoundHandler(this as unknown as Context<string, E>)
   }
 }

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -22,17 +22,14 @@ export type MiddlewareHandler<
   S extends Partial<Schema> = Schema
 > = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
 
-export type NotFoundHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>) => Response | Promise<Response>
+export type NotFoundHandler<E extends Partial<Environment> = Environment> = (
+  c: Context<string, E>
+) => Response | Promise<Response>
 
-export type ErrorHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (err: Error, c: Context<P, E, S>) => Response
+export type ErrorHandler<E extends Partial<Environment> = Environment> = (
+  err: Error,
+  c: Context<string, E>
+) => Response
 
 export type Next = () => Promise<void>
 

--- a/deno_test/hono.test.ts
+++ b/deno_test/hono.test.ts
@@ -1,4 +1,4 @@
-import { HonoContext } from '../deno_dist/context.ts'
+import { Context } from '../deno_dist/context.ts'
 import { Hono } from '../deno_dist/mod.ts'
 import { assertEquals } from './deps.ts'
 
@@ -19,8 +19,7 @@ Deno.test('Hello World', async () => {
   assertEquals(res.headers.get('x-query'), 'bar')
 })
 
-
 Deno.test('runtime', async () => {
-  const c = new HonoContext(new Request('http://localhost/'))
+  const c = new Context(new Request('http://localhost/'))
   assertEquals(c.runtime, 'deno')
 })

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -1,6 +1,5 @@
 import { compose } from './compose'
-import type { Context } from './context'
-import { HonoContext } from './context'
+import { Context } from './context'
 import { extendRequestPrototype } from './request'
 
 extendRequestPrototype()
@@ -85,7 +84,7 @@ describe('Handler and middlewares', () => {
   const middleware: Function[] = []
 
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
 
   const mHandlerFoo = async (c: Context, next: Function) => {
     c.req.headers.append('x-header-foo', 'foo')
@@ -121,7 +120,7 @@ describe('compose with Context - 200 success', () => {
   const middleware: Function[] = []
 
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
   const handler = (c: Context) => {
     return c.text('Hello')
   }
@@ -145,7 +144,7 @@ describe('compose with Context - 404 not found', () => {
   const middleware: Function[] = []
 
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
   const onNotFound = (c: Context) => {
     return c.text('onNotFound', 404)
   }
@@ -169,7 +168,7 @@ describe('compose with Context - 401 not authorized', () => {
   const middleware: Function[] = []
 
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
   const handler = (c: Context, _next: Function) => {
     return c.text('Hello')
   }
@@ -195,7 +194,7 @@ describe('compose with Context - next() below', () => {
   const middleware: Function[] = []
 
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
   const handler = (c: Context) => {
     const message = c.req.header('x-custom') || 'blank'
     return c.text(message)
@@ -222,7 +221,7 @@ describe('compose with Context - 500 error', () => {
   const middleware: Function[] = []
 
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
 
   it('Error on handler', async () => {
     const handler = () => {
@@ -271,7 +270,7 @@ describe('compose with Context - 500 error', () => {
 })
 describe('compose with Context - not finalized', () => {
   const req = new Request('http://localhost/')
-  const c: Context = new HonoContext(req)
+  const c: Context = new Context(req)
   const onNotFound = (c: Context) => {
     return c.text('onNotFound', 404)
   }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,6 +1,5 @@
-import { HonoContext } from './context'
+import { Context } from './context'
 import type { Environment, NotFoundHandler, ErrorHandler } from './types'
-import type { Schema } from './validator/schema'
 
 interface ComposeContext {
   finalized: boolean
@@ -8,15 +7,10 @@ interface ComposeContext {
 }
 
 // Based on the code in the MIT licensed `koa-compose` package.
-export const compose = <
-  C extends ComposeContext,
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  D extends Partial<Schema> = Schema
->(
+export const compose = <C extends ComposeContext, E extends Partial<Environment> = Environment>(
   middleware: Function[],
-  onNotFound?: NotFoundHandler<P, E, D>,
-  onError?: ErrorHandler<P, E, D>
+  onNotFound?: NotFoundHandler<E>,
+  onError?: ErrorHandler<E>
 ) => {
   const middlewareLength = middleware.length
   return (context: C, next?: Function) => {
@@ -35,7 +29,7 @@ export const compose = <
       let isError = false
 
       if (!handler) {
-        if (context instanceof HonoContext && context.finalized === false && onNotFound) {
+        if (context instanceof Context && context.finalized === false && onNotFound) {
           res = onNotFound(context)
         }
       } else {
@@ -45,7 +39,7 @@ export const compose = <
             return dispatchRes instanceof Promise ? dispatchRes : Promise.resolve(dispatchRes)
           })
         } catch (err) {
-          if (err instanceof Error && context instanceof HonoContext && onError) {
+          if (err instanceof Error && context instanceof Context && onError) {
             context.error = err
             res = onError(err, context)
             isError = true
@@ -69,7 +63,7 @@ export const compose = <
             return context
           })
           .catch((err) => {
-            if (err instanceof Error && context instanceof HonoContext && onError) {
+            if (err instanceof Error && context instanceof Context && onError) {
               context.error = err
               context.res = onError(err, context)
               return context

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,12 +1,12 @@
-import type { Context } from './context'
-import { HonoContext } from './context'
+//import type { Context } from './context'
+import { Context } from './context'
 
 describe('Context', () => {
   const req = new Request('http://localhost/')
 
   let c: Context
   beforeEach(() => {
-    c = new HonoContext(req)
+    c = new Context(req)
   })
 
   it('c.text()', async () => {
@@ -136,14 +136,14 @@ describe('Context', () => {
   it('Should be able read env', async () => {
     const req = new Request('http://localhost/')
     const key = 'a-secret-key'
-    const ctx = new HonoContext(req, {
+    const ctx = new Context(req, {
       API_KEY: key,
     })
     expect(ctx.env.API_KEY).toBe(key)
   })
 
   it('set and set', async () => {
-    const ctx = new HonoContext(req)
+    const ctx = new Context(req)
     expect(ctx.get('k-foo')).toEqual(undefined)
     ctx.set('k-foo', 'v-foo')
     expect(ctx.get('k-foo')).toEqual('v-foo')
@@ -153,7 +153,7 @@ describe('Context', () => {
   })
 
   it('has res object by default', async () => {
-    c = new HonoContext(req)
+    c = new Context(req)
     c.res.headers.append('foo', 'bar')
     const res = c.text('foo')
     expect(res.headers.get('foo')).not.toBeNull()
@@ -165,7 +165,7 @@ describe('Context header', () => {
   const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
-    c = new HonoContext(req)
+    c = new Context(req)
   })
   it('Should return only one content-type value', async () => {
     c.header('Content-Type', 'foo')

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,49 +8,11 @@ type HeaderField = [string, string]
 type Headers = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
 
-export interface Context<
+export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
   S extends Partial<Schema> | unknown = Schema
 > {
-  req: Request<P, S extends Schema ? SchemaToProp<S> : any>
-  env: E['Bindings']
-  event: FetchEvent
-  executionCtx: ExecutionContext
-  finalized: boolean
-  error: Error | undefined
-
-  get res(): Response
-  set res(_res: Response)
-  header: (name: string, value: string, options?: { append?: boolean }) => void
-  status: (status: StatusCode) => void
-  set: {
-    <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
-    <Key extends keyof E['Variables']>(key: Key, value: E['Variables'][Key]): void
-    (key: string, value: unknown): void
-  }
-  get: {
-    <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
-    <Key extends keyof E['Variables']>(key: Key): E['Variables'][Key]
-    <T = any>(key: string): T
-  }
-  pretty: (prettyJSON: boolean, space?: number) => void
-  newResponse: (data: Data | null, status: StatusCode, headers: Headers) => Response
-  body: (data: Data | null, status?: StatusCode, headers?: Headers) => Response
-  text: (text: string, status?: StatusCode, headers?: Headers) => Response
-  json: <T>(object: T, status?: StatusCode, headers?: Headers) => Response
-  html: (html: string, status?: StatusCode, headers?: Headers) => Response
-  redirect: (location: string, status?: StatusCode) => Response
-  cookie: (name: string, value: string, options?: CookieOptions) => void
-  notFound: () => Response | Promise<Response>
-}
-
-export class HonoContext<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> implements Context<P, E, S>
-{
   req: Request<P, S extends Schema ? SchemaToProp<S> : any>
   env: E['Bindings']
   finalized: boolean
@@ -63,13 +25,13 @@ export class HonoContext<
   private _map: Record<string, unknown> | undefined
   private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
-  private notFoundHandler: NotFoundHandler<P, E, S>
+  private notFoundHandler: NotFoundHandler<E>
 
   constructor(
     req: Request<P>,
     env: E['Bindings'] = {},
     executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
-    notFoundHandler: NotFoundHandler<P, E, S> = () => new Response()
+    notFoundHandler: NotFoundHandler<E> = () => new Response()
   ) {
     this._executionCtx = executionCtx
     this.req = req as Request<P, S extends Schema ? SchemaToProp<S> : any>
@@ -228,6 +190,6 @@ export class HonoContext<
   }
 
   notFound(): Response | Promise<Response> {
-    return this.notFoundHandler(this)
+    return this.notFoundHandler(this as unknown as Context<string, E>)
   }
 }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,6 +1,5 @@
 import { compose } from './compose'
-import type { Context } from './context'
-import { HonoContext } from './context'
+import { Context } from './context'
 import { extendRequestPrototype } from './request'
 import type { Router } from './router'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE, METHODS } from './router'
@@ -100,21 +99,22 @@ export class Hono<
     Object.assign(this, init)
   }
 
-  private notFoundHandler: NotFoundHandler<P, E, S> = (c: Context<P, E, S>) => {
+  private notFoundHandler: NotFoundHandler<E> = (c: Context<string, E>) => {
     return c.text('404 Not Found', 404)
   }
 
-  private errorHandler: ErrorHandler<P, E, S> = (err: Error, c: Context<P, E, S>) => {
+  private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {
     console.trace(err.message)
     const message = 'Internal Server Error'
     return c.text(message, 500)
   }
 
-  route(path: string, app?: Hono<E, P, S>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  route(path: string, app?: Hono<any>) {
     this._tempPath = path
     if (app) {
       app.routes.map((r) => {
-        this.addRoute(r.method, r.path, r.handler)
+        this.addRoute(r.method, r.path, r.handler as unknown as Handler<P, E>)
       })
       this._tempPath = ''
     }
@@ -140,12 +140,12 @@ export class Hono<
     return this
   }
 
-  onError(handler: ErrorHandler<P, E, S>) {
+  onError(handler: ErrorHandler<E>) {
     this.errorHandler = handler
     return this
   }
 
-  notFound(handler: NotFoundHandler<P, E, S>) {
+  notFound(handler: NotFoundHandler<E>) {
     this.notFoundHandler = handler
     return this
   }
@@ -164,7 +164,7 @@ export class Hono<
     return this.router.match(method, path)
   }
 
-  private handleError(err: unknown, c: Context<P, E, S>) {
+  private handleError(err: unknown, c: Context<string, E, S>) {
     if (err instanceof Error) {
       return this.errorHandler(err, c)
     }
@@ -182,7 +182,7 @@ export class Hono<
     const result = this.matchRoute(method, path)
     request.paramData = result?.params
 
-    const c = new HonoContext<P, E, S>(request, env, eventOrExecutionCtx, this.notFoundHandler)
+    const c = new Context<string, E, S>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
     // Do not `compose` if it has only one handler
     if (result && result.handlers.length === 1) {
@@ -213,11 +213,7 @@ export class Hono<
     }
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
-    const composed = compose<HonoContext<P, E, S>, P, E, S>(
-      handlers,
-      this.notFoundHandler,
-      this.errorHandler
-    )
+    const composed = compose<Context<P, E, S>, E>(handlers, this.notFoundHandler, this.errorHandler)
 
     return (async () => {
       try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,17 +22,14 @@ export type MiddlewareHandler<
   S extends Partial<Schema> = Schema
 > = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
 
-export type NotFoundHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (c: Context<P, E, S>) => Response | Promise<Response>
+export type NotFoundHandler<E extends Partial<Environment> = Environment> = (
+  c: Context<string, E>
+) => Response | Promise<Response>
 
-export type ErrorHandler<
-  P extends string = string,
-  E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
-> = (err: Error, c: Context<P, E, S>) => Response
+export type ErrorHandler<E extends Partial<Environment> = Environment> = (
+  err: Error,
+  c: Context<string, E>
+) => Response
 
 export type Next = () => Promise<void>
 

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -61,7 +61,6 @@ describe('Basic - queries', () => {
   it('Should be invalid - ids', async () => {
     const validator = v.queries('ids').isRequired()
     const results = await validator.validate(req)
-    console.log(results)
     expect(results[0].isValid).toBe(true)
     expect(results[1].isValid).toBe(false)
     expect(results[1].message).toBe(


### PR DESCRIPTION
This PR is about refactoring. Remove `HonoContext`; use instead of `Context` as a class. Polish `ErrorHandler` and `NotFoundHandler` types.