### PR TITLE
fix(type): infer types correctly

### DIFF
--- a/deno_dist/validator/schema.ts
+++ b/deno_dist/validator/schema.ts
@@ -23,32 +23,36 @@ export type Schema = {
     | VArray<Schema>
 }
 
-export type SchemaToProp<T> = {
-  [K in keyof T]: T[K] extends VNumberArray
-    ? number[]
-    : T[K] extends VBooleanArray
-    ? boolean[]
-    : T[K] extends VStringArray
-    ? string[]
-    : T[K] extends VNumber
-    ? number
-    : T[K] extends VBoolean
-    ? boolean
-    : T[K] extends VString
-    ? string
-    : T[K] extends VObjectBase<Schema>
-    ? T[K]['container'] extends VNumber
-      ? number
-      : T[K]['container'] extends VString
-      ? string
-      : T[K]['container'] extends VBoolean
-      ? boolean
-      : T[K] extends VArray<Schema>
-      ? SchemaToProp<ReadonlyArray<T[K]['container']>>
-      : T[K] extends VObject<Schema>
-      ? SchemaToProp<T[K]['container']>
-      : T[K] extends Schema
-      ? SchemaToProp<T[K]>
-      : never
-    : SchemaToProp<T[K]>
-}
+export type SchemaToProp<T> = T extends VArray<infer R>
+  ? SchemaToProp<R>[]
+  : T extends VObject<infer R>
+  ? SchemaToProp<R>
+  : {
+      [K in keyof T]: T[K] extends VNumberArray
+        ? number[]
+        : T[K] extends VBooleanArray
+        ? boolean[]
+        : T[K] extends VStringArray
+        ? string[]
+        : T[K] extends VString
+        ? string
+        : T[K] extends VNumber
+        ? number
+        : T[K] extends VBoolean
+        ? boolean
+        : T[K] extends VObjectBase<Schema>
+        ? T[K]['container'] extends VNumber
+          ? number
+          : T[K]['container'] extends VString
+          ? string
+          : T[K]['container'] extends VBoolean
+          ? boolean
+          : T[K] extends VArray<infer R>
+          ? SchemaToProp<R>[]
+          : T[K] extends VObject<infer R>
+          ? SchemaToProp<R>
+          : T[K] extends Schema
+          ? SchemaToProp<T[K]>
+          : never
+        : SchemaToProp<T[K]>
+    }

--- a/src/validator/schema.test.ts
+++ b/src/validator/schema.test.ts
@@ -1,0 +1,41 @@
+import type { Expect, Equal } from '../utils/types'
+import type { SchemaToProp } from './schema'
+import type { Validator } from './validator'
+
+describe('SchemaToProp', () => {
+  const schema = (v: Validator) => ({
+    post: {
+      id: v.json('id').asNumber(),
+      title: v.json('title'),
+      tags: v.array('tags', (v) => ({
+        name: v.json('name'),
+      })),
+      meta: v.object('meta', (v) => ({
+        currentPage: v.json('currentPage').asNumber(),
+      })),
+    },
+  })
+
+  it('Should return correct types', () => {
+    const data = {
+      post: {
+        id: 1,
+        title: 'Hello',
+        tags: [
+          {
+            name: 'Daily',
+          },
+        ],
+        meta: {
+          currentPage: 1,
+        },
+      },
+    }
+
+    type T = SchemaToProp<ReturnType<typeof schema>>
+    type Data = typeof data
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type verify = Expect<Equal<T, Data>>
+    expect(true).toBe(true) // Fake
+  })
+})

--- a/src/validator/schema.ts
+++ b/src/validator/schema.ts
@@ -23,32 +23,36 @@ export type Schema = {
     | VArray<Schema>
 }
 
-export type SchemaToProp<T> = {
-  [K in keyof T]: T[K] extends VNumberArray
-    ? number[]
-    : T[K] extends VBooleanArray
-    ? boolean[]
-    : T[K] extends VStringArray
-    ? string[]
-    : T[K] extends VNumber
-    ? number
-    : T[K] extends VBoolean
-    ? boolean
-    : T[K] extends VString
-    ? string
-    : T[K] extends VObjectBase<Schema>
-    ? T[K]['container'] extends VNumber
-      ? number
-      : T[K]['container'] extends VString
-      ? string
-      : T[K]['container'] extends VBoolean
-      ? boolean
-      : T[K] extends VArray<Schema>
-      ? SchemaToProp<ReadonlyArray<T[K]['container']>>
-      : T[K] extends VObject<Schema>
-      ? SchemaToProp<T[K]['container']>
-      : T[K] extends Schema
-      ? SchemaToProp<T[K]>
-      : never
-    : SchemaToProp<T[K]>
-}
+export type SchemaToProp<T> = T extends VArray<infer R>
+  ? SchemaToProp<R>[]
+  : T extends VObject<infer R>
+  ? SchemaToProp<R>
+  : {
+      [K in keyof T]: T[K] extends VNumberArray
+        ? number[]
+        : T[K] extends VBooleanArray
+        ? boolean[]
+        : T[K] extends VStringArray
+        ? string[]
+        : T[K] extends VString
+        ? string
+        : T[K] extends VNumber
+        ? number
+        : T[K] extends VBoolean
+        ? boolean
+        : T[K] extends VObjectBase<Schema>
+        ? T[K]['container'] extends VNumber
+          ? number
+          : T[K]['container'] extends VString
+          ? string
+          : T[K]['container'] extends VBoolean
+          ? boolean
+          : T[K] extends VArray<infer R>
+          ? SchemaToProp<R>[]
+          : T[K] extends VObject<infer R>
+          ? SchemaToProp<R>
+          : T[K] extends Schema
+          ? SchemaToProp<T[K]>
+          : never
+        : SchemaToProp<T[K]>
+    }


### PR DESCRIPTION
This PR will make`SchemaToProps` return types correctly. We can get "normal types" from `c.req.valid()`. I think this is a good change.

Before:
<img width="442" alt="SS" src="https://user-images.githubusercontent.com/10682/206883003-4d0ab291-6a8d-41ff-996e-897f83624c74.png">

After:
<img width="424" alt="SS" src="https://user-images.githubusercontent.com/10682/206883008-d7907f8c-c498-438a-a9fb-94955b2b1ebe.png">
