### PR TITLE
fix(error): make `notFound()` enables to catch errors correctly

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -202,11 +202,11 @@ export class Hono<
         let awaited: Response | undefined | void
         try {
           awaited = await res
+          if (!awaited) {
+            return this.notFoundHandler(c)
+          }
         } catch (err) {
           return this.handleError(err, c)
-        }
-        if (!awaited) {
-          return this.notFoundHandler(c)
         }
         return awaited
       })()

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.161.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.162.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -178,7 +178,7 @@ describe('Routing', () => {
       three.get('/hi', (c) => c.text('hi'))
       one.route('/two', two)
       two.route('/three', three)
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -187,7 +187,7 @@ describe('Routing', () => {
       two.route('/three', three)
       three.get('/hi', (c) => c.text('hi'))
       one.route('/two', two)
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -196,7 +196,7 @@ describe('Routing', () => {
       two.route('/three', three)
       one.route('/two', two)
       three.get('/hi', (c) => c.text('hi'))
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -205,7 +205,7 @@ describe('Routing', () => {
       one.route('/two', two)
       three.get('/hi', (c) => c.text('hi'))
       two.route('/three', three)
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -214,7 +214,7 @@ describe('Routing', () => {
       one.route('/two', two)
       two.route('/three', three)
       three.get('/hi', (c) => c.text('hi'))
-  
+
       const { status } = await one.request('http://localhost/two/three/hi', { method: 'GET' })
       expect(status).toBe(404)
     })
@@ -669,6 +669,26 @@ describe('Error handling in middleware', () => {
     expect(await res.text()).toBe(
       'Handle the error in middleware with async, original message is Error message'
     )
+  })
+
+  describe('Error in `notFound()`', () => {
+    const app = new Hono()
+
+    app.use('*', async () => {})
+
+    app.notFound(() => {
+      throw new Error('Error in Not Found')
+    })
+
+    app.onError((err, c) => {
+      return c.text(err.message, 400)
+    })
+
+    it('Should handle the error thrown in `notFound()``', async () => {
+      const res = await app.request('http://localhost/')
+      expect(res.status).toBe(400)
+      expect(await res.text()).toBe('Error in Not Found')
+    })
   })
 })
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -202,11 +202,11 @@ export class Hono<
         let awaited: Response | undefined | void
         try {
           awaited = await res
+          if (!awaited) {
+            return this.notFoundHandler(c)
+          }
         } catch (err) {
           return this.handleError(err, c)
-        }
-        if (!awaited) {
-          return this.notFoundHandler(c)
         }
         return awaited
       })()


### PR DESCRIPTION
This will fix #647