### PR TITLE
feat: `hc` - Hono Client

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -1,0 +1,122 @@
+import type { Hono } from '../hono.ts'
+import type { ValidationTypes } from '../types.ts'
+import type { UnionToIntersection } from '../utils/types.ts'
+import type { Callback, Client, RequestOption } from './types.ts'
+import { replaceUrlParam, mergePath, removeIndexString } from './utils.ts'
+
+const createProxy = (callback: Callback, path: string[]) => {
+  const proxy: unknown = new Proxy(() => {}, {
+    get(_obj, key) {
+      if (typeof key !== 'string') return undefined
+      return createProxy(callback, [...path, key])
+    },
+    apply(_1, _2, args) {
+      return callback({
+        path,
+        args,
+      })
+    },
+  })
+  return proxy
+}
+
+class ClientRequestImpl {
+  private url: string
+  private method: string
+  private queryParams: URLSearchParams | undefined = undefined
+  private pathParams: Record<string, string> = {}
+  private rBody: BodyInit | undefined
+  private cType: string | undefined = undefined
+
+  constructor(url: string, method: string) {
+    this.url = url
+    this.method = method
+  }
+  fetch = (
+    args?: ValidationTypes & {
+      param?: Record<string, string>
+    },
+    opt?: RequestOption
+  ) => {
+    if (args) {
+      if (args.query) {
+        for (const [k, v] of Object.entries(args.query)) {
+          this.queryParams ||= new URLSearchParams()
+          this.queryParams.set(k, v)
+        }
+      }
+
+      if (args.queries) {
+        for (const [k, v] of Object.entries(args.queries)) {
+          for (const v2 of v) {
+            this.queryParams ||= new URLSearchParams()
+            this.queryParams.append(k, v2)
+          }
+        }
+      }
+
+      if (args.form) {
+        const form = new FormData()
+        for (const [k, v] of Object.entries(args.form)) {
+          form.append(k, v)
+        }
+        this.rBody = form
+      }
+
+      if (args.json) {
+        this.rBody = JSON.stringify(args.json)
+        this.cType = 'application/json'
+      }
+
+      if (args.param) {
+        this.pathParams = args.param
+      }
+    }
+
+    let methodUpperCase = this.method.toUpperCase()
+    let setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
+
+    const headerValues: Record<string, string> = opt?.headers ? opt.headers : {}
+    if (this.cType) headerValues['Content-Type'] = this.cType
+
+    const headers = new Headers(headerValues ?? undefined)
+    let url = this.url
+
+    url = removeIndexString(url)
+    url = replaceUrlParam(url, this.pathParams)
+
+    if (this.queryParams) {
+      url = url + '?' + this.queryParams.toString()
+    }
+    methodUpperCase = this.method.toUpperCase()
+    setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
+
+    // Pass URL string to 1st arg for testing with MSW and node-fetch
+    return fetch(url, {
+      body: setBody ? this.rBody : undefined,
+      method: methodUpperCase,
+      headers: headers,
+    })
+  }
+}
+
+export const hc = <T extends Hono>(baseUrl: string) =>
+  createProxy(async (opts) => {
+    const parts = [...opts.path]
+
+    let method = ''
+    if (/^\$/.test(parts[parts.length - 1])) {
+      const last = parts.pop()
+      if (last) {
+        method = last.replace(/^\$/, '')
+      }
+    }
+
+    const path = parts.join('/')
+    const url = mergePath(baseUrl, path)
+    const req = new ClientRequestImpl(url, method)
+    if (method) {
+      return req.fetch(opts.args[0], opts.args[1])
+    }
+    return req
+  }, []) as UnionToIntersection<Client<T>>

--- a/deno_dist/client/index.ts
+++ b/deno_dist/client/index.ts
@@ -1,0 +1,2 @@
+export { hc } from './client.ts'
+export type { InferResponseType } from './types.ts'

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -1,0 +1,63 @@
+import type { Hono } from '../hono.ts'
+import type { ValidationTypes, Env } from '../types.ts'
+
+type MethodName = `$${string}`
+
+type Endpoint = Record<MethodName, Data>
+
+type Data = {
+  input: Partial<ValidationTypes> & {
+    param?: Record<string, string>
+  }
+  output: {}
+}
+
+export type RequestOption = {
+  headers?: Record<string, string>
+}
+
+type ClientRequest<S extends Data> = {
+  [M in keyof S]: S[M] extends { input: infer R; output: infer O }
+    ? (args?: R, options?: RequestOption) => Promise<ClientResponse<O>>
+    : never
+}
+
+export interface ClientResponse<T> extends Response {
+  json(): Promise<T>
+}
+
+export type InferResponseType<T> = T extends Record<MethodName, infer R>
+  ? R extends () => Promise<ClientResponse<infer O>>
+    ? O
+    : never
+  : never
+
+type PathToChain<
+  Path extends string,
+  E extends Endpoint,
+  Original extends string = ''
+> = Path extends `/${infer P}`
+  ? PathToChain<P, E, Path>
+  : Path extends `${infer P}/${infer R}`
+  ? { [K in P]: PathToChain<R, E, Original> }
+  : {
+      [K in Path extends '' ? 'index' : Path]: ClientRequest<
+        E extends Record<string, unknown> ? E[Original] : never
+      >
+    }
+
+export type Client<T> = T extends Hono<Env, infer S>
+  ? S extends Record<infer K, Endpoint>
+    ? K extends string
+      ? PathToChain<K, S>
+      : never
+    : never
+  : never
+
+export type Callback = (opts: CallbackOptions) => unknown
+
+interface CallbackOptions {
+  path: string[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any[]
+}

--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -1,0 +1,25 @@
+import { getPathFromURL } from '../utils/url.ts'
+
+export const mergePath = (base: string, path: string) => {
+  base = base.replace(/\/+$/, '')
+  base = base + '/'
+  path = path.replace(/^\/+/, '')
+  return base + path
+}
+
+export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
+  for (const [k, v] of Object.entries(params)) {
+    const reg = new RegExp('/:' + k)
+    urlString = urlString.replace(reg, `/${v}`)
+  }
+  return urlString
+}
+
+export const removeIndexString = (urlSting: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [path, _] = getPathFromURL(urlSting)
+  if (path === '/index') {
+    return urlSting.replace(/index$/, '')
+  }
+  return urlSting
+}

--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
       "import": "./dist/utils/*.js",
       "require": "./dist/cjs/utils/*.js"
     },
+    "./client": {
+      "types": "./dist/types/client/index.d.ts",
+      "import": "./dist/client/index.js",
+      "require": "./dist/cjs/client/index.js"
+    },
     "./cloudflare-workers": {
       "types": "./dist/types/adapter/cloudflare-workers/index.d.ts",
       "import": "./dist/adapter/cloudflare-workers/index.js",
@@ -233,6 +238,9 @@
       "utils/*": [
         "./dist/types/utils/*"
       ],
+      "client": [
+        "./dist/types/client/index.d.ts"
+      ],
       "cloudflare-workers": [
         "./dist/types/adapter/cloudflare-workers"
       ],
@@ -279,6 +287,7 @@
     "@types/glob": "^8.0.0",
     "@types/jest": "^29.0.2",
     "@types/node": "^17.0.29",
+    "@types/node-fetch": "^2.6.2",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
@@ -298,6 +307,8 @@
     "jest": "^29.0.3",
     "jest-environment-miniflare": "2.7.1",
     "jest-preset-fastly-js-compute": "^0.6.1",
+    "msw": "^1.0.0",
+    "node-fetch": "2",
     "np": "^7.6.2",
     "prettier": "^2.6.2",
     "publint": "^0.1.8",

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,0 +1,249 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import FormData from 'form-data'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import _fetch, { Request as NodeFetchRequest } from 'node-fetch'
+import { Hono } from '../hono'
+import { validator } from '../middleware/validator'
+import type { Equal, Expect } from '../utils/types'
+import { hc } from './client'
+import type { InferResponseType } from './types'
+
+// @ts-ignore
+global.fetch = _fetch
+// @ts-ignore
+global.Request = NodeFetchRequest
+// @ts-ignore
+global.FormData = FormData
+
+describe('Basic - JSON', () => {
+  const app = new Hono()
+
+  const route = app
+    .post(
+      '/posts',
+      validator('json', () => {
+        return {} as {
+          id: number
+          title: string
+        }
+      }),
+      (c) => {
+        return c.jsonT({
+          success: true,
+          message: 'dummy',
+          requestContentType: 'dummy',
+          requestMessage: 'dummy',
+          requestBody: {
+            id: 123,
+            title: 'dummy',
+          },
+        })
+      }
+    )
+    .get('/hello-not-found', (c) => c.notFound())
+
+  type AppType = typeof route
+
+  const server = setupServer(
+    rest.post('http://localhost/posts', async (req, res, ctx) => {
+      const requestContentType = req.headers.get('content-type')
+      const requestMessage = req.headers.get('x-message')
+      const requestBody = await req.json()
+      const payload = {
+        message: 'Hello!',
+        success: true,
+        requestContentType,
+        requestMessage,
+        requestBody,
+      }
+      return res(ctx.status(200), ctx.json(payload))
+    }),
+    rest.get('http://localhost/hello-not-found', (_req, res, ctx) => {
+      return res(ctx.status(404))
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  const payload = {
+    id: 123,
+    title: 'Hello! Hono!',
+  }
+
+  const client = hc<AppType>('http://localhost')
+
+  it('Should get 200 response', async () => {
+    const res = await client.posts.$post(
+      {
+        json: payload,
+      },
+      {
+        headers: {
+          'x-message': 'foobar',
+        },
+      }
+    )
+
+    expect(res.ok).toBe(true)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+    expect(data.message).toBe('Hello!')
+    expect(data.requestContentType).toBe('application/json')
+    expect(data.requestMessage).toBe('foobar')
+    expect(data.requestBody).toEqual(payload)
+  })
+
+  it('Should get 404 response', async () => {
+    const res = await client['hello-not-found'].$get()
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('Basic - query, queries, form, and path params', () => {
+  const app = new Hono()
+
+  const route = app
+    .get(
+      '/search',
+      validator('query', () => {
+        return {} as { q: string }
+      }),
+      (c) => {
+        return c.jsonT({
+          entries: [
+            {
+              title: 'Foo',
+            },
+          ],
+        })
+      }
+    )
+    .get(
+      '/posts',
+      validator('queries', () => {
+        return {
+          tags: ['a', 'b'],
+        }
+      }),
+      (c) => {
+        const data = c.req.valid('queries')
+        return c.jsonT(data)
+      }
+    )
+    .put(
+      '/posts/:id',
+      validator('form', () => {
+        return {
+          title: 'Hello',
+        }
+      }),
+      (c) => {
+        const data = c.req.valid('form')
+        return c.jsonT(data)
+      }
+    )
+
+  const server = setupServer(
+    rest.get('http://localhost/api/search', (req, res, ctx) => {
+      const url = new URL(req.url)
+      const query = url.searchParams.get('q')
+      return res(
+        ctx.status(200),
+        ctx.json({
+          q: query,
+        })
+      )
+    }),
+    rest.get('http://localhost/api/posts', (req, res, ctx) => {
+      const url = new URL(req.url)
+      const tags = url.searchParams.getAll('tags')
+      return res(
+        ctx.status(200),
+        ctx.json({
+          tags: tags,
+        })
+      )
+    }),
+    rest.put('http://localhost/api/posts/123', async (req, res, ctx) => {
+      const buffer = await req.arrayBuffer()
+      // @ts-ignore
+      const string = String.fromCharCode.apply('', new Uint8Array(buffer))
+      return res(ctx.status(200), ctx.text(string))
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  type AppType = typeof route
+
+  const client = hc<AppType>('http://localhost/api')
+
+  it('Should get 200 response - query', async () => {
+    const res = await client.search.$get({
+      query: {
+        q: 'foobar',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      q: 'foobar',
+    })
+  })
+
+  it('Should get 200 response - queries', async () => {
+    const res = await client.posts.$get({
+      queries: {
+        tags: ['A', 'B', 'C'],
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      tags: ['A', 'B', 'C'],
+    })
+  })
+
+  it('Should get 200 response - form, params', async () => {
+    const res = await client.posts[':id'].$put({
+      form: {
+        title: 'Good Night',
+      },
+      param: {
+        id: '123',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toMatch('Good Night')
+  })
+})
+
+describe('Infer the request type', () => {
+  const app = new Hono()
+  const route = app.get('/', (c) =>
+    c.jsonT({
+      id: 123,
+      title: 'Morning!',
+    })
+  )
+
+  type AppType = typeof route
+
+  it('Should infer the type correctly', () => {
+    const client = hc<AppType>('/')
+
+    type Actual = InferResponseType<typeof client.index>
+    type Expected = {
+      id: number
+      title: string
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+})

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,0 +1,122 @@
+import type { Hono } from '../hono'
+import type { ValidationTypes } from '../types'
+import type { UnionToIntersection } from '../utils/types'
+import type { Callback, Client, RequestOption } from './types'
+import { replaceUrlParam, mergePath, removeIndexString } from './utils'
+
+const createProxy = (callback: Callback, path: string[]) => {
+  const proxy: unknown = new Proxy(() => {}, {
+    get(_obj, key) {
+      if (typeof key !== 'string') return undefined
+      return createProxy(callback, [...path, key])
+    },
+    apply(_1, _2, args) {
+      return callback({
+        path,
+        args,
+      })
+    },
+  })
+  return proxy
+}
+
+class ClientRequestImpl {
+  private url: string
+  private method: string
+  private queryParams: URLSearchParams | undefined = undefined
+  private pathParams: Record<string, string> = {}
+  private rBody: BodyInit | undefined
+  private cType: string | undefined = undefined
+
+  constructor(url: string, method: string) {
+    this.url = url
+    this.method = method
+  }
+  fetch = (
+    args?: ValidationTypes & {
+      param?: Record<string, string>
+    },
+    opt?: RequestOption
+  ) => {
+    if (args) {
+      if (args.query) {
+        for (const [k, v] of Object.entries(args.query)) {
+          this.queryParams ||= new URLSearchParams()
+          this.queryParams.set(k, v)
+        }
+      }
+
+      if (args.queries) {
+        for (const [k, v] of Object.entries(args.queries)) {
+          for (const v2 of v) {
+            this.queryParams ||= new URLSearchParams()
+            this.queryParams.append(k, v2)
+          }
+        }
+      }
+
+      if (args.form) {
+        const form = new FormData()
+        for (const [k, v] of Object.entries(args.form)) {
+          form.append(k, v)
+        }
+        this.rBody = form
+      }
+
+      if (args.json) {
+        this.rBody = JSON.stringify(args.json)
+        this.cType = 'application/json'
+      }
+
+      if (args.param) {
+        this.pathParams = args.param
+      }
+    }
+
+    let methodUpperCase = this.method.toUpperCase()
+    let setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
+
+    const headerValues: Record<string, string> = opt?.headers ? opt.headers : {}
+    if (this.cType) headerValues['Content-Type'] = this.cType
+
+    const headers = new Headers(headerValues ?? undefined)
+    let url = this.url
+
+    url = removeIndexString(url)
+    url = replaceUrlParam(url, this.pathParams)
+
+    if (this.queryParams) {
+      url = url + '?' + this.queryParams.toString()
+    }
+    methodUpperCase = this.method.toUpperCase()
+    setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
+
+    // Pass URL string to 1st arg for testing with MSW and node-fetch
+    return fetch(url, {
+      body: setBody ? this.rBody : undefined,
+      method: methodUpperCase,
+      headers: headers,
+    })
+  }
+}
+
+export const hc = <T extends Hono>(baseUrl: string) =>
+  createProxy(async (opts) => {
+    const parts = [...opts.path]
+
+    let method = ''
+    if (/^\$/.test(parts[parts.length - 1])) {
+      const last = parts.pop()
+      if (last) {
+        method = last.replace(/^\$/, '')
+      }
+    }
+
+    const path = parts.join('/')
+    const url = mergePath(baseUrl, path)
+    const req = new ClientRequestImpl(url, method)
+    if (method) {
+      return req.fetch(opts.args[0], opts.args[1])
+    }
+    return req
+  }, []) as UnionToIntersection<Client<T>>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,2 @@
+export { hc } from './client'
+export type { InferResponseType } from './types'

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,63 @@
+import type { Hono } from '../hono'
+import type { ValidationTypes, Env } from '../types'
+
+type MethodName = `$${string}`
+
+type Endpoint = Record<MethodName, Data>
+
+type Data = {
+  input: Partial<ValidationTypes> & {
+    param?: Record<string, string>
+  }
+  output: {}
+}
+
+export type RequestOption = {
+  headers?: Record<string, string>
+}
+
+type ClientRequest<S extends Data> = {
+  [M in keyof S]: S[M] extends { input: infer R; output: infer O }
+    ? (args?: R, options?: RequestOption) => Promise<ClientResponse<O>>
+    : never
+}
+
+export interface ClientResponse<T> extends Response {
+  json(): Promise<T>
+}
+
+export type InferResponseType<T> = T extends Record<MethodName, infer R>
+  ? R extends () => Promise<ClientResponse<infer O>>
+    ? O
+    : never
+  : never
+
+type PathToChain<
+  Path extends string,
+  E extends Endpoint,
+  Original extends string = ''
+> = Path extends `/${infer P}`
+  ? PathToChain<P, E, Path>
+  : Path extends `${infer P}/${infer R}`
+  ? { [K in P]: PathToChain<R, E, Original> }
+  : {
+      [K in Path extends '' ? 'index' : Path]: ClientRequest<
+        E extends Record<string, unknown> ? E[Original] : never
+      >
+    }
+
+export type Client<T> = T extends Hono<Env, infer S>
+  ? S extends Record<infer K, Endpoint>
+    ? K extends string
+      ? PathToChain<K, S>
+      : never
+    : never
+  : never
+
+export type Callback = (opts: CallbackOptions) => unknown
+
+interface CallbackOptions {
+  path: string[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any[]
+}

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,0 +1,35 @@
+import { mergePath, removeIndexString, replaceUrlParam } from './utils'
+
+describe('mergePath', () => {
+  it('Should merge paths correctly', () => {
+    expect(mergePath('http://localhost', '/api')).toBe('http://localhost/api')
+    expect(mergePath('http://localhost/', '/api')).toBe('http://localhost/api')
+    expect(mergePath('http://localhost', 'api')).toBe('http://localhost/api')
+    expect(mergePath('http://localhost/', 'api')).toBe('http://localhost/api')
+    expect(mergePath('http://localhost/', '/')).toBe('http://localhost/')
+  })
+})
+
+describe('replaceUrlParams', () => {
+  it('Should replace correctly', () => {
+    const url = 'http://localhost/posts/:postId/comments/:commentId'
+    const params = {
+      postId: '123',
+      commentId: '456',
+    }
+    const replacedUrl = replaceUrlParam(url, params)
+    expect(replacedUrl).toBe('http://localhost/posts/123/comments/456')
+  })
+})
+
+describe('removeIndexString', () => {
+  it('Should remove last `index` string', () => {
+    let url = 'http://localhost/index'
+    let newUrl = removeIndexString(url)
+    expect(newUrl).toBe('http://localhost/')
+
+    url = '/index'
+    newUrl = removeIndexString(url)
+    expect(newUrl).toBe('/')
+  })
+})

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,0 +1,25 @@
+import { getPathFromURL } from '../utils/url'
+
+export const mergePath = (base: string, path: string) => {
+  base = base.replace(/\/+$/, '')
+  base = base + '/'
+  path = path.replace(/^\/+/, '')
+  return base + path
+}
+
+export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
+  for (const [k, v] of Object.entries(params)) {
+    const reg = new RegExp('/:' + k)
+    urlString = urlString.replace(reg, `/${v}`)
+  }
+  return urlString
+}
+
+export const removeIndexString = (urlSting: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [path, _] = getPathFromURL(urlSting)
+  if (path === '/index') {
+    return urlSting.replace(/index$/, '')
+  }
+  return urlSting
+}

--- a/src/middleware/validator/index.test.ts
+++ b/src/middleware/validator/index.test.ts
@@ -17,6 +17,7 @@ const validatorFunc =
     const data = parsed.data as z.infer<T>
     return data
   }
+
 describe('Validator middleware', () => {
   const app = new Hono()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,6 +1029,28 @@
     undici "5.9.1"
     ws "^8.2.2"
 
+"@mswjs/cookies@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
+  integrity sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.17.5":
+  version "0.17.7"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.17.7.tgz#3a41c6a56ddf236eddc0afd513026559ae4a1e5c"
+  integrity sha512-dPInyLEF6ybLxfKGY99euI+mbT6ls4PVO9qPgGIsRk3+2VZVfT7fo9Sq6Q8eKT9W38QtUyhG74hN7xMtKWioGw==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@types/debug" "^4.1.7"
+    "@xmldom/xmldom" "^0.8.3"
+    debug "^4.3.3"
+    headers-polyfill "^3.1.0"
+    outvariant "^1.2.1"
+    strict-event-emitter "^0.2.4"
+    web-encoding "^1.1.5"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1150,6 +1172,11 @@
   integrity sha512-kWMohLCIvnwApRmxRFDOqve7puiNNdtVfgwdDOm6QyJNorWOgKv2/AodCcGqx63o28kF7Dr4/nJCatrwwqhULg==
   dependencies:
     "@octokit/openapi-types" "^12.5.0"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@remix-run/web-blob@^3.0.3", "@remix-run/web-blob@^3.0.4":
   version "3.0.4"
@@ -1318,6 +1345,11 @@
   resolved "https://registry.yarnpkg.com/@types/comment-json/-/comment-json-1.1.1.tgz#b4ae889912a93e64619f97989aecaff8ce889dca"
   integrity sha512-U70oEqvnkeSSp8BIJwJclERtT13rd9ejK7XkIzMCQQePZe3VW1b7iQggXyW4ZvfGtGeXD0pZw24q5iWNe++HqQ==
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
 "@types/cookiejar@*":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
@@ -1327,6 +1359,13 @@
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
   integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
 
 "@types/glob@^8.0.0":
   version "8.0.0"
@@ -1375,6 +1414,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/js-levenshtein@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
+  integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
+
 "@types/json-buffer@~3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/json-buffer/-/json-buffer-3.0.0.tgz#85c1ff0f0948fc159810d4b5be35bf8c20875f64"
@@ -1407,6 +1451,19 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
@@ -1436,6 +1493,13 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz#b6a955219b54151bfebd4521170723df5e13caad"
+  integrity sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==
   dependencies:
     "@types/node" "*"
 
@@ -1561,6 +1625,11 @@
   resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
   integrity sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==
 
+"@xmldom/xmldom@^0.8.3":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
+  integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
+
 "@zxing/text-encoding@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
@@ -1678,6 +1747,14 @@ anymatch@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
+anymatch@~3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -1821,10 +1898,29 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 before-after-hook@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bluebird@3.7.2:
   version "3.7.2"
@@ -1860,7 +1956,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1906,6 +2002,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -1995,6 +2099,14 @@ caniuse-lite@^1.0.30001370:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz#1bf994ca375d7f33f8d01ce03b7d5139e8587873"
   integrity sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==
 
+chalk@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -2015,7 +2127,7 @@ chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2037,6 +2149,21 @@ check-more-types@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
+
+chokidar@^3.4.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -2077,6 +2204,11 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
+
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
@@ -2110,6 +2242,11 @@ clone-response@^1.0.2:
   integrity sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==
   dependencies:
     mimic-response "^1.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -2209,7 +2346,7 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie@^0.4.1:
+cookie@^0.4.1, cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -2269,7 +2406,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@4.3.4, debug@^4.3.4:
+debug@4.3.4, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2343,6 +2480,13 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+defaults@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
+  integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
+  dependencies:
+    clone "^1.0.2"
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -2949,6 +3093,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 evt@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/evt/-/evt-2.4.2.tgz#8f29f53a71609f1f5ad09ba313ad8cc0b9c63077"
@@ -3127,6 +3276,15 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -3254,7 +3412,7 @@ gitignore-parser@0.0.2:
   resolved "https://registry.yarnpkg.com/gitignore-parser/-/gitignore-parser-0.0.2.tgz#f61259b985dd91414b9a7168faef9171c2eec5df"
   integrity sha512-X6mpqUv59uWLGD4n3hZ8Cu8KbF2PMWPSFYmxZjdkpm3yOU7hSUYnzTkZI1mcWqchphvqyuz3/BhgBR4E/JtkCg==
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -3396,6 +3554,11 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
+"graphql@^15.0.0 || ^16.0.0":
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+
 hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
@@ -3457,6 +3620,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+headers-polyfill@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.1.2.tgz#9a4dcb545c5b95d9569592ef7ec0708aab763fbe"
+  integrity sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==
+
 hexoid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
@@ -3507,6 +3675,11 @@ iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-walk@^3.0.3:
   version "3.0.4"
@@ -3571,7 +3744,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3638,6 +3811,27 @@ inquirer@^7.0.0, inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.2.0:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
+  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -3666,6 +3860,13 @@ is-bigint@^1.0.1:
   integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
   dependencies:
     has-bigints "^1.0.1"
+
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
 
 is-boolean-object@^1.1.0:
   version "1.1.2"
@@ -3752,7 +3953,7 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3784,6 +3985,11 @@ is-negative-zero@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
 
 is-npm@^5.0.0:
   version "5.0.0"
@@ -4415,6 +4621,11 @@ joi@^17.6.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4652,7 +4863,7 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
-log-symbols@^4.0.0:
+log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -4914,6 +5125,31 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-1.0.0.tgz#4f8e63aa23912561a63b99ff560a089da6969418"
+  integrity sha512-8QVa1RAN/Nzbn/tKmtimJ+b2M1QZOMdETQW7/1TmBOZ4w+wJojfxuh1Hj5J4FYdBgZWW/TK4CABUOlOM4OjTOA==
+  dependencies:
+    "@mswjs/cookies" "^0.2.2"
+    "@mswjs/interceptors" "^0.17.5"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/js-levenshtein" "^1.1.1"
+    chalk "4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.2"
+    graphql "^15.0.0 || ^16.0.0"
+    headers-polyfill "^3.1.0"
+    inquirer "^8.2.0"
+    is-node-process "^1.0.1"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.7"
+    outvariant "^1.3.0"
+    path-to-regexp "^6.2.0"
+    strict-event-emitter "^0.4.3"
+    type-fest "^2.19.0"
+    yargs "^17.3.1"
+
 mustache@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
@@ -4940,6 +5176,13 @@ new-github-release-url@^1.0.0:
   integrity sha512-dle7yf655IMjyFUqn6Nxkb18r4AOAkzRcgcZv6WZ0IqrOH4QCEZ8Sm6I7XX21zvHdBeeMeTkhR9qT2Z0EJDx6A==
   dependencies:
     type-fest "^0.4.1"
+
+node-fetch@2:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.7:
   version "2.6.7"
@@ -4988,7 +5231,7 @@ normalize-package-data@^3.0.0:
     semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -5172,6 +5415,21 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
 org-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/org-regex/-/org-regex-1.0.0.tgz#67ebb9ab3cb124fea5841289d60b59434f041a59"
@@ -5181,6 +5439,11 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+
+outvariant@^1.2.1, outvariant@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.3.0.tgz#c39723b1d2cba729c930b74bf962317a81b9b1c9"
+  integrity sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==
 
 ow@^0.21.0:
   version "0.21.0"
@@ -5383,6 +5646,11 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-to-regexp@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -5400,7 +5668,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -5553,6 +5821,22 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
+readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -5698,7 +5982,7 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.5.4:
+rxjs@^7.5.4, rxjs@^7.5.5:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
@@ -5716,6 +6000,11 @@ safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
@@ -5781,6 +6070,11 @@ semver@^7.3.8:
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+set-cookie-parser@^2.4.6:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz#ddd3e9a566b0e8e0862aca974a6ac0e01349430b"
+  integrity sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==
 
 set-cookie-parser@^2.4.8:
   version "2.4.8"
@@ -5942,6 +6236,18 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
+strict-event-emitter@^0.2.4:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz#b4e768927c67273c14c13d20e19d5e6c934b47ca"
+  integrity sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==
+  dependencies:
+    events "^3.3.0"
+
+strict-event-emitter@^0.4.3:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.4.tgz#47e98eb408fbed187460592385f6547ca200cffb"
+  integrity sha512-rTCFXHBxs2/XvNc7InSkSwUkwyQ0T9eop/Qvm0atNUXpBxjwsJ5yb7Ih/tgHbjPdeCcB4aCP8K4tuo7hNKssNg==
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -5996,6 +6302,13 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -6319,6 +6632,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -6410,6 +6728,11 @@ urlpattern-polyfill@^4.0.3:
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz#c1fa7a73eb4e6c6a1ffb41b24cf31974f7392d3b"
   integrity sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==
 
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 util@^0.12.3:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
@@ -6473,7 +6796,14 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-web-encoding@1.1.5:
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
+  dependencies:
+    defaults "^1.0.3"
+
+web-encoding@1.1.5, web-encoding@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
   integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==


### PR DESCRIPTION
This PR introduces a new feature, "Hono Client". "hc" for the same purpose was built as `@hono/hc`, but making it obsolete, includes it in the core package.

## Usage

First, create the API server. Write the endpoint and export the type of route:

```ts
// server.ts
import { Hono } from 'hono'
import { z } from 'zod'
import { zValidator } from '@hono/zod-validator'

const app = new Hono()

const route = app.post(
  '/api/v2/posts',
  zValidator(
    'json',
    z.object({
      id: z.number(),
      title: z.string(),
    })
  ),
  (c) => {
    const { id, title } = c.req.valid('json')
   // Use `c.jsonT()` to emit types
    return c.jsonT({
      message: `${id} is ${title}`,
      success: true,
    })
  }
)

export type AppType = typeof route // export the type
```

Second, start writing the `client.ts`, import the type from `server.ts` and pass it to the `hc` function as Generics:

```ts
import { hc } from 'hono/client'

import type { AppType } from './server'

const client = hc<AppType>('http://localhost:8787/')
```

Then, time for magic:

https://user-images.githubusercontent.com/10682/216456881-7c9d4bad-e669-4cfb-a027-86ce98074973.mov

It will suggest the code based on the path and schema of the API server endpoint.

And handle the response:

https://user-images.githubusercontent.com/10682/216457919-1484ed48-b1d3-4428-b6be-565f7a9ee879.mov

`data` has the appropriate type. Great!

The final code is here:

```ts
const res = await client.api.v2.posts.$post({
  json: {
    id: 123,
    title: 'Hello!!',
  },
})

const data = await res.json()

console.log(data.message)
```

### Don't you use `@hono/hc`?

Separating core packages and `hc` is good, but it makes development difficult. For example, if we want to refer to the same `Hono` or `ValidationTypes` types, but the projects are separated, it is difficult to do so, and type errors occur frequently. Even if we include it in the core package, it is independent of `hono`, so the bundle size will not change unless we use it. In addition, it is very small and does not depend on an external library.