### PR TITLE
`cookie` should return `string | undefined`

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -33,7 +33,7 @@ declare global {
       (): Record<string, string>
     }
     cookie: {
-      (name: string): string
+      (name: string): string | undefined
       (): Cookie
     }
     bodyData?: BodyData

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1085,8 +1085,10 @@ describe('Cookie', () => {
         const yummyCookie = c.req.cookie('yummy_cookie')
         const tastyCookie = c.req.cookie('tasty_cookie')
         const res = new Response('Good cookie')
-        res.headers.set('Yummy-Cookie', yummyCookie)
-        res.headers.set('Tasty-Cookie', tastyCookie)
+        if (yummyCookie && tastyCookie) {
+          res.headers.set('Yummy-Cookie', yummyCookie)
+          res.headers.set('Tasty-Cookie', tastyCookie)
+        }
         return res
       })
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -33,7 +33,7 @@ declare global {
       (): Record<string, string>
     }
     cookie: {
-      (name: string): string
+      (name: string): string | undefined
       (): Cookie
     }
     bodyData?: BodyData


### PR DESCRIPTION
if a cookie with a name isn't present, `cookie` function returns undefined although this isn't reflected at the type level.