### PR TITLE
refactor(utils): splitRoutingPath, allow `@` to be safely used in parameter names.

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -38,6 +38,12 @@ describe('url', () => {
 
     ps = splitRoutingPath('/users/:name{[0-9a-zA-Z_-]{3,10}}')
     expect(ps).toStrictEqual(['users', ':name{[0-9a-zA-Z_-]{3,10}}'])
+
+    ps = splitRoutingPath('/users/:@name{[0-9a-zA-Z_-]{3,10}}')
+    expect(ps).toStrictEqual(['users', ':@name{[0-9a-zA-Z_-]{3,10}}'])
+
+    ps = splitRoutingPath('/users/:dept{\\d+}/:@name{[0-9a-zA-Z_-]{3,10}}')
+    expect(ps).toStrictEqual(['users', ':dept{\\d+}', ':@name{[0-9a-zA-Z_-]{3,10}}'])
   })
 
   it('getPattern', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -9,13 +9,15 @@ export const splitPath = (path: string): string[] => {
 }
 
 export const splitRoutingPath = (path: string): string[] => {
-  const groups : string[] = []
-  for (let i = 0;; i++) {
+  const groups: [string, string][] = [] // [mark, original string]
+  for (let i = 0; ; ) {
     let replaced = false
-    path = path.replace(/\{[^}]+\}/, (m) => {
-      groups[i] = m
+    path = path.replace(/\{[^}]+\}/g, (m) => {
+      const mark = `@\\${i}`
+      groups[i] = [mark, m]
+      i++
       replaced = true
-      return `@${i}`
+      return mark
     })
     if (!replaced) {
       break
@@ -27,9 +29,10 @@ export const splitRoutingPath = (path: string): string[] => {
     paths.shift()
   }
   for (let i = groups.length - 1; i >= 0; i--) {
+    const [mark] = groups[i]
     for (let j = paths.length - 1; j >= 0; j--) {
-      if (paths[j].match('@' + i)) {
-        paths[j] = paths[j].replace('@' + i, groups[i])
+      if (paths[j].indexOf(mark) !== -1) {
+        paths[j] = paths[j].replace(mark, groups[i][1])
         break
       }
     }


### PR DESCRIPTION
I noticed that `@` is not part of the path, but is available as part of the parameter name.
I don't expect many people to use @ in parameter names, but I would like to make @ available because fewer restrictions due to internal implementation methods is better.
I don't think it is quintessential to use `\` as a parameter name, so I don't think there is any conflict if it is `@\\{i}`.

### For another discussion

To simplify future discussions, it may be possible to decide in some version that "only `[a-zA-Z_][a-zA-Z0-9_]+` can be used for parameter names".