### PR TITLE
fix(context): check cloudflare before checking node in `c.runtime`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -198,10 +198,6 @@ export class Context<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const global = globalThis as any
 
-    if (global?.process?.title === 'node') {
-      return 'node'
-    }
-
     if (global?.Deno !== undefined) {
       return 'deno'
     }
@@ -220,6 +216,10 @@ export class Context<
 
     if (typeof global?.EdgeRuntime !== 'string') {
       return 'vercel'
+    }
+
+    if (global?.process?.title === 'node') {
+      return 'node'
     }
 
     return 'other'

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -160,9 +160,9 @@ describe('Context', () => {
     expect(res.headers.get('foo')).toBe('bar')
   })
 
-  it('returns current runtime (node)', async () => {
+  it('returns current runtime (cloudflare)', async () => {
     c = new Context(req)
-    expect(c.runtime).toBe('node')
+    expect(c.runtime).toBe('cloudflare')
   })
 })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -198,10 +198,6 @@ export class Context<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const global = globalThis as any
 
-    if (global?.process?.title === 'node') {
-      return 'node'
-    }
-
     if (global?.Deno !== undefined) {
       return 'deno'
     }
@@ -220,6 +216,10 @@ export class Context<
 
     if (typeof global?.EdgeRuntime !== 'string') {
       return 'vercel'
+    }
+
+    if (global?.process?.title === 'node') {
+      return 'node'
     }
 
     return 'other'


### PR DESCRIPTION
In my environment the test in `context.test.ts` fails:

<img width="563" alt="SS" src="https://user-images.githubusercontent.com/10682/199666904-33bb63fe-5d86-4ca0-954c-c9791403b449.png">

I don't know why it is be passed on the CI, but I think we have to fix the test and `contex.ts`.

Actually, the test environment with `miniflare` is not only "node" but also "cloudflare". There are both `global.process.title` and `global.WebSocketPair` in my environment.

<img width="526" alt="SS" src="https://user-images.githubusercontent.com/10682/199667891-f70623e3-369b-4bc4-bf22-ff73a44dadc0.png">

In this case, we have to check first whether it is `cloudflare` or not and check it later for `node`.
