### PR TITLE
perf: optimize parsing queries and headers / 19% faster than 2.7.1

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -186,7 +186,8 @@ export class Hono<
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
     env?: E['Bindings']
   ): Response | Promise<Response> {
-    const path = getPathFromURL(request.url, this.strict)
+    const [path, queryIndex] = getPathFromURL(request.url, this.strict)
+
     const method = request.method
 
     const result = this.matchRoute(method, path)
@@ -197,10 +198,11 @@ export class Hono<
       executionCtx: eventOrExecutionCtx,
       notFoundHandler: this.notFoundHandler,
       paramData,
+      queryIndex,
     })
 
     // Do not `compose` if it has only one handler
-    if (result && result.handlers.length === 1) {
+    if (result?.handlers.length === 1) {
       const handler = result.handlers[0] as unknown as Handler<E>
       let res: ReturnType<Handler>
 

--- a/deno_dist/middleware/logger/index.ts
+++ b/deno_dist/middleware/logger/index.ts
@@ -56,7 +56,8 @@ function log(
 export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async (c, next) => {
     const { method } = c.req
-    const path = getPathFromURL(c.req.url)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [path, _] = getPathFromURL(c.req.url)
 
     log(fn, LogPrefix.Incoming, method, path)
 

--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "https://deno.land/std@0.170.0/node/buffer.ts";
+import { Buffer } from "https://deno.land/std@0.171.0/node/buffer.ts";
 export const encodeBase64 = (str: string): string => {
   if (str === null) {
     throw new TypeError('1st argument of "encodeBase64" should not be null.')

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -35,21 +35,6 @@ export const getPattern = (label: string): Pattern | null => {
   return null
 }
 
-export const getPathFromURLWithRegExp = (url: string, strict: boolean = true): [string, string] => {
-  const regExp = /^https?:\/\/[^/]+(\/[^?]+)\?*([^#]*)$/
-  const match = url.match(regExp)
-
-  if (match) {
-    if (strict === false && match[1].endsWith('/')) {
-      return [match[1].slice(0, -1), match[2]]
-    } else {
-      return [match[1], match[2]]
-    }
-  }
-
-  return ['/', '']
-}
-
 export const getPathFromURL = (url: string, strict: boolean = true): [string, number] => {
   const queryIndex = url.indexOf('?')
   const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -1,7 +1,7 @@
 export type Pattern = readonly [string, string, RegExp | true] | '*'
 
 export const splitPath = (path: string): string[] => {
-  const paths = path.split(/\//) // faster than path.split('/')
+  const paths = path.split('/')
   if (paths[0] === '') {
     paths.shift()
   }
@@ -35,22 +35,36 @@ export const getPattern = (label: string): Pattern | null => {
   return null
 }
 
-export const getPathFromURL = (url: string, strict: boolean = true): string => {
+export const getPathFromURLWithRegExp = (url: string, strict: boolean = true): [string, string] => {
+  const regExp = /^https?:\/\/[^/]+(\/[^?]+)\?*([^#]*)$/
+  const match = url.match(regExp)
+
+  if (match) {
+    if (strict === false && match[1].endsWith('/')) {
+      return [match[1].slice(0, -1), match[2]]
+    } else {
+      return [match[1], match[2]]
+    }
+  }
+
+  return ['/', '']
+}
+
+export const getPathFromURL = (url: string, strict: boolean = true): [string, number] => {
   const queryIndex = url.indexOf('?')
   const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
   if (strict === false && result.endsWith('/')) {
-    return result.slice(0, -1)
+    return [result.slice(0, -1), queryIndex]
   }
 
-  return result
+  return [result, queryIndex]
 }
 
-export const getQueryStringFromURL = (url: string): string => {
-  const queryIndex = url.indexOf('?')
-  const result = queryIndex !== -1 ? url.substring(queryIndex) : ''
+export const getQueryStringFromURL = (url: string, queryIndex: number): string => {
+  const result = queryIndex !== -1 ? url.slice(queryIndex + 1) : ''
   return result
 }
 
@@ -98,4 +112,71 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   const base = match[1]
   const optional = base + match[2]
   return [base, optional]
+}
+
+const filterQueryString = (queryString: string): string => {
+  const fragIndex = queryString.indexOf('#')
+  if (fragIndex !== -1) {
+    queryString = queryString.slice(0, fragIndex)
+  }
+  return queryString
+}
+
+// Optimized
+export const getQueryParam = (
+  queryString: string,
+  key?: string
+): string | null | Record<string, string> => {
+  queryString = filterQueryString(queryString)
+
+  const results: Record<string, string> = {}
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const andIndex = queryString.indexOf('&')
+    let strings = ''
+    if (andIndex === -1) {
+      strings = queryString
+    } else {
+      strings = queryString.slice(0, andIndex)
+    }
+
+    const eqIndex = strings.indexOf('=')
+    if (eqIndex !== -1) {
+      const v = strings.slice(eqIndex + 1)
+      const k = strings.slice(0, eqIndex)
+      if (key === k) {
+        return v.indexOf('%') !== -1 ? decodeURI(v) : v
+      } else {
+        results[k] ||= v
+      }
+    } else if (strings === key) {
+      return ''
+    }
+
+    if (andIndex === -1) break
+    queryString = queryString.slice(andIndex + 1, queryString.length)
+  }
+
+  if (key) return null
+  return results
+}
+
+export const getQueryParams = (
+  queryString: string,
+  key?: string
+): string[] | null | Record<string, string[]> => {
+  queryString = filterQueryString(queryString)
+  const results: Record<string, string[]> = {}
+
+  for (const strings of queryString.split('&')) {
+    let [k, v] = strings.split('=')
+    if (v === undefined) v = ''
+    results[k] ||= []
+    results[k].push(v.indexOf('%') !== -1 ? decodeURI(v) : v)
+  }
+
+  if (key) return results[key] ? results[key] : null
+
+  return results
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -48,9 +48,9 @@ export class Context<
   private _headers: Headers | undefined = undefined
   private _preparedHeaders: Record<string, string> | undefined = undefined
   private _res: Response | undefined
-  private _paramData: Record<string, string> | undefined
+  private _paramData?: Record<string, string> | null
   private _queryIndex: number | undefined
-  private rawRequest: Request
+  private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E, R> = () => new Response()
 
   constructor(req: Request, options?: ContextOptions<E, R>) {
@@ -70,7 +70,12 @@ export class Context<
     if (this._req) {
       return this._req
     } else {
-      this._req = new HonoRequest<R, I>(this.rawRequest, this._paramData, this._queryIndex)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this._req = new HonoRequest<R, I>(this.rawRequest!, this._paramData!, this._queryIndex)
+      this.rawRequest = null
+      delete this.rawRequest
+      this._paramData = null
+      delete this._paramData
       return this._req
     }
   }
@@ -145,7 +150,8 @@ export class Context<
     this._prettySpace = space
   }
 
-  newResponse(data: Data | null, status: StatusCode, headers?: HeaderRecord): Response {
+  newResponse(data: Data | null, status?: StatusCode, headers?: HeaderRecord): Response {
+    // Optimized
     if (!headers && !this._headers && !this._res) {
       return new Response(data, {
         status,
@@ -156,7 +162,7 @@ export class Context<
     this._preparedHeaders ??= {}
 
     if (!this._headers) {
-      this._headers ??= new Headers()
+      this._headers = new Headers()
       for (const [k, v] of Object.entries(this._preparedHeaders)) {
         this._headers.set(k, v)
       }
@@ -196,12 +202,24 @@ export class Context<
   text(text: string, status?: StatusCode, headers?: HeaderRecord): Response {
     // If the header is empty, return Response immediately.
     // Content-Type will be added automatically as `text/plain`.
-    if (!headers && !status && !this._res && !this._headers && !this._preparedHeaders) {
-      return new Response(text)
+    if (!this._preparedHeaders) {
+      if (!headers && !this._res && !this._headers && !status) {
+        return new Response(text)
+      }
+      this._preparedHeaders = {}
     }
-    this._preparedHeaders ??= {}
+    // If Content-Type is not set, we don't have to set `text/plain`.
+    // Fewer the header values, it will be faster.
+    if (!this._preparedHeaders['content-type']) {
+      return new Response(text, {
+        status,
+        headers: this._preparedHeaders,
+      })
+    }
+
     this._preparedHeaders['content-type'] = 'text/plain; charset=UTF8'
-    return this.newResponse(text, status ?? this._status, headers)
+
+    return this.newResponse(text, status, headers)
   }
 
   json<T>(object: T, status: StatusCode = this._status, headers?: HeaderRecord): Response {

--- a/src/context.ts
+++ b/src/context.ts
@@ -210,15 +210,9 @@ export class Context<
     }
     // If Content-Type is not set, we don't have to set `text/plain`.
     // Fewer the header values, it will be faster.
-    if (!this._preparedHeaders['content-type']) {
-      return new Response(text, {
-        status,
-        headers: this._preparedHeaders,
-      })
+    if (this._preparedHeaders['content-type']) {
+      this._preparedHeaders['content-type'] = 'text/plain; charset=UTF8'
     }
-
-    this._preparedHeaders['content-type'] = 'text/plain; charset=UTF8'
-
     return this.newResponse(text, status, headers)
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -152,9 +152,8 @@ export class Context<
 
   newResponse(data: Data | null, status?: StatusCode, headers?: HeaderRecord): Response {
     // Optimized
-    if (!headers && !this._headers && !this._res) {
+    if (!headers && !this._headers && !this._res && !status) {
       return new Response(data, {
-        status,
         headers: this._preparedHeaders,
       })
     }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -202,7 +202,7 @@ export class Hono<
     })
 
     // Do not `compose` if it has only one handler
-    if (result && result.handlers.length === 1) {
+    if (result?.handlers.length === 1) {
       const handler = result.handlers[0] as unknown as Handler<E>
       let res: ReturnType<Handler>
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -187,6 +187,7 @@ export class Hono<
     env?: E['Bindings']
   ): Response | Promise<Response> {
     const [path, queryIndex] = getPathFromURL(request.url, this.strict)
+
     const method = request.method
 
     const result = this.matchRoute(method, path)

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -176,27 +176,9 @@ describe('url', () => {
 
   describe('getQueryParam', () => {
     it('Parse URL query strings', () => {
-      // expect(getQueryParam('?name=hey', 'name')).toBe('hey')
-      // expect(getQueryParam('?name=hey#fragment', 'name')).toEqual('hey')
-      // expect(getQueryParam('?name=hey&age=20&tall=170', 'age')).toBe('20')
-      // const searchParams = new URLSearchParams({ name: '炎' })
-      // expect(getQueryParam('?' + searchParams.toString(), 'name')).toBe('炎')
-      // expect(getQueryParam('?name=hey&age=20&tall=170', 'weight')).toBe(null)
-      // expect(getQueryParam('?name=hey&age=20&tall=170')).toEqual({
-      //   name: 'hey',
-      //   age: '20',
-      //   tall: '170',
-      // })
-      // expect(getQueryParam('?pretty', 'pretty')).toBe('')
-      // expect(getQueryParam('?pretty', 'prtt')).toBe(null)
-      // expect(getQueryParam('?name=sam&name=tom', 'name')).toBe('sam')
-      // expect(getQueryParam('?name=sam&name=tom')).toEqual({
-      //   name: 'sam',
-      // })
-
       expect(getQueryParam('name=hey', 'name')).toBe('hey')
       expect(getQueryParam('name=hey&age=20&tall=170', 'age')).toBe('20')
-      const searchParams = new URLSearchParams({ name: '炎' })
+      let searchParams = new URLSearchParams({ name: '炎' })
       expect(getQueryParam(searchParams.toString(), 'name')).toBe('炎')
       expect(getQueryParam('name=hey&age=20&tall=170', 'weight')).toBe(null)
       expect(getQueryParam('name=hey&age=20&tall=170')).toEqual({
@@ -210,6 +192,8 @@ describe('url', () => {
       expect(getQueryParam('name=sam&name=tom')).toEqual({
         name: 'sam',
       })
+      searchParams = new URLSearchParams('?name=sam=tom')
+      expect(getQueryParam('name', searchParams.get('name')?.toString()))
     })
   })
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -5,6 +5,9 @@ import {
   mergePath,
   getQueryStringFromURL,
   checkOptionalParameter,
+  getQueryParam,
+  getQueryParams,
+  getPathFromURLWithRegExp,
 } from './url'
 
 describe('url', () => {
@@ -37,6 +40,44 @@ describe('url', () => {
     expect(res?.[2]).toEqual(/^[0-9]+$/)
     res = getPattern('*')
     expect(res).toBe('*')
+  })
+
+  describe('getPathFromURLWithRegex', () => {
+    it('getPathFromURLWithRegex - no trailing slash', () => {
+      let path = getPathFromURLWithRegExp('https://example.com/')
+      expect(path[0]).toBe('/')
+      expect(path[1]).toBe('')
+      path = getPathFromURLWithRegExp('https://example.com/hello')
+      expect(path[0]).toBe('/hello')
+      expect(path[1]).toBe('')
+      path = getPathFromURLWithRegExp('https://example.com/hello/hey')
+      expect(path[0]).toBe('/hello/hey')
+      expect(path[1]).toBe('')
+      path = getPathFromURLWithRegExp('https://example.com/hello?name=foo')
+      expect(path[0]).toBe('/hello')
+      expect(path[1]).toBe('name=foo')
+      path = getPathFromURLWithRegExp('https://example.com/hello/hey?name=foo&name=bar')
+      expect(path[0]).toBe('/hello/hey')
+      expect(path[1]).toBe('name=foo&name=bar')
+    })
+
+    it('getPathFromURLWithRegex - with trailing slash', () => {
+      let path = getPathFromURLWithRegExp('https://example.com/hello/')
+      expect(path[0]).toBe('/hello/')
+      expect(path[1]).toBe('')
+      path = getPathFromURLWithRegExp('https://example.com/hello/hey/')
+      expect(path[0]).toBe('/hello/hey/')
+      expect(path[1]).toBe('')
+    })
+
+    it('getPathFromURLWithRegex - no strict is false', () => {
+      let path = getPathFromURLWithRegExp('https://example.com/hello/', false)
+      expect(path[0]).toBe('/hello')
+      expect(path[1]).toBe('')
+      path = getPathFromURLWithRegExp('https://example.com/hello/hey/', false)
+      expect(path[0]).toBe('/hello/hey')
+      expect(path[1]).toBe('')
+    })
   })
 
   describe('getPathFromURL', () => {
@@ -76,17 +117,17 @@ describe('url', () => {
   describe('getQueryStringFromURL', () => {
     it('should return strings of query params', () => {
       let queryString = getQueryStringFromURL('https://example.com/?foo=bar', 20)
-      expect(queryString).toBe('?foo=bar')
+      expect(queryString).toBe('foo=bar')
       queryString = getQueryStringFromURL('https://example.com/?foo=bar&foo2=bar2', 20)
-      expect(queryString).toBe('?foo=bar&foo2=bar2')
+      expect(queryString).toBe('foo=bar&foo2=bar2')
       queryString = getQueryStringFromURL('https://example.com/', -1)
       expect(queryString).toBe('')
       // This specification allows the fragments as query strings
       queryString = getQueryStringFromURL('https://example.com/?#foo=#bar&#foo2=#bar2', 20)
-      expect(queryString).toBe('?#foo=#bar&#foo2=#bar2')
+      expect(queryString).toBe('#foo=#bar&#foo2=#bar2')
       // This specification allows that the string includes two `?` or more
       queryString = getQueryStringFromURL('https://example.com/?foo=bar?foo2=bar2', 20)
-      expect(queryString).toBe('?foo=bar?foo2=bar2')
+      expect(queryString).toBe('foo=bar?foo2=bar2')
     })
   })
 
@@ -130,6 +171,70 @@ describe('url', () => {
       expect(checkOptionalParameter('/api/animals')).toBeNull()
       expect(checkOptionalParameter('/api/:animals?/type')).toBeNull()
       expect(checkOptionalParameter('/api/animals/:type?/')).toBeNull()
+    })
+  })
+
+  describe('getQueryParam', () => {
+    it('Parse URL query strings', () => {
+      // expect(getQueryParam('?name=hey', 'name')).toBe('hey')
+      // expect(getQueryParam('?name=hey#fragment', 'name')).toEqual('hey')
+      // expect(getQueryParam('?name=hey&age=20&tall=170', 'age')).toBe('20')
+      // const searchParams = new URLSearchParams({ name: '炎' })
+      // expect(getQueryParam('?' + searchParams.toString(), 'name')).toBe('炎')
+      // expect(getQueryParam('?name=hey&age=20&tall=170', 'weight')).toBe(null)
+      // expect(getQueryParam('?name=hey&age=20&tall=170')).toEqual({
+      //   name: 'hey',
+      //   age: '20',
+      //   tall: '170',
+      // })
+      // expect(getQueryParam('?pretty', 'pretty')).toBe('')
+      // expect(getQueryParam('?pretty', 'prtt')).toBe(null)
+      // expect(getQueryParam('?name=sam&name=tom', 'name')).toBe('sam')
+      // expect(getQueryParam('?name=sam&name=tom')).toEqual({
+      //   name: 'sam',
+      // })
+
+      expect(getQueryParam('name=hey', 'name')).toBe('hey')
+      expect(getQueryParam('name=hey&age=20&tall=170', 'age')).toBe('20')
+      const searchParams = new URLSearchParams({ name: '炎' })
+      expect(getQueryParam(searchParams.toString(), 'name')).toBe('炎')
+      expect(getQueryParam('name=hey&age=20&tall=170', 'weight')).toBe(null)
+      expect(getQueryParam('name=hey&age=20&tall=170')).toEqual({
+        name: 'hey',
+        age: '20',
+        tall: '170',
+      })
+      expect(getQueryParam('pretty', 'pretty')).toBe('')
+      expect(getQueryParam('pretty', 'prtt')).toBe(null)
+      expect(getQueryParam('name=sam&name=tom', 'name')).toBe('sam')
+      expect(getQueryParam('name=sam&name=tom')).toEqual({
+        name: 'sam',
+      })
+    })
+  })
+
+  describe('getQueryParams', () => {
+    it('Parse URL query strings', () => {
+      expect(getQueryParams('name=hey', 'name')).toEqual(['hey'])
+      expect(getQueryParams('name=hey#fragment', 'name')).toEqual(['hey'])
+      expect(getQueryParams('name=hey&name=foo', 'name')).toEqual(['hey', 'foo'])
+      expect(getQueryParams('name=hey&age=20&tall=170', 'age')).toEqual(['20'])
+      expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30', 'age')).toEqual([
+        '20',
+        '30',
+      ])
+      const searchParams = new URLSearchParams()
+      searchParams.append('tag', '炎')
+      searchParams.append('tag', 'ほのお')
+      expect(getQueryParams(searchParams.toString(), 'tag')).toEqual(['炎', 'ほのお'])
+      expect(getQueryParams('name=hey&age=20&tall=170', 'weight')).toEqual(null)
+      expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30&tall=180')).toEqual({
+        name: ['hey', 'foo'],
+        age: ['20', '30'],
+        tall: ['170', '180'],
+      })
+      expect(getQueryParams('pretty', 'pretty')).toEqual([''])
+      expect(getQueryParams('pretty', 'prtt')).toBe(null)
     })
   })
 })

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -7,7 +7,6 @@ import {
   checkOptionalParameter,
   getQueryParam,
   getQueryParams,
-  getPathFromURLWithRegExp,
 } from './url'
 
 describe('url', () => {
@@ -40,44 +39,6 @@ describe('url', () => {
     expect(res?.[2]).toEqual(/^[0-9]+$/)
     res = getPattern('*')
     expect(res).toBe('*')
-  })
-
-  describe('getPathFromURLWithRegex', () => {
-    it('getPathFromURLWithRegex - no trailing slash', () => {
-      let path = getPathFromURLWithRegExp('https://example.com/')
-      expect(path[0]).toBe('/')
-      expect(path[1]).toBe('')
-      path = getPathFromURLWithRegExp('https://example.com/hello')
-      expect(path[0]).toBe('/hello')
-      expect(path[1]).toBe('')
-      path = getPathFromURLWithRegExp('https://example.com/hello/hey')
-      expect(path[0]).toBe('/hello/hey')
-      expect(path[1]).toBe('')
-      path = getPathFromURLWithRegExp('https://example.com/hello?name=foo')
-      expect(path[0]).toBe('/hello')
-      expect(path[1]).toBe('name=foo')
-      path = getPathFromURLWithRegExp('https://example.com/hello/hey?name=foo&name=bar')
-      expect(path[0]).toBe('/hello/hey')
-      expect(path[1]).toBe('name=foo&name=bar')
-    })
-
-    it('getPathFromURLWithRegex - with trailing slash', () => {
-      let path = getPathFromURLWithRegExp('https://example.com/hello/')
-      expect(path[0]).toBe('/hello/')
-      expect(path[1]).toBe('')
-      path = getPathFromURLWithRegExp('https://example.com/hello/hey/')
-      expect(path[0]).toBe('/hello/hey/')
-      expect(path[1]).toBe('')
-    })
-
-    it('getPathFromURLWithRegex - no strict is false', () => {
-      let path = getPathFromURLWithRegExp('https://example.com/hello/', false)
-      expect(path[0]).toBe('/hello')
-      expect(path[1]).toBe('')
-      path = getPathFromURLWithRegExp('https://example.com/hello/hey/', false)
-      expect(path[0]).toBe('/hello/hey')
-      expect(path[1]).toBe('')
-    })
   })
 
   describe('getPathFromURL', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -35,21 +35,6 @@ export const getPattern = (label: string): Pattern | null => {
   return null
 }
 
-export const getPathFromURLWithRegExp = (url: string, strict: boolean = true): [string, string] => {
-  const regExp = /^https?:\/\/[^/]+(\/[^?]+)\?*([^#]*)$/
-  const match = url.match(regExp)
-
-  if (match) {
-    if (strict === false && match[1].endsWith('/')) {
-      return [match[1].slice(0, -1), match[2]]
-    } else {
-      return [match[1], match[2]]
-    }
-  }
-
-  return ['/', '']
-}
-
 export const getPathFromURL = (url: string, strict: boolean = true): [string, number] => {
   const queryIndex = url.indexOf('?')
   const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,7 @@
 export type Pattern = readonly [string, string, RegExp | true] | '*'
 
 export const splitPath = (path: string): string[] => {
-  const paths = path.split(/\//) // faster than path.split('/')
+  const paths = path.split('/')
   if (paths[0] === '') {
     paths.shift()
   }
@@ -35,6 +35,21 @@ export const getPattern = (label: string): Pattern | null => {
   return null
 }
 
+export const getPathFromURLWithRegExp = (url: string, strict: boolean = true): [string, string] => {
+  const regExp = /^https?:\/\/[^/]+(\/[^?]+)\?*([^#]*)$/
+  const match = url.match(regExp)
+
+  if (match) {
+    if (strict === false && match[1].endsWith('/')) {
+      return [match[1].slice(0, -1), match[2]]
+    } else {
+      return [match[1], match[2]]
+    }
+  }
+
+  return ['/', '']
+}
+
 export const getPathFromURL = (url: string, strict: boolean = true): [string, number] => {
   const queryIndex = url.indexOf('?')
   const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
@@ -48,9 +63,8 @@ export const getPathFromURL = (url: string, strict: boolean = true): [string, nu
   return [result, queryIndex]
 }
 
-export const getQueryStringFromURL = (url: string, queryIndex?: number): string => {
-  queryIndex ||= url.indexOf('?')
-  const result = queryIndex !== -1 ? url.substring(queryIndex) : ''
+export const getQueryStringFromURL = (url: string, queryIndex: number): string => {
+  const result = queryIndex !== -1 ? url.slice(queryIndex + 1) : ''
   return result
 }
 
@@ -98,4 +112,72 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   const base = match[1]
   const optional = base + match[2]
   return [base, optional]
+}
+
+const filterQueryString = (queryString: string): string => {
+  const fragIndex = queryString.indexOf('#')
+  if (fragIndex !== -1) {
+    queryString = queryString.slice(0, fragIndex)
+  }
+  return queryString
+}
+
+// Optimized
+export const getQueryParam = (
+  queryString: string,
+  key?: string
+): string | null | Record<string, string> => {
+  queryString = filterQueryString(queryString)
+
+  const results: Record<string, string> = {}
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const andIndex = queryString.indexOf('&')
+    let strings = ''
+    if (andIndex === -1) {
+      strings = queryString
+    } else {
+      strings = queryString.slice(0, andIndex)
+    }
+
+    const kv = strings.split('=')
+
+    if (kv.length > 1) {
+      const k = kv[0]
+      const v = kv[1]
+      if (key === k) {
+        return v.indexOf('%') !== -1 ? decodeURI(v) : v
+      } else {
+        results[k] ||= v
+      }
+    } else if (strings === key) {
+      return ''
+    }
+
+    if (andIndex === -1) break
+    queryString = queryString.slice(andIndex + 1, queryString.length)
+  }
+
+  if (key) return null
+  return results
+}
+
+export const getQueryParams = (
+  queryString: string,
+  key?: string
+): string[] | null | Record<string, string[]> => {
+  queryString = filterQueryString(queryString)
+  const results: Record<string, string[]> = {}
+
+  for (const strings of queryString.split('&')) {
+    let [k, v] = strings.split('=')
+    if (v === undefined) v = ''
+    results[k] ||= []
+    results[k].push(v.indexOf('%') !== -1 ? decodeURI(v) : v)
+  }
+
+  if (key) return results[key] ? results[key] : null
+
+  return results
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -141,11 +141,10 @@ export const getQueryParam = (
       strings = queryString.slice(0, andIndex)
     }
 
-    const kv = strings.split('=')
-
-    if (kv.length > 1) {
-      const k = kv[0]
-      const v = kv[1]
+    const eqIndex = strings.indexOf('=')
+    if (eqIndex !== -1) {
+      const v = strings.slice(eqIndex + 1)
+      const k = strings.slice(0, eqIndex)
       if (key === k) {
         return v.indexOf('%') !== -1 ? decodeURI(v) : v
       } else {


### PR DESCRIPTION
This PR includes many changes for optimization.

* Avoid using `URLSearchParams`.
* Created original function to parse query params.
* Optimize handling headers.
* Reduced the number of headers passed to `Response`.
* Decode URL based on whether it contains `%` or not.
* Pass static value to `split` instead of regexp.
* Use `indexOf` instead of `slice`.

The result, 19% faster than 2.7.1!

<img width="771" alt="SS" src="https://user-images.githubusercontent.com/10682/211026398-4fc9625d-2659-4e75-9adc-fb964fe0e848.png">


