### PR TITLE
feat: rewnew output types

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,6 +1,6 @@
 import { HonoRequest } from './request.ts'
 import type { TypeResponse } from './types.ts'
-import type { Env, NotFoundHandler } from './types.ts'
+import type { Env, NotFoundHandler, Input } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
@@ -33,8 +33,8 @@ export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Path extends string = any,
-  Schema = {}
+  P extends string = any,
+  I extends Input = {}
 > {
   env: E['Bindings'] = {}
   finalized: boolean = false
@@ -68,7 +68,7 @@ export class Context<
     }
   }
 
-  get req(): HonoRequest<Path, Schema> {
+  get req(): HonoRequest<P, I> {
     if (this._req) {
       return this._req
     } else {

--- a/deno_dist/middleware/validator/index.ts
+++ b/deno_dist/middleware/validator/index.ts
@@ -11,7 +11,7 @@ export const validator = <
   P extends string,
   M extends string,
   U extends ValidationTypeByMethod<M>,
-  V extends { type: U; data: T },
+  V extends { [K in U]: T },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
@@ -47,8 +47,7 @@ export const validator = <
         break
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = validationFunc(value, c as any)
+    const res = validationFunc(value, c)
 
     if (res instanceof Response || res instanceof Promise) {
       return res

--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -1,10 +1,14 @@
 import { Hono } from './hono.ts'
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   class ExtendableEvent extends Event {
     constructor(type: string, init?: EventInit)
     waitUntil(promise: Promise<void>): void
   }
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   abstract class FetchEvent extends ExtendableEvent {
     readonly request: Request
     respondWith(promise: Response | Promise<Response>): void
@@ -17,12 +21,12 @@ declare global {
 }
 
 export type {
-  Next,
-  MiddlewareHandler,
+  Env,
   ErrorHandler,
+  MiddlewareHandler,
+  Next,
   NotFoundHandler,
   ValidationTypes,
-  Env,
 } from './types.ts'
 import type { CustomHandler } from './types.ts'
 export type { CustomHandler as Handler }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -1,4 +1,11 @@
-import type { InputToData, InputToTypeData, ValidationTypes } from './types.ts'
+import type {
+  Input,
+  InputToData,
+  InputToDataByType,
+  ParamKeys,
+  ParamKeyToRecord,
+  ValidationTypes,
+} from './types.ts'
 import { parseBody } from './utils/body.ts'
 import type { BodyData } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
@@ -7,29 +14,12 @@ import { mergeObjects } from './utils/object.ts'
 import type { UnionToIntersection } from './utils/types.ts'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url.ts'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
-  ? Name
-  : NameWithPattern
-
-type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
-  ? ParamKeyName<NameWithPattern>
-  : never
-
-type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
-  ? ParamKey<Component> | ParamKeys<Rest>
-  : ParamKey<Path>
-
 type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
-type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
-  ? Record<R, string | undefined>
-  : Record<T, string>
-
-export class HonoRequest<Path extends string = '/', Input = {}> {
+export class HonoRequest<P extends string = '/', I extends Input = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined
@@ -51,8 +41,8 @@ export class HonoRequest<Path extends string = '/', Input = {}> {
     this.validatedData = {}
   }
 
-  param(key: RemoveQuestion<ParamKeys<Path>>): UndefinedIfHavingQuestion<ParamKeys<Path>>
-  param(): UnionToIntersection<ParamKeyToRecord<ParamKeys<Path>>>
+  param(key: RemoveQuestion<ParamKeys<P>>): UndefinedIfHavingQuestion<ParamKeys<P>>
+  param(): UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>>
   param(key?: string): unknown {
     if (this.paramData) {
       if (key) {
@@ -164,8 +154,8 @@ export class HonoRequest<Path extends string = '/', Input = {}> {
     this.validatedData[type] = merged
   }
 
-  valid(): InputToData<Input>
-  valid<T extends keyof ValidationTypes>(type: T): InputToTypeData<T, Input>
+  valid(): InputToData<I>
+  valid<T extends keyof ValidationTypes>(type: T): InputToDataByType<I, T>
   valid<T extends keyof ValidationTypes>(type?: T) {
     if (type) {
       const data = this.validatedData[type]

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -4,6 +4,8 @@ import type {
   InputToDataByType,
   ParamKeys,
   ParamKeyToRecord,
+  RemoveQuestion,
+  UndefinedIfHavingQuestion,
   ValidationTypes,
 } from './types.ts'
 import { parseBody } from './utils/body.ts'
@@ -13,11 +15,6 @@ import { parse } from './utils/cookie.ts'
 import { mergeObjects } from './utils/object.ts'
 import type { UnionToIntersection } from './utils/types.ts'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url.ts'
-
-type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
 export class HonoRequest<P extends string = '/', I extends Input = {}> {
   raw: Request

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -21,7 +21,7 @@ export type Env = {
 
 export type Next = () => Promise<void>
 
-export type Input = ValidationTypes | unknown
+export type Input = unknown
 
 ////////////////////////////////////////
 //////                            //////
@@ -331,7 +331,7 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
 
 ////////////////////////////////////////
 //////                            //////
-//////       Input to data        //////
+/////       For HonoRequest       //////
 //////                            //////
 ////////////////////////////////////////
 
@@ -346,6 +346,10 @@ export type InputToDataByType<T extends Input, Type extends keyof ValidationType
 }
   ? R
   : never
+
+export type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
+
+export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
 ////////////////////////////////////////
 //////                            //////

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -5,11 +5,11 @@ import type { Context } from './context.ts'
 import type { Hono } from './hono.ts'
 import type { UnionToIntersection } from './utils/types.ts'
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Values             //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////           Values           //////
+//////                            //////
+////////////////////////////////////////
 
 export type Bindings = Record<string, unknown>
 export type Variables = Record<string, unknown>
@@ -23,11 +23,11 @@ export type Next = () => Promise<void>
 
 export type Input = ValidationTypes | unknown
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Handlers           //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////          Handlers          //////
+//////                            //////
+////////////////////////////////////////
 
 export type Handler<
   E extends Env = any,
@@ -47,11 +47,11 @@ export type MiddlewareHandler<E extends Env = any, P extends string = any, I ext
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   HandlerInterface   //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////     HandlerInterface       //////
+//////                            //////
+////////////////////////////////////////
 
 export interface HandlerInterface<E extends Env = Env, M extends string = any, S = {}> {
   //// app.get(...handlers[])
@@ -141,11 +141,11 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   >
 }
 
-///////////////////////////////////////////////////
-//////////                               //////////
-//////////  MiddlewareHandlerInterface   //////////
-//////////                               //////////
-///////////////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+////// MiddlewareHandlerInterface //////
+//////                            //////
+////////////////////////////////////////
 
 export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
   //// app.get(...handlers[])
@@ -154,11 +154,11 @@ export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
   <P extends string>(path: P, ...handlers: MiddlewareHandler<E, P>[]): Hono<E, S>
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////  OnHandlerInterface  //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////     OnHandlerInterface     //////
+//////                            //////
+////////////////////////////////////////
 
 export interface OnHandlerInterface<E extends Env = Env, S = {}> {
   // app.on(method, path, handler, handler)
@@ -222,11 +222,11 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
     : never
   : string
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Schema             //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////           Schema           //////
+//////                            //////
+////////////////////////////////////////
 
 export type Schema<M extends string, P extends string, I extends Input, O> = {
   [K in P]: AddDollar<{ [K2 in M]: { input: AddParam<I, P>; output: O } }>
@@ -242,11 +242,11 @@ export type AddDollar<T> = T extends Record<infer K, infer R>
     : never
   : never
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   TypeResponse       //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////        TypeResponse        //////
+//////                            //////
+////////////////////////////////////////
 
 export type TypeResponse<T = unknown> = {
   response: Response | Promise<Response>
@@ -254,11 +254,11 @@ export type TypeResponse<T = unknown> = {
   format: 'json' // Currently, support only `json` with `c.jsonT()`
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   CustomHandler      //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////       CustomHandler        //////
+//////                            //////
+////////////////////////////////////////
 
 // This is not used for internally
 // Will be used by users as `Handler`
@@ -293,11 +293,11 @@ export interface CustomHandler<E = Env, P = any, I = any, O = any> {
   ): Response | Promise<Response | TypeResponse<O>> | TypeResponse<O>
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   ValidationTypes    //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////      ValidationTypes       //////
+//////                            //////
+////////////////////////////////////////
 
 export type ValidationTypes = {
   json: object
@@ -306,11 +306,11 @@ export type ValidationTypes = {
   queries: Record<string, string[]>
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Path parameters    //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////      Path parameters       //////
+//////                            //////
+////////////////////////////////////////
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
@@ -329,11 +329,11 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
   ? Record<R, string | undefined>
   : { [K in T]: string }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Input to data      //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////       Input to data        //////
+//////                            //////
+////////////////////////////////////////
 
 export type InputToData<T extends Input> = T extends {
   [K in keyof ValidationTypes]?: infer R
@@ -347,10 +347,10 @@ export type InputToDataByType<T extends Input, Type extends keyof ValidationType
   ? R
   : never
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Utilities          //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////         Utilities          //////
+//////                            //////
+////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -141,6 +141,19 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   >
 }
 
+///////////////////////////////////////////////////
+//////////                               //////////
+//////////  MiddlewareHandlerInterface   //////////
+//////////                               //////////
+///////////////////////////////////////////////////
+
+export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
+  //// app.get(...handlers[])
+  (...handlers: MiddlewareHandler<E, ExtractKey<S>>[]): Hono<E, S>
+  //// app.get(path, ...handlers[])
+  <P extends string>(path: P, ...handlers: MiddlewareHandler<E, P>[]): Hono<E, S>
+}
+
 //////////////////////////////////////////
 //////////                      //////////
 //////////  OnHandlerInterface  //////////
@@ -203,7 +216,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
   ): Hono<E, S & Schema<M, P, I, O>>
 }
 
-export type ExtractKey<S> = S extends Record<infer Key, unknown>
+type ExtractKey<S> = S extends Record<infer Key, unknown>
   ? Key extends string
     ? Key
     : never

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import { HonoRequest } from './request'
 import type { TypeResponse } from './types'
-import type { Env, NotFoundHandler } from './types'
+import type { Env, NotFoundHandler, Input } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
@@ -33,8 +33,8 @@ export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Path extends string = any,
-  Schema = {}
+  P extends string = any,
+  I extends Input = {}
 > {
   env: E['Bindings'] = {}
   finalized: boolean = false
@@ -68,7 +68,7 @@ export class Context<
     }
   }
 
-  get req(): HonoRequest<Path, Schema> {
+  get req(): HonoRequest<P, I> {
     if (this._req) {
       return this._req
     } else {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -805,7 +805,9 @@ describe('Request methods with custom middleware', () => {
 
   app.use('*', async (c, next) => {
     const query = c.req.query('foo')
-    const param = c.req.param('foo')
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const param = c.req.param('foo') // This will cause a type error.
     const header = c.req.header('User-Agent')
     await next()
     c.header('X-Query-2', query)

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -8,14 +8,17 @@ import { SmartRouter } from './router/smart-router'
 import { StaticRouter } from './router/static-router'
 import { TrieRouter } from './router/trie-router'
 import type {
-  TypeResponse,
-  HandlerInterface,
-  ToAppType,
-  Handler,
-  ErrorHandler,
-  NotFoundHandler,
   Env,
+  ErrorHandler,
+  ExtractKey,
+  Handler,
+  HandlerInterface,
+  Input,
   MiddlewareHandler,
+  NotFoundHandler,
+  OnHandlerInterface,
+  Schema,
+  TypeResponse,
 } from './types'
 import { HTTPException } from './utils/http-exception'
 import { getPathFromURL, mergePath } from './utils/url'
@@ -29,26 +32,16 @@ interface RouterRoute {
 }
 
 function defineDynamicClass(): {
-  new <
-    E extends Env = Env,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _M extends string = string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    P extends string = any
-  >(): {
-    [M in Methods]: HandlerInterface<E, M, P>
+  new <E extends Env = Env, S = {}>(): {
+    [M in Methods]: HandlerInterface<E, M, S>
+  } & {
+    on: OnHandlerInterface<E, S>
   }
 } {
   return class {} as never
 }
 
-export class Hono<
-  E extends Env = Env,
-  P extends string = string,
-  M extends string = string,
-  I = {},
-  O = {}
-> extends defineDynamicClass()<E, M, P> {
+export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S> {
   readonly router: Router<Handler> = new SmartRouter({
     routers: [new StaticRouter(), new RegExpRouter(), new TrieRouter()],
   })
@@ -61,10 +54,9 @@ export class Hono<
   constructor(init: Partial<Pick<Hono, 'router' | 'strict'>> = {}) {
     super()
 
+    // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
     allMethods.map((method) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       this[method] = (args1: string | Handler, ...args: Handler[]) => {
         if (typeof args1 === 'string') {
           this.path = args1
@@ -79,6 +71,16 @@ export class Hono<
         return this
       }
     })
+
+    // Implementation of app.on(method, path, ...handlers[])
+    this.on = (method: string, path: string, ...handlers: Handler[]) => {
+      if (!method) return this
+      this.path = path
+      handlers.map((handler) => {
+        this.addRoute(method.toUpperCase(), this.path, handler)
+      })
+      return this
+    }
 
     Object.assign(this, init)
   }
@@ -108,12 +110,14 @@ export class Hono<
     return this
   }
 
-  use(...middleware: MiddlewareHandler<E>[]): Hono<E, string, 'all', I, O>
-  use<Path extends string>(
-    arg1: Path,
+  use<I extends Input, O = {}>(
     ...middleware: MiddlewareHandler<E>[]
-  ): Hono<E, Path, 'all', I, O>
-  use(arg1: string | MiddlewareHandler<E>, ...handlers: MiddlewareHandler<E>[]) {
+  ): Hono<E, S & Schema<'all', ExtractKey<S>, I, O>>
+  use<P extends string, I extends Input, O = {}>(
+    arg1: P,
+    ...middleware: MiddlewareHandler<E, P, I>[]
+  ): Hono<E, S & Schema<'all', P, I, O>>
+  use(arg1: string | MiddlewareHandler, ...handlers: MiddlewareHandler[]) {
     if (typeof arg1 === 'string') {
       this.path = arg1
     } else {
@@ -123,26 +127,6 @@ export class Hono<
       this.addRoute(METHOD_NAME_ALL, this.path, handler)
     })
     return this as unknown
-  }
-
-  on<Method extends string, Path extends string>(
-    method: Method,
-    path: Path,
-    ...handlers: Handler<E, Path>[]
-  ): Hono<E, Path, Method, I, O>
-  on(method: string, path: string, ...handlers: Handler<E>[]) {
-    if (!method) return this
-    this.path = path
-    handlers.map((handler) => {
-      this.addRoute(method.toUpperCase(), this.path, handler)
-    })
-    return this
-  }
-
-  build = (): ToAppType<typeof this> => {
-    const app = {} as typeof this
-    type AppType = ToAppType<typeof app>
-    return {} as AppType
   }
 
   onError(handler: ErrorHandler<E>) {
@@ -164,8 +148,7 @@ export class Hono<
     })
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private addRoute(method: string, path: string, handler: Handler<any, any>) {
+  private addRoute(method: string, path: string, handler: Handler) {
     method = method.toUpperCase()
     if (this._tempPath) {
       path = mergePath(this._tempPath, path)
@@ -249,8 +232,7 @@ export class Hono<
 
     return (async () => {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tmp = composed(c as any)
+        const tmp = composed(c)
         const context = tmp instanceof Promise ? await tmp : tmp
         if (!context.finalized) {
           throw new Error(

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -10,14 +10,12 @@ import { TrieRouter } from './router/trie-router'
 import type {
   Env,
   ErrorHandler,
-  ExtractKey,
   Handler,
   HandlerInterface,
-  Input,
   MiddlewareHandler,
+  MiddlewareHandlerInterface,
   NotFoundHandler,
   OnHandlerInterface,
-  Schema,
   TypeResponse,
 } from './types'
 import { HTTPException } from './utils/http-exception'
@@ -36,6 +34,8 @@ function defineDynamicClass(): {
     [M in Methods]: HandlerInterface<E, M, S>
   } & {
     on: OnHandlerInterface<E, S>
+  } & {
+    use: MiddlewareHandlerInterface<E, S>
   }
 } {
   return class {} as never
@@ -82,6 +82,19 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
       return this
     }
 
+    // Implementation of app.use(...handlers[]) or app.get(path, ...handlers[])
+    this.use = (arg1: string | MiddlewareHandler, ...handlers: MiddlewareHandler[]) => {
+      if (typeof arg1 === 'string') {
+        this.path = arg1
+      } else {
+        handlers.unshift(arg1)
+      }
+      handlers.map((handler) => {
+        this.addRoute(METHOD_NAME_ALL, this.path, handler)
+      })
+      return this
+    }
+
     Object.assign(this, init)
   }
 
@@ -108,25 +121,6 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
       this._tempPath = ''
     }
     return this
-  }
-
-  use<I extends Input, O = {}>(
-    ...middleware: MiddlewareHandler<E>[]
-  ): Hono<E, S & Schema<'all', ExtractKey<S>, I, O>>
-  use<P extends string, I extends Input, O = {}>(
-    arg1: P,
-    ...middleware: MiddlewareHandler<E, P, I>[]
-  ): Hono<E, S & Schema<'all', P, I, O>>
-  use(arg1: string | MiddlewareHandler, ...handlers: MiddlewareHandler[]) {
-    if (typeof arg1 === 'string') {
-      this.path = arg1
-    } else {
-      handlers.unshift(arg1)
-    }
-    handlers.map((handler) => {
-      this.addRoute(METHOD_NAME_ALL, this.path, handler)
-    })
-    return this as unknown
   }
 
   onError(handler: ErrorHandler<E>) {

--- a/src/middleware/validator/index.ts
+++ b/src/middleware/validator/index.ts
@@ -11,7 +11,7 @@ export const validator = <
   P extends string,
   M extends string,
   U extends ValidationTypeByMethod<M>,
-  V extends { type: U; data: T },
+  V extends { [K in U]: T },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
@@ -47,8 +47,7 @@ export const validator = <
         break
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = validationFunc(value, c as any)
+    const res = validationFunc(value, c)
 
     if (res instanceof Response || res instanceof Promise) {
       return res

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,10 +1,14 @@
 import { Hono } from './hono'
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   class ExtendableEvent extends Event {
     constructor(type: string, init?: EventInit)
     waitUntil(promise: Promise<void>): void
   }
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   abstract class FetchEvent extends ExtendableEvent {
     readonly request: Request
     respondWith(promise: Response | Promise<Response>): void
@@ -17,12 +21,12 @@ declare global {
 }
 
 export type {
-  Next,
-  MiddlewareHandler,
+  Env,
   ErrorHandler,
+  MiddlewareHandler,
+  Next,
   NotFoundHandler,
   ValidationTypes,
-  Env,
 } from './types'
 import type { CustomHandler } from './types'
 export type { CustomHandler as Handler }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,11 @@
-import type { InputToData, InputToTypeData, ValidationTypes } from './types'
+import type {
+  Input,
+  InputToData,
+  InputToDataByType,
+  ParamKeys,
+  ParamKeyToRecord,
+  ValidationTypes,
+} from './types'
 import { parseBody } from './utils/body'
 import type { BodyData } from './utils/body'
 import type { Cookie } from './utils/cookie'
@@ -7,29 +14,12 @@ import { mergeObjects } from './utils/object'
 import type { UnionToIntersection } from './utils/types'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
-  ? Name
-  : NameWithPattern
-
-type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
-  ? ParamKeyName<NameWithPattern>
-  : never
-
-type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
-  ? ParamKey<Component> | ParamKeys<Rest>
-  : ParamKey<Path>
-
 type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
-type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
-  ? Record<R, string | undefined>
-  : Record<T, string>
-
-export class HonoRequest<Path extends string = '/', Input = {}> {
+export class HonoRequest<P extends string = '/', I extends Input = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined
@@ -51,8 +41,8 @@ export class HonoRequest<Path extends string = '/', Input = {}> {
     this.validatedData = {}
   }
 
-  param(key: RemoveQuestion<ParamKeys<Path>>): UndefinedIfHavingQuestion<ParamKeys<Path>>
-  param(): UnionToIntersection<ParamKeyToRecord<ParamKeys<Path>>>
+  param(key: RemoveQuestion<ParamKeys<P>>): UndefinedIfHavingQuestion<ParamKeys<P>>
+  param(): UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>>
   param(key?: string): unknown {
     if (this.paramData) {
       if (key) {
@@ -164,8 +154,8 @@ export class HonoRequest<Path extends string = '/', Input = {}> {
     this.validatedData[type] = merged
   }
 
-  valid(): InputToData<Input>
-  valid<T extends keyof ValidationTypes>(type: T): InputToTypeData<T, Input>
+  valid(): InputToData<I>
+  valid<T extends keyof ValidationTypes>(type: T): InputToDataByType<I, T>
   valid<T extends keyof ValidationTypes>(type?: T) {
     if (type) {
       const data = this.validatedData[type]

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,6 +4,8 @@ import type {
   InputToDataByType,
   ParamKeys,
   ParamKeyToRecord,
+  RemoveQuestion,
+  UndefinedIfHavingQuestion,
   ValidationTypes,
 } from './types'
 import { parseBody } from './utils/body'
@@ -13,11 +15,6 @@ import { parse } from './utils/cookie'
 import { mergeObjects } from './utils/object'
 import type { UnionToIntersection } from './utils/types'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url'
-
-type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
 export class HonoRequest<P extends string = '/', I extends Input = {}> {
   raw: Request

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type Env = {
 
 export type Next = () => Promise<void>
 
-export type Input = ValidationTypes | unknown
+export type Input = unknown
 
 ////////////////////////////////////////
 //////                            //////
@@ -331,7 +331,7 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
 
 ////////////////////////////////////////
 //////                            //////
-//////       Input to data        //////
+/////       For HonoRequest       //////
 //////                            //////
 ////////////////////////////////////////
 
@@ -346,6 +346,10 @@ export type InputToDataByType<T extends Input, Type extends keyof ValidationType
 }
   ? R
   : never
+
+export type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
+
+export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,11 @@ import type { Context } from './context'
 import type { Hono } from './hono'
 import type { UnionToIntersection } from './utils/types'
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Values             //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////           Values           //////
+//////                            //////
+////////////////////////////////////////
 
 export type Bindings = Record<string, unknown>
 export type Variables = Record<string, unknown>
@@ -23,11 +23,11 @@ export type Next = () => Promise<void>
 
 export type Input = ValidationTypes | unknown
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Handlers           //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////          Handlers          //////
+//////                            //////
+////////////////////////////////////////
 
 export type Handler<
   E extends Env = any,
@@ -47,11 +47,11 @@ export type MiddlewareHandler<E extends Env = any, P extends string = any, I ext
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   HandlerInterface   //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////     HandlerInterface       //////
+//////                            //////
+////////////////////////////////////////
 
 export interface HandlerInterface<E extends Env = Env, M extends string = any, S = {}> {
   //// app.get(...handlers[])
@@ -141,11 +141,11 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   >
 }
 
-///////////////////////////////////////////////////
-//////////                               //////////
-//////////  MiddlewareHandlerInterface   //////////
-//////////                               //////////
-///////////////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+////// MiddlewareHandlerInterface //////
+//////                            //////
+////////////////////////////////////////
 
 export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
   //// app.get(...handlers[])
@@ -154,11 +154,11 @@ export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
   <P extends string>(path: P, ...handlers: MiddlewareHandler<E, P>[]): Hono<E, S>
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////  OnHandlerInterface  //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////     OnHandlerInterface     //////
+//////                            //////
+////////////////////////////////////////
 
 export interface OnHandlerInterface<E extends Env = Env, S = {}> {
   // app.on(method, path, handler, handler)
@@ -222,11 +222,11 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
     : never
   : string
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Schema             //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////           Schema           //////
+//////                            //////
+////////////////////////////////////////
 
 export type Schema<M extends string, P extends string, I extends Input, O> = {
   [K in P]: AddDollar<{ [K2 in M]: { input: AddParam<I, P>; output: O } }>
@@ -242,11 +242,11 @@ export type AddDollar<T> = T extends Record<infer K, infer R>
     : never
   : never
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   TypeResponse       //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////        TypeResponse        //////
+//////                            //////
+////////////////////////////////////////
 
 export type TypeResponse<T = unknown> = {
   response: Response | Promise<Response>
@@ -254,11 +254,11 @@ export type TypeResponse<T = unknown> = {
   format: 'json' // Currently, support only `json` with `c.jsonT()`
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   CustomHandler      //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////       CustomHandler        //////
+//////                            //////
+////////////////////////////////////////
 
 // This is not used for internally
 // Will be used by users as `Handler`
@@ -293,11 +293,11 @@ export interface CustomHandler<E = Env, P = any, I = any, O = any> {
   ): Response | Promise<Response | TypeResponse<O>> | TypeResponse<O>
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   ValidationTypes    //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////      ValidationTypes       //////
+//////                            //////
+////////////////////////////////////////
 
 export type ValidationTypes = {
   json: object
@@ -306,11 +306,11 @@ export type ValidationTypes = {
   queries: Record<string, string[]>
 }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Path parameters    //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////      Path parameters       //////
+//////                            //////
+////////////////////////////////////////
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
@@ -329,11 +329,11 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
   ? Record<R, string | undefined>
   : { [K in T]: string }
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Input to data      //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////       Input to data        //////
+//////                            //////
+////////////////////////////////////////
 
 export type InputToData<T extends Input> = T extends {
   [K in keyof ValidationTypes]?: infer R
@@ -347,10 +347,10 @@ export type InputToDataByType<T extends Input, Type extends keyof ValidationType
   ? R
   : never
 
-//////////////////////////////////////////
-//////////                      //////////
-//////////   Utilities          //////////
-//////////                      //////////
-//////////////////////////////////////////
+////////////////////////////////////////
+//////                            //////
+//////         Utilities          //////
+//////                            //////
+////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,19 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   >
 }
 
+///////////////////////////////////////////////////
+//////////                               //////////
+//////////  MiddlewareHandlerInterface   //////////
+//////////                               //////////
+///////////////////////////////////////////////////
+
+export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
+  //// app.get(...handlers[])
+  (...handlers: MiddlewareHandler<E, ExtractKey<S>>[]): Hono<E, S>
+  //// app.get(path, ...handlers[])
+  <P extends string>(path: P, ...handlers: MiddlewareHandler<E, P>[]): Hono<E, S>
+}
+
 //////////////////////////////////////////
 //////////                      //////////
 //////////  OnHandlerInterface  //////////
@@ -203,7 +216,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
   ): Hono<E, S & Schema<M, P, I, O>>
 }
 
-export type ExtractKey<S> = S extends Record<infer Key, unknown>
+type ExtractKey<S> = S extends Record<infer Key, unknown>
   ? Key extends string
     ? Key
     : never

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ import type { Context } from './context'
 import type { Hono } from './hono'
 import type { UnionToIntersection } from './utils/types'
 
+//////////////////////////////////////////
+//////////                      //////////
+//////////   Values             //////////
+//////////                      //////////
+//////////////////////////////////////////
+
 export type Bindings = Record<string, unknown>
 export type Variables = Record<string, unknown>
 
@@ -13,35 +19,100 @@ export type Env = {
   Variables?: Variables
 }
 
-export type Handler<E extends Env = any, P extends string = any, I = {}, O = {}> = (
+export type Next = () => Promise<void>
+
+export type Input = ValidationTypes | unknown
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   Handlers           //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+export type Handler<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = Input,
+  O = {}
+> = (
   c: Context<E, P, I>,
   next: Next
 ) => Response | Promise<Response | TypeResponse<O> | void> | TypeResponse<O> | void
 
-export type MiddlewareHandler<E extends Env = any, P extends string = any, I = {}> = (
+export type MiddlewareHandler<E extends Env = any, P extends string = any, I extends Input = {}> = (
   c: Context<E, P, I>,
   next: Next
 ) => Promise<Response | undefined | void>
 
-export interface HandlerInterface<
-  E extends Env = Env,
-  M extends string = any,
-  S extends string = string
-> {
-  // app.get(...handler)
-  <I = {}, O = {}>(...handlers: Handler<E, S, I, O>[]): Hono<E, S, M, I, O>
+export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
+export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   HandlerInterface   //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+export interface HandlerInterface<E extends Env = Env, M extends string = any, S = {}> {
+  //// app.get(...handlers[])
+
+  // app.get(handler, handler)
+  <I = {}, O = {}>(
+    ...handlers: [Handler<E, ExtractKey<S>, I, O>, Handler<E, ExtractKey<S>, I, O>]
+  ): Hono<E, S & Schema<M, ExtractKey<S>, I, O>>
+
+  // app.get(handler x 3)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+    ...handlers: [
+      Handler<E, ExtractKey<S>, I, O>,
+      Handler<E, ExtractKey<S>, I2, O>,
+      Handler<E, ExtractKey<S>, I3, O>
+    ]
+  ): Hono<E, S & Schema<M, ExtractKey<S>, I3, O>>
+
+  // app.get(handler x 4)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+    ...handlers: [
+      Handler<E, ExtractKey<S>, I, O>,
+      Handler<E, ExtractKey<S>, I2, O>,
+      Handler<E, ExtractKey<S>, I3, O>,
+      Handler<E, ExtractKey<S>, I4, O>
+    ]
+  ): Hono<E, S & Schema<M, ExtractKey<S>, I4, O>>
+
+  // app.get(handler x 5)
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
+    ...handlers: [
+      Handler<E, ExtractKey<S>, I, O>,
+      Handler<E, ExtractKey<S>, I2, O>,
+      Handler<E, ExtractKey<S>, I3, O>,
+      Handler<E, ExtractKey<S>, I4, O>,
+      Handler<E, ExtractKey<S>, I5, O>
+    ]
+  ): Hono<E, S & Schema<M, ExtractKey<S>, I5, O>>
+
+  // app.get(...handlers[])
+  <I = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
+    E,
+    S & Schema<M, ExtractKey<S>, I, O>
+  >
+
+  ////  app.get(path, ...handlers[])
+
   // app.get(path, handler, handler)
   <P extends string, O = {}, I = {}>(
     path: P,
     ...handlers: [Handler<E, P, I, O>, Handler<E, P, I, O>]
-  ): Hono<E, P, M, I, O>
+  ): Hono<E, S & Schema<M, P, I, O>>
+
   // app.get(path, handler x3)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2>(
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     path: P,
     ...handlers: [Handler<E, P, I, O>, Handler<E, P, I2, O>, Handler<E, P, I3, O>]
-  ): Hono<E, P, M, I3, O>
+  ): Hono<E, S & Schema<M, P, I3, O>>
+
   // app.get(path, handler x4)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3>(
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     path: P,
     ...handlers: [
       Handler<E, P, I, O>,
@@ -49,9 +120,10 @@ export interface HandlerInterface<
       Handler<E, P, I3, O>,
       Handler<E, P, I4, O>
     ]
-  ): Hono<E, P, M, I4, O>
+  ): Hono<E, S & Schema<M, P, I4, O>>
+
   // app.get(path, handler x5)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3, I5 = I3 | I4>(
+  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
     path: P,
     ...handlers: [
       Handler<E, P, I, O>,
@@ -60,150 +132,120 @@ export interface HandlerInterface<
       Handler<E, P, I4, O>,
       Handler<E, P, I5, O>
     ]
-  ): Hono<E, P, M, I5, O>
-  // app.get(path, handler x6)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I | I2, I4 = I2 | I3, I5 = I3 | I4, I6 = I4 | I5>(
-    path: P,
-    ...handlers: [
-      Handler<E, P, I, O>,
-      Handler<E, P, I2, O>,
-      Handler<E, P, I3, O>,
-      Handler<E, P, I4, O>,
-      Handler<E, P, I5, O>,
-      Handler<E, P, I6, O>
-    ]
-  ): Hono<E, P, M, I6, O>
-  // app.get(path, handler x7)
-  <
-    P extends string,
-    O = {},
-    I = {},
-    I2 = I,
-    I3 = I | I2,
-    I4 = I2 | I3,
-    I5 = I3 | I4,
-    I6 = I4 | I5,
-    I7 = I5 | I6
-  >(
-    path: P,
-    ...handlers: [
-      Handler<E, P, I, O>,
-      Handler<E, P, I2, O>,
-      Handler<E, P, I3, O>,
-      Handler<E, P, I4, O>,
-      Handler<E, P, I5, O>,
-      Handler<E, P, I6, O>,
-      Handler<E, P, I7, O>
-    ]
-  ): Hono<E, P, M, I7, O>
-  // app.get(path, handler x8)
-  <
-    P extends string,
-    O = {},
-    I = {},
-    I2 = I,
-    I3 = I | I2,
-    I4 = I2 | I3,
-    I5 = I3 | I4,
-    I6 = I4 | I5,
-    I7 = I5 | I6,
-    I8 = I6 | I7
-  >(
-    path: P,
-    ...handlers: [
-      Handler<E, P, I, O>,
-      Handler<E, P, I2, O>,
-      Handler<E, P, I3, O>,
-      Handler<E, P, I4, O>,
-      Handler<E, P, I5, O>,
-      Handler<E, P, I6, O>,
-      Handler<E, P, I7, O>,
-      Handler<E, P, I8, O>
-    ]
-  ): Hono<E, P, M, I8, O>
-  // app.get(path, handler x9)
-  <
-    P extends string,
-    O = {},
-    I = {},
-    I2 = I,
-    I3 = I | I2,
-    I4 = I2 | I3,
-    I5 = I3 | I4,
-    I6 = I4 | I5,
-    I7 = I5 | I6,
-    I8 = I6 | I7,
-    I9 = I7 | I8
-  >(
-    path: P,
-    ...handlers: [
-      Handler<E, P, I, O>,
-      Handler<E, P, I2, O>,
-      Handler<E, P, I3, O>,
-      Handler<E, P, I4, O>,
-      Handler<E, P, I5, O>,
-      Handler<E, P, I6, O>,
-      Handler<E, P, I7, O>,
-      Handler<E, P, I8, O>,
-      Handler<E, P, I9, O>
-    ]
-  ): Hono<E, P, M, I9, O>
-  // app.get(path, handler x10)
-  <
-    P extends string,
-    O = {},
-    I = {},
-    I2 = I,
-    I3 = I | I2,
-    I4 = I2 | I3,
-    I5 = I3 | I4,
-    I6 = I4 | I5,
-    I7 = I5 | I6,
-    I8 = I6 | I7,
-    I9 = I7 | I8,
-    I10 = I8 | I9
-  >(
-    path: P,
-    ...handlers: [
-      Handler<E, P, I, O>,
-      Handler<E, P, I2, O>,
-      Handler<E, P, I3, O>,
-      Handler<E, P, I4, O>,
-      Handler<E, P, I5, O>,
-      Handler<E, P, I6, O>,
-      Handler<E, P, I7, O>,
-      Handler<E, P, I8, O>,
-      Handler<E, P, I9, O>,
-      Handler<E, P, I10, O>
-    ]
-  ): Hono<E, P, M, I10, O>
-  // app.get(path, ...handler)
+  ): Hono<E, S & Schema<M, P, I5, O>>
+
+  // app.get(path, ...handlers[])
   <P extends string, I = {}, O = {}>(path: P, ...handlers: Handler<E, P, I, O>[]): Hono<
     E,
-    P,
-    M,
-    I,
-    O
+    S & Schema<M, P, I, O>
   >
 }
 
-export type ExtractType<T> = T extends TypeResponse<infer R>
-  ? R
-  : T extends Promise<TypeResponse<infer R>>
-  ? R
+//////////////////////////////////////////
+//////////                      //////////
+//////////  OnHandlerInterface  //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+export interface OnHandlerInterface<E extends Env = Env, S = {}> {
+  // app.on(method, path, handler, handler)
+  <M extends string, P extends string, O = {}, I = {}>(
+    method: M,
+    path: P,
+    ...handlers: [Handler<E, P, I, O>, Handler<E, P, I, O>]
+  ): Hono<E, S & Schema<M, P, I, O>>
+
+  // app.get(method, path, handler x3)
+  <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+    method: M,
+    path: P,
+    ...handlers: [Handler<E, P, I, O>, Handler<E, P, I2, O>, Handler<E, P, I3, O>]
+  ): Hono<E, S & Schema<M, P, I3, O>>
+
+  // app.get(method, path, handler x4)
+  <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+    method: M,
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>
+    ]
+  ): Hono<E, S & Schema<M, P, I4, O>>
+
+  // app.get(method, path, handler x5)
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I = {},
+    I2 = I,
+    I3 = I & I2,
+    I4 = I2 & I3,
+    I5 = I3 & I4
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      Handler<E, P, I, O>,
+      Handler<E, P, I2, O>,
+      Handler<E, P, I3, O>,
+      Handler<E, P, I4, O>,
+      Handler<E, P, I5, O>
+    ]
+  ): Hono<E, S & Schema<M, P, I5, O>>
+
+  <M extends string, P extends string, O extends {} = {}, I = {}>(
+    method: M,
+    path: P,
+    ...handlers: Handler<E, P, I, O>[]
+  ): Hono<E, S & Schema<M, P, I, O>>
+}
+
+export type ExtractKey<S> = S extends Record<infer Key, unknown>
+  ? Key extends string
+    ? Key
+    : never
+  : string
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   Schema             //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+export type Schema<M extends string, P extends string, I extends Input, O> = {
+  [K in P]: AddDollar<{ [K2 in M]: { input: AddParam<I, P>; output: O } }>
+}
+
+export type AddParam<I, P extends string> = ParamKeys<P> extends never
+  ? I
+  : I & { param: UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>> }
+
+export type AddDollar<T> = T extends Record<infer K, infer R>
+  ? K extends string
+    ? { [MethodName in `$${Lowercase<K>}`]: R }
+    : never
   : never
 
-export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
-
-export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
-
-export type Next = () => Promise<void>
+//////////////////////////////////////////
+//////////                      //////////
+//////////   TypeResponse       //////////
+//////////                      //////////
+//////////////////////////////////////////
 
 export type TypeResponse<T = unknown> = {
   response: Response | Promise<Response>
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
 }
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   CustomHandler      //////////
+//////////                      //////////
+//////////////////////////////////////////
 
 // This is not used for internally
 // Will be used by users as `Handler`
@@ -214,19 +256,35 @@ export interface CustomHandler<E = Env, P = any, I = any, O = any> {
       E extends string ? E : P extends string ? P : never,
       E extends Env
         ? P extends string
-          ? I
+          ? I extends Partial<Input>
+            ? I
+            : never
           : E extends Env
-          ? E
+          ? E extends Partial<Input>
+            ? E
+            : never
           : never
         : E extends string
         ? P extends Env
-          ? E
-          : P
-        : E
+          ? E extends Partial<Input>
+            ? E
+            : never
+          : P extends Partial<Input>
+          ? P
+          : never
+        : E extends Partial<Input>
+        ? E
+        : never
     >,
     next: Next
   ): Response | Promise<Response | TypeResponse<O>> | TypeResponse<O>
 }
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   ValidationTypes    //////////
+//////////                      //////////
+//////////////////////////////////////////
 
 export type ValidationTypes = {
   json: object
@@ -235,50 +293,51 @@ export type ValidationTypes = {
   queries: Record<string, string[]>
 }
 
-export type ToAppType<T> = T extends Hono<infer _, infer P, infer M, infer I, infer O>
-  ? ToAppTypeInner<P, M, I, O>
+//////////////////////////////////////////
+//////////                      //////////
+//////////   Path parameters    //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
+  ? Name
+  : NameWithPattern
+
+type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
+  ? ParamKeyName<NameWithPattern>
   : never
 
-type RemoveBlank<T> = {
-  [K in keyof T]: T extends { type: ValidationTypes } ? T : never
+export type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
+  ? ParamKey<Component> | ParamKeys<Rest>
+  : ParamKey<Path>
+
+export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
+  ? Record<R, string | undefined>
+  : { [K in T]: string }
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   Input to data      //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+export type InputToData<T extends Input> = T extends {
+  [K in keyof ValidationTypes]?: infer R
 }
+  ? UnionToIntersection<R>
+  : never
 
-type InputSchema = {
-  [K in string]: { type: ValidationTypes; data: unknown }
-}
-
-type ToAppTypeInner<P extends string, M extends string, I, O> = RemoveBlank<I> extends InputSchema
-  ? {
-      [K in M]: {
-        [K2 in P]: {
-          input: UnionToIntersection<
-            I extends { type: keyof ValidationTypes; data: unknown }
-              ? I extends { type: infer R }
-                ? R extends string
-                  ? { [K in R]: I['data'] }
-                  : never
-                : never
-              : never
-          >
-          output: O extends Record<string, never> ? unknown : { json: O } // Currently, support only JSON
-        }
-      }
-    }
-  : { output: O extends Record<string, never> ? unknown : { json: O } }
-
-export type InputToData<T> = ExtractData<T> extends never
-  ? any
-  : UnionToIntersection<ExtractData<T>>
-
-type ExtractData<T> = T extends { type: keyof ValidationTypes }
-  ? T extends { type: keyof ValidationTypes; data?: infer R }
-    ? R
-    : any
-  : T
-
-export type InputToTypeData<K extends keyof ValidationTypes, T> = T extends {
-  type: K
-  data: infer R
+export type InputToDataByType<T extends Input, Type extends keyof ValidationTypes> = T extends {
+  [K in Type]: infer R
 }
   ? R
   : never
+
+//////////////////////////////////////////
+//////////                      //////////
+//////////   Utilities          //////////
+//////////                      //////////
+//////////////////////////////////////////
+
+export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never


### PR DESCRIPTION
This PR renews output types emitted from "app".

Before this PR, it will output types with `app.build()` and the client such as `hc` use it. But in this PR, we don't have to use `app.build()`, and emitted types are changed:

For example, write the endpoint with the validator middleware:

```ts
const route = app.post(
  '/api/v2/posts',
  validator(
    'json',
    validatorFunc(
      z.object({
        id: z.number(),
        title: z.string(),
      })
    )
  ),
  (c) => {
    return c.jsonT({
      success: true,
    })
  }
)
```

And we can get the type:

```ts
export type AppType = typeof route
type Schema = ExtractSchema<typeof route>
```

The extracted types are the followings. `Schema` will be:

```ts
type Schema = {
  '/api/v2/posts': {
    $post: {
      input: {
        json: {
          id: number
          title: string
        }
      }
      output: {
        success: boolean
      }
    }
  }
}
```

I think this format is very useful for writing the client.  Just a simple use of this types and the client looks like this.

https://user-images.githubusercontent.com/10682/215485265-a74e85e1-ea8a-44f3-abf3-423b08051222.mov

This client has no implementation but is more type-safe.

I think this is good PR.

BTW:

I am now thinking of rewriting the client and creating it in the core project as `hono/client`. This is because it is easier to handle and develop.