### PR TITLE
fix(trie-router): bug for routing orders with named param

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -554,6 +554,7 @@ describe('Routing order With named parameters', () => {
   const node = new Node()
   node.insert('get', '/book/a', 'no-slug')
   node.insert('get', '/book/:slug', 'slug')
+  node.insert('get', '/book/b', 'no-slug-b')
   it('/book/a', () => {
     const res = node.search('get', '/book/a')
     expect(res).not.toBeNull()
@@ -565,5 +566,11 @@ describe('Routing order With named parameters', () => {
     expect(res).not.toBeNull()
     expect(res?.handlers).toEqual(['slug'])
     expect(res?.params['slug']).toBe('foo')
+  })
+  it('/book/b', () => {
+    const res = node.search('get', '/book/b')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['slug', 'no-slug-b'])
+    expect(res?.params['slug']).toBe('b')
   })
 })

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -135,22 +135,6 @@ describe('page', () => {
   })
 })
 
-describe('routing order with named parameters', () => {
-  const router = new TrieRouter<string>()
-  router.add('GET', '/book/a', 'no-slug')
-  router.add('GET', '/book/:slug', 'slug')
-  it('GET /book/a', async () => {
-    const res = router.match('GET', '/book/a')
-    expect(res?.handlers).toEqual(['no-slug', 'slug'])
-    expect(res?.params['slug']).toBeUndefined()
-  })
-  it('GET /book/foo', async () => {
-    const res = router.match('GET', '/book/foo')
-    expect(res?.handlers).toEqual(['slug'])
-    expect(res?.params['slug']).toBe('foo')
-  })
-})
-
 describe('Optional route', () => {
   const router = new TrieRouter<string>()
   router.add('GET', '/api/animals/:type?', 'animals')
@@ -163,5 +147,27 @@ describe('Optional route', () => {
     const res = router.match('GET', '/api/animals')
     expect(res?.handlers).toEqual(['animals'])
     expect(res?.params['type']).toBeUndefined()
+  })
+})
+
+describe('routing order with named parameters', () => {
+  const router = new TrieRouter<string>()
+  router.add('GET', '/book/a', 'no-slug')
+  router.add('GET', '/book/:slug', 'slug')
+  router.add('GET', '/book/b', 'no-slug-b')
+  it('GET /book/a', async () => {
+    const res = router.match('GET', '/book/a')
+    expect(res?.handlers).toEqual(['no-slug', 'slug'])
+    expect(res?.params['slug']).toBeUndefined()
+  })
+  it('GET /book/foo', async () => {
+    const res = router.match('GET', '/book/foo')
+    expect(res?.handlers).toEqual(['slug'])
+    expect(res?.params['slug']).toBe('foo')
+  })
+  it('GET /book/b', async () => {
+    const res = router.match('GET', '/book/b')
+    expect(res?.handlers).toEqual(['slug', 'no-slug-b'])
+    expect(res?.params['slug']).toBe('b')
   })
 })


### PR DESCRIPTION
Fixed the bug, we could not capture the named path parameter following the pattern. When accessing `GET /hello/world`, the `console.log()` may show `undefined`:

```ts
app.get('/hello/:foo', async (c, next) => {
  const foo = c.req.param('foo')
  console.log(foo)
  await next()
})

app.get('/hello/world', (c) => {
  const foo = c.req.param('foo')
  return c.text('res')
})
```

This is a bug of TrieRouter. Already been fixed in this PR.  This bug is reported by this tweet: https://twitter.com/_ayame113_/status/1600467184853319680 Thanks!