### PR TITLE
fix: Support tsconfig.json "moduleResolution" : "NodeNext"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/cjs/index.js",
   "type": "module",
   "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],
@@ -18,7 +18,7 @@
     "lint": "eslint --ext js,ts src .eslintrc.cjs",
     "lint:fix": "eslint --ext js,ts src .eslintrc.cjs --fix",
     "denoify": "rimraf deno_dist && denoify && rimraf 'deno_dist/**/*.test.ts'",
-    "copy:package.cjs.json": "cp ./package.cjs.json ./dist/cjs/package.json",
+    "copy:package.cjs.json": "cp ./package.cjs.json ./dist/cjs/package.json && cp ./package.cjs.json ./dist/types/package.json ",
     "build": "rimraf dist && tsx ./build.ts && yarn copy:package.cjs.json",
     "watch": "rimraf dist && tsx ./build.ts --watch && yarn copy:package.cjs.json",
     "prerelease": "yarn denoify && yarn test:deno && yarn build",
@@ -26,125 +26,125 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./basic-auth": {
-      "types": "./dist/middleware/basic-auth/index.d.ts",
+      "types": "./dist/types/middleware/basic-auth/index.d.ts",
       "import": "./dist/middleware/basic-auth/index.js",
       "require": "./dist/cjs/middleware/basic-auth/index.js"
     },
     "./bearer-auth": {
-      "types": "./dist/middleware/bearer-auth/index.d.ts",
+      "types": "./dist/types/middleware/bearer-auth/index.d.ts",
       "import": "./dist/middleware/bearer-auth/index.js",
       "require": "./dist/cjs/middleware/bearer-auth/index.js"
     },
     "./cache": {
-      "types": "./dist/middleware/cache/index.d.ts",
+      "types": "./dist/types/middleware/cache/index.d.ts",
       "import": "./dist/middleware/cache/index.js",
       "require": "./dist/cjs/middleware/cache/index.js"
     },
     "./compress": {
-      "types": "./dist/middleware/compress/index.d.ts",
+      "types": "./dist/types/middleware/compress/index.d.ts",
       "import": "./dist/middleware/compress/index.js",
       "require": "./dist/cjs/middleware/compress/index.js"
     },
     "./cors": {
-      "types": "./dist/middleware/cors/index.d.ts",
+      "types": "./dist/types/middleware/cors/index.d.ts",
       "import": "./dist/middleware/cors/index.js",
       "require": "./dist/cjs/middleware/cors/index.js"
     },
     "./etag": {
-      "types": "./dist/middleware/etag/index.d.ts",
+      "types": "./dist/types/middleware/etag/index.d.ts",
       "import": "./dist/middleware/etag/index.js",
       "require": "./dist/cjs/middleware/etag/index.js"
     },
     "./html": {
-      "types": "./dist/middleware/html/index.d.ts",
+      "types": "./dist/types/middleware/html/index.d.ts",
       "import": "./dist/middleware/html/index.js",
       "require": "./dist/cjs/middleware/html/index.js"
     },
     "./jsx": {
-      "types": "./dist/middleware/jsx/index.d.ts",
+      "types": "./dist/types/middleware/jsx/index.d.ts",
       "import": "./dist/middleware/jsx/index.js",
       "require": "./dist/cjs/middleware/jsx/index.js"
     },
     "./jsx/jsx-dev-runtime": {
-      "types": "./dist/middleware/jsx/jsx-dev-runtime.d.ts",
+      "types": "./dist/types/middleware/jsx/jsx-dev-runtime.d.ts",
       "import": "./dist/middleware/jsx/jsx-dev-runtime.js",
       "require": "./dist/cjs/middleware/jsx/jsx-dev-runtime.js"
     },
     "./jsx/jsx-runtime": {
-      "types": "./dist/middleware/jsx/jsx-runtime.d.ts",
+      "types": "./dist/types/middleware/jsx/jsx-runtime.d.ts",
       "import": "./dist/middleware/jsx/jsx-runtime.js",
       "require": "./dist/cjs/middleware/jsx/jsx-runtime.js"
     },
     "./jwt": {
-      "types": "./dist/middleware/jwt/index.d.ts",
+      "types": "./dist/types/middleware/jwt/index.d.ts",
       "import": "./dist/middleware/jwt/index.js",
       "require": "./dist/cjs/middleware/jwt/index.js"
     },
     "./logger": {
-      "types": "./dist/middleware/logger/index.d.ts",
+      "types": "./dist/types/middleware/logger/index.d.ts",
       "import": "./dist/middleware/logger/index.js",
       "require": "./dist/cjs/middleware/logger/index.js"
     },
     "./powered-by": {
-      "types": "./dist/middleware/powered-by/index.d.ts",
+      "types": "./dist/types/middleware/powered-by/index.d.ts",
       "import": "./dist/middleware/powered-by/index.js",
       "require": "./dist/cjs/middleware/powered-by/index.js"
     },
     "./pretty-json": {
-      "types": "./dist/middleware/pretty-json/index.d.ts",
+      "types": "./dist/types/middleware/pretty-json/index.d.ts",
       "import": "./dist/middleware/pretty-json/index.js",
       "require": "./dist/cjs/middleware/pretty-json/index.js"
     },
     "./serve-static": {
-      "types": "./dist/middleware/serve-static/index.d.ts",
+      "types": "./dist/types/middleware/serve-static/index.d.ts",
       "import": "./dist/middleware/serve-static/index.js",
       "require": "./dist/cjs/middleware/serve-static/index.js"
     },
     "./serve-static.bun": {
-      "types": "./dist/middleware/serve-static/bun.d.ts",
+      "types": "./dist/types/middleware/serve-static/bun.d.ts",
       "import": "./dist/middleware/serve-static/bun.js",
       "require": "./dist/cjs/middleware/serve-static/bun.js"
     },
     "./serve-static.module": {
-      "types": "./dist/middleware/serve-static/module.d.ts",
+      "types": "./dist/types/middleware/serve-static/module.d.ts",
       "import": "./dist/middleware/serve-static/module.js"
     },
     "./validator": {
-      "types": "./dist/middleware/validator/index.d.ts",
+      "types": "./dist/types/middleware/validator/index.d.ts",
       "import": "./dist/middleware/validator/index.js",
       "require": "./dist/cjs/middleware/validator/index.js"
     },
     "./router/reg-exp-router": {
-      "types": "./dist/router/reg-exp-router/index.d.ts",
+      "types": "./dist/types/router/reg-exp-router/index.d.ts",
       "import": "./dist/router/reg-exp-router/index.js",
       "require": "./dist/cjs/router/reg-exp-router/index.js"
     },
     "./router/smart-router": {
-      "types": "./dist/router/smart-router/index.d.ts",
+      "types": "./dist/types/router/smart-router/index.d.ts",
       "import": "./dist/router/smart-router/index.js",
       "require": "./dist/cjs/router/smart-router/index.js"
     },
     "./router/static-router": {
-      "import": "./dist/router/static-router/index.js",
+      "import": "./dist/types/router/static-router/index.js",
       "require": "./dist/cjs/router/static-router/index.js"
     },
     "./router/trie-router": {
-      "types": "./dist/router/trie-router/index.d.ts",
+      "types": "./dist/types/router/trie-router/index.d.ts",
       "import": "./dist/router/trie-router/index.js",
       "require": "./dist/cjs/router/trie-router/index.js"
     },
     "./utils/jwt": {
-      "types": "./dist/utils/jwt/index.d.ts",
+      "types": "./dist/types/utils/jwt/index.d.ts",
       "import": "./dist/utils/jwt/index.js",
       "require": "./dist/cjs/utils/jwt/index.js"
     },
     "./utils/*": {
-      "types": "./dist/utils/*.d.ts",
+      "types": "./dist/types/utils/*.d.ts",
       "import": "./dist/utils/*.js",
       "require": "./dist/cjs/utils/*.js"
     }
@@ -152,76 +152,76 @@
   "typesVersions": {
     "*": {
       "basic-auth": [
-        "./dist/middleware/basic-auth"
+        "./dist/types/middleware/basic-auth"
       ],
       "bearer-auth": [
-        "./dist/middleware/bearer-auth"
+        "./dist/types/middleware/bearer-auth"
       ],
       "cache": [
-        "./dist/middleware/cache"
+        "./dist/types/middleware/cache"
       ],
       "compress": [
-        "./dist/middleware/compress"
+        "./dist/types/middleware/compress"
       ],
       "cors": [
-        "./dist/middleware/cors"
+        "./dist/types/middleware/cors"
       ],
       "etag": [
-        "./dist/middleware/etag"
+        "./dist/types/middleware/etag"
       ],
       "html": [
-        "./dist/middleware/html"
+        "./dist/types/middleware/html"
       ],
       "jsx": [
-        "./dist/middleware/jsx"
+        "./dist/types/middleware/jsx"
       ],
       "jsx/jsx-runtime": [
-        "./dist/middleware/jsx/jsx-runtime.d.ts"
+        "./dist/types/middleware/jsx/jsx-runtime.d.ts"
       ],
       "jsx/jsx-dev-runtime": [
-        "./dist/middleware/jsx/jsx-dev-runtime.d.ts"
+        "./dist/types/middleware/jsx/jsx-dev-runtime.d.ts"
       ],
       "jwt": [
-        "./dist/middleware/jwt"
+        "./dist/types/middleware/jwt"
       ],
       "logger": [
-        "./dist/middleware/logger"
+        "./dist/types/middleware/logger"
       ],
       "powered-by": [
-        "./dist/middleware/powered-by"
+        "./dist/types/middleware/powered-by"
       ],
       "pretty-json": [
-        "./dist/middleware/pretty-json"
+        "./dist/types/middleware/pretty-json"
       ],
       "serve-static": [
-        "./dist/middleware/serve-static/index.d.ts"
+        "./dist/types/middleware/serve-static/index.d.ts"
       ],
       "serve-static.bun": [
-        "./dist/middleware/serve-static/bun.d.ts"
+        "./dist/types/middleware/serve-static/bun.d.ts"
       ],
       "serve-static.module": [
-        "./dist/middleware/serve-static/module.d.ts"
+        "./dist/types/middleware/serve-static/module.d.ts"
       ],
       "validator": [
-        "./dist/middleware/validator"
+        "./dist/types/middleware/validator"
       ],
       "router/reg-exp-router": [
-        "./dist/router/reg-exp-router/router.d.ts"
+        "./dist/types/router/reg-exp-router/router.d.ts"
       ],
       "router/smart-router": [
-        "./dist/router/smart-router/router.d.ts"
+        "./dist/types/router/smart-router/router.d.ts"
       ],
       "router/static-router": [
-        "./dist/router/static-router/router.d.ts"
+        "./dist/types/router/static-router/router.d.ts"
       ],
       "router/trie-router": [
-        "./dist/router/trie-router/router.d.ts"
+        "./dist/types/router/trie-router/router.d.ts"
       ],
       "utils/jwt": [
-        "./dist/utils/jwt/index.d.ts"
+        "./dist/types/utils/jwt/index.d.ts"
       ],
       "utils/*": [
-        "./dist/utils/*"
+        "./dist/types/utils/*"
       ]
     }
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "ES2020",
     "rootDir": "./src/",
-    "outDir": "./dist/",
+    "outDir": "./dist/types/",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
   },


### PR DESCRIPTION
To support "moduleResolution" : "NodeNext", output .d.ts to the dist/types directory and add dist/types/package.json { "type": "commonjs" }.

#679 
#668