### PR TITLE
feat(validator): support multiple handlers w/ complex patterns.

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -15,7 +15,6 @@ import type {
   ErrorHandler,
   NotFoundHandler,
   Env,
-  Route,
   MiddlewareHandler,
 } from './types.ts'
 import { HTTPException } from './utils/http-exception.ts'
@@ -45,10 +44,11 @@ function defineDynamicClass(): {
 
 export class Hono<
   E extends Env = Env,
-  R extends Route = Route,
+  P extends string = string,
+  M extends string = string,
   I = {},
   O = {}
-> extends defineDynamicClass()<E, R['method'], R['path']> {
+> extends defineDynamicClass()<E, M, P> {
   readonly router: Router<Handler> = new SmartRouter({
     routers: [new StaticRouter(), new RegExpRouter(), new TrieRouter()],
   })
@@ -108,11 +108,11 @@ export class Hono<
     return this
   }
 
-  use(...middleware: MiddlewareHandler<E>[]): Hono<E, { method: 'all'; path: string }, I, O>
+  use(...middleware: MiddlewareHandler<E>[]): Hono<E, string, 'all', I, O>
   use<Path extends string>(
     arg1: Path,
     ...middleware: MiddlewareHandler<E>[]
-  ): Hono<E, { method: 'all'; path: Path }, I, O>
+  ): Hono<E, Path, 'all', I, O>
   use(arg1: string | MiddlewareHandler<E>, ...handlers: MiddlewareHandler<E>[]) {
     if (typeof arg1 === 'string') {
       this.path = arg1
@@ -129,7 +129,7 @@ export class Hono<
     method: Method,
     path: Path,
     ...handlers: Handler<E, Path>[]
-  ): Hono<E, { method: Method; path: Path }, I, O>
+  ): Hono<E, Path, Method, I, O>
   on(method: string, path: string, ...handlers: Handler<E>[]) {
     if (!method) return this
     this.path = path

--- a/deno_dist/middleware/validator/index.ts
+++ b/deno_dist/middleware/validator/index.ts
@@ -9,17 +9,16 @@ type ValidationTypeByMethod<M> = M extends 'get' | 'head' // GET and HEAD reques
 
 export const validator = <
   T,
-  Path extends string,
-  Method extends string,
-  U extends ValidationTypeByMethod<Method>,
+  P extends string,
+  M extends string,
+  U extends ValidationTypeByMethod<M>,
   V extends { type: U; data: T },
-  V2 = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
   type: U,
   validationFunc: (value: ValidationTypes[U], c: Context<E>) => T | Response | Promise<Response>
-): MiddlewareHandler<E, Path, V | V2> => {
+): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
 

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -13,29 +13,178 @@ export type Env = {
   Variables?: Variables
 }
 
-export type Route = {
-  path: string
-  method: string
-}
-
 export type Handler<E extends Env = any, P extends string = any, I = {}, O = {}> = (
   c: Context<E, P, I>,
   next: Next
-) => Response | Promise<Response | void | TypeResponse<O>> | TypeResponse<O>
+) => Response | Promise<Response | TypeResponse<O> | void> | TypeResponse<O> | void
+
+export type MiddlewareHandler<E extends Env = any, P extends string = any, I = {}> = (
+  c: Context<E, P, I>,
+  next: Next
+) => Promise<Response | undefined | void>
 
 export interface HandlerInterface<
   E extends Env = Env,
   M extends string = any,
-  P extends string = any
+  S extends string = string
 > {
-  <Input = {}, Output = {}>(
-    ...handlers: (Handler<E, P, Input, Output> | MiddlewareHandler<E, P, Input>)[]
-  ): Hono<E, { method: M; path: P }, Input, Output>
-
-  <Path extends string, Input = {}, Output = {}>(
-    path: Path,
-    ...handlers: (Handler<E, Path, Input, Output> | MiddlewareHandler<E, Path, Input>)[]
-  ): Hono<E, { method: M; path: Path }, Input, Output>
+  // app.get(...handler)
+  <I = {}, O = {}>(...handlers: Handler<E, S, I, O>[]): Hono<E, S, M, I, O>
+  // app.get(path, handler, handler)
+  <P extends string, O = {}, I = {}>(
+    path: P,
+    ...handlers: [Handler<E, P, I, O>, Handler<E, P, I, O>]
+  ): Hono<E, P, M, I, O>
+  // app.get(path, handler x3)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2>(
+    path: P,
+    ...handlers: [Handler<E, P, I, O>, Handler<E, P, I2, O>, Handler<E, P, I3, O>]
+  ): Hono<E, P, M, I3, O>
+  // app.get(path, handler x4)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3>(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>
+    ]
+  ): Hono<E, P, M, I4, O>
+  // app.get(path, handler x5)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3, I5 = I3 | I4>(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>
+    ]
+  ): Hono<E, P, M, I5, O>
+  // app.get(path, handler x6)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3, I5 = I3 | I4, I6 = I4 | I5>(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>
+    ]
+  ): Hono<E, P, M, I6, O>
+  // app.get(path, handler x7)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>
+    ]
+  ): Hono<E, P, M, I7, O>
+  // app.get(path, handler x8)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6,
+    I8 = I6 | I7
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>,
+      Handler<E, P, I8, O>
+    ]
+  ): Hono<E, P, M, I8, O>
+  // app.get(path, handler x9)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6,
+    I8 = I6 | I7,
+    I9 = I7 | I8
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>,
+      Handler<E, P, I8, O>,
+      Handler<E, P, I9, O>
+    ]
+  ): Hono<E, P, M, I9, O>
+  // app.get(path, handler x10)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6,
+    I8 = I6 | I7,
+    I9 = I7 | I8,
+    I10 = I8 | I9
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>,
+      Handler<E, P, I8, O>,
+      Handler<E, P, I9, O>,
+      Handler<E, P, I10, O>
+    ]
+  ): Hono<E, P, M, I10, O>
+  // app.get(path, ...handler)
+  <P extends string, I = {}, O = {}>(path: P, ...handlers: Handler<E, P, I, O>[]): Hono<
+    E,
+    P,
+    M,
+    I,
+    O
+  >
 }
 
 export type ExtractType<T> = T extends TypeResponse<infer R>
@@ -43,11 +192,6 @@ export type ExtractType<T> = T extends TypeResponse<infer R>
   : T extends Promise<TypeResponse<infer R>>
   ? R
   : never
-
-export type MiddlewareHandler<E extends Env = any, P extends string = any, I = {}> = (
-  c: Context<E, P, I>,
-  next: Next
-) => Promise<Response | undefined | void>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 
@@ -63,7 +207,7 @@ export type TypeResponse<T = unknown> = {
 
 // This is not used for internally
 // Will be used by users as `Handler`
-export interface CustomHandler<E = Env, P = any, I = any> {
+export interface CustomHandler<E = Env, P = any, I = any, O = any> {
   (
     c: Context<
       E extends Env ? E : Env,
@@ -74,14 +218,14 @@ export interface CustomHandler<E = Env, P = any, I = any> {
           : E extends Env
           ? E
           : never
-        : E extends Route | string
+        : E extends string
         ? P extends Env
           ? E
           : P
         : E
     >,
     next: Next
-  ): Response | Promise<Response | undefined | void>
+  ): Response | Promise<Response | TypeResponse<O>> | TypeResponse<O>
 }
 
 export type ValidationTypes = {
@@ -91,8 +235,8 @@ export type ValidationTypes = {
   queries: Record<string, string[]>
 }
 
-export type ToAppType<T> = T extends Hono<infer _, infer R, infer I, infer O>
-  ? ToAppTypeInner<R, I, O>
+export type ToAppType<T> = T extends Hono<infer _, infer P, infer M, infer I, infer O>
+  ? ToAppTypeInner<P, M, I, O>
   : never
 
 type RemoveBlank<T> = {
@@ -103,10 +247,10 @@ type InputSchema = {
   [K in string]: { type: ValidationTypes; data: unknown }
 }
 
-type ToAppTypeInner<R extends Route, I, O> = RemoveBlank<I> extends InputSchema
+type ToAppTypeInner<P extends string, M extends string, I, O> = RemoveBlank<I> extends InputSchema
   ? {
-      [K in R['method']]: {
-        [K2 in R['path']]: {
+      [K in M]: {
+        [K2 in P]: {
           input: UnionToIntersection<
             I extends { type: keyof ValidationTypes; data: unknown }
               ? I extends { type: infer R }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -15,7 +15,6 @@ import type {
   ErrorHandler,
   NotFoundHandler,
   Env,
-  Route,
   MiddlewareHandler,
 } from './types'
 import { HTTPException } from './utils/http-exception'
@@ -45,10 +44,11 @@ function defineDynamicClass(): {
 
 export class Hono<
   E extends Env = Env,
-  R extends Route = Route,
+  P extends string = string,
+  M extends string = string,
   I = {},
   O = {}
-> extends defineDynamicClass()<E, R['method'], R['path']> {
+> extends defineDynamicClass()<E, M, P> {
   readonly router: Router<Handler> = new SmartRouter({
     routers: [new StaticRouter(), new RegExpRouter(), new TrieRouter()],
   })
@@ -108,11 +108,11 @@ export class Hono<
     return this
   }
 
-  use(...middleware: MiddlewareHandler<E>[]): Hono<E, { method: 'all'; path: string }, I, O>
+  use(...middleware: MiddlewareHandler<E>[]): Hono<E, string, 'all', I, O>
   use<Path extends string>(
     arg1: Path,
     ...middleware: MiddlewareHandler<E>[]
-  ): Hono<E, { method: 'all'; path: Path }, I, O>
+  ): Hono<E, Path, 'all', I, O>
   use(arg1: string | MiddlewareHandler<E>, ...handlers: MiddlewareHandler<E>[]) {
     if (typeof arg1 === 'string') {
       this.path = arg1
@@ -129,7 +129,7 @@ export class Hono<
     method: Method,
     path: Path,
     ...handlers: Handler<E, Path>[]
-  ): Hono<E, { method: Method; path: Path }, I, O>
+  ): Hono<E, Path, Method, I, O>
   on(method: string, path: string, ...handlers: Handler<E>[]) {
     if (!method) return this
     this.path = path

--- a/src/middleware/validator/index.test.ts
+++ b/src/middleware/validator/index.test.ts
@@ -23,6 +23,9 @@ describe('Validator middleware', () => {
   const route = app
     .get(
       '/search',
+      async (_c, next) => {
+        await next()
+      },
       validator('query', (value, c) => {
         if (!value) {
           return c.text('Invalid!', 400)

--- a/src/middleware/validator/index.ts
+++ b/src/middleware/validator/index.ts
@@ -9,17 +9,16 @@ type ValidationTypeByMethod<M> = M extends 'get' | 'head' // GET and HEAD reques
 
 export const validator = <
   T,
-  Path extends string,
-  Method extends string,
-  U extends ValidationTypeByMethod<Method>,
+  P extends string,
+  M extends string,
+  U extends ValidationTypeByMethod<M>,
   V extends { type: U; data: T },
-  V2 = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
   type: U,
   validationFunc: (value: ValidationTypes[U], c: Context<E>) => T | Response | Promise<Response>
-): MiddlewareHandler<E, Path, V | V2> => {
+): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -2,13 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Hono } from './hono'
 import { poweredBy } from './middleware/powered-by'
-import type {
-  Env,
-  CustomHandler as Handler,
-  InputToData,
-  MiddlewareHandler,
-  ToAppType,
-} from './types'
+import type { Env, CustomHandler as Handler, InputToData, ToAppType } from './types'
 import type { Expect, Equal } from './utils/types'
 
 describe('Test types of CustomHandler', () => {
@@ -94,37 +88,12 @@ describe('Test types of CustomHandler', () => {
   })
 })
 
-describe('CustomHandler as middleware', () => {
-  const app = new Hono()
-  const mid1 = (): MiddlewareHandler => {
-    return async (_c, next) => {
-      await next()
-    }
-  }
-
-  const mid2 = (): Handler => {
-    return async (_c, next) => {
-      await next()
-    }
-  }
-
-  it('Should not throw Type error', async () => {
-    app.get('*', mid1(), mid2(), (c) => {
-      return c.text('foo')
-    })
-    const res = await app.request('http://localhost/')
-    expect(res.status).toBe(200)
-  })
-})
-
 describe('Types used in the validator', () => {
   test('ToAppType', () => {
     type SampleHono = Hono<
       Env,
-      {
-        path: '/author'
-        method: 'post'
-      },
+      '/author',
+      'post',
       {
         type: 'json'
         data: { name: string; age: number }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,29 +13,178 @@ export type Env = {
   Variables?: Variables
 }
 
-export type Route = {
-  path: string
-  method: string
-}
-
 export type Handler<E extends Env = any, P extends string = any, I = {}, O = {}> = (
   c: Context<E, P, I>,
   next: Next
-) => Response | Promise<Response | void | TypeResponse<O>> | TypeResponse<O>
+) => Response | Promise<Response | TypeResponse<O> | void> | TypeResponse<O> | void
+
+export type MiddlewareHandler<E extends Env = any, P extends string = any, I = {}> = (
+  c: Context<E, P, I>,
+  next: Next
+) => Promise<Response | undefined | void>
 
 export interface HandlerInterface<
   E extends Env = Env,
   M extends string = any,
-  P extends string = any
+  S extends string = string
 > {
-  <Input = {}, Output = {}>(
-    ...handlers: (Handler<E, P, Input, Output> | MiddlewareHandler<E, P, Input>)[]
-  ): Hono<E, { method: M; path: P }, Input, Output>
-
-  <Path extends string, Input = {}, Output = {}>(
-    path: Path,
-    ...handlers: (Handler<E, Path, Input, Output> | MiddlewareHandler<E, Path, Input>)[]
-  ): Hono<E, { method: M; path: Path }, Input, Output>
+  // app.get(...handler)
+  <I = {}, O = {}>(...handlers: Handler<E, S, I, O>[]): Hono<E, S, M, I, O>
+  // app.get(path, handler, handler)
+  <P extends string, O = {}, I = {}>(
+    path: P,
+    ...handlers: [Handler<E, P, I, O>, Handler<E, P, I, O>]
+  ): Hono<E, P, M, I, O>
+  // app.get(path, handler x3)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2>(
+    path: P,
+    ...handlers: [Handler<E, P, I, O>, Handler<E, P, I2, O>, Handler<E, P, I3, O>]
+  ): Hono<E, P, M, I3, O>
+  // app.get(path, handler x4)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3>(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>
+    ]
+  ): Hono<E, P, M, I4, O>
+  // app.get(path, handler x5)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3, I5 = I3 | I4>(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>
+    ]
+  ): Hono<E, P, M, I5, O>
+  // app.get(path, handler x6)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3, I5 = I3 | I4, I6 = I4 | I5>(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>
+    ]
+  ): Hono<E, P, M, I6, O>
+  // app.get(path, handler x7)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>
+    ]
+  ): Hono<E, P, M, I7, O>
+  // app.get(path, handler x8)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6,
+    I8 = I6 | I7
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>,
+      Handler<E, P, I8, O>
+    ]
+  ): Hono<E, P, M, I8, O>
+  // app.get(path, handler x9)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6,
+    I8 = I6 | I7,
+    I9 = I7 | I8
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>,
+      Handler<E, P, I8, O>,
+      Handler<E, P, I9, O>
+    ]
+  ): Hono<E, P, M, I9, O>
+  // app.get(path, handler x10)
+  <
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I | I2,
+    I4 = I2 | I3,
+    I5 = I3 | I4,
+    I6 = I4 | I5,
+    I7 = I5 | I6,
+    I8 = I6 | I7,
+    I9 = I7 | I8,
+    I10 = I8 | I9
+  >(
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>,
+      Handler<E, P, I6, O>,
+      Handler<E, P, I7, O>,
+      Handler<E, P, I8, O>,
+      Handler<E, P, I9, O>,
+      Handler<E, P, I10, O>
+    ]
+  ): Hono<E, P, M, I10, O>
+  // app.get(path, ...handler)
+  <P extends string, I = {}, O = {}>(path: P, ...handlers: Handler<E, P, I, O>[]): Hono<
+    E,
+    P,
+    M,
+    I,
+    O
+  >
 }
 
 export type ExtractType<T> = T extends TypeResponse<infer R>
@@ -43,11 +192,6 @@ export type ExtractType<T> = T extends TypeResponse<infer R>
   : T extends Promise<TypeResponse<infer R>>
   ? R
   : never
-
-export type MiddlewareHandler<E extends Env = any, P extends string = any, I = {}> = (
-  c: Context<E, P, I>,
-  next: Next
-) => Promise<Response | undefined | void>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 
@@ -63,7 +207,7 @@ export type TypeResponse<T = unknown> = {
 
 // This is not used for internally
 // Will be used by users as `Handler`
-export interface CustomHandler<E = Env, P = any, I = any> {
+export interface CustomHandler<E = Env, P = any, I = any, O = any> {
   (
     c: Context<
       E extends Env ? E : Env,
@@ -74,14 +218,14 @@ export interface CustomHandler<E = Env, P = any, I = any> {
           : E extends Env
           ? E
           : never
-        : E extends Route | string
+        : E extends string
         ? P extends Env
           ? E
           : P
         : E
     >,
     next: Next
-  ): Response | Promise<Response | undefined | void>
+  ): Response | Promise<Response | TypeResponse<O>> | TypeResponse<O>
 }
 
 export type ValidationTypes = {
@@ -91,8 +235,8 @@ export type ValidationTypes = {
   queries: Record<string, string[]>
 }
 
-export type ToAppType<T> = T extends Hono<infer _, infer R, infer I, infer O>
-  ? ToAppTypeInner<R, I, O>
+export type ToAppType<T> = T extends Hono<infer _, infer P, infer M, infer I, infer O>
+  ? ToAppTypeInner<P, M, I, O>
   : never
 
 type RemoveBlank<T> = {
@@ -103,10 +247,10 @@ type InputSchema = {
   [K in string]: { type: ValidationTypes; data: unknown }
 }
 
-type ToAppTypeInner<R extends Route, I, O> = RemoveBlank<I> extends InputSchema
+type ToAppTypeInner<P extends string, M extends string, I, O> = RemoveBlank<I> extends InputSchema
   ? {
-      [K in R['method']]: {
-        [K2 in R['path']]: {
+      [K in M]: {
+        [K2 in P]: {
           input: UnionToIntersection<
             I extends { type: keyof ValidationTypes; data: unknown }
               ? I extends { type: infer R }


### PR DESCRIPTION
This PR enable we can register multiple validator/handlers with complex patterns.

See: <https://github.com/honojs/hono/issues/823>

Thanks to everyone, it comes true. We can write like this:

<img width="974" alt="SS" src="https://user-images.githubusercontent.com/10682/213915299-df0ea5c5-cfec-43a0-a600-7c0a3f74e43b.png">

Note:

* We can't register over ten handlers with validators. Have to write it down in the document when releasing the "v3".
* There may be some things to fix, but I'll merge them in, to be fixed later.
