### PR TITLE
feat: introduce HonoRequest with "wrapper pattern"

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -37,11 +37,11 @@ export class Context<
   private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
   private _paramData: Record<string, string> | undefined
-  private originalRequest: Request
+  private rawRequest: Request
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
   constructor(req: Request, options?: ContextOptions<E>) {
-    this.originalRequest = req
+    this.rawRequest = req
     if (options) {
       this._executionCtx = options.executionCtx
       this._paramData = options.paramData
@@ -57,7 +57,7 @@ export class Context<
       return this._req
     } else {
       this._req = new HonoRequest<P, S extends Schema ? SchemaToProp<S> : S>(
-        this.originalRequest,
+        this.rawRequest,
         this._paramData
       )
       return this._req

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,3 +1,4 @@
+import { HonoRequest } from './request.ts'
 import type { ExecutionContext } from './types.ts'
 import type { Environment, NotFoundHandler, ContextVariableMap } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
@@ -10,17 +11,24 @@ type Headers = Record<string, string | string[]>
 type Runtime = 'node' | 'deno' | 'bun' | 'cloudflare' | 'fastly' | 'vercel' | 'other'
 export type Data = string | ArrayBuffer | ReadableStream
 
+type ContextOptions<E extends Partial<Environment>> = {
+  env?: E['Bindings']
+  executionCtx?: FetchEvent | ExecutionContext | undefined
+  notFoundHandler?: NotFoundHandler<E>
+  paramData?: Record<string, string>
+}
+
 export class Context<
   P extends string = string,
   E extends Partial<Environment> = Environment,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   S = any
 > {
-  req: Request<unknown, P, S extends Schema ? SchemaToProp<S> : S>
-  env: E['Bindings']
-  finalized: boolean
+  env: E['Bindings'] = {}
+  finalized: boolean = false
   error: Error | undefined = undefined
 
+  private _req?: HonoRequest<P, S extends Schema ? SchemaToProp<S> : S>
   private _status: StatusCode = 200
   private _executionCtx: FetchEvent | ExecutionContext | undefined
   private _pretty: boolean = false
@@ -28,20 +36,32 @@ export class Context<
   private _map: Record<string, unknown> | undefined
   private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
-  private notFoundHandler: NotFoundHandler<E>
+  private _paramData: Record<string, string> | undefined
+  private originalRequest: Request
+  private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
-  constructor(
-    req: Request<unknown, P>,
-    env: E['Bindings'] = {},
-    executionCtx: FetchEvent | ExecutionContext | undefined = undefined,
-    notFoundHandler: NotFoundHandler<E> = () => new Response()
-  ) {
-    this._executionCtx = executionCtx
-    this.req = req as Request<unknown, P>
-    this.env = env
+  constructor(req: Request, options?: ContextOptions<E>) {
+    this.originalRequest = req
+    if (options) {
+      this._executionCtx = options.executionCtx
+      this._paramData = options.paramData
+      this.env = options.env
+      if (options.notFoundHandler) {
+        this.notFoundHandler = options.notFoundHandler
+      }
+    }
+  }
 
-    this.notFoundHandler = notFoundHandler
-    this.finalized = false
+  get req(): HonoRequest<P, S extends Schema ? SchemaToProp<S> : S> {
+    if (this._req) {
+      return this._req
+    } else {
+      this._req = new HonoRequest<P, S extends Schema ? SchemaToProp<S> : S>(
+        this.originalRequest,
+        this._paramData
+      )
+      return this._req
+    }
   }
 
   get event(): FetchEvent {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -1,6 +1,5 @@
 import { compose } from './compose.ts'
 import { Context } from './context.ts'
-import { extendRequestPrototype } from './request.ts'
 import type { Router } from './router.ts'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE, METHODS } from './router.ts'
 import { RegExpRouter } from './router/reg-exp-router/index.ts'
@@ -77,8 +76,6 @@ export class Hono<
 
   constructor(init: Partial<Pick<Hono, 'router' | 'strict'>> = {}) {
     super()
-
-    extendRequestPrototype()
 
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
@@ -203,9 +200,14 @@ export class Hono<
     const method = request.method
 
     const result = this.matchRoute(method, path)
-    request.paramData = result?.params
+    const paramData = result?.params
 
-    const c = new Context<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
+    const c = new Context<string, E>(request, {
+      env,
+      executionCtx: eventOrExecutionCtx,
+      notFoundHandler: this.notFoundHandler,
+      paramData,
+    })
 
     // Do not `compose` if it has only one handler
     if (result && result.handlers.length === 1) {

--- a/deno_dist/middleware/basic-auth/index.ts
+++ b/deno_dist/middleware/basic-auth/index.ts
@@ -1,3 +1,4 @@
+import type { HonoRequest } from '../../request.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 import { timingSafeEqual } from '../../utils/buffer.ts'
 import { decodeBase64 } from '../../utils/encode.ts'
@@ -5,7 +6,7 @@ import { decodeBase64 } from '../../utils/encode.ts'
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/
 
-const auth = (req: Request) => {
+const auth = (req: HonoRequest) => {
   const match = CREDENTIALS_REGEXP.exec(req.headers.get('Authorization') || '')
   if (!match) {
     return undefined

--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -14,7 +14,7 @@ export const cache = (options: {
   }
 
   return async (c, next) => {
-    const key = c.req.original
+    const key = c.req.raw
     const cache = await caches.open(options.cacheName)
     const response = await cache.match(key)
     if (!response) {

--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -14,7 +14,7 @@ export const cache = (options: {
   }
 
   return async (c, next) => {
-    const key = c.req
+    const key = c.req.original
     const cache = await caches.open(options.cacheName)
     const response = await cache.match(key)
     if (!response) {

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -9,7 +9,7 @@ export class HonoRequest<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Data = any
 > {
-  original: Request
+  raw: Request
 
   private paramData: Record<string, string> | undefined
   private headerData: Record<string, string> | undefined
@@ -20,7 +20,7 @@ export class HonoRequest<
   private data: Data | undefined
 
   constructor(request: Request, paramData?: Record<string, string> | undefined) {
-    this.original = request
+    this.raw = request
     this.paramData = paramData
   }
 
@@ -85,7 +85,7 @@ export class HonoRequest<
   header(name?: string) {
     if (!this.headerData) {
       this.headerData = {}
-      this.original.headers.forEach((value, key) => {
+      this.raw.headers.forEach((value, key) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.headerData![key] = value
       })
@@ -100,7 +100,7 @@ export class HonoRequest<
   cookie(key: string): string | undefined
   cookie(): Cookie
   cookie(key?: string) {
-    const cookie = this.original.headers.get('Cookie')
+    const cookie = this.raw.headers.get('Cookie')
     if (!cookie) return
     const obj = parse(cookie)
     if (key) {
@@ -115,7 +115,7 @@ export class HonoRequest<
     // Cache the parsed body
     let body: BodyType
     if (!this.bodyData) {
-      body = await parseBody<BodyType>(this.original)
+      body = await parseBody<BodyType>(this.raw)
       this.bodyData = body
     } else {
       body = this.bodyData as BodyType
@@ -127,7 +127,7 @@ export class HonoRequest<
     // Cache the JSON body
     let jsonData: Promise<Partial<JSONData>>
     if (!this.jsonData) {
-      jsonData = this.original.json()
+      jsonData = this.raw.json()
       this.jsonData = jsonData
     } else {
       jsonData = this.jsonData
@@ -136,19 +136,19 @@ export class HonoRequest<
   }
 
   async text() {
-    return this.original.text()
+    return this.raw.text()
   }
 
   async arrayBuffer() {
-    return this.original.arrayBuffer()
+    return this.raw.arrayBuffer()
   }
 
   async blob() {
-    return this.original.blob()
+    return this.raw.blob()
   }
 
   async formData() {
-    return this.original.formData()
+    return this.raw.formData()
   }
 
   valid(data?: unknown) {
@@ -162,45 +162,45 @@ export class HonoRequest<
   }
 
   get url() {
-    return this.original.url
+    return this.raw.url
   }
   get method() {
-    return this.original.method
+    return this.raw.method
   }
   get headers() {
-    return this.original.headers
+    return this.raw.headers
   }
   get redirect() {
-    return this.original.redirect
+    return this.raw.redirect
   }
   get body() {
-    return this.original.body
+    return this.raw.body
   }
   get bodyUsed() {
-    return this.original.bodyUsed
+    return this.raw.bodyUsed
   }
   get cache() {
-    return this.original.cache
+    return this.raw.cache
   }
   get credentials() {
-    return this.original.credentials
+    return this.raw.credentials
   }
   get integrity() {
-    return this.original.integrity
+    return this.raw.integrity
   }
   get keepalive() {
-    return this.original.keepalive
+    return this.raw.keepalive
   }
   get mode() {
-    return this.original.mode
+    return this.raw.mode
   }
   get referrer() {
-    return this.original.referrer
+    return this.raw.referrer
   }
   get refererPolicy() {
-    return this.original.referrerPolicy
+    return this.raw.referrerPolicy
   }
   get signal() {
-    return this.original.signal
+    return this.raw.signal
   }
 }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -15,7 +15,8 @@ export class HonoRequest<
   private headerData: Record<string, string> | undefined
   private queryData: Record<string, string> | undefined
   private bodyData: BodyData | undefined
-  private jsonData: any | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private jsonData: Promise<any> | undefined
   private data: Data | undefined
 
   constructor(request: Request, paramData?: Record<string, string> | undefined) {
@@ -124,9 +125,9 @@ export class HonoRequest<
 
   async json<JSONData = unknown>() {
     // Cache the JSON body
-    let jsonData: Partial<JSONData>
+    let jsonData: Promise<Partial<JSONData>>
     if (!this.jsonData) {
-      jsonData = JSON.parse(await this.original.text())
+      jsonData = this.original.json()
       this.jsonData = jsonData
     } else {
       jsonData = this.jsonData
@@ -135,19 +136,19 @@ export class HonoRequest<
   }
 
   async text() {
-    return await this.original.text()
+    return this.original.text()
   }
 
   async arrayBuffer() {
-    return await this.original.arrayBuffer()
+    return this.original.arrayBuffer()
   }
 
   async blob() {
-    return await this.original.blob()
+    return this.original.blob()
   }
 
   async formData() {
-    return await this.original.formData()
+    return this.original.formData()
   }
 
   valid(data?: unknown) {

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -4,57 +4,28 @@ import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 import { getQueryStringFromURL } from './utils/url.ts'
 
-declare global {
-  interface Request<
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    CfHostMetadata = unknown,
-    ParamKeyType extends string = string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Data = any
-  > {
-    paramData?: Record<ParamKeyType, string>
-    param: {
-      (key: ParamKeyType): string
-      (): Record<ParamKeyType, string>
-    }
-    queryData?: Record<string, string>
-    query: {
-      (key: string): string
-      (): Record<string, string>
-    }
-    queries: {
-      (key: string): string[]
-      (): Record<string, string[]>
-    }
-    headerData?: Record<string, string>
-    header: {
-      (name: string): string
-      (): Record<string, string>
-    }
-    cookie: {
-      (name: string): string | undefined
-      (): Cookie
-    }
-    bodyData?: BodyData
-    parseBody<BodyType extends BodyData>(): Promise<BodyType>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    jsonData?: any
-    json<T>(): Promise<T>
-    data: Data
-    valid: {
-      (data: Data): Data
-      (): Data
-    }
-  }
-}
+export class HonoRequest<
+  ParamKey extends string = string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Data = any
+> {
+  original: Request
 
-export function extendRequestPrototype() {
-  if (!!Request.prototype.param as boolean) {
-    // already extended
-    return
+  private paramData: Record<string, string> | undefined
+  private headerData: Record<string, string> | undefined
+  private queryData: Record<string, string> | undefined
+  private bodyData: BodyData | undefined
+  private jsonData: any | undefined
+  private data: Data | undefined
+
+  constructor(request: Request, paramData?: Record<string, string> | undefined) {
+    this.original = request
+    this.paramData = paramData
   }
 
-  Request.prototype.param = function (this: Request, key?: string) {
+  param(key: ParamKey): string
+  param(): Record<ParamKey, string>
+  param(key?: string) {
     if (this.paramData) {
       if (key) {
         const param = this.paramData[key]
@@ -63,7 +34,7 @@ export function extendRequestPrototype() {
         const decoded: Record<string, string> = {}
 
         for (const [key, value] of Object.entries(this.paramData)) {
-          if (value) {
+          if (value && typeof value === 'string') {
             decoded[key] = decodeURIComponent(value)
           }
         }
@@ -72,24 +43,11 @@ export function extendRequestPrototype() {
       }
     }
     return null
-  } as InstanceType<typeof Request>['param']
+  }
 
-  Request.prototype.header = function (this: Request, name?: string) {
-    if (!this.headerData) {
-      this.headerData = {}
-      this.headers.forEach((value, key) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.headerData![key] = value
-      })
-    }
-    if (name) {
-      return this.headerData[name.toLowerCase()]
-    } else {
-      return this.headerData
-    }
-  } as InstanceType<typeof Request>['header']
-
-  Request.prototype.query = function (this: Request, key?: string) {
+  query(key: string): string
+  query(): Record<string, string>
+  query(key?: string) {
     const queryString = getQueryStringFromURL(this.url)
     const searchParams = new URLSearchParams(queryString)
     if (!this.queryData) {
@@ -103,9 +61,11 @@ export function extendRequestPrototype() {
     } else {
       return this.queryData
     }
-  } as InstanceType<typeof Request>['query']
+  }
 
-  Request.prototype.queries = function (this: Request, key?: string) {
+  queries(key: string): string[]
+  queries(): Record<string, string[]>
+  queries(key?: string) {
     const queryString = getQueryStringFromURL(this.url)
     const searchParams = new URLSearchParams(queryString)
     if (key) {
@@ -117,10 +77,30 @@ export function extendRequestPrototype() {
       }
       return result
     }
-  } as InstanceType<typeof Request>['queries']
+  }
 
-  Request.prototype.cookie = function (this: Request, key?: string) {
-    const cookie = this.headers.get('Cookie') || ''
+  header(name: string): string
+  header(): Record<string, string>
+  header(name?: string) {
+    if (!this.headerData) {
+      this.headerData = {}
+      this.original.headers.forEach((value, key) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.headerData![key] = value
+      })
+    }
+    if (name) {
+      return this.headerData[name.toLowerCase()]
+    } else {
+      return this.headerData
+    }
+  }
+
+  cookie(key: string): string | undefined
+  cookie(): Cookie
+  cookie(key?: string) {
+    const cookie = this.original.headers.get('Cookie')
+    if (!cookie) return
     const obj = parse(cookie)
     if (key) {
       const value = obj[key]
@@ -128,41 +108,98 @@ export function extendRequestPrototype() {
     } else {
       return obj
     }
-  } as InstanceType<typeof Request>['cookie']
+  }
 
-  Request.prototype.parseBody = async function <BodyType extends BodyData>(
-    this: Request
-  ): Promise<BodyType> {
+  async parseBody<BodyType extends BodyData>(): Promise<BodyType> {
     // Cache the parsed body
     let body: BodyType
     if (!this.bodyData) {
-      body = await parseBody<BodyType>(this)
+      body = await parseBody<BodyType>(this.original)
       this.bodyData = body
     } else {
       body = this.bodyData as BodyType
     }
     return body
-  } as InstanceType<typeof Request>['parseBody']
+  }
 
-  Request.prototype.json = async function <JSONData = unknown>(this: Request) {
+  async json<JSONData = unknown>() {
     // Cache the JSON body
     let jsonData: Partial<JSONData>
     if (!this.jsonData) {
-      jsonData = JSON.parse(await this.text())
+      jsonData = JSON.parse(await this.original.text())
       this.jsonData = jsonData
     } else {
       jsonData = this.jsonData
     }
     return jsonData
-  } as InstanceType<typeof Request>['jsonData']
+  }
 
-  Request.prototype.valid = function (this: Request, data?: unknown) {
+  async text() {
+    return await this.original.text()
+  }
+
+  async arrayBuffer() {
+    return await this.original.arrayBuffer()
+  }
+
+  async blob() {
+    return await this.original.blob()
+  }
+
+  async formData() {
+    return await this.original.formData()
+  }
+
+  valid(data?: unknown) {
     if (!this.data) {
-      this.data = {}
+      this.data = {} as Data
     }
     if (data) {
-      this.data = data
+      this.data = data as Data
     }
     return this.data
-  } as InstanceType<typeof Request>['valid']
+  }
+
+  get url() {
+    return this.original.url
+  }
+  get method() {
+    return this.original.method
+  }
+  get headers() {
+    return this.original.headers
+  }
+  get redirect() {
+    return this.original.redirect
+  }
+  get body() {
+    return this.original.body
+  }
+  get bodyUsed() {
+    return this.original.bodyUsed
+  }
+  get cache() {
+    return this.original.cache
+  }
+  get credentials() {
+    return this.original.credentials
+  }
+  get integrity() {
+    return this.original.integrity
+  }
+  get keepalive() {
+    return this.original.keepalive
+  }
+  get mode() {
+    return this.original.mode
+  }
+  get referrer() {
+    return this.original.referrer
+  }
+  get refererPolicy() {
+    return this.original.referrerPolicy
+  }
+  get signal() {
+    return this.original.signal
+  }
 }

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.167.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.168.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -1,3 +1,4 @@
+import type { HonoRequest } from '../request.ts'
 import { JSONPathCopy } from './../utils/json.ts'
 import type { JSONObject, JSONPrimitive, JSONArray } from './../utils/json.ts'
 import { rule } from './rule.ts'
@@ -201,7 +202,7 @@ export abstract class VBase {
     return this
   }
 
-  validate = async <R extends Request>(req: R): Promise<ValidateResult[]> => {
+  validate = async <R extends HonoRequest>(req: R): Promise<ValidateResult[]> => {
     let value: Type = undefined
     let jsonData: JSONObject | undefined = undefined
 

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -1,8 +1,5 @@
 import { compose } from './compose'
 import { Context } from './context'
-import { extendRequestPrototype } from './request'
-
-extendRequestPrototype()
 
 type C = {
   req: Record<string, string>

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -137,7 +137,9 @@ describe('Context', () => {
     const req = new Request('http://localhost/')
     const key = 'a-secret-key'
     const ctx = new Context(req, {
-      API_KEY: key,
+      env: {
+        API_KEY: key,
+      },
     })
     expect(ctx.env.API_KEY).toBe(key)
   })

--- a/src/context.ts
+++ b/src/context.ts
@@ -37,11 +37,11 @@ export class Context<
   private _headers: Record<string, string[]> | undefined
   private _res: Response | undefined
   private _paramData: Record<string, string> | undefined
-  private originalRequest: Request
+  private rawRequest: Request
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
   constructor(req: Request, options?: ContextOptions<E>) {
-    this.originalRequest = req
+    this.rawRequest = req
     if (options) {
       this._executionCtx = options.executionCtx
       this._paramData = options.paramData
@@ -57,7 +57,7 @@ export class Context<
       return this._req
     } else {
       this._req = new HonoRequest<P, S extends Schema ? SchemaToProp<S> : S>(
-        this.originalRequest,
+        this.rawRequest,
         this._paramData
       )
       return this._req

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1209,8 +1209,6 @@ describe('Parse Body', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    const body = await req.parseBody()
-    expect(body).toEqual({})
   })
 
   it('POST with `multipart/form-data`', async () => {
@@ -1224,7 +1222,6 @@ describe('Parse Body', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(await req.parseBody()).toEqual({ message: 'hello' })
     expect(await res.json()).toEqual({ message: 'hello' })
   })
 
@@ -1242,7 +1239,6 @@ describe('Parse Body', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(await req.parseBody()).toEqual({ message: 'hello' })
     expect(await res.json()).toEqual({ message: 'hello' })
   })
 })

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,6 +1,5 @@
 import { compose } from './compose'
 import { Context } from './context'
-import { extendRequestPrototype } from './request'
 import type { Router } from './router'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE, METHODS } from './router'
 import { RegExpRouter } from './router/reg-exp-router'
@@ -77,8 +76,6 @@ export class Hono<
 
   constructor(init: Partial<Pick<Hono, 'router' | 'strict'>> = {}) {
     super()
-
-    extendRequestPrototype()
 
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
@@ -203,9 +200,14 @@ export class Hono<
     const method = request.method
 
     const result = this.matchRoute(method, path)
-    request.paramData = result?.params
+    const paramData = result?.params
 
-    const c = new Context<string, E>(request, env, eventOrExecutionCtx, this.notFoundHandler)
+    const c = new Context<string, E>(request, {
+      env,
+      executionCtx: eventOrExecutionCtx,
+      notFoundHandler: this.notFoundHandler,
+      paramData,
+    })
 
     // Do not `compose` if it has only one handler
     if (result && result.handlers.length === 1) {

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -1,3 +1,4 @@
+import type { HonoRequest } from '../../request'
 import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
 import { decodeBase64 } from '../../utils/encode'
@@ -5,7 +6,7 @@ import { decodeBase64 } from '../../utils/encode'
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/
 
-const auth = (req: Request) => {
+const auth = (req: HonoRequest) => {
   const match = CREDENTIALS_REGEXP.exec(req.headers.get('Authorization') || '')
   if (!match) {
     return undefined

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -14,7 +14,7 @@ export const cache = (options: {
   }
 
   return async (c, next) => {
-    const key = c.req.original
+    const key = c.req.raw
     const cache = await caches.open(options.cacheName)
     const response = await cache.match(key)
     if (!response) {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -14,7 +14,7 @@ export const cache = (options: {
   }
 
   return async (c, next) => {
-    const key = c.req
+    const key = c.req.original
     const cache = await caches.open(options.cacheName)
     const response = await cache.match(key)
     if (!response) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,7 +9,7 @@ export class HonoRequest<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Data = any
 > {
-  original: Request
+  raw: Request
 
   private paramData: Record<string, string> | undefined
   private headerData: Record<string, string> | undefined
@@ -20,7 +20,7 @@ export class HonoRequest<
   private data: Data | undefined
 
   constructor(request: Request, paramData?: Record<string, string> | undefined) {
-    this.original = request
+    this.raw = request
     this.paramData = paramData
   }
 
@@ -85,7 +85,7 @@ export class HonoRequest<
   header(name?: string) {
     if (!this.headerData) {
       this.headerData = {}
-      this.original.headers.forEach((value, key) => {
+      this.raw.headers.forEach((value, key) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.headerData![key] = value
       })
@@ -100,7 +100,7 @@ export class HonoRequest<
   cookie(key: string): string | undefined
   cookie(): Cookie
   cookie(key?: string) {
-    const cookie = this.original.headers.get('Cookie')
+    const cookie = this.raw.headers.get('Cookie')
     if (!cookie) return
     const obj = parse(cookie)
     if (key) {
@@ -115,7 +115,7 @@ export class HonoRequest<
     // Cache the parsed body
     let body: BodyType
     if (!this.bodyData) {
-      body = await parseBody<BodyType>(this.original)
+      body = await parseBody<BodyType>(this.raw)
       this.bodyData = body
     } else {
       body = this.bodyData as BodyType
@@ -127,7 +127,7 @@ export class HonoRequest<
     // Cache the JSON body
     let jsonData: Promise<Partial<JSONData>>
     if (!this.jsonData) {
-      jsonData = this.original.json()
+      jsonData = this.raw.json()
       this.jsonData = jsonData
     } else {
       jsonData = this.jsonData
@@ -136,19 +136,19 @@ export class HonoRequest<
   }
 
   async text() {
-    return this.original.text()
+    return this.raw.text()
   }
 
   async arrayBuffer() {
-    return this.original.arrayBuffer()
+    return this.raw.arrayBuffer()
   }
 
   async blob() {
-    return this.original.blob()
+    return this.raw.blob()
   }
 
   async formData() {
-    return this.original.formData()
+    return this.raw.formData()
   }
 
   valid(data?: unknown) {
@@ -162,45 +162,45 @@ export class HonoRequest<
   }
 
   get url() {
-    return this.original.url
+    return this.raw.url
   }
   get method() {
-    return this.original.method
+    return this.raw.method
   }
   get headers() {
-    return this.original.headers
+    return this.raw.headers
   }
   get redirect() {
-    return this.original.redirect
+    return this.raw.redirect
   }
   get body() {
-    return this.original.body
+    return this.raw.body
   }
   get bodyUsed() {
-    return this.original.bodyUsed
+    return this.raw.bodyUsed
   }
   get cache() {
-    return this.original.cache
+    return this.raw.cache
   }
   get credentials() {
-    return this.original.credentials
+    return this.raw.credentials
   }
   get integrity() {
-    return this.original.integrity
+    return this.raw.integrity
   }
   get keepalive() {
-    return this.original.keepalive
+    return this.raw.keepalive
   }
   get mode() {
-    return this.original.mode
+    return this.raw.mode
   }
   get referrer() {
-    return this.original.referrer
+    return this.raw.referrer
   }
   get refererPolicy() {
-    return this.original.referrerPolicy
+    return this.raw.referrerPolicy
   }
   get signal() {
-    return this.original.signal
+    return this.raw.signal
   }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,57 +4,28 @@ import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
 import { getQueryStringFromURL } from './utils/url'
 
-declare global {
-  interface Request<
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    CfHostMetadata = unknown,
-    ParamKeyType extends string = string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Data = any
-  > {
-    paramData?: Record<ParamKeyType, string>
-    param: {
-      (key: ParamKeyType): string
-      (): Record<ParamKeyType, string>
-    }
-    queryData?: Record<string, string>
-    query: {
-      (key: string): string
-      (): Record<string, string>
-    }
-    queries: {
-      (key: string): string[]
-      (): Record<string, string[]>
-    }
-    headerData?: Record<string, string>
-    header: {
-      (name: string): string
-      (): Record<string, string>
-    }
-    cookie: {
-      (name: string): string | undefined
-      (): Cookie
-    }
-    bodyData?: BodyData
-    parseBody<BodyType extends BodyData>(): Promise<BodyType>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    jsonData?: any
-    json<T>(): Promise<T>
-    data: Data
-    valid: {
-      (data: Data): Data
-      (): Data
-    }
-  }
-}
+export class HonoRequest<
+  ParamKey extends string = string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Data = any
+> {
+  original: Request
 
-export function extendRequestPrototype() {
-  if (!!Request.prototype.param as boolean) {
-    // already extended
-    return
+  private paramData: Record<string, string> | undefined
+  private headerData: Record<string, string> | undefined
+  private queryData: Record<string, string> | undefined
+  private bodyData: BodyData | undefined
+  private jsonData: any | undefined
+  private data: Data | undefined
+
+  constructor(request: Request, paramData?: Record<string, string> | undefined) {
+    this.original = request
+    this.paramData = paramData
   }
 
-  Request.prototype.param = function (this: Request, key?: string) {
+  param(key: ParamKey): string
+  param(): Record<ParamKey, string>
+  param(key?: string) {
     if (this.paramData) {
       if (key) {
         const param = this.paramData[key]
@@ -63,7 +34,7 @@ export function extendRequestPrototype() {
         const decoded: Record<string, string> = {}
 
         for (const [key, value] of Object.entries(this.paramData)) {
-          if (value) {
+          if (value && typeof value === 'string') {
             decoded[key] = decodeURIComponent(value)
           }
         }
@@ -72,24 +43,11 @@ export function extendRequestPrototype() {
       }
     }
     return null
-  } as InstanceType<typeof Request>['param']
+  }
 
-  Request.prototype.header = function (this: Request, name?: string) {
-    if (!this.headerData) {
-      this.headerData = {}
-      this.headers.forEach((value, key) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.headerData![key] = value
-      })
-    }
-    if (name) {
-      return this.headerData[name.toLowerCase()]
-    } else {
-      return this.headerData
-    }
-  } as InstanceType<typeof Request>['header']
-
-  Request.prototype.query = function (this: Request, key?: string) {
+  query(key: string): string
+  query(): Record<string, string>
+  query(key?: string) {
     const queryString = getQueryStringFromURL(this.url)
     const searchParams = new URLSearchParams(queryString)
     if (!this.queryData) {
@@ -103,9 +61,11 @@ export function extendRequestPrototype() {
     } else {
       return this.queryData
     }
-  } as InstanceType<typeof Request>['query']
+  }
 
-  Request.prototype.queries = function (this: Request, key?: string) {
+  queries(key: string): string[]
+  queries(): Record<string, string[]>
+  queries(key?: string) {
     const queryString = getQueryStringFromURL(this.url)
     const searchParams = new URLSearchParams(queryString)
     if (key) {
@@ -117,10 +77,30 @@ export function extendRequestPrototype() {
       }
       return result
     }
-  } as InstanceType<typeof Request>['queries']
+  }
 
-  Request.prototype.cookie = function (this: Request, key?: string) {
-    const cookie = this.headers.get('Cookie') || ''
+  header(name: string): string
+  header(): Record<string, string>
+  header(name?: string) {
+    if (!this.headerData) {
+      this.headerData = {}
+      this.original.headers.forEach((value, key) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.headerData![key] = value
+      })
+    }
+    if (name) {
+      return this.headerData[name.toLowerCase()]
+    } else {
+      return this.headerData
+    }
+  }
+
+  cookie(key: string): string | undefined
+  cookie(): Cookie
+  cookie(key?: string) {
+    const cookie = this.original.headers.get('Cookie')
+    if (!cookie) return
     const obj = parse(cookie)
     if (key) {
       const value = obj[key]
@@ -128,41 +108,98 @@ export function extendRequestPrototype() {
     } else {
       return obj
     }
-  } as InstanceType<typeof Request>['cookie']
+  }
 
-  Request.prototype.parseBody = async function <BodyType extends BodyData>(
-    this: Request
-  ): Promise<BodyType> {
+  async parseBody<BodyType extends BodyData>(): Promise<BodyType> {
     // Cache the parsed body
     let body: BodyType
     if (!this.bodyData) {
-      body = await parseBody<BodyType>(this)
+      body = await parseBody<BodyType>(this.original)
       this.bodyData = body
     } else {
       body = this.bodyData as BodyType
     }
     return body
-  } as InstanceType<typeof Request>['parseBody']
+  }
 
-  Request.prototype.json = async function <JSONData = unknown>(this: Request) {
+  async json<JSONData = unknown>() {
     // Cache the JSON body
     let jsonData: Partial<JSONData>
     if (!this.jsonData) {
-      jsonData = JSON.parse(await this.text())
+      jsonData = JSON.parse(await this.original.text())
       this.jsonData = jsonData
     } else {
       jsonData = this.jsonData
     }
     return jsonData
-  } as InstanceType<typeof Request>['jsonData']
+  }
 
-  Request.prototype.valid = function (this: Request, data?: unknown) {
+  async text() {
+    return await this.original.text()
+  }
+
+  async arrayBuffer() {
+    return await this.original.arrayBuffer()
+  }
+
+  async blob() {
+    return await this.original.blob()
+  }
+
+  async formData() {
+    return await this.original.formData()
+  }
+
+  valid(data?: unknown) {
     if (!this.data) {
-      this.data = {}
+      this.data = {} as Data
     }
     if (data) {
-      this.data = data
+      this.data = data as Data
     }
     return this.data
-  } as InstanceType<typeof Request>['valid']
+  }
+
+  get url() {
+    return this.original.url
+  }
+  get method() {
+    return this.original.method
+  }
+  get headers() {
+    return this.original.headers
+  }
+  get redirect() {
+    return this.original.redirect
+  }
+  get body() {
+    return this.original.body
+  }
+  get bodyUsed() {
+    return this.original.bodyUsed
+  }
+  get cache() {
+    return this.original.cache
+  }
+  get credentials() {
+    return this.original.credentials
+  }
+  get integrity() {
+    return this.original.integrity
+  }
+  get keepalive() {
+    return this.original.keepalive
+  }
+  get mode() {
+    return this.original.mode
+  }
+  get referrer() {
+    return this.original.referrer
+  }
+  get refererPolicy() {
+    return this.original.referrerPolicy
+  }
+  get signal() {
+    return this.original.signal
+  }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -15,7 +15,8 @@ export class HonoRequest<
   private headerData: Record<string, string> | undefined
   private queryData: Record<string, string> | undefined
   private bodyData: BodyData | undefined
-  private jsonData: any | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private jsonData: Promise<any> | undefined
   private data: Data | undefined
 
   constructor(request: Request, paramData?: Record<string, string> | undefined) {
@@ -124,9 +125,9 @@ export class HonoRequest<
 
   async json<JSONData = unknown>() {
     // Cache the JSON body
-    let jsonData: Partial<JSONData>
+    let jsonData: Promise<Partial<JSONData>>
     if (!this.jsonData) {
-      jsonData = JSON.parse(await this.original.text())
+      jsonData = this.original.json()
       this.jsonData = jsonData
     } else {
       jsonData = this.jsonData
@@ -135,19 +136,19 @@ export class HonoRequest<
   }
 
   async text() {
-    return await this.original.text()
+    return this.original.text()
   }
 
   async arrayBuffer() {
-    return await this.original.arrayBuffer()
+    return this.original.arrayBuffer()
   }
 
   async blob() {
-    return await this.original.blob()
+    return this.original.blob()
   }
 
   async formData() {
-    return await this.original.formData()
+    return this.original.formData()
   }
 
   valid(data?: unknown) {

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -4,8 +4,8 @@ import { Validator } from './validator'
 describe('Basic - query', () => {
   const v = new Validator()
 
-  const originalRequest = new Request('http://localhost/?q=foo&page=3')
-  const req = new HonoRequest(originalRequest)
+  const rawRequest = new Request('http://localhost/?q=foo&page=3')
+  const req = new HonoRequest(rawRequest)
 
   it('Should be valid - page', async () => {
     const validator = v.query('page').trim().isNumeric()
@@ -45,8 +45,8 @@ describe('Basic - query', () => {
 describe('Basic - queries', () => {
   const v = new Validator()
 
-  const originalRequest = new Request('http://localhost/?tag=foo&tag=bar&id=123&id=456')
-  const req = new HonoRequest(originalRequest)
+  const rawRequest = new Request('http://localhost/?tag=foo&tag=bar&id=123&id=456')
+  const req = new HonoRequest(rawRequest)
 
   it('Should be valid - tag', async () => {
     const validator = v.queries('tag').isRequired()
@@ -90,14 +90,14 @@ describe('Basic - queries', () => {
 describe('Basic - header', () => {
   const v = new Validator()
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     headers: {
       'x-message': 'hello world!',
       'x-number': '12345',
     },
   })
 
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should be valid - x-message', async () => {
     const validator = v.header('x-message').isRequired().contains('Hello', { ignoreCase: true })
@@ -126,12 +126,12 @@ describe('Basic - body', () => {
   const body = new FormData()
   body.append('title', '  abcdef ')
   body.append('title2', 'abcdef')
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: body,
   })
 
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should be valid - title', async () => {
     const validator = v.body('title').trim().isLength({ max: 10 }).isRequired()
@@ -167,11 +167,11 @@ describe('Basic - JSON', () => {
     },
   }
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify(post),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should be valid - id', async () => {
     const validator = v.json('id').asNumber().isEqual(1234)
@@ -204,11 +204,11 @@ describe('Basic - JSON', () => {
 describe('Handle required values', () => {
   const v = new Validator()
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify({ comment: null, name: 'John', admin: false }),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should be valid - `name` is required', async () => {
     const validator = v.json('name').isRequired()
@@ -236,10 +236,10 @@ describe('Handle required values', () => {
 describe('Handle optional values', () => {
   it('Should be valid - `comment` is optional', async () => {
     const v = new Validator()
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
     const validator = v.body('comment').isOptional()
     const results = await validator.validate(req)
     expect(results[0].isValid).toBe(true)
@@ -247,8 +247,8 @@ describe('Handle optional values', () => {
   it('Should be valid - "isNumeric" but "isOptional"', async () => {
     const v = new Validator()
     const validator = v.query('page').isNumeric().isOptional()
-    const originalRequest = new Request('http://localhost/')
-    const req = new HonoRequest(originalRequest)
+    const rawRequest = new Request('http://localhost/')
+    const req = new HonoRequest(rawRequest)
     const results = await validator.validate(req)
     expect(results[0].isValid).toBe(true)
     expect(results[1].isValid).toBe(true)
@@ -265,11 +265,11 @@ describe('Handling types error', () => {
     published: 'true',
   }
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify(post),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should be invalid - "1234" is not number', async () => {
     const validator = v.json('id').asNumber().isEqual(1234)
@@ -321,11 +321,11 @@ describe('Handle array paths', () => {
     ],
   }
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify(body),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should validate targeted path in array', async () => {
     const validator = v.json('posts[*].published').asArray().asBoolean().isRequired()
@@ -386,7 +386,7 @@ describe('Handle array paths', () => {
     it(`Should allow ${
       value === undefined ? 'undefined' : 'empty'
     } arrays when optional`, async () => {
-      const originalRequest = new Request('http://localhost/', {
+      const rawRequest = new Request('http://localhost/', {
         method: 'POST',
         body: JSON.stringify({
           blog: {
@@ -394,7 +394,7 @@ describe('Handle array paths', () => {
           },
         }),
       })
-      const req = new HonoRequest(originalRequest)
+      const req = new HonoRequest(rawRequest)
       const vObject = v.object('blog', (v) => ({
         posts: v
           .array('posts', (v) => ({
@@ -444,11 +444,11 @@ describe('Validate with asArray', () => {
     },
   }
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify(json),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should validate array values', async () => {
     const validator = v.json('post.title').asArray().isAlpha()
@@ -528,10 +528,10 @@ describe('Invalid HTTP request handling', () => {
   const v = new Validator()
 
   it('Should throw malformed error when JSON body absent', async () => {
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
 
     let error
     try {
@@ -545,11 +545,11 @@ describe('Invalid HTTP request handling', () => {
   })
 
   it('Should throw malformed error when a JSON body is not valid JSON', async () => {
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: 'Not json!',
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
 
     let error
     try {
@@ -617,11 +617,11 @@ describe('Nested objects', () => {
     },
   }
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify(json),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should validate nested array values', async () => {
     const v = new Validator()
@@ -824,11 +824,11 @@ describe('Nested objects', () => {
   }
 
   it('Should threat `v.json()` as a nested array type only inside an array', async () => {
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: JSON.stringify(blogJson),
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
 
     const v = new Validator()
     const vObject = v.object('blog', (v) => ({
@@ -871,11 +871,11 @@ describe('Nested objects', () => {
   })
 
   it('Should correctly handle sequences of nested objects inside an array', async () => {
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: JSON.stringify(blogJson),
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
 
     const v = new Validator()
     const vObject = v.object('blog', (v) => ({
@@ -897,11 +897,11 @@ describe('Nested objects', () => {
   })
 
   it('Should correctly handle values inside objects and arrays', async () => {
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: JSON.stringify(blogJson),
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
 
     const v = new Validator()
     const vObject = v.object('blog', (v) => ({
@@ -936,11 +936,11 @@ describe('Custom message', () => {
     ],
   }
 
-  const originalRequest = new Request('http://localhost/', {
+  const rawRequest = new Request('http://localhost/', {
     method: 'POST',
     body: JSON.stringify(json),
   })
-  const req = new HonoRequest(originalRequest)
+  const req = new HonoRequest(rawRequest)
 
   it('Should return custom error message - value', async () => {
     const customMessage1 = 'Custom message: not contain!'
@@ -981,11 +981,11 @@ describe('Custom rule', () => {
     const body = new FormData()
     body.append('screenName', 'honojs_honojs_honojs_honojs_honojs')
 
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: body,
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
     const results = await validator.validate(req)
     expect(results[0].isValid).toBe(true)
     expect(results[1].isValid).toBe(true)
@@ -995,11 +995,11 @@ describe('Custom rule', () => {
     const body = new FormData()
     body.append('screenName', 'honojs+honojs')
 
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: body,
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
     const results = await validator.validate(req)
     expect(results[0].isValid).toBe(true)
     expect(results[1].isValid).toBe(false)
@@ -1018,11 +1018,11 @@ describe('Sanitizer', () => {
 
       const post = { name: ' a bc ' }
 
-      const originalRequest = new Request('http://localhost/', {
+      const rawRequest = new Request('http://localhost/', {
         method: 'POST',
         body: JSON.stringify(post),
       })
-      const req = new HonoRequest(originalRequest)
+      const req = new HonoRequest(rawRequest)
 
       const validator = v.json('name').trim()
       const [result] = await validator.validate(req)
@@ -1036,11 +1036,11 @@ describe('Sanitizer', () => {
 
     const post = { name: ' a bc ' }
 
-    const originalRequest = new Request('http://localhost/', {
+    const rawRequest = new Request('http://localhost/', {
       method: 'POST',
       body: JSON.stringify(post),
     })
-    const req = new HonoRequest(originalRequest)
+    const req = new HonoRequest(rawRequest)
 
     const validator = v
       .json('name')

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,3 +1,4 @@
+import type { HonoRequest } from '../request'
 import { JSONPathCopy } from './../utils/json'
 import type { JSONObject, JSONPrimitive, JSONArray } from './../utils/json'
 import { rule } from './rule'
@@ -201,7 +202,7 @@ export abstract class VBase {
     return this
   }
 
-  validate = async <R extends Request>(req: R): Promise<ValidateResult[]> => {
+  validate = async <R extends HonoRequest>(req: R): Promise<ValidateResult[]> => {
     let value: Type = undefined
     let jsonData: JSONObject | undefined = undefined
 


### PR DESCRIPTION
This PR introduces "HonoRequest" class to handle a request object with a "wrapper pattern". This is told in #712 . For the same purpose @stefanmaric is implementing "HonoRequest" with "proxy pattern". #727 .

The wrapper pattern has two features.

1. There are no "big" breaking changes, but access to environment-specific properties such as `c.req.cf` must be changed to `c.req.original.cf`.
2. There is no performance degradation with this change. It may even improve it.

Detail. First, HonoRequest will no longer be compatible with `Request`. So, if we want to use the raw `Request` object, we should write like this:

```ts
const cacheKey = c.req.original
```

But, all standard methods and properties of `Request` are ported. We can use `c.req` the same way we have always used it.

```ts
const value = c.req.header('key')
const value2 = c.req.headers.get('key2')
const url = c.req.url
const method = c.req.method
```

If we give enough notice, it could be released as a minor update such "v2.7.0" instead of a major update "v3.0.0".

Second, about performance. Using the implementation in #732 with "proxy pattern", we can not avoid that it will be slower.

https://github.com/stefanmaric/hono/compare/poc/hono-request...stefanmaric:hono:poc/hono-request-proxy

This is the benchmark score with [the scripts](https://github.com/SaltyAom/bun-http-framework-benchmark):

<img width="721" alt="SS" src="https://user-images.githubusercontent.com/10682/208286426-c2c27990-297a-4a94-93a4-d285d424bc2f.png">

For Hono, being fast is of great importance. So, I believe that the implementation in this PR is an advantage over #732 (However, I am very thankful to @stefanmaric).

---

This matter is still open for discussion and the PR will not be merged immediately.