### PR TITLE
feat(adapter)!: simplify HandleInterface and reduce bundle size

### DIFF
--- a/src/adapter/cloudflare-pages/handler.test.ts
+++ b/src/adapter/cloudflare-pages/handler.test.ts
@@ -31,7 +31,7 @@ describe('Adapter for Cloudflare Pages', () => {
     app.get('/foo', (c) => {
       return c.text('/api/foo')
     })
-    const handler = handle('/api', app)
+    const handler = handle(app, '/api')
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const res = await handler({ request })

--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -9,23 +9,14 @@ type EventContext = {
 }
 
 interface HandleInterface {
-  <E extends Env>(app: Hono<E>): (eventContext: EventContext) => Response | Promise<Response>
-  <E extends Env>(path: string, app: Hono<E>): (
+  <E extends Env>(app: Hono<E>, path?: string): (
     eventContext: EventContext
   ) => Response | Promise<Response>
 }
 
-export const handle: HandleInterface = (arg1: string | Hono, arg2?: Hono) => {
-  if (typeof arg1 === 'string') {
-    const app = new Hono()
-    app.route(arg1, arg2)
-    return (eventContext) => {
-      const { request, env, waitUntil } = eventContext
-      return app.fetch(request, env, { waitUntil, passThroughOnException: () => {} })
-    }
-  }
-  return (eventContext) => {
-    const { request, env, waitUntil } = eventContext
-    return arg1.fetch(request, env, { waitUntil, passThroughOnException: () => {} })
-  }
-}
+export const handle: HandleInterface =
+  <E extends Env>(subApp: Hono<E>, path: string = '/') =>
+  ({ request, env, waitUntil }) =>
+    new Hono()
+      .route(path, subApp)
+      .fetch(request, env, { waitUntil, passThroughOnException: () => {} })

--- a/src/adapter/nextjs/handler.test.ts
+++ b/src/adapter/nextjs/handler.test.ts
@@ -19,7 +19,7 @@ describe('Adapter for Next.js', () => {
     app.get('/foo', (c) => {
       return c.text('/api/foo')
     })
-    const handler = handle('/api', app)
+    const handler = handle(app, '/api')
     const req = new Request('http://localhost/api/foo')
     const res = await handler(req)
     expect(res.status).toBe(200)

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -3,21 +3,10 @@ import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
 interface HandleInterface {
-  <E extends Env, R extends Request, R2 extends Response>(app: Hono<E>): (req: R) => Promise<R2>
-  <E extends Env, R extends Request, R2 extends Response>(path: string, app: Hono<E>): (
-    req: R
-  ) => Promise<R2>
+  <E extends Env>(subApp: Hono<E>, path?: string): (req: Request) => Promise<Response>
 }
 
-export const handle: HandleInterface = (arg1: string | Hono, arg2?: Hono) => {
-  if (typeof arg1 === 'string') {
-    const app = new Hono()
-    app.route(arg1, arg2)
-    return async (req) => {
-      return app.fetch(req)
-    }
-  }
-  return async (req) => {
-    return arg1.fetch(req)
-  }
-}
+export const handle: HandleInterface =
+  <E extends Env>(subApp: Hono<E>, path: string = '/') =>
+  async (req) =>
+    new Hono().route(path, subApp).fetch(req)


### PR DESCRIPTION
***This PR breaks compatibility with rc.12 but is still compatible with rc.11.*** Since rc.12 is only 9 hours old and adapters aren't in the stable releases yet, I hope this breaking change doesn't have any significant impact.

With this PR, type definitions for `handle` in Cloudflare Pages and Next.js become simpler and parameter names are more descriptive. It also saves the bundle size; minified ESM for Cloudflare Pages adapter is reduced from 825B to 503B and Next.js adapter from 561B to 406B.

Here are the pros/cons I can think of:

<dl>
<dt>Pros</dt>
  <dd>

  - Bundle size is smaller.
  - Interface is simpler.
  </dd>
<dt>Cons</dt>
  <dd>

  - Parameter order is different from `Hono.prototype.route`. Some people might feel awkward.
  - A new Hono app is always instantiated and this has a slight overhead. That said, I think it won't be a problem because:
    - The overhead is negligible compared to other heavy work user's app does.
    - I guess people want to mount `subApp` to a dedicated path like `/api` when they use these adapters (at least I do). So `new Hono()` is called anyway in rc.12 as well.
</dl>

Feel free to close if you disagree to this change.