### PR TITLE
fix: Cache middleware throws Internal Server Error on Cloudflare Workers

### DIFF
--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -19,6 +19,9 @@ export const cache = (options: {
     const response = await cache.match(key)
     if (!response) {
       await next()
+      if (!c.res.ok) {
+        return
+      }
       addHeader(c.res)
       const response = c.res.clone()
       if (options.wait) {
@@ -27,7 +30,7 @@ export const cache = (options: {
         c.executionCtx.waitUntil(cache.put(key, response))
       }
     } else {
-      return response
+      return new Response(await response.blob(), { headers: response.headers })
     }
   }
 }


### PR DESCRIPTION
Cache middleware throws Internal Server Error when return a cached response.
I've investigate some logs but I can't locate the problem.
In this investigation, I found that response wrapped by new Response will resolve problems, so for now I've added code which wrap response with new Response.

And I've added code that will avoid caching response with status >= 400.
