### PR TITLE
feat(app): introduce `app.on(method, path, handler)`

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -140,6 +140,15 @@ export class Hono<
     return this
   }
 
+  on(method: string, path: string, ...handlers: Handler<P, E, S>[]) {
+    if (!method) return this
+    this.path = path
+    handlers.map((handler) => {
+      this.addRoute(method.toUpperCase(), this.path, handler)
+    })
+    return this
+  }
+
   onError(handler: ErrorHandler<E>) {
     this.errorHandler = handler
     return this

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -88,7 +88,7 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error('Can not add a route since the matcher is already built.')
     }
 
-    if (!methodNames.find((m) => m === method)) methodNames.push(method.toLocaleUpperCase())
+    if (!methodNames.includes(method)) methodNames.push(method)
 
     if (path === '/*') {
       path = '*'

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -6,7 +6,7 @@ import { PATH_ERROR } from './node.ts'
 import type { ParamMap } from './trie.ts'
 import { Trie } from './trie.ts'
 
-const METHOD_NAMES = [METHOD_NAME_ALL, ...METHODS].map((method) => method.toUpperCase())
+const methodNames = [METHOD_NAME_ALL, ...METHODS].map((method) => method.toUpperCase())
 
 type HandlerData<T> = [T[], ParamMap | null]
 type Matcher<T> = [RegExp, HandlerData<T>[]]
@@ -88,6 +88,8 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error('Can not add a route since the matcher is already built.')
     }
 
+    if (!methodNames.find((m) => m === method)) methodNames.push(method.toLocaleUpperCase())
+
     if (path === '/*') {
       path = '*'
     }
@@ -164,7 +166,7 @@ export class RegExpRouter<T> implements Router<T> {
   private buildAllMatchers(): Record<string, Matcher<T>> {
     const matchers: Record<string, Matcher<T>> = {}
 
-    METHOD_NAMES.forEach((method) => {
+    methodNames.forEach((method) => {
       matchers[method] = this.buildMatcher(method) || matchers[METHOD_NAME_ALL]
     })
 

--- a/deno_dist/router/static-router/router.ts
+++ b/deno_dist/router/static-router/router.ts
@@ -16,6 +16,8 @@ export class StaticRouter<T> implements Router<T> {
   }
 
   add(method: string, path: string, handler: T) {
+    this.routes[method.toUpperCase()] ||= {}
+
     const { middleware, routes } = this
 
     if (path === '/*') {

--- a/deno_dist/router/static-router/router.ts
+++ b/deno_dist/router/static-router/router.ts
@@ -15,10 +15,23 @@ export class StaticRouter<T> implements Router<T> {
     })
   }
 
-  add(method: string, path: string, handler: T) {
-    this.routes[method.toUpperCase()] ||= {}
+  private newRoute(): Record<string, Result<T>> {
+    const route: Record<string, Result<T>> = {}
+    const routeAll = this.routes[METHOD_NAME_ALL]
+    Object.keys(routeAll).forEach((path) => {
+      route[path] = {
+        handlers: [...routeAll[path].handlers],
+        params: {},
+      }
+    })
 
+    return route
+  }
+
+  add(method: string, path: string, handler: T) {
     const { middleware, routes } = this
+
+    routes[method] ||= this.newRoute()
 
     if (path === '/*') {
       path = '*'

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -3,6 +3,9 @@ import type { Context } from './context'
 import { Hono } from './hono'
 import { logger } from './middleware/logger'
 import { poweredBy } from './middleware/powered-by'
+import { RegExpRouter } from './router/reg-exp-router'
+import { StaticRouter } from './router/static-router'
+import { TrieRouter } from './router/trie-router'
 import type { Handler, Next } from './types'
 import type { Expect, Equal } from './utils/types'
 
@@ -864,6 +867,47 @@ describe('Hono with `app.route`', () => {
   })
 })
 
+describe('Using other methods with `app.on`', () => {
+  it('Should handle PURGE method with StaticRouter', async () => {
+    const app = new Hono({ router: new StaticRouter() })
+
+    app.on('PURGE', '/purge', (c) => c.text('Accepted', 202))
+
+    const req = new Request('http://localhost/purge', {
+      method: 'PURGE',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(202)
+    expect(await res.text()).toBe('Accepted')
+  })
+
+  it('Should handle PURGE method with RegExpRouter', async () => {
+    const app = new Hono({ router: new RegExpRouter() })
+
+    app.on('PURGE', '/purge', (c) => c.text('Accepted', 202))
+
+    const req = new Request('http://localhost/purge', {
+      method: 'PURGE',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(202)
+    expect(await res.text()).toBe('Accepted')
+  })
+
+  it('Should handle PURGE method with TrieRouter', async () => {
+    const app = new Hono({ router: new TrieRouter() })
+
+    app.on('PURGE', '/purge', (c) => c.text('Accepted', 202))
+
+    const req = new Request('http://localhost/purge', {
+      method: 'PURGE',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(202)
+    expect(await res.text()).toBe('Accepted')
+  })
+})
+
 describe('Multiple handler', () => {
   describe('handler + handler', () => {
     const app = new Hono()
@@ -1286,7 +1330,7 @@ describe('Handler as variables', () => {
   })
 })
 
-describe.only('Show routes', () => {
+describe('Show routes', () => {
   const app = new Hono()
   jest.spyOn(console, 'log')
   it('Should call `console.log()` with `app.showRoutes()`', async () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -140,6 +140,15 @@ export class Hono<
     return this
   }
 
+  on(method: string, path: string, ...handlers: Handler<P, E, S>[]) {
+    if (!method) return this
+    this.path = path
+    handlers.map((handler) => {
+      this.addRoute(method.toUpperCase(), this.path, handler)
+    })
+    return this
+  }
+
   onError(handler: ErrorHandler<E>) {
     this.errorHandler = handler
     return this

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -6,6 +6,7 @@ describe('Basic Usage', () => {
 
   router.add('GET', '/hello', 'get hello')
   router.add('POST', '/hello', 'post hello')
+  router.add('PURGE', '/hello', 'purge hello')
 
   it('get, post hello', async () => {
     let res = router.match('GET', '/hello')
@@ -15,6 +16,10 @@ describe('Basic Usage', () => {
     res = router.match('POST', '/hello')
     expect(res).not.toBeNull()
     expect(res?.handlers).toEqual(['post hello'])
+
+    res = router.match('PURGE', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['purge hello'])
 
     res = router.match('PUT', '/hello')
     expect(res).toBeNull()

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -6,7 +6,7 @@ import { PATH_ERROR } from './node'
 import type { ParamMap } from './trie'
 import { Trie } from './trie'
 
-const METHOD_NAMES = [METHOD_NAME_ALL, ...METHODS].map((method) => method.toUpperCase())
+const methodNames = [METHOD_NAME_ALL, ...METHODS].map((method) => method.toUpperCase())
 
 type HandlerData<T> = [T[], ParamMap | null]
 type Matcher<T> = [RegExp, HandlerData<T>[]]
@@ -88,6 +88,8 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error('Can not add a route since the matcher is already built.')
     }
 
+    if (!methodNames.find((m) => m === method)) methodNames.push(method.toLocaleUpperCase())
+
     if (path === '/*') {
       path = '*'
     }
@@ -164,7 +166,7 @@ export class RegExpRouter<T> implements Router<T> {
   private buildAllMatchers(): Record<string, Matcher<T>> {
     const matchers: Record<string, Matcher<T>> = {}
 
-    METHOD_NAMES.forEach((method) => {
+    methodNames.forEach((method) => {
       matchers[method] = this.buildMatcher(method) || matchers[METHOD_NAME_ALL]
     })
 

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -88,7 +88,7 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error('Can not add a route since the matcher is already built.')
     }
 
-    if (!methodNames.find((m) => m === method)) methodNames.push(method.toLocaleUpperCase())
+    if (!methodNames.includes(method)) methodNames.push(method)
 
     if (path === '/*') {
       path = '*'

--- a/src/router/smart-router/router.test.ts
+++ b/src/router/smart-router/router.test.ts
@@ -11,6 +11,7 @@ describe('StaticRouter', () => {
 
     router.add('GET', '/hello', 'get hello')
     router.add('POST', '/hello', 'post hello')
+    router.add('PURGE', '/hello', 'purge hello')
 
     it('get, post hello', async () => {
       let res = router.match('GET', '/hello')
@@ -20,6 +21,10 @@ describe('StaticRouter', () => {
       res = router.match('POST', '/hello')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['post hello'])
+
+      res = router.match('PURGE', '/hello')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['purge hello'])
 
       res = router.match('PUT', '/hello')
       expect(res).toBeNull()
@@ -68,7 +73,7 @@ describe('RegExpRouter', () => {
         routers: [new StaticRouter(), new RegExpRouter(), new TrieRouter()],
       })
     })
-  
+
     it('Named Param', async () => {
       router.add('GET', '/entry/:id', 'get entry')
       const res = router.match('GET', '/entry/123')
@@ -77,14 +82,14 @@ describe('RegExpRouter', () => {
       expect(res?.params['id']).toBe('123')
       expect(router.activeRouter).toBeInstanceOf(RegExpRouter)
     })
-  
+
     it('Wildcard', async () => {
       router.add('GET', '/wild/*/card', 'get wildcard')
       const res = router.match('GET', '/wild/xxx/card')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['get wildcard'])
     })
-  
+
     it('Default', async () => {
       router.add('GET', '/api/abc', 'get api')
       router.add('GET', '/api/*', 'fallback')
@@ -95,7 +100,7 @@ describe('RegExpRouter', () => {
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['fallback'])
     })
-  
+
     it('Regexp', async () => {
       router.add('GET', '/post/:date{[0-9]+}/:title{[a-z]+}', 'get post')
       let res = router.match('GET', '/post/20210101/hello')
@@ -108,17 +113,17 @@ describe('RegExpRouter', () => {
       res = router.match('GET', '/post/123/123')
       expect(res).toBeNull()
     })
-  
+
     it('/*', async () => {
       router.add('GET', '/api/*', 'auth middleware')
       router.add('GET', '/api', 'top')
       router.add('GET', '/api/posts', 'posts')
       router.add('GET', '/api/*', 'fallback')
-  
+
       let res = router.match('GET', '/api')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['auth middleware', 'top', 'fallback'])
-  
+
       res = router.match('GET', '/api/posts')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['auth middleware', 'posts', 'fallback'])

--- a/src/router/static-router/router.test.ts
+++ b/src/router/static-router/router.test.ts
@@ -5,6 +5,7 @@ describe('Basic Usage', () => {
 
   router.add('GET', '/hello', 'get hello')
   router.add('POST', '/hello', 'post hello')
+  router.add('PURGE', '/hello', 'purge hello')
 
   it('get, post hello', async () => {
     let res = router.match('GET', '/hello')
@@ -14,6 +15,10 @@ describe('Basic Usage', () => {
     res = router.match('POST', '/hello')
     expect(res).not.toBeNull()
     expect(res?.handlers).toEqual(['post hello'])
+
+    res = router.match('PURGE', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['purge hello'])
 
     res = router.match('PUT', '/hello')
     expect(res).toBeNull()

--- a/src/router/static-router/router.ts
+++ b/src/router/static-router/router.ts
@@ -16,6 +16,8 @@ export class StaticRouter<T> implements Router<T> {
   }
 
   add(method: string, path: string, handler: T) {
+    this.routes[method.toUpperCase()] ||= {}
+
     const { middleware, routes } = this
 
     if (path === '/*') {

--- a/src/router/static-router/router.ts
+++ b/src/router/static-router/router.ts
@@ -15,10 +15,23 @@ export class StaticRouter<T> implements Router<T> {
     })
   }
 
-  add(method: string, path: string, handler: T) {
-    this.routes[method.toUpperCase()] ||= {}
+  private newRoute(): Record<string, Result<T>> {
+    const route: Record<string, Result<T>> = {}
+    const routeAll = this.routes[METHOD_NAME_ALL]
+    Object.keys(routeAll).forEach((path) => {
+      route[path] = {
+        handlers: [...routeAll[path].handlers],
+        params: {},
+      }
+    })
 
+    return route
+  }
+
+  add(method: string, path: string, handler: T) {
     const { middleware, routes } = this
+
+    routes[method] ||= this.newRoute()
 
     if (path === '/*') {
       path = '*'

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -5,6 +5,7 @@ describe('Basic Usage', () => {
 
   router.add('GET', '/hello', 'get hello')
   router.add('POST', '/hello', 'post hello')
+  router.add('PURGE', '/hello', 'purge hello')
 
   it('get, post hello', async () => {
     let res = router.match('GET', '/hello')
@@ -14,6 +15,10 @@ describe('Basic Usage', () => {
     res = router.match('POST', '/hello')
     expect(res).not.toBeNull()
     expect(res?.handlers).toEqual(['post hello'])
+
+    res = router.match('PURGE', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['purge hello'])
 
     res = router.match('PUT', '/hello')
     expect(res).toBeNull()


### PR DESCRIPTION
This PR introduces `app.on()`.

Currently, the HTTP methods we can use are specified in the code:

https://github.com/honojs/hono/blob/fadce526736a610248ec5175ca66ddcc5a84c883/src/router.ts#L3

The `app.on()` function will enable we set the custom HTTP method as we like:

```ts
app.on('PURGE', '/foo', async (c) => {
  await purgeCache('foo')
  return c.redirect('/')
})
```
