### PR TITLE
chore: remove unnecessary config testPathIgnorePatterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,6 @@ export default {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  testPathIgnorePatterns: ['./examples'],
   testEnvironment: 'miniflare',
   testEnvironmentOptions: {
     /*


### PR DESCRIPTION
## Changes
- This PR removes unnecessary jest config `testPathIgnorePatterns: ['./examples']`.

## Background
The config was introduced when `examples` directory was created.
https://github.com/honojs/hono/commit/511c0ebd7e63706d748a2950e016c1e542c8103c

I guess we can remove it since `examples` directory has been removed.
https://github.com/honojs/hono/commit/13373f0836cf4976e28e1ed7afab26b452da8de7