### PR TITLE
fix(validator): fix jsons validation after arrays

### DIFF
--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -104,10 +104,10 @@ export class Validator {
     this.isArray = true
     const res = validator(this)
     const arr = new VArray(res, path)
+    this.isArray = false
     return arr
   }
   object = <T extends Schema>(path: string, validator: (v: Validator) => T): VObject<T> => {
-    this.isArray = false
     const res = validator(this)
     const obj = new VObject(res, path)
     return obj

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -87,8 +87,8 @@ export class VArray<T extends Schema> extends VObjectBase<T> {
   }
 }
 
-class RecursiveValidator {
-  constructor(private inArray: boolean) {}
+export class Validator {
+  constructor(private inArray: boolean = false) {}
 
   query = (key: string): VString => new VString({ target: 'query', key: key })
   queries = (key: string): VStringArray => new VStringArray({ target: 'queries', key: key })
@@ -102,21 +102,17 @@ class RecursiveValidator {
     }
   }
   array = <T extends Schema>(path: string, validatorFn: (v: Validator) => T): VArray<T> => {
-    const validator = new RecursiveValidator(true)
+    const validator = new Validator(true)
     const res = validatorFn(validator)
     const arr = new VArray(res, path)
     return arr
   }
   object = <T extends Schema>(path: string, validatorFn: (v: Validator) => T): VObject<T> => {
-    const validator = new RecursiveValidator(this.inArray)
+    const validator = new Validator(this.inArray)
     const res = validatorFn(validator)
     const obj = new VObject(res, path)
     return obj
   }
-}
-
-export class Validator extends RecursiveValidator {
-  constructor() { super(false) }
 }
 
 type VOptions = {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -87,31 +87,36 @@ export class VArray<T extends Schema> extends VObjectBase<T> {
   }
 }
 
-export class Validator {
-  isArray: boolean = false
+class RecursiveValidator {
+  constructor(private inArray: boolean) {}
+
   query = (key: string): VString => new VString({ target: 'query', key: key })
   queries = (key: string): VStringArray => new VStringArray({ target: 'queries', key: key })
   header = (key: string): VString => new VString({ target: 'header', key: key })
   body = (key: string): VString => new VString({ target: 'body', key: key })
   json = (key: string) => {
-    if (this.isArray) {
+    if (this.inArray) {
       return new VStringArray({ target: 'json', key: key })
     } else {
       return new VString({ target: 'json', key: key })
     }
   }
-  array = <T extends Schema>(path: string, validator: (v: Validator) => T): VArray<T> => {
-    this.isArray = true
-    const res = validator(this)
+  array = <T extends Schema>(path: string, validatorFn: (v: Validator) => T): VArray<T> => {
+    const validator = new RecursiveValidator(true)
+    const res = validatorFn(validator)
     const arr = new VArray(res, path)
-    this.isArray = false
     return arr
   }
-  object = <T extends Schema>(path: string, validator: (v: Validator) => T): VObject<T> => {
-    const res = validator(this)
+  object = <T extends Schema>(path: string, validatorFn: (v: Validator) => T): VObject<T> => {
+    const validator = new RecursiveValidator(this.inArray)
+    const res = validatorFn(validator)
     const obj = new VObject(res, path)
     return obj
   }
+}
+
+export class Validator extends RecursiveValidator {
+  constructor() { super(false) }
 }
 
 type VOptions = {


### PR DESCRIPTION
fix the bug of `v.json()` calls made after a `v.array()` to be mistakenly considered as still being inside the array

fixes one of the issues mentioned in #677

____

This is the result of the test I've added before applying the change:
![before](https://user-images.githubusercontent.com/61631103/204113972-97527d99-f89b-4a7f-bc40-f1c42d1c031d.png)

(the rest of the checks passed already, but I've included them for completeness and to cover all cases for `v.json()` :slightly_smiling_face: )