### PR TITLE
Updated CORS

### DIFF
--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -32,8 +32,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
   })(opts.origin)
 
   return async (c, next) => {
-    await next()
-
+    
     function set(key: string, value: string) {
       c.res.headers.append(key, value)
     }
@@ -57,7 +56,10 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       set('Access-Control-Expose-Headers', opts.exposeHeaders.join(','))
     }
 
-    if (c.req.method === 'OPTIONS') {
+    if (c.req.method !== 'OPTIONS') {
+      await next()
+    }
+    else {
       // Preflight
 
       if (opts.maxAge != null) {

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -12,7 +12,7 @@ type CORSOptions = {
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',
-    allowMethods: ['GET', 'HEAD'],
+    allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
     allowHeaders: [],
     exposeHeaders: [],
   }

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -13,8 +13,8 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',
     allowMethods: ['GET', 'HEAD'],
-    allowHeaders: ['Content-Type'],
-    exposeHeaders: ['Content-Length'],
+    allowHeaders: [],
+    exposeHeaders: [],
   }
   const opts = {
     ...defaults,

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -12,9 +12,9 @@ type CORSOptions = {
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',
-    allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
-    allowHeaders: [],
-    exposeHeaders: [],
+    allowMethods: ['GET', 'HEAD'],
+    allowHeaders: ['Content-Type'],
+    exposeHeaders: ['Content-Length'],
   }
   const opts = {
     ...defaults,
@@ -32,8 +32,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
   })(opts.origin)
 
   return async (c, next) => {
-    await next()
-
+    
     function set(key: string, value: string) {
       c.res.headers.append(key, value)
     }
@@ -57,7 +56,10 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       set('Access-Control-Expose-Headers', opts.exposeHeaders.join(','))
     }
 
-    if (c.req.method === 'OPTIONS') {
+    if (c.req.method !== 'OPTIONS') {
+      await next()
+    }
+    else {
       // Preflight
 
       if (opts.maxAge != null) {


### PR DESCRIPTION
Do not call `next` for OPTIONS pre-flight requests to avoid side effects and more sensible defaults.