### PR TITLE
fix(validator): fix subsequent nested objects names

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -46,8 +46,6 @@ export abstract class VObjectBase<T extends Schema> {
 
   getValidators = (): VBase[] => {
     const validators: VBase[] = []
-    const thisKeys: string[] = []
-    Object.assign(thisKeys, this.keys)
 
     const walk = (container: T, keys: string[], isOptional: boolean) => {
       for (const v of Object.values(container)) {
@@ -55,11 +53,7 @@ export abstract class VObjectBase<T extends Schema> {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           isOptional ||= v._isOptional
-          keys.push(...v.keys)
-          walk(v.container as T, keys, isOptional)
-          const tmp: string[] = []
-          Object.assign(tmp, thisKeys)
-          keys = tmp
+          walk(v.container as T, [...keys, ...v.keys], isOptional)
         } else if (v instanceof VBase) {
           if (isOptional) v.isOptional()
           v.baseKeys.push(...keys)
@@ -88,27 +82,28 @@ export class VArray<T extends Schema> extends VObjectBase<T> {
 }
 
 export class Validator {
-  isArray: boolean = false
+  constructor(private inArray: boolean = false) {}
+
   query = (key: string): VString => new VString({ target: 'query', key: key })
   queries = (key: string): VStringArray => new VStringArray({ target: 'queries', key: key })
   header = (key: string): VString => new VString({ target: 'header', key: key })
   body = (key: string): VString => new VString({ target: 'body', key: key })
   json = (key: string) => {
-    if (this.isArray) {
+    if (this.inArray) {
       return new VStringArray({ target: 'json', key: key })
     } else {
       return new VString({ target: 'json', key: key })
     }
   }
-  array = <T extends Schema>(path: string, validator: (v: Validator) => T): VArray<T> => {
-    this.isArray = true
-    const res = validator(this)
+  array = <T extends Schema>(path: string, validatorFn: (v: Validator) => T): VArray<T> => {
+    const validator = new Validator(true)
+    const res = validatorFn(validator)
     const arr = new VArray(res, path)
     return arr
   }
-  object = <T extends Schema>(path: string, validator: (v: Validator) => T): VObject<T> => {
-    this.isArray = false
-    const res = validator(this)
+  object = <T extends Schema>(path: string, validatorFn: (v: Validator) => T): VObject<T> => {
+    const validator = new Validator(this.inArray)
+    const res = validatorFn(validator)
     const obj = new VObject(res, path)
     return obj
   }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -46,8 +46,6 @@ export abstract class VObjectBase<T extends Schema> {
 
   getValidators = (): VBase[] => {
     const validators: VBase[] = []
-    const thisKeys: string[] = []
-    Object.assign(thisKeys, this.keys)
 
     const walk = (container: T, keys: string[], isOptional: boolean) => {
       for (const v of Object.values(container)) {
@@ -55,11 +53,7 @@ export abstract class VObjectBase<T extends Schema> {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           isOptional ||= v._isOptional
-          keys.push(...v.keys)
-          walk(v.container as T, keys, isOptional)
-          const tmp: string[] = []
-          Object.assign(tmp, thisKeys)
-          keys = tmp
+          walk(v.container as T, [...keys, ...v.keys], isOptional)
         } else if (v instanceof VBase) {
           if (isOptional) v.isOptional()
           v.baseKeys.push(...keys)


### PR DESCRIPTION
fix the bug of having subsequent objects inside a nested structure causing the validator to forget the previous keys in the scheme's path

fixes point 1 of #677