### PR TITLE
feat(adapter): `handle(path, app)` for CF Pages & Next.js

### DIFF
--- a/src/adapter/cloudflare-pages/handler.test.ts
+++ b/src/adapter/cloudflare-pages/handler.test.ts
@@ -7,7 +7,7 @@ type Env = {
   }
 }
 
-describe('Handler for Cloudflare Pages', () => {
+describe('Adapter for Cloudflare Pages', () => {
   it('Should return 200 response', async () => {
     const request = new Request('http://localhost/api/foo')
     const env = {
@@ -23,5 +23,19 @@ describe('Handler for Cloudflare Pages', () => {
     const res = await handler({ request, env })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('HONOISCOOL')
+  })
+
+  it('Should return 200 response with path', async () => {
+    const request = new Request('http://localhost/api/foo')
+    const app = new Hono()
+    app.get('/foo', (c) => {
+      return c.text('/api/foo')
+    })
+    const handler = handle('/api', app)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const res = await handler({ request })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/api/foo')
   })
 })

--- a/src/adapter/nextjs/handler.test.ts
+++ b/src/adapter/nextjs/handler.test.ts
@@ -1,0 +1,28 @@
+import { Hono } from '../../hono'
+import { handle } from './handler'
+
+describe('Adapter for Next.js', () => {
+  it('Should return 200 response', async () => {
+    const app = new Hono()
+    app.get('/api/foo', (c) => {
+      return c.text('/api/foo')
+    })
+    const handler = handle(app)
+    const req = new Request('http://localhost/api/foo')
+    const res = await handler(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/api/foo')
+  })
+
+  it('Should return 200 response with path', async () => {
+    const app = new Hono()
+    app.get('/foo', (c) => {
+      return c.text('/api/foo')
+    })
+    const handler = handle('/api', app)
+    const req = new Request('http://localhost/api/foo')
+    const res = await handler(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/api/foo')
+  })
+})

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -1,9 +1,23 @@
 // @denoify-ignore
-import type { Hono } from '../../hono'
+import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
-export const handle = <E extends Env, R extends Request>(app: Hono<E>) => {
-  return async (req: R) => {
-    return app.fetch(req)
+interface HandleInterface {
+  <E extends Env, R extends Request, R2 extends Response>(app: Hono<E>): (req: R) => Promise<R2>
+  <E extends Env, R extends Request, R2 extends Response>(path: string, app: Hono<E>): (
+    req: R
+  ) => Promise<R2>
+}
+
+export const handle: HandleInterface = (arg1: string | Hono, arg2?: Hono) => {
+  if (typeof arg1 === 'string') {
+    const app = new Hono()
+    app.route(arg1, arg2)
+    return async (req) => {
+      return app.fetch(req)
+    }
+  }
+  return async (req) => {
+    return arg1.fetch(req)
   }
 }


### PR DESCRIPTION
This PR is for the adapter of Cloudflare Pages and Next.js. It allows passing the mount path as an argument to `handle`.

For example, if you struct the Next.js project like this:

<img width="191" alt="SS" src="https://user-images.githubusercontent.com/10682/218135327-6cbc7c72-8e16-441e-9119-d8f989896243.png">

`pages/api/[route].ts` could be follows:

```ts
import { Hono } from 'hono'
import { handle } from 'hono/nextjs'

const app = new Hono()

app.get('/hello', (c) => {
  return c.json({
    message: 'Hello',
  })
})

app.get('/morning', (c) => {
  return c.json({
    message: 'Morning',
  })
})

export default handle('/api', app)
```

It is simpler because you don't have to write `/api` in the argument of `app.get` every time.