### PR TITLE
fix(reg-exp-router): Copy from METHOD_NAME_ALL for new methods

### DIFF
--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -97,7 +97,13 @@ export class RegExpRouter<T> implements Router<T> {
     }
 
     if (/\*$/.test(path)) {
-      middleware[method] ||= {}
+      if (!middleware[method]) {
+        middleware[method] = {}
+        Object.keys(middleware[METHOD_NAME_ALL]).forEach((p) => {
+          middleware[method][p] = [...middleware[METHOD_NAME_ALL][p]]
+        })
+      }
+
       const re = buildWildcardRegExp(path)
       middleware[method][path] ||=
         findMiddleware(middleware[method], path) ||
@@ -110,13 +116,6 @@ export class RegExpRouter<T> implements Router<T> {
           })
         }
       })
-      if (method !== METHOD_NAME_ALL) {
-        Object.keys(middleware[METHOD_NAME_ALL]).forEach((p) => {
-          if (!middleware[method][p] && (path === '*' || re.test(p))) {
-            middleware[method][p] = [...middleware[METHOD_NAME_ALL][p], handler]
-          }
-        })
-      }
 
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
@@ -129,11 +128,16 @@ export class RegExpRouter<T> implements Router<T> {
       return
     }
 
+    if (!routes[method]) {
+      routes[method] = {}
+      Object.keys(routes[METHOD_NAME_ALL]).forEach((p) => {
+        routes[method][p] = [...routes[METHOD_NAME_ALL][p]]
+      })
+    }
+
     const paths = checkOptionalParameter(path) || [path]
     for (let i = 0, len = paths.length; i < len; i++) {
       const path = paths[i]
-
-      routes[method] ||= {}
 
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -91,19 +91,20 @@ export class RegExpRouter<T> implements Router<T> {
     }
 
     if (!methodNames.includes(method)) methodNames.push(method)
+    if (!middleware[method]) {
+      ;[middleware, routes].forEach((handlerMap) => {
+        handlerMap[method] = {}
+        Object.keys(handlerMap[METHOD_NAME_ALL]).forEach((p) => {
+          handlerMap[method][p] = [...handlerMap[METHOD_NAME_ALL][p]]
+        })
+      })
+    }
 
     if (path === '/*') {
       path = '*'
     }
 
     if (/\*$/.test(path)) {
-      if (!middleware[method]) {
-        middleware[method] = {}
-        Object.keys(middleware[METHOD_NAME_ALL]).forEach((p) => {
-          middleware[method][p] = [...middleware[METHOD_NAME_ALL][p]]
-        })
-      }
-
       const re = buildWildcardRegExp(path)
       middleware[method][path] ||=
         findMiddleware(middleware[method], path) ||
@@ -126,13 +127,6 @@ export class RegExpRouter<T> implements Router<T> {
       })
 
       return
-    }
-
-    if (!routes[method]) {
-      routes[method] = {}
-      Object.keys(routes[METHOD_NAME_ALL]).forEach((p) => {
-        routes[method][p] = [...routes[METHOD_NAME_ALL][p]]
-      })
     }
 
     const paths = checkOptionalParameter(path) || [path]

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -136,8 +136,7 @@ export class RegExpRouter<T> implements Router<T> {
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
           routes[m][path] ||= [
-            ...(routes[METHOD_NAME_ALL][path] ||
-              findMiddleware(middleware[method], path) ||
+            ...(findMiddleware(middleware[m], path) ||
               findMiddleware(middleware[METHOD_NAME_ALL], path) ||
               []),
           ]

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -343,3 +343,16 @@ describe('static routes of ALL and GET', () => {
     expect(res?.handlers).toEqual(['foo'])
   })
 })
+
+describe('ALL and Star', () => {
+  const router = new RegExpRouter<string>()
+
+  router.add('ALL', '/x', '/x')
+  router.add('GET', '*', 'star')
+
+  it('Should return /x and star', async () => {
+    const res = router.match('GET', '/x')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['/x', 'star'])
+  })
+})

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -331,3 +331,15 @@ describe('long prefix, then star', () => {
     })
   })
 })
+
+describe('static routes of ALL and GET', () => {
+  const router = new RegExpRouter<string>()
+
+  router.add('ALL', '/foo', 'foo')
+  router.add('GET', '/bar', 'bar')
+
+  it('get /foo', () => {
+    const res = router.match('GET', '/foo')
+    expect(res?.handlers).toEqual(['foo'])
+  })
+})

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -356,3 +356,18 @@ describe('ALL and Star', () => {
     expect(res?.handlers).toEqual(['/x', 'star'])
   })
 })
+
+describe('GET star, ALL static, GET star...', () => {
+  const router = new RegExpRouter<string>()
+
+  router.add('GET', '*', 'star1')
+  router.add('ALL', '/x', '/x')
+  router.add('GET', '*', 'star2')
+  router.add('GET', '*', 'star3')
+
+  it('Should return /x and star', async () => {
+    const res = router.match('GET', '/x')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['star1', '/x', 'star2', 'star3'])
+  })
+})

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -97,7 +97,13 @@ export class RegExpRouter<T> implements Router<T> {
     }
 
     if (/\*$/.test(path)) {
-      middleware[method] ||= {}
+      if (!middleware[method]) {
+        middleware[method] = {}
+        Object.keys(middleware[METHOD_NAME_ALL]).forEach((p) => {
+          middleware[method][p] = [...middleware[METHOD_NAME_ALL][p]]
+        })
+      }
+
       const re = buildWildcardRegExp(path)
       middleware[method][path] ||=
         findMiddleware(middleware[method], path) ||
@@ -110,13 +116,6 @@ export class RegExpRouter<T> implements Router<T> {
           })
         }
       })
-      if (method !== METHOD_NAME_ALL) {
-        Object.keys(middleware[METHOD_NAME_ALL]).forEach((p) => {
-          if (!middleware[method][p] && (path === '*' || re.test(p))) {
-            middleware[method][p] = [...middleware[METHOD_NAME_ALL][p], handler]
-          }
-        })
-      }
 
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
@@ -129,11 +128,16 @@ export class RegExpRouter<T> implements Router<T> {
       return
     }
 
+    if (!routes[method]) {
+      routes[method] = {}
+      Object.keys(routes[METHOD_NAME_ALL]).forEach((p) => {
+        routes[method][p] = [...routes[METHOD_NAME_ALL][p]]
+      })
+    }
+
     const paths = checkOptionalParameter(path) || [path]
     for (let i = 0, len = paths.length; i < len; i++) {
       const path = paths[i]
-
-      routes[method] ||= {}
 
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -91,19 +91,20 @@ export class RegExpRouter<T> implements Router<T> {
     }
 
     if (!methodNames.includes(method)) methodNames.push(method)
+    if (!middleware[method]) {
+      ;[middleware, routes].forEach((handlerMap) => {
+        handlerMap[method] = {}
+        Object.keys(handlerMap[METHOD_NAME_ALL]).forEach((p) => {
+          handlerMap[method][p] = [...handlerMap[METHOD_NAME_ALL][p]]
+        })
+      })
+    }
 
     if (path === '/*') {
       path = '*'
     }
 
     if (/\*$/.test(path)) {
-      if (!middleware[method]) {
-        middleware[method] = {}
-        Object.keys(middleware[METHOD_NAME_ALL]).forEach((p) => {
-          middleware[method][p] = [...middleware[METHOD_NAME_ALL][p]]
-        })
-      }
-
       const re = buildWildcardRegExp(path)
       middleware[method][path] ||=
         findMiddleware(middleware[method], path) ||
@@ -126,13 +127,6 @@ export class RegExpRouter<T> implements Router<T> {
       })
 
       return
-    }
-
-    if (!routes[method]) {
-      routes[method] = {}
-      Object.keys(routes[METHOD_NAME_ALL]).forEach((p) => {
-        routes[method][p] = [...routes[METHOD_NAME_ALL][p]]
-      })
     }
 
     const paths = checkOptionalParameter(path) || [path]

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -136,8 +136,7 @@ export class RegExpRouter<T> implements Router<T> {
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
           routes[m][path] ||= [
-            ...(routes[METHOD_NAME_ALL][path] ||
-              findMiddleware(middleware[method], path) ||
+            ...(findMiddleware(middleware[m], path) ||
               findMiddleware(middleware[METHOD_NAME_ALL], path) ||
               []),
           ]


### PR DESCRIPTION
Hi @yusukebe !

I don't think #684 is the cause of this problem, as #688 reproduces in v2.5.6 as well.
However, the cause is in a similar area and it is my fault for not noticing this problem when fixing #684.

In the current RegExpRouter architecture, handlers added with METHOD_NAME_ALL are copied to each method, so I believe that copying all existing handlers the first time they (new method) are added will correct the problem, including #681.