### PR TITLE
fix(request): `param()` return `''` instead of `undefined`

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -58,7 +58,7 @@ export function extendRequestPrototype() {
     if (this.paramData) {
       if (key) {
         const param = this.paramData[key]
-        return param ? decodeURIComponent(param) : undefined
+        return param ? decodeURIComponent(param) : ''
       } else {
         const decoded: Record<string, string> = {}
 
@@ -71,7 +71,7 @@ export function extendRequestPrototype() {
         return decoded
       }
     }
-    return null
+    return ''
   } as InstanceType<typeof Request>['param']
 
   Request.prototype.header = function (this: Request, name?: string) {

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -39,7 +39,7 @@ export type Next = () => Promise<void>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
   ? Name
-  : NameWithPattern
+  : string
 
 type ParamKey<Component> = Component extends `:${infer NameWithPattern}?`
   ? ParamKeyName<NameWithPattern>

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -392,15 +392,13 @@ describe('param and query', () => {
   describe('param with undefined', () => {
     const app = new Hono()
     app.get('/foo/:foo', (c) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      /* @ts-ignore */
       const bar = c.req.param('bar')
       return c.json({ foo: bar })
     })
-    it('param of /foo/foo should return undefined not "undefined"', async () => {
+    it('param of /foo/foo should return ""', async () => {
       const res = await app.request('http://localhost/foo/foo')
       expect(res.status).toBe(200)
-      expect(await res.json()).toEqual({ foo: undefined })
+      expect(await res.json()).toEqual({ foo: '' })
     })
   })
 })
@@ -1385,5 +1383,31 @@ describe('Show routes', () => {
     app.get('/foo', (c) => c.text('/'))
     app.showRoutes()
     expect(console.log).toBeCalled()
+  })
+})
+
+describe('Optional parameters', () => {
+  const app = new Hono()
+  app.get('/api/animal/:type?', (c) => {
+    const type = c.req.param('type')
+    return c.json({
+      type: type,
+    })
+  })
+
+  it('Should match with an optional parameter', async () => {
+    const res = await app.request('http://localhost/api/animal/bird')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      type: 'bird',
+    })
+  })
+
+  it('Should match without an optional parameter', async () => {
+    const res = await app.request('http://localhost/api/animal')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      type: '',
+    })
   })
 })

--- a/src/request.ts
+++ b/src/request.ts
@@ -58,7 +58,7 @@ export function extendRequestPrototype() {
     if (this.paramData) {
       if (key) {
         const param = this.paramData[key]
-        return param ? decodeURIComponent(param) : undefined
+        return param ? decodeURIComponent(param) : ''
       } else {
         const decoded: Record<string, string> = {}
 
@@ -71,7 +71,7 @@ export function extendRequestPrototype() {
         return decoded
       }
     }
-    return null
+    return ''
   } as InstanceType<typeof Request>['param']
 
   Request.prototype.header = function (this: Request, name?: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type Next = () => Promise<void>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
   ? Name
-  : NameWithPattern
+  : string
 
 type ParamKey<Component> = Component extends `:${infer NameWithPattern}?`
   ? ParamKeyName<NameWithPattern>


### PR DESCRIPTION
This will fix #821 and includes a "little" breaking change.

If define the route with an optional parameter:

```ts
  app.get('/api/animal/:type?', (c) => {
    const type = c.req.param('type')
    return c.json({
      type: type,
    })
  })
```

And then get access to `/api/animal`. Currently, the `type` will be `undefined`.

In this PR, that will be `''` - blank string.

Does `type` return `string` or `string | undefined`? was ambiguous, so we decided always to return `string` in this PR.

