### PR TITLE
fix(context): fixed bug raw `Response` content-type is overwritten

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -66,6 +66,7 @@ export class Context<
 
   set res(_res: Response) {
     if (this._res) {
+      this._res.headers.delete('content-type')
       this._res.headers.forEach((v, k) => {
         _res.headers.set(k, v)
       })

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -123,10 +123,15 @@ describe('Context', () => {
 
   it('Should append the previous headers to new Response', () => {
     c.res.headers.set('x-Custom1', 'Message1')
-    const res2 = new Response('foo2')
+    const res2 = new Response('foo2', {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
     res2.headers.set('x-Custom2', 'Message2')
     c.res = res2
     expect(c.res.headers.get('x-Custom1')).toBe('Message1')
+    expect(c.res.headers.get('Content-Type')).toBe('application/json')
   })
 
   it('Should return 200 response', async () => {
@@ -182,10 +187,8 @@ describe('Context header', () => {
   })
   it('Should return only one content-type value', async () => {
     c.header('Content-Type', 'foo')
-    c.header('content-type', 'foo')
     const res = c.html('foo')
     expect(res.headers.get('Content-Type')).toBe('text/html; charset=UTF-8')
-    expect(res.headers.get('content-type')).toBe('text/html; charset=UTF-8')
   })
   it('Should rewrite header values correctly', async () => {
     c.res = c.html('foo')

--- a/src/context.ts
+++ b/src/context.ts
@@ -66,6 +66,7 @@ export class Context<
 
   set res(_res: Response) {
     if (this._res) {
+      this._res.headers.delete('content-type')
       this._res.headers.forEach((v, k) => {
         _res.headers.set(k, v)
       })

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -435,6 +435,25 @@ describe('Middleware', () => {
       return c.text('hello')
     })
 
+    app.use('/json/*', async (c, next) => {
+      c.res.headers.append('foo', 'bar')
+      await next()
+    })
+
+    app.get('/json', (c) => {
+      // With a raw response
+      return new Response(
+        JSON.stringify({
+          message: 'hello',
+        }),
+        {
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      )
+    })
+
     app.get('/hello/:message', (c) => {
       const message = c.req.param('message')
       return c.text(`${message}`)
@@ -463,6 +482,12 @@ describe('Middleware', () => {
       expect(await res.text()).toBe('message')
       expect(res.headers.get('x-custom')).toBe('root')
       expect(res.headers.get('x-message-2')).toBe('custom-header-2')
+    })
+
+    it('should return correct the content-type header', async () => {
+      const res = await app.request('http://localhost/json')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toMatch(/^application\/json/)
     })
 
     it('not found', async () => {


### PR DESCRIPTION
Fix #835 