### PR TITLE
perf(context): `c.text()` returns a response immediately if header is empty

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -163,7 +163,14 @@ export class Context<
     return this.newResponse(data, status, headers)
   }
 
-  text(text: string, status: StatusCode = this._status, headers: Headers = {}): Response {
+  text(text: string, status?: StatusCode, headers?: Headers): Response {
+    // If the header is empty, return Response immediately.
+    // Content-Type will be added automatically as `text/plain`.
+    if (!headers && !status && !this._res && !this._headers) {
+      return new Response(text)
+    }
+    status ||= this._status
+    headers ||= {}
     headers['content-type'] = 'text/plain; charset=UTF-8'
     return this.newResponse(text, status, headers)
   }

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -12,7 +12,7 @@ describe('Context', () => {
   it('c.text()', async () => {
     const res = c.text('text in c', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)
-    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=UTF-8')
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
     expect(await res.text()).toBe('text in c')
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
@@ -182,6 +182,6 @@ describe('Context header', () => {
   it('Should rewrite header values correctly', async () => {
     c.res = c.html('foo')
     const res = c.text('foo')
-    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=UTF-8')
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
   })
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -163,7 +163,14 @@ export class Context<
     return this.newResponse(data, status, headers)
   }
 
-  text(text: string, status: StatusCode = this._status, headers: Headers = {}): Response {
+  text(text: string, status?: StatusCode, headers?: Headers): Response {
+    // If the header is empty, return Response immediately.
+    // Content-Type will be added automatically as `text/plain`.
+    if (!headers && !status && !this._res && !this._headers) {
+      return new Response(text)
+    }
+    status ||= this._status
+    headers ||= {}
     headers['content-type'] = 'text/plain; charset=UTF-8'
     return this.newResponse(text, status, headers)
   }


### PR DESCRIPTION
`c.text()` returns `Response` immediately if headers are empty.

It does not set `Content-Type` intentionally, but `text/plain` is added automatically, so it is not a breaking change. This is mainly for benchmarking, but benchmarking is important.

`GET /` will become 13% faster on Bun!

<img width="SS" alt="SS" src="https://user-images.githubusercontent.com/10682/207391017-a64a0f91-d480-424a-b6c2-d3a1acdc501c.png">
