### PR TITLE
Fix 404 error on Serve Static Middleware

### DIFF
--- a/src/deno/serve-static.ts
+++ b/src/deno/serve-static.ts
@@ -21,7 +21,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
     const url = new URL(c.req.url)
 
     let path = getFilePath({
-      filename: options.path ?? url.pathname,
+      filename: options.path ?? decodeURI(url.pathname),
       root: options.root,
       defaultDocument: DEFAULT_DOCUMENT,
     })


### PR DESCRIPTION
There will be a 404 error when non-standard characters appear in URL. Add `decodeURI()` to fix it.