### PR TITLE
remove unnecessary individual strict mode family options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "strictPropertyInitialization": true,
-    "strictNullChecks": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "lib": [


### PR DESCRIPTION
The [TypeScript documentation](https://www.typescriptlang.org/tsconfig#strict) said:

> The `strict` flag enables a wide range of type checking behavior that results in stronger guarantees of program correctness. **Turning this on is equivalent to enabling all of the strict mode family options**, which are outlined below. You can then turn off individual strict mode family checks as needed.

Because there is already a `strict` flag, so `strictPropertyInitialization` and `strictNullChecks` are redundant.