### PR TITLE
fix(request): `c.req.param()` should return `undefined` not "undefined"

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -57,12 +57,15 @@ export function extendRequestPrototype() {
   Request.prototype.param = function (this: Request, key?: string) {
     if (this.paramData) {
       if (key) {
-        return decodeURIComponent(this.paramData[key])
+        const param = this.paramData[key]
+        return param ? decodeURIComponent(param) : undefined
       } else {
         const decoded: Record<string, string> = {}
 
         for (const [key, value] of Object.entries(this.paramData)) {
-          decoded[key] = decodeURIComponent(value)
+          if (value) {
+            decoded[key] = decodeURIComponent(value)
+          }
         }
 
         return decoded

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -373,6 +373,21 @@ describe('param and query', () => {
       expect(await res.text()).toBe('foo is Bar')
     })
   })
+
+  describe('param with undefined', () => {
+    const app = new Hono()
+    app.get('/foo/:foo', (c) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      /* @ts-ignore */
+      const bar = c.req.param('bar')
+      return c.json({ foo: bar })
+    })
+    it('param of /foo/foo should return undefined not "undefined"', async () => {
+      const res = await app.request('http://localhost/foo/foo')
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ foo: undefined })
+    })
+  })
 })
 
 describe('Middleware', () => {
@@ -1246,7 +1261,7 @@ describe('Both two middleware returning response', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('Bar')
-    expect(res.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
   })
 })
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -57,12 +57,15 @@ export function extendRequestPrototype() {
   Request.prototype.param = function (this: Request, key?: string) {
     if (this.paramData) {
       if (key) {
-        return decodeURIComponent(this.paramData[key])
+        const param = this.paramData[key]
+        return param ? decodeURIComponent(param) : undefined
       } else {
         const decoded: Record<string, string> = {}
 
         for (const [key, value] of Object.entries(this.paramData)) {
-          decoded[key] = decodeURIComponent(value)
+          if (value) {
+            decoded[key] = decodeURIComponent(value)
+          }
         }
 
         return decoded


### PR DESCRIPTION
`c.req.param('missing-parameter')` was returning "undefined". It was a string!! not `undefined`.  Of course, it should not return a string, should return `undefined`.

This was taught to me by noil on Discord. Thanks.