### PR TITLE
feat: introduce `HTTPException`

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -17,6 +17,7 @@ import type {
   Environment,
   Route,
 } from './types.ts'
+import { HTTPException } from './utils/http-exception.ts'
 import { getPathFromURL, mergePath } from './utils/url.ts'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -87,6 +88,9 @@ export class Hono<
   }
 
   private errorHandler: ErrorHandler<E> = (err: Error, c: Context<E>) => {
+    if (err instanceof HTTPException) {
+      return err.getResponse()
+    }
     console.trace(err)
     const message = 'Internal Server Error'
     return c.text(message, 500)

--- a/deno_dist/middleware/basic-auth/index.ts
+++ b/deno_dist/middleware/basic-auth/index.ts
@@ -2,6 +2,7 @@ import type { HonoRequest } from '../../request.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 import { timingSafeEqual } from '../../utils/buffer.ts'
 import { decodeBase64 } from '../../utils/encode.ts'
+import { HTTPException } from '../../utils/http-exception.ts'
 
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/
@@ -54,11 +55,12 @@ export const basicAuth = (
         }
       }
     }
-    return new Response('Unauthorized', {
+    const res = new Response('Unauthorized', {
       status: 401,
       headers: {
         'WWW-Authenticate': 'Basic realm="' + options.realm?.replace(/"/g, '\\"') + '"',
       },
     })
+    throw new HTTPException(401, { res })
   }
 }

--- a/deno_dist/middleware/bearer-auth/index.ts
+++ b/deno_dist/middleware/bearer-auth/index.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from '../../types.ts'
 import { timingSafeEqual } from '../../utils/buffer.ts'
+import { HTTPException } from '../../utils/http-exception.ts'
 
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
@@ -27,33 +28,36 @@ export const bearerAuth = (options: {
 
     if (!headerToken) {
       // No Authorization header
-      return new Response('Unauthorized', {
+      const res = new Response('Unauthorized', {
         status: 401,
         headers: {
           'WWW-Authenticate': `${options.prefix} realm="` + realm + '"',
         },
       })
+      throw new HTTPException(401, { res })
     } else {
       const regexp = new RegExp('^' + options.prefix + ' +(' + TOKEN_STRINGS + ') *$')
       const match = regexp.exec(headerToken)
       if (!match) {
         // Invalid Request
-        return new Response('Bad Request', {
+        const res = new Response('Bad Request', {
           status: 400,
           headers: {
             'WWW-Authenticate': `${options.prefix} error="invalid_request"`,
           },
         })
+        throw new HTTPException(400, { res })
       } else {
         const equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
         if (!equal) {
           // Invalid Token
-          return new Response('Unauthorized', {
+          const res = new Response('Unauthorized', {
             status: 401,
             headers: {
               'WWW-Authenticate': `${options.prefix} error="invalid_token"`,
             },
           })
+          throw new HTTPException(401, { res })
         }
       }
     }

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from '../../types.ts'
+import { HTTPException } from '../../utils/http-exception.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
 
@@ -21,12 +22,13 @@ export const jwt = (options: {
     if (credentials) {
       const parts = credentials.split(/\s+/)
       if (parts.length !== 2) {
-        return new Response('Unauthorized', {
+        const res = new Response('Unauthorized', {
           status: 401,
           headers: {
             'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="invalid credentials structure"`,
           },
         })
+        throw new HTTPException(401, { res })
       } else {
         token = parts[1]
       }
@@ -35,12 +37,13 @@ export const jwt = (options: {
     }
 
     if (!token) {
-      return new Response('Unauthorized', {
+      const res = new Response('Unauthorized', {
         status: 401,
         headers: {
           'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="no authorization included in request"`,
         },
       })
+      throw new HTTPException(401, { res })
     }
 
     let authorized = false
@@ -51,13 +54,14 @@ export const jwt = (options: {
       msg = `${e}`
     }
     if (!authorized) {
-      return new Response('Unauthorized', {
+      const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,
         headers: {
           'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_token",error_description="token verification failure"`,
         },
       })
+      throw new HTTPException(401, { res })
     }
 
     await next()

--- a/deno_dist/utils/http-exception.ts
+++ b/deno_dist/utils/http-exception.ts
@@ -1,0 +1,27 @@
+import type { StatusCode } from './http-status.ts'
+import { getStatusText } from './http-status.ts'
+
+type HTTPExceptionOptions = {
+  res?: Response
+  message?: string
+}
+
+export class HTTPException extends Error {
+  readonly res?: Response
+  readonly status: StatusCode
+  constructor(status: StatusCode = 500, options?: HTTPExceptionOptions) {
+    const message = options?.message || getStatusText(status)
+    super(message)
+    this.res = options?.res
+    this.status = status
+  }
+  getResponse(): Response {
+    if (this.res) {
+      return this.res
+    }
+    return new Response(this.message, {
+      status: this.status,
+      statusText: getStatusText(this.status),
+    })
+  }
+}

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -17,6 +17,7 @@ import type {
   Environment,
   Route,
 } from './types'
+import { HTTPException } from './utils/http-exception'
 import { getPathFromURL, mergePath } from './utils/url'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -87,6 +88,9 @@ export class Hono<
   }
 
   private errorHandler: ErrorHandler<E> = (err: Error, c: Context<E>) => {
+    if (err instanceof HTTPException) {
+      return err.getResponse()
+    }
     console.trace(err)
     const message = 'Internal Server Error'
     return c.text(message, 500)

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -2,6 +2,7 @@ import type { HonoRequest } from '../../request'
 import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
 import { decodeBase64 } from '../../utils/encode'
+import { HTTPException } from '../../utils/http-exception'
 
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/
@@ -54,11 +55,12 @@ export const basicAuth = (
         }
       }
     }
-    return new Response('Unauthorized', {
+    const res = new Response('Unauthorized', {
       status: 401,
       headers: {
         'WWW-Authenticate': 'Basic realm="' + options.realm?.replace(/"/g, '\\"') + '"',
       },
     })
+    throw new HTTPException(401, { res })
   }
 }

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
+import { HTTPException } from '../../utils/http-exception'
 
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
@@ -27,33 +28,36 @@ export const bearerAuth = (options: {
 
     if (!headerToken) {
       // No Authorization header
-      return new Response('Unauthorized', {
+      const res = new Response('Unauthorized', {
         status: 401,
         headers: {
           'WWW-Authenticate': `${options.prefix} realm="` + realm + '"',
         },
       })
+      throw new HTTPException(401, { res })
     } else {
       const regexp = new RegExp('^' + options.prefix + ' +(' + TOKEN_STRINGS + ') *$')
       const match = regexp.exec(headerToken)
       if (!match) {
         // Invalid Request
-        return new Response('Bad Request', {
+        const res = new Response('Bad Request', {
           status: 400,
           headers: {
             'WWW-Authenticate': `${options.prefix} error="invalid_request"`,
           },
         })
+        throw new HTTPException(400, { res })
       } else {
         const equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
         if (!equal) {
           // Invalid Token
-          return new Response('Unauthorized', {
+          const res = new Response('Unauthorized', {
             status: 401,
             headers: {
               'WWW-Authenticate': `${options.prefix} error="invalid_token"`,
             },
           })
+          throw new HTTPException(401, { res })
         }
       }
     }

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from '../../types'
+import { HTTPException } from '../../utils/http-exception'
 import { Jwt } from '../../utils/jwt'
 import type { AlgorithmTypes } from '../../utils/jwt/types'
 
@@ -21,12 +22,13 @@ export const jwt = (options: {
     if (credentials) {
       const parts = credentials.split(/\s+/)
       if (parts.length !== 2) {
-        return new Response('Unauthorized', {
+        const res = new Response('Unauthorized', {
           status: 401,
           headers: {
             'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="invalid credentials structure"`,
           },
         })
+        throw new HTTPException(401, { res })
       } else {
         token = parts[1]
       }
@@ -35,12 +37,13 @@ export const jwt = (options: {
     }
 
     if (!token) {
-      return new Response('Unauthorized', {
+      const res = new Response('Unauthorized', {
         status: 401,
         headers: {
           'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_request",error_description="no authorization included in request"`,
         },
       })
+      throw new HTTPException(401, { res })
     }
 
     let authorized = false
@@ -51,13 +54,14 @@ export const jwt = (options: {
       msg = `${e}`
     }
     if (!authorized) {
-      return new Response('Unauthorized', {
+      const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,
         headers: {
           'WWW-Authenticate': `Bearer realm="${ctx.req.url}",error="invalid_token",error_description="token verification failure"`,
         },
       })
+      throw new HTTPException(401, { res })
     }
 
     await next()

--- a/src/utils/http-exceoption.test.ts
+++ b/src/utils/http-exceoption.test.ts
@@ -1,0 +1,13 @@
+import { HTTPException } from './http-exception'
+
+describe('HTTPFatalError', () => {
+  it('Should be 401 HTTP exception object', () => {
+    // We should throw an exception if is not authorized
+    // because next handlers should not be fired.
+    const exception = new HTTPException(401)
+    expect(exception.status).toBe(401)
+    expect(exception.message).toBe('Unauthorized')
+    const res = exception.getResponse()
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/utils/http-exception.ts
+++ b/src/utils/http-exception.ts
@@ -1,0 +1,27 @@
+import type { StatusCode } from './http-status'
+import { getStatusText } from './http-status'
+
+type HTTPExceptionOptions = {
+  res?: Response
+  message?: string
+}
+
+export class HTTPException extends Error {
+  readonly res?: Response
+  readonly status: StatusCode
+  constructor(status: StatusCode = 500, options?: HTTPExceptionOptions) {
+    const message = options?.message || getStatusText(status)
+    super(message)
+    this.res = options?.res
+    this.status = status
+  }
+  getResponse(): Response {
+    if (this.res) {
+      return this.res
+    }
+    return new Response(this.message, {
+      status: this.status,
+      statusText: getStatusText(this.status),
+    })
+  }
+}

--- a/test_lagon/index.ts
+++ b/test_lagon/index.ts
@@ -4,6 +4,7 @@ import { bearerAuth } from '../src/middleware/bearer-auth'
 import { etag } from '../src/middleware/etag'
 import { poweredBy } from '../src/middleware/powered-by'
 import { prettyJSON } from '../src/middleware/pretty-json'
+import { HTTPException } from '../src/utils/http-exception'
 
 const app = new Hono()
 
@@ -47,6 +48,9 @@ app.notFound((c) => {
 
 // Error handling
 app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return err.getResponse()
+  }
   console.error(`${err}`)
   return c.text('Custom Error Message', 500)
 })


### PR DESCRIPTION
In this PR, I will introduce `HTTPException`.

Until now, we have not dared to create an `Exception` class that extends `Error`. Because we can handle it with the middleware looking up status codes.

```ts
app.post('/validator', async (c, next) => {
  await next()
  if (c.res.status === 400) {
    return c.text('Validation error!', 400)
  }
})
```

But, if 401 error occurs in Basic Auth or Bearer Auth middleware, another middleware cannot handle it because Basic Auth and Bearer Auth middleware immediately returns the Response. We must not fire the next middleware handler for a security issue.

So, when a fatal error occurs, such as an authentication error, we can throw this `HTTPException` and handle it with `app.onError`.

```ts
app.onError((e, c) => {
  if (e instanceof HTTPException && e.status === 401) {
    return c.json(
      {
        message: 'Custom error message!',
      },
      401
    )
  }
  return c.text('Internal Server Error', 500)
})
```

It is not usually used, but it is a necessary feature to customize the error message for such an "Unauthorized" error.

This will be merged into "next" branch.