### PR TITLE
feat(trie-router): `regexp` support path including slashes

### DIFF
--- a/deno_dist/router/trie-router/node.ts
+++ b/deno_dist/router/trie-router/node.ts
@@ -172,6 +172,15 @@ export class Node<T> {
           // Named match
           // `/posts/:id` => match /posts/123
           const [key, name, matcher] = pattern
+
+          // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
+          const restPathString = parts.slice(i).join('')
+          if (matcher instanceof RegExp && matcher.test(restPathString)) {
+            handlerSets.push(...this.getHandlerSets(node.children[key], method))
+            params[name] = restPathString
+            continue
+          }
+
           if (matcher === true || (matcher instanceof RegExp && matcher.test(part))) {
             if (typeof key === 'string') {
               if (isLast === true) {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -359,6 +359,30 @@ describe('Multi match', () => {
       expect(res?.handlers).toEqual(['Middleware A', 'Middleware B'])
     })
   })
+
+  describe('Including slashes', () => {
+    const node = new Node()
+    node.insert('get', '/js/:filename{[a-z0-9]+.js}', 'any file')
+    node.insert('get', '/js/main.js', 'main.js')
+
+    it('get /js/main.js', () => {
+      const res = node.search('get', '/js/main.js')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['any file', 'main.js'])
+    })
+
+    it('get /js/chunk/123.js', () => {
+      const res = node.search('get', '/js/chunk/123.js')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['any file'])
+    })
+
+    it('get /js/chunk/nest/123.js', () => {
+      const res = node.search('get', '/js/chunk/nest/123.js')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['any file'])
+    })
+  })
 })
 
 describe('Duplicate param name', () => {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -362,25 +362,46 @@ describe('Multi match', () => {
 
   describe('Including slashes', () => {
     const node = new Node()
-    node.insert('get', '/js/:filename{[a-z0-9]+.js}', 'any file')
+    node.insert('get', '/js/:filename{[a-z0-9/]+.js}', 'any file')
     node.insert('get', '/js/main.js', 'main.js')
 
     it('get /js/main.js', () => {
       const res = node.search('get', '/js/main.js')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['any file', 'main.js'])
+      expect(res?.params).toEqual({ filename: 'main.js' })
     })
 
     it('get /js/chunk/123.js', () => {
       const res = node.search('get', '/js/chunk/123.js')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['any file'])
+      expect(res?.params).toEqual({ filename: 'chunk/123.js' })
     })
 
     it('get /js/chunk/nest/123.js', () => {
       const res = node.search('get', '/js/chunk/nest/123.js')
       expect(res).not.toBeNull()
       expect(res?.handlers).toEqual(['any file'])
+      expect(res?.params).toEqual({ filename: 'chunk/nest/123.js' })
+    })
+  })
+
+  describe('REST API', () => {
+    const node = new Node()
+    node.insert('get', '/users/:username{[a-z]+}', 'profile')
+    node.insert('get', '/users/:username{[a-z]+}/posts', 'posts')
+
+    it('get /users/hono', () => {
+      const res = node.search('get', '/users/hono')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['profile'])
+    })
+
+    it('get /users/hono/posts', () => {
+      const res = node.search('get', '/users/hono/posts')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['posts'])
     })
   })
 })

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -172,6 +172,15 @@ export class Node<T> {
           // Named match
           // `/posts/:id` => match /posts/123
           const [key, name, matcher] = pattern
+
+          // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
+          const restPathString = parts.slice(i).join('')
+          if (matcher instanceof RegExp && matcher.test(restPathString)) {
+            handlerSets.push(...this.getHandlerSets(node.children[key], method))
+            params[name] = restPathString
+            continue
+          }
+
           if (matcher === true || (matcher instanceof RegExp && matcher.test(part))) {
             if (typeof key === 'string') {
               if (isLast === true) {

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -1,7 +1,7 @@
 import type { Result } from '../../router'
 import { METHOD_NAME_ALL } from '../../router'
 import type { Pattern } from '../../utils/url'
-import { splitPath, getPattern } from '../../utils/url'
+import { splitPath, splitRoutingPath, getPattern } from '../../utils/url'
 
 type HandlerSet<T> = {
   handler: T
@@ -54,7 +54,7 @@ export class Node<T> {
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let curNode: Node<T> = this
-    const parts = splitPath(path)
+    const parts = splitRoutingPath(path)
 
     const parentPatterns: Pattern[] = []
     const errorMessage = (name: string): string => {
@@ -174,7 +174,7 @@ export class Node<T> {
           const [key, name, matcher] = pattern
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
-          const restPathString = parts.slice(i).join('')
+          const restPathString = parts.slice(i).join('/')
           if (matcher instanceof RegExp && matcher.test(restPathString)) {
             handlerSets.push(...this.getHandlerSets(node.children[key], method))
             params[name] = restPathString

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -38,6 +38,12 @@ describe('url', () => {
 
     ps = splitRoutingPath('/users/:name{[0-9a-zA-Z_-]{3,10}}')
     expect(ps).toStrictEqual(['users', ':name{[0-9a-zA-Z_-]{3,10}}'])
+
+    ps = splitRoutingPath('/users/:@name{[0-9a-zA-Z_-]{3,10}}')
+    expect(ps).toStrictEqual(['users', ':@name{[0-9a-zA-Z_-]{3,10}}'])
+
+    ps = splitRoutingPath('/users/:dept{\\d+}/:@name{[0-9a-zA-Z_-]{3,10}}')
+    expect(ps).toStrictEqual(['users', ':dept{\\d+}', ':@name{[0-9a-zA-Z_-]{3,10}}'])
   })
 
   it('getPattern', () => {

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,5 +1,6 @@
 import {
   splitPath,
+  splitRoutingPath,
   getPattern,
   getPathFromURL,
   mergePath,
@@ -14,15 +15,29 @@ describe('url', () => {
 
     ps = splitPath('/hello')
     expect(ps).toStrictEqual(['hello'])
+  })
 
-    ps = splitPath('*')
+  it('splitRoutingPath', () => {
+    let ps = splitRoutingPath('/')
+    expect(ps).toStrictEqual([''])
+
+    ps = splitRoutingPath('/hello')
+    expect(ps).toStrictEqual(['hello'])
+
+    ps = splitRoutingPath('*')
     expect(ps).toStrictEqual(['*'])
 
-    ps = splitPath('/wildcard-abc/*/wildcard-efg')
+    ps = splitRoutingPath('/wildcard-abc/*/wildcard-efg')
     expect(ps).toStrictEqual(['wildcard-abc', '*', 'wildcard-efg'])
 
-    ps = splitPath('/map/:location/events')
+    ps = splitRoutingPath('/map/:location/events')
     expect(ps).toStrictEqual(['map', ':location', 'events'])
+
+    ps = splitRoutingPath('/js/:location{[a-z/]+.js}')
+    expect(ps).toStrictEqual(['js', ':location{[a-z/]+.js}'])
+
+    ps = splitRoutingPath('/users/:name{[0-9a-zA-Z_-]{3,10}}')
+    expect(ps).toStrictEqual(['users', ':name{[0-9a-zA-Z_-]{3,10}}'])
   })
 
   it('getPattern', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -9,13 +9,15 @@ export const splitPath = (path: string): string[] => {
 }
 
 export const splitRoutingPath = (path: string): string[] => {
-  const groups : string[] = []
-  for (let i = 0;; i++) {
+  const groups: [string, string][] = [] // [mark, original string]
+  for (let i = 0; ; ) {
     let replaced = false
-    path = path.replace(/\{[^}]+\}/, (m) => {
-      groups[i] = m
+    path = path.replace(/\{[^}]+\}/g, (m) => {
+      const mark = `@\\${i}`
+      groups[i] = [mark, m]
+      i++
       replaced = true
-      return `@${i}`
+      return mark
     })
     if (!replaced) {
       break
@@ -27,9 +29,10 @@ export const splitRoutingPath = (path: string): string[] => {
     paths.shift()
   }
   for (let i = groups.length - 1; i >= 0; i--) {
+    const [mark] = groups[i]
     for (let j = paths.length - 1; j >= 0; j--) {
-      if (paths[j].match('@' + i)) {
-        paths[j] = paths[j].replace('@' + i, groups[i])
+      if (paths[j].indexOf(mark) !== -1) {
+        paths[j] = paths[j].replace(mark, groups[i][1])
         break
       }
     }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -8,6 +8,36 @@ export const splitPath = (path: string): string[] => {
   return paths
 }
 
+export const splitRoutingPath = (path: string): string[] => {
+  const groups : string[] = []
+  for (let i = 0;; i++) {
+    let replaced = false
+    path = path.replace(/\{[^}]+\}/, (m) => {
+      groups[i] = m
+      replaced = true
+      return `@${i}`
+    })
+    if (!replaced) {
+      break
+    }
+  }
+
+  const paths = path.split(/\//) // faster than path.split('/')
+  if (paths[0] === '') {
+    paths.shift()
+  }
+  for (let i = groups.length - 1; i >= 0; i--) {
+    for (let j = paths.length - 1; j >= 0; j--) {
+      if (paths[j].match('@' + i)) {
+        paths[j] = paths[j].replace('@' + i, groups[i])
+        break
+      }
+    }
+  }
+
+  return paths
+}
+
 const patternCache: { [key: string]: Pattern } = {}
 export const getPattern = (label: string): Pattern | null => {
   // *            => wildcard


### PR DESCRIPTION
"TrieRouter" did not support regexp routing with slash `/`. This means that it will match paths in the same depth but cannot match paths in a dynamic depth. 

```ts
// GET `/js/chunk/abc.js` is not matched
app.get('/:filename{.+.js$}', async (c, next) => {
  console.log(`You access ${c.req.param('filename')}`)
  await next()
})
```

In this PR, make it supports slash.

Will match `/js/chunk/abc.js` not only `/abc.js`.

P.S.

Currently, "RegExpRouter" also does **not** support regexp routing with slashes. It would be good to support it.