### PR TITLE
feat(handler): "schema" allow normal types

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -13,7 +13,7 @@ export type Data = string | ArrayBuffer | ReadableStream
 export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > {
   req: Request<unknown, P, S extends Schema ? SchemaToProp<S> : S>
   env: E['Bindings']

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -13,7 +13,8 @@ export type Data = string | ArrayBuffer | ReadableStream
 export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  S = any
 > {
   req: Request<unknown, P, S extends Schema ? SchemaToProp<S> : S>
   env: E['Bindings']

--- a/deno_dist/middleware/html/index.ts
+++ b/deno_dist/middleware/html/index.ts
@@ -14,9 +14,11 @@ export const html = (strings: TemplateStringsArray, ...values: unknown[]): HtmlE
   for (let i = 0, len = strings.length - 1; i < len; i++) {
     buffer[0] += strings[i]
 
-    const children = values[i] instanceof Array ? (values[i] as Array<unknown>).flat(Infinity) : [values[i]]
+    const children =
+      values[i] instanceof Array ? (values[i] as Array<unknown>).flat(Infinity) : [values[i]]
     for (let i = 0, len = children.length; i < len; i++) {
-      const child = children[i]
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const child = children[i] as any
       if (typeof child === 'string') {
         escapeToBuffer(child, buffer)
       } else if (typeof child === 'boolean' || child === null || child === undefined) {

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -20,13 +20,13 @@ type Done<P extends string, E extends Partial<Environment> = Environment> = (
 type ValidationFunction<
   P extends string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > = (v: Validator, c: Context<P, E>) => S
 
 export const validatorMiddleware = <
   P extends string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 >(
   validationFunction: ValidationFunction<P, E, S>,
   options?: { done?: Done<P, E> }

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -21,7 +21,7 @@ type ValidationFunction<
   P extends string,
   E extends Partial<Environment> = Environment,
   S = Schema
-> = (v: Validator, c: Context<P, E, S>) => S
+> = (v: Validator, c: Context<P, E>) => S
 
 export const validatorMiddleware = <
   P extends string,
@@ -107,7 +107,7 @@ export const validatorMiddleware = <
     }
 
     if (options && options.done) {
-      const res = options.done(resultSet, c as unknown as Context<string, E, Schema>)
+      const res = options.done(resultSet, c)
       if (res) {
         return res
       }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -4,14 +4,13 @@ import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 import { getQueryStringFromURL } from './utils/url.ts'
 
-type ValidatedData = Record<string, unknown>
-
 declare global {
   interface Request<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     CfHostMetadata = unknown,
     ParamKeyType extends string = string,
-    Data extends ValidatedData = ValidatedData
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Data = any
   > {
     paramData?: Record<ParamKeyType, string>
     param: {
@@ -43,7 +42,7 @@ declare global {
     json<T>(): Promise<T>
     data: Data
     valid: {
-      (key: string | string[], value: unknown): Data
+      (data: Data): Data
       (): Data
     }
   }
@@ -154,19 +153,12 @@ export function extendRequestPrototype() {
     return jsonData
   } as InstanceType<typeof Request>['jsonData']
 
-  Request.prototype.valid = function (this: Request, keys?: string | string[], value?: unknown) {
+  Request.prototype.valid = function (this: Request, data?: unknown) {
     if (!this.data) {
       this.data = {}
     }
-    if (keys !== undefined) {
-      if (typeof keys === 'string') {
-        keys = [keys]
-      }
-      let data = this.data
-      for (let i = 0; i < keys.length - 1; i++) {
-        data = (data[keys[i]] ||= {}) as ValidatedData
-      }
-      data[keys[keys.length - 1]] = value
+    if (data) {
+      this.data = data
     }
     return this.data
   } as InstanceType<typeof Request>['valid']

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -15,13 +15,13 @@ export type Environment = {
 export type Handler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
 
 export type MiddlewareHandler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
 
 export type NotFoundHandler<E extends Partial<Environment> = Environment> = (
@@ -50,33 +50,23 @@ export type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
 
 // This is not used for internally
 // Will be used by users as `Handler`
-export interface CustomHandler<
-  P extends string | Partial<Environment> | Schema = string,
-  E = Partial<Environment> | Partial<Schema>,
-  S = Partial<Schema>
-> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface CustomHandler<P = string, E = Partial<Environment>, S = any> {
   (
     c: Context<
+      P extends string ? P : string,
+      P extends Partial<Environment> ? P : E extends Partial<Environment> ? E : never,
       P extends string
-        ? P
+        ? E extends Partial<Environment>
+          ? S
+          : P extends Partial<Environment>
+          ? E
+          : never
         : P extends Partial<Environment>
-        ? string
-        : P extends Partial<Schema>
-        ? string
-        : never,
-      P extends Partial<Environment>
-        ? P
-        : P extends Partial<Schema>
-        ? Partial<Environment>
-        : E extends Partial<Environment>
-        ? E extends Partial<Schema>
-          ? Environment
+        ? E extends Partial<Environment>
+          ? S
           : E
-        : E extends Partial<Schema>
-        ? Partial<Environment>
-        : Environment,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      S extends Schema ? S : P extends Schema ? P : E extends Schema ? E : any
+        : P
     >,
     next: Next
   ): Response | Promise<Response | undefined | void>

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -15,13 +15,13 @@ export type Environment = {
 export type Handler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
 
 export type MiddlewareHandler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
 
 export type NotFoundHandler<E extends Partial<Environment> = Environment> = (

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,7 +13,7 @@ export type Data = string | ArrayBuffer | ReadableStream
 export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > {
   req: Request<unknown, P, S extends Schema ? SchemaToProp<S> : S>
   env: E['Bindings']

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,7 +13,8 @@ export type Data = string | ArrayBuffer | ReadableStream
 export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  S = any
 > {
   req: Request<unknown, P, S extends Schema ? SchemaToProp<S> : S>
   env: E['Bindings']

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -10,7 +10,6 @@ import { TrieRouter } from './router/trie-router'
 import type { ExecutionContext } from './types'
 import type { Handler, Environment, ParamKeys, ErrorHandler, NotFoundHandler } from './types'
 import { getPathFromURL, mergePath } from './utils/url'
-import type { Schema } from './validator/schema'
 
 interface HandlerInterface<
   P extends string,
@@ -19,18 +18,22 @@ interface HandlerInterface<
   U = Hono<E, P, S>
 > {
   // app.get(handler...)
-  <Path extends string, Data>(
+  <Path extends string, Data = S>(
     ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, E, Data>[]
-  ): U
-  (...handlers: Handler<string, E, S>[]): U
+  ): Hono<E, Path, Data & S>
+  (...handlers: Handler<P, E, S>[]): U
 
   // app.get('/', handler, handler...)
-  <Path extends string, Data>(
+  <Path extends string, Data = S>(
     path: Path,
     ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, E, Data>[]
-  ): U
-  <Path extends string, Data>(path: Path, ...handlers: Handler<string, E, Data>[]): U
-  (path: string, ...handlers: Handler<string, E, S>[]): U
+  ): Hono<E, Path, Data & S>
+  <Path extends string, Data = S>(path: Path, ...handlers: Handler<string, E, Data>[]): Hono<
+    E,
+    string,
+    Data & S
+  >
+  (path: string, ...handlers: Handler<P, E, S>[]): U
 }
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -39,7 +42,7 @@ function defineDynamicClass(): {
   new <
     E extends Partial<Environment> = Environment,
     P extends string = string,
-    S = Schema,
+    S = unknown,
     U = Hono<E, P, S>
   >(): {
     [K in Methods]: HandlerInterface<P, E, S, U>
@@ -51,7 +54,7 @@ function defineDynamicClass(): {
 interface Route<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > {
   path: string
   method: string
@@ -61,7 +64,7 @@ interface Route<
 export class Hono<
   E extends Partial<Environment> = Environment,
   P extends string = '/',
-  S = Schema
+  S = unknown
 > extends defineDynamicClass()<E, P, S, Hono<E, P, S>> {
   readonly router: Router<Handler<P, E, S>> = new SmartRouter({
     routers: [new StaticRouter(), new RegExpRouter(), new TrieRouter()],
@@ -79,7 +82,7 @@ export class Hono<
 
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
-      this[method] = <Env extends Environment, Data extends Schema>(
+      this[method] = <Env extends Environment, Data>(
         args1: string | Handler<string, Env, Data>,
         ...args: Handler<string, Env, Data>[]
       ) => {
@@ -93,7 +96,8 @@ export class Hono<
             this.addRoute(method, this.path, handler as unknown as Handler<P, E, S>)
           }
         })
-        return this
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return this as unknown as Hono<E, any, any>
       }
     })
 
@@ -122,10 +126,10 @@ export class Hono<
     return this
   }
 
-  use<Path extends string = string, Data extends Partial<Schema> = Schema>(
+  use<Path extends string = string, Data = unknown>(
     ...middleware: Handler<Path, E, Data>[]
   ): Hono<E, P, S>
-  use<Path extends string = string, Data extends Partial<Schema> = Schema>(
+  use<Path extends string = string, Data = unknown>(
     arg1: string,
     ...middleware: Handler<Path, E, Data>[]
   ): Hono<E, P, S>

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -14,22 +14,22 @@ import type { Schema } from './validator/schema'
 
 interface HandlerInterface<
   P extends string,
-  E extends Partial<Environment>,
-  S extends Partial<Schema>,
+  E extends Partial<Environment> = Environment,
+  S = unknown,
   U = Hono<E, P, S>
 > {
   // app.get(handler...)
-  <Path extends string, Data extends Schema>(
+  <Path extends string, Data>(
     ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, E, Data>[]
   ): U
   (...handlers: Handler<string, E, S>[]): U
 
   // app.get('/', handler, handler...)
-  <Path extends string, Data extends Partial<Schema> = Schema>(
+  <Path extends string, Data>(
     path: Path,
     ...handlers: Handler<ParamKeys<Path> extends never ? string : ParamKeys<Path>, E, Data>[]
   ): U
-  <Path extends string, Data extends Schema>(path: Path, ...handlers: Handler<string, E, Data>[]): U
+  <Path extends string, Data>(path: Path, ...handlers: Handler<string, E, Data>[]): U
   (path: string, ...handlers: Handler<string, E, S>[]): U
 }
 
@@ -39,7 +39,7 @@ function defineDynamicClass(): {
   new <
     E extends Partial<Environment> = Environment,
     P extends string = string,
-    S extends Partial<Schema> = Schema,
+    S = Schema,
     U = Hono<E, P, S>
   >(): {
     [K in Methods]: HandlerInterface<P, E, S, U>
@@ -51,7 +51,7 @@ function defineDynamicClass(): {
 interface Route<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > {
   path: string
   method: string
@@ -61,7 +61,7 @@ interface Route<
 export class Hono<
   E extends Partial<Environment> = Environment,
   P extends string = '/',
-  S extends Partial<Schema> = Schema
+  S = Schema
 > extends defineDynamicClass()<E, P, S, Hono<E, P, S>> {
   readonly router: Router<Handler<P, E, S>> = new SmartRouter({
     routers: [new StaticRouter(), new RegExpRouter(), new TrieRouter()],
@@ -201,7 +201,7 @@ export class Hono<
     const result = this.matchRoute(method, path)
     request.paramData = result?.params
 
-    const c = new Context<string, E, S>(request, env, eventOrExecutionCtx, this.notFoundHandler)
+    const c = new Context<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
 
     // Do not `compose` if it has only one handler
     if (result && result.handlers.length === 1) {
@@ -209,10 +209,10 @@ export class Hono<
       let res: ReturnType<Handler<P>>
 
       try {
-        res = handler(c, async () => {})
-        if (!res) return this.notFoundHandler(c as Context)
+        res = handler(c as unknown as Context<string, E, S>, async () => {})
+        if (!res) return this.notFoundHandler(c)
       } catch (err) {
-        return this.handleError(err, c as Context)
+        return this.handleError(err, c)
       }
 
       if (res instanceof Response) return res
@@ -222,17 +222,17 @@ export class Hono<
         try {
           awaited = await res
           if (!awaited) {
-            return this.notFoundHandler(c as Context)
+            return this.notFoundHandler(c)
           }
         } catch (err) {
-          return this.handleError(err, c as Context)
+          return this.handleError(err, c)
         }
         return awaited
       })()
     }
 
     const handlers = result ? result.handlers : [this.notFoundHandler]
-    const composed = compose<Context<P, E, S>, E>(handlers, this.notFoundHandler, this.errorHandler)
+    const composed = compose<Context<P, E>, E>(handlers, this.notFoundHandler, this.errorHandler)
 
     return (async () => {
       try {
@@ -245,7 +245,7 @@ export class Hono<
         }
         return context.res
       } catch (err) {
-        return this.handleError(err, c as Context)
+        return this.handleError(err, c)
       }
     })()
   }

--- a/src/middleware/html/index.ts
+++ b/src/middleware/html/index.ts
@@ -14,9 +14,11 @@ export const html = (strings: TemplateStringsArray, ...values: unknown[]): HtmlE
   for (let i = 0, len = strings.length - 1; i < len; i++) {
     buffer[0] += strings[i]
 
-    const children = values[i] instanceof Array ? (values[i] as Array<unknown>).flat(Infinity) : [values[i]]
+    const children =
+      values[i] instanceof Array ? (values[i] as Array<unknown>).flat(Infinity) : [values[i]]
     for (let i = 0, len = children.length; i < len; i++) {
-      const child = children[i]
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const child = children[i] as any
       if (typeof child === 'string') {
         escapeToBuffer(child, buffer)
       } else if (typeof child === 'boolean' || child === null || child === undefined) {

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -20,13 +20,13 @@ type Done<P extends string, E extends Partial<Environment> = Environment> = (
 type ValidationFunction<
   P extends string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > = (v: Validator, c: Context<P, E>) => S
 
 export const validatorMiddleware = <
   P extends string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 >(
   validationFunction: ValidationFunction<P, E, S>,
   options?: { done?: Done<P, E> }

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -21,7 +21,7 @@ type ValidationFunction<
   P extends string,
   E extends Partial<Environment> = Environment,
   S = Schema
-> = (v: Validator, c: Context<P, E, S>) => S
+> = (v: Validator, c: Context<P, E>) => S
 
 export const validatorMiddleware = <
   P extends string,
@@ -107,7 +107,7 @@ export const validatorMiddleware = <
     }
 
     if (options && options.done) {
-      const res = options.done(resultSet, c as unknown as Context<string, E, Schema>)
+      const res = options.done(resultSet, c)
       if (res) {
         return res
       }

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,14 +4,13 @@ import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
 import { getQueryStringFromURL } from './utils/url'
 
-type ValidatedData = Record<string, unknown>
-
 declare global {
   interface Request<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     CfHostMetadata = unknown,
     ParamKeyType extends string = string,
-    Data extends ValidatedData = ValidatedData
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Data = any
   > {
     paramData?: Record<ParamKeyType, string>
     param: {
@@ -43,7 +42,7 @@ declare global {
     json<T>(): Promise<T>
     data: Data
     valid: {
-      (key: string | string[], value: unknown): Data
+      (data: Data): Data
       (): Data
     }
   }
@@ -154,19 +153,12 @@ export function extendRequestPrototype() {
     return jsonData
   } as InstanceType<typeof Request>['jsonData']
 
-  Request.prototype.valid = function (this: Request, keys?: string | string[], value?: unknown) {
+  Request.prototype.valid = function (this: Request, data?: unknown) {
     if (!this.data) {
       this.data = {}
     }
-    if (keys !== undefined) {
-      if (typeof keys === 'string') {
-        keys = [keys]
-      }
-      let data = this.data
-      for (let i = 0; i < keys.length - 1; i++) {
-        data = (data[keys[i]] ||= {}) as ValidatedData
-      }
-      data[keys[keys.length - 1]] = value
+    if (data) {
+      this.data = data
     }
     return this.data
   } as InstanceType<typeof Request>['valid']

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -149,4 +149,17 @@ describe('Test types of CustomHandler', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('bar')
   })
+
+  test('Normal types', () => {
+    type User = {
+      name: string
+      age: number
+    }
+
+    const handler: Handler<User> = (c) => {
+      const user = c.req.valid()
+      type verifySchema = Expect<Equal<typeof user, User>>
+      return c.text('Hi')
+    }
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import type { Context } from './context'
-import type { Schema } from './validator/schema'
 
 export interface ContextVariableMap {}
 
@@ -15,13 +14,13 @@ export type Environment = {
 export type Handler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
 
 export type MiddlewareHandler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S = Schema
+  S = unknown
 > = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
 
 export type NotFoundHandler<E extends Partial<Environment> = Environment> = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,13 +15,13 @@ export type Environment = {
 export type Handler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > = (c: Context<P, E, S>, next: Next) => Response | Promise<Response | undefined | void>
 
 export type MiddlewareHandler<
   P extends string = string,
   E extends Partial<Environment> = Environment,
-  S extends Partial<Schema> = Schema
+  S = Schema
 > = (c: Context<P, E, S>, next: Next) => Promise<Response | undefined | void>
 
 export type NotFoundHandler<E extends Partial<Environment> = Environment> = (
@@ -50,33 +50,23 @@ export type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
 
 // This is not used for internally
 // Will be used by users as `Handler`
-export interface CustomHandler<
-  P extends string | Partial<Environment> | Schema = string,
-  E = Partial<Environment> | Partial<Schema>,
-  S = Partial<Schema>
-> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface CustomHandler<P = string, E = Partial<Environment>, S = any> {
   (
     c: Context<
+      P extends string ? P : string,
+      P extends Partial<Environment> ? P : E extends Partial<Environment> ? E : never,
       P extends string
-        ? P
+        ? E extends Partial<Environment>
+          ? S
+          : P extends Partial<Environment>
+          ? E
+          : never
         : P extends Partial<Environment>
-        ? string
-        : P extends Partial<Schema>
-        ? string
-        : never,
-      P extends Partial<Environment>
-        ? P
-        : P extends Partial<Schema>
-        ? Partial<Environment>
-        : E extends Partial<Environment>
-        ? E extends Partial<Schema>
-          ? Environment
+        ? E extends Partial<Environment>
+          ? S
           : E
-        : E extends Partial<Schema>
-        ? Partial<Environment>
-        : Environment,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      S extends Schema ? S : P extends Schema ? P : E extends Schema ? E : any
+        : P
     >,
     next: Next
   ): Response | Promise<Response | undefined | void>


### PR DESCRIPTION
This PR allows normal types, instead of only allowing `Schema` in the Handler.

```ts
type User = {
  id: string
  name: string
  age: number
}

const handler: Handler<User> = (c) => {
  const user = c.req.valid() // <--- user is User
  // ...
}
```

This change also makes it possible to use the 3rd party library such as "[Zod](https://zod.dev)" for validation.

```ts
import { z } from 'zod'
import type { ZodType } from 'zod'
import { Hono } from '../../../src/hono'
import type { Handler } from '../../../src/index'

const app = new Hono()

const schema = z.object({
  id: z.string(),
  name: z.string(),
  age: z.number(),
})

// You can write a custom validator with Zod:
const zValidtor = <T extends ZodType>(schema: T): Handler<z.infer<T>> => {
  return async (c, next) => {
    const parsed = schema.safeParse(await c.req.json())
    if (!parsed.success) {
      return c.text('Invalid!', 400)
    }
    c.req.valid(parsed.data)
    await next()
  }
}

app.post('/post', zValidtor(schema), (c) => {
  const user = c.req.valid() // <--- user will be `User`
  return c.json(user)
})
```

Builtin Validator is recommended, but if developers want to use Zod, they can.

This may resolve #689 