### PR TITLE
fix(package.json): typo exports static-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
       "require": "./dist/cjs/router/smart-router/index.js"
     },
     "./router/static-router": {
-      "import": "./dist/types/router/static-router/index.js",
+      "types": "./dist/types/router/static-router/index.d.ts",
+      "import": "./dist/router/static-router/index.js",
       "require": "./dist/cjs/router/static-router/index.js"
     },
     "./router/trie-router": {


### PR DESCRIPTION
There was a mistake in #747 , sorry.
I was able to find it in publint.
``npx publint`` or https://publint.dev/hono