### PR TITLE
feat(app): introduce `app.showRoutes()`

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -150,6 +150,15 @@ export class Hono<
     return this
   }
 
+  showRoutes() {
+    const length = 8
+    this.routes.map((route) => {
+      console.log(
+        `\x1b[32m${route.method}\x1b[0m ${' '.repeat(length - route.method.length)} ${route.path}`
+      )
+    })
+  }
+
   private addRoute(method: string, path: string, handler: Handler<P, E, S>) {
     method = method.toUpperCase()
     if (this._tempPath) {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -178,7 +178,7 @@ describe('Routing', () => {
       three.get('/hi', (c) => c.text('hi'))
       one.route('/two', two)
       two.route('/three', three)
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -187,7 +187,7 @@ describe('Routing', () => {
       two.route('/three', three)
       three.get('/hi', (c) => c.text('hi'))
       one.route('/two', two)
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -196,7 +196,7 @@ describe('Routing', () => {
       two.route('/three', three)
       one.route('/two', two)
       three.get('/hi', (c) => c.text('hi'))
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -205,7 +205,7 @@ describe('Routing', () => {
       one.route('/two', two)
       three.get('/hi', (c) => c.text('hi'))
       two.route('/three', three)
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -214,7 +214,7 @@ describe('Routing', () => {
       one.route('/two', two)
       two.route('/three', three)
       three.get('/hi', (c) => c.text('hi'))
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -1263,5 +1263,16 @@ describe('Handler as variables', () => {
     const res = await app.request('http://localhost/posts/123')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('Post id is 123')
+  })
+})
+
+describe.only('Show routes', () => {
+  const app = new Hono()
+  jest.spyOn(console, 'log')
+  it('Should call `console.log()` with `app.showRoutes()`', async () => {
+    app.get('/', (c) => c.text('/'))
+    app.get('/foo', (c) => c.text('/'))
+    app.showRoutes()
+    expect(console.log).toBeCalled()
   })
 })

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -150,6 +150,15 @@ export class Hono<
     return this
   }
 
+  showRoutes() {
+    const length = 8
+    this.routes.map((route) => {
+      console.log(
+        `\x1b[32m${route.method}\x1b[0m ${' '.repeat(length - route.method.length)} ${route.path}`
+      )
+    })
+  }
+
   private addRoute(method: string, path: string, handler: Handler<P, E, S>) {
     method = method.toUpperCase()
     if (this._tempPath) {


### PR DESCRIPTION
This PR includes a new feature `app.showRoutes()`.

Sometimes it is difficult to see what routes are registered. I've created this feature to prevent us from losing time on that. Using `app.showRoutes`, will show the routes that are registered:

<img width="476" alt="SS" src="https://user-images.githubusercontent.com/10682/199637644-77ccca0b-6218-4dd8-a7fa-8cd218fee245.png">
