### PR TITLE
fix(package.json): add "type": "module"

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   testMatch: ['**/test/**/*.+(ts|tsx|js)', '**/src/**/(*.)+(spec|test).+(ts|tsx|js)'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.5",
   "description": "Ultrafast web framework for Cloudflare Workers, Deno, and Bun.",
   "main": "dist/cjs/index.js",
+  "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
hono did not work with ESM project.
Added type field to package.json.

```
import { Hono } from "hono";
         ^^^^
SyntaxError: Named export 'Hono' not found. The requested module 'hono' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'hono';
const { Hono } = pkg;
```