### PR TITLE
fix(request): make optional param type correct

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -82,10 +82,9 @@ export class Hono<
 
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
-      this[method] = <Env extends Environment, Data>(
-        args1: string | Handler<string, Env, Data>,
-        ...args: Handler<string, Env, Data>[]
-      ) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this[method] = (args1: string | Handler, ...args: Handler[]) => {
         if (typeof args1 === 'string') {
           this.path = args1
         } else {
@@ -213,7 +212,8 @@ export class Hono<
       let res: ReturnType<Handler<P>>
 
       try {
-        res = handler(c as unknown as Context<string, E, S>, async () => {})
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        res = handler(c as any, async () => {})
         if (!res) return this.notFoundHandler(c)
       } catch (err) {
         return this.handleError(err, c)
@@ -240,7 +240,8 @@ export class Hono<
 
     return (async () => {
       try {
-        const tmp = composed(c)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const tmp = composed(c as any)
         const context = tmp instanceof Promise ? await tmp : tmp
         if (!context.finalized) {
           throw new Error(

--- a/deno_dist/middleware/validator/middleware.ts
+++ b/deno_dist/middleware/validator/middleware.ts
@@ -42,6 +42,8 @@ export const validatorMiddleware = <
       results: [],
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     const schema = validationFunction(v, c)
     const validatorList = getValidatorList(schema)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -110,6 +112,8 @@ export const validatorMiddleware = <
     }
 
     if (options && options.done) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       const res = options.done(resultSet, c)
       if (res) {
         return res

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -2,20 +2,28 @@ import { parseBody } from './utils/body.ts'
 import type { BodyData } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
+import type { UnionToIntersection } from './utils/types.ts'
 import { getQueryStringFromURL } from './utils/url.ts'
+
+type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
+type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
+  ? Record<R, string | undefined>
+  : Record<T, string>
 
 declare global {
   interface Request<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     CfHostMetadata = unknown,
-    ParamKeyType extends string = string,
+    ParamKey extends string = string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Data = any
   > {
-    paramData?: Record<ParamKeyType, string>
+    paramData?: Record<ParamKey, string>
     param: {
-      (key: ParamKeyType): string
-      (): Record<ParamKeyType, string>
+      (key: RemoveQuestion<ParamKey>): UndefinedIfHavingQuestion<ParamKey>
+      (): UnionToIntersection<ParamKeyToRecord<ParamKey>>
     }
     queryData?: Record<string, string>
     query: {

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -41,9 +41,7 @@ type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${in
   ? Name
   : NameWithPattern
 
-type ParamKey<Component> = Component extends `:${infer NameWithPattern}?`
-  ? ParamKeyName<NameWithPattern>
-  : Component extends `:${infer NameWithPattern}`
+type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
   ? ParamKeyName<NameWithPattern>
   : never
 

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -1,5 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type Expect<T extends true> = T
 export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
   ? true
   : false
 export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true
+
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1387,3 +1387,34 @@ describe('Show routes', () => {
     expect(console.log).toBeCalled()
   })
 })
+
+describe('Optional parameters', () => {
+  const app = new Hono()
+  app.get('/api/:version/animal/:type?', (c) => {
+    const type1 = c.req.param('type')
+    type verify = Expect<Equal<typeof type1, string | undefined>>
+    const { type, version } = c.req.param()
+    type verify2 = Expect<Equal<typeof version, string>>
+    type verify3 = Expect<Equal<typeof type, string | undefined>>
+
+    return c.json({
+      type: type,
+    })
+  })
+
+  it('Should match with an optional parameter', async () => {
+    const res = await app.request('http://localhost/api/v1/animal/bird')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      type: 'bird',
+    })
+  })
+
+  it('Should match without an optional parameter', async () => {
+    const res = await app.request('http://localhost/api/v1/animal')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      type: undefined,
+    })
+  })
+})

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -82,10 +82,9 @@ export class Hono<
 
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
-      this[method] = <Env extends Environment, Data>(
-        args1: string | Handler<string, Env, Data>,
-        ...args: Handler<string, Env, Data>[]
-      ) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this[method] = (args1: string | Handler, ...args: Handler[]) => {
         if (typeof args1 === 'string') {
           this.path = args1
         } else {
@@ -213,7 +212,8 @@ export class Hono<
       let res: ReturnType<Handler<P>>
 
       try {
-        res = handler(c as unknown as Context<string, E, S>, async () => {})
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        res = handler(c as any, async () => {})
         if (!res) return this.notFoundHandler(c)
       } catch (err) {
         return this.handleError(err, c)
@@ -240,7 +240,8 @@ export class Hono<
 
     return (async () => {
       try {
-        const tmp = composed(c)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const tmp = composed(c as any)
         const context = tmp instanceof Promise ? await tmp : tmp
         if (!context.finalized) {
           throw new Error(

--- a/src/middleware/validator/middleware.ts
+++ b/src/middleware/validator/middleware.ts
@@ -42,6 +42,8 @@ export const validatorMiddleware = <
       results: [],
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     const schema = validationFunction(v, c)
     const validatorList = getValidatorList(schema)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -110,6 +112,8 @@ export const validatorMiddleware = <
     }
 
     if (options && options.done) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       const res = options.done(resultSet, c)
       if (res) {
         return res

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,20 +2,28 @@ import { parseBody } from './utils/body'
 import type { BodyData } from './utils/body'
 import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
+import type { UnionToIntersection } from './utils/types'
 import { getQueryStringFromURL } from './utils/url'
+
+type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
+type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
+  ? Record<R, string | undefined>
+  : Record<T, string>
 
 declare global {
   interface Request<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     CfHostMetadata = unknown,
-    ParamKeyType extends string = string,
+    ParamKey extends string = string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Data = any
   > {
-    paramData?: Record<ParamKeyType, string>
+    paramData?: Record<ParamKey, string>
     param: {
-      (key: ParamKeyType): string
-      (): Record<ParamKeyType, string>
+      (key: RemoveQuestion<ParamKey>): UndefinedIfHavingQuestion<ParamKey>
+      (): UnionToIntersection<ParamKeyToRecord<ParamKey>>
     }
     queryData?: Record<string, string>
     query: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,9 +41,7 @@ type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${in
   ? Name
   : NameWithPattern
 
-type ParamKey<Component> = Component extends `:${infer NameWithPattern}?`
-  ? ParamKeyName<NameWithPattern>
-  : Component extends `:${infer NameWithPattern}`
+type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
   ? ParamKeyName<NameWithPattern>
   : never
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type Expect<T extends true> = T
 export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
   ? true
   : false
 export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true
+
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never


### PR DESCRIPTION
This PR fix #821 

In the current version, if `/api/animal/:type?` is defined as a route, `type` will be `string` though it is "optional". It's the wrong type. In this PR, it will be `string | undefined`.

<img width="508" alt="SS" src="https://user-images.githubusercontent.com/10682/213830168-8efd6d2b-2f9f-4ce3-87bb-88b301179ed5.png">

I've made PR #825  which makes it a blank string `''` not `string | undefined`. But, after getting advice from @pmbanugo, I rethought it should be `string | undefined`.