### PR TITLE
feat: use added app's errorHandler and notFoundHandler for fallback.

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -61,6 +61,16 @@ interface Route<
   handler: Handler<P, E, S>
 }
 
+const notFoundHandler = <E extends Partial<Environment>>(c: Context<string, E>) => {
+  return c.text('404 Not Found', 404)
+}
+
+const errorHandler = <E extends Partial<Environment>>(err: Error, c: Context<string, E>) => {
+  console.trace(err)
+  const message = 'Internal Server Error'
+  return c.text(message, 500)
+}
+
 export class Hono<
   E extends Partial<Environment> = Environment,
   P extends string = string,
@@ -103,23 +113,39 @@ export class Hono<
     Object.assign(this, init)
   }
 
-  private notFoundHandler: NotFoundHandler<E> = (c: Context<string, E>) => {
-    return c.text('404 Not Found', 404)
-  }
-
-  private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {
-    console.trace(err)
-    const message = 'Internal Server Error'
-    return c.text(message, 500)
-  }
+  private notFoundHandler: NotFoundHandler<E> = notFoundHandler
+  private errorHandler: ErrorHandler<E> = errorHandler
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   route(path: string, app?: Hono<any>) {
     this._tempPath = path
     if (app) {
       app.routes.map((r) => {
-        this.addRoute(r.method, r.path, r.handler as unknown as Handler<P, E, S>)
+        const handler = (
+          app.notFoundHandler === notFoundHandler && app.errorHandler === errorHandler
+            ? r.handler
+            : async (c, next) => {
+                /* eslint-disable @typescript-eslint/no-explicit-any */
+                try {
+                  const res = await r.handler(c as any, next)
+                  return !res && !c.finalized
+                    ? app.notFoundHandler(c as unknown as Context<string, any, any>)
+                    : res
+                } catch (err) {
+                  if (err instanceof Error) {
+                    c.error = err
+                    return app.handleError(err, c as unknown as Context<string, any, any>)
+                  }
+                  throw err
+                }
+                /* eslint-enable @typescript-eslint/no-explicit-any */
+              }
+        ) as Handler<P, E, S>
+        this.addRoute(r.method, r.path, handler)
       })
+      if (app.notFoundHandler !== notFoundHandler) {
+        this.use('*', app.notFoundHandler)
+      }
       this._tempPath = ''
     }
     return this

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -935,6 +935,89 @@ describe('Hono with `app.route`', () => {
       expect(await res.text()).toBe('book 123')
     })
   })
+
+  describe('onError', () => {
+    const app = new Hono()
+    const sub = new Hono()
+
+    app.use('*', async (c, next) => {
+      await next()
+      if (c.req.query('app-error')) {
+        throw new Error('This is Error')
+      }
+    })
+
+    app.onError((err, c) => {
+      return c.text('onError by app', 500)
+    })
+
+    sub.get('/ok', (c) => {
+      return c.text('ok')
+    })
+
+    sub.get('/error', () => {
+      throw new Error('This is Error')
+    })
+
+    sub.onError((err, c) => {
+      return c.text('onError by sub', 500)
+    })
+
+    app.route('/sub', sub)
+
+    it('handled by app', async () => {
+      const res = await app.request('https://example.com/sub/ok?app-error=1')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toBe('onError by app')
+    })
+
+    it('handled by sub', async () => {
+      const res = await app.request('https://example.com/sub/error')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toBe('onError by sub')
+    })
+  })
+
+  describe('notFound', () => {
+    const app = new Hono()
+    const sub = new Hono()
+
+    app.get('/explicit-404', async (c) => {
+      c.header('explicit', '1')
+    })
+
+    app.notFound((c) => {
+      return c.text('404 Not Found by app', 404)
+    })
+
+    sub.get('/ok', (c) => {
+      return c.text('ok')
+    })
+
+    sub.get('/explicit-404', async (c) => {
+      c.header('explicit', '1')
+    })
+
+    sub.notFound((c) => {
+      return c.text('404 Not Found by sub', 404)
+    })
+
+    app.route('/sub', sub)
+
+    it('explicit-404 handled by app', async () => {
+      const res = await app.request('https://example.com/explicit-404')
+      expect(res.status).toBe(404)
+      expect(res.headers.get('explicit')).toBe('1')
+      expect(await res.text()).toBe('404 Not Found by app')
+    })
+
+    it('explicit-404 handled by sub', async () => {
+      const res = await app.request('https://example.com/sub/explicit-404')
+      expect(res.status).toBe(404)
+      expect(res.headers.get('explicit')).toBe('1')
+      expect(await res.text()).toBe('404 Not Found by sub')
+    })
+  })
 })
 
 describe('Using other methods with `app.on`', () => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1017,6 +1017,20 @@ describe('Hono with `app.route`', () => {
       expect(res.headers.get('explicit')).toBe('1')
       expect(await res.text()).toBe('404 Not Found by sub')
     })
+
+    it('implicit-404 handled by app', async () => {
+      const res = await app.request('https://example.com/implicit-404')
+      expect(res.status).toBe(404)
+      expect(res.headers.get('explicit')).toBe(null)
+      expect(await res.text()).toBe('404 Not Found by app')
+    })
+
+    it('implicit-404 handled by sub', async () => {
+      const res = await app.request('https://example.com/sub/implicit-404')
+      expect(res.status).toBe(404)
+      expect(res.headers.get('explicit')).toBe(null)
+      expect(await res.text()).toBe('404 Not Found by sub')
+    })
   })
 })
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -61,6 +61,16 @@ interface Route<
   handler: Handler<P, E, S>
 }
 
+const notFoundHandler = <E extends Partial<Environment>>(c: Context<string, E>) => {
+  return c.text('404 Not Found', 404)
+}
+
+const errorHandler = <E extends Partial<Environment>>(err: Error, c: Context<string, E>) => {
+  console.trace(err)
+  const message = 'Internal Server Error'
+  return c.text(message, 500)
+}
+
 export class Hono<
   E extends Partial<Environment> = Environment,
   P extends string = string,
@@ -103,22 +113,35 @@ export class Hono<
     Object.assign(this, init)
   }
 
-  private notFoundHandler: NotFoundHandler<E> = (c: Context<string, E>) => {
-    return c.text('404 Not Found', 404)
-  }
-
-  private errorHandler: ErrorHandler<E> = (err: Error, c: Context<string, E>) => {
-    console.trace(err)
-    const message = 'Internal Server Error'
-    return c.text(message, 500)
-  }
+  private notFoundHandler: NotFoundHandler<E> = notFoundHandler
+  private errorHandler: ErrorHandler<E> = errorHandler
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   route(path: string, app?: Hono<any>) {
     this._tempPath = path
     if (app) {
       app.routes.map((r) => {
-        this.addRoute(r.method, r.path, r.handler as unknown as Handler<P, E, S>)
+        const handler = (
+          app.notFoundHandler === notFoundHandler && app.errorHandler === errorHandler
+            ? r.handler
+            : async (c, next) => {
+                /* eslint-disable @typescript-eslint/no-explicit-any */
+                try {
+                  const res = await r.handler(c as any, next)
+                  return !res && !c.finalized
+                    ? app.notFoundHandler(c as unknown as Context<string, any, any>)
+                    : res
+                } catch (err) {
+                  if (err instanceof Error) {
+                    c.error = err
+                    return app.handleError(err, c as unknown as Context<string, any, any>)
+                  }
+                  throw err
+                }
+                /* eslint-enable @typescript-eslint/no-explicit-any */
+              }
+        ) as Handler<P, E, S>
+        this.addRoute(r.method, r.path, handler)
       })
       this._tempPath = ''
     }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -143,6 +143,9 @@ export class Hono<
         ) as Handler<P, E, S>
         this.addRoute(r.method, r.path, handler)
       })
+      if (app.notFoundHandler !== notFoundHandler) {
+        this.use('*', app.notFoundHandler)
+      }
       this._tempPath = ''
     }
     return this


### PR DESCRIPTION
### about `errorHandler`

As for errorHandler, I think it would be the expected result for any app.

### about `notFoundHandler`

As for notFoundHandler, I think most apps will get the expected results, but cb6eff90f99cdce38d69e15dc79a7cacb8b8c812 commitments will lead to unexpected results in some cases.

#### unexpected results ?

```typescript
// prepare
const app = new Hono()
const api = new Hono()
const middleware = new Hono()

api.get('/posts', (c) => c.text('List'))

middleware.use('*', async (c, next) => {
  await next()
  c.res.headers.append('x-custom-b', 'b')
})
middleware.notFound((c) => c.text('Not Found', 404))

app.route('/api', middleware)
app.route('/api', api)

// request
app.request('http://localhost/api/posts') // => not found
```

However, this is a very rare usage, and if you don't add cb6eff90f99cdce38d69e15dc79a7cacb8b8c812, notFound will be ignored, so it's still cb6eff90f99cdce38d69e15dc79a7cacb 8b8c812 should be added, in my opinion.
