### PR TITLE
fix: correctly export pages adapter

### DIFF
--- a/src/adapter/cloudflare-pages/index.ts
+++ b/src/adapter/cloudflare-pages/index.ts
@@ -1,0 +1,2 @@
+// @denoify-ignore
+export { handle } from './handler'


### PR DESCRIPTION
In v3 RC, `hono/cloudflare-pages` is currently unusable due to discordance between the `exports` field and actual build asset:

https://github.com/honojs/hono/blob/2cb250faf9b8520719102b2a4e522307323ba803/package.json#L145-L149

and

```console
$ cd repro && cd $_
$ npm init -y && npm install hono@next
$ ls node_modules/hono/dist/adapter/cloudflare-pages
handler.js
```

This PR aims to fix the problem.