### PR TITLE
feat(`app`): support multiple methods with `app.on()`

### DIFF
--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -44,15 +44,15 @@ export default app
 
 ## Benchmarks
 
-**Hono is fastest**, compared to other routers for Cloudflare Workers.
+**Hono is **the **fastest**, compared to other routers for Cloudflare Workers.
 
-```plain
-Hono x 616,464 ops/sec ±4.76% (83 runs sampled)
-itty-router x 203,074 ops/sec ±3.66% (88 runs sampled)
-sunder x 314,306 ops/sec ±2.28% (87 runs sampled)
-worktop x 194,111 ops/sec ±2.78% (81 runs sampled)
+```txt
+Hono x 385,807 ops/sec ±5.02% (76 runs sampled)
+itty-router x 205,318 ops/sec ±3.63% (84 runs sampled)
+sunder x 287,198 ops/sec ±4.90% (74 runs sampled)
+worktop x 191,134 ops/sec ±3.06% (85 runs sampled)
 Fastest is Hono
-✨  Done in 30.77s.
+✨  Done in 27.51s.
 ```
 
 ## Documentation

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -86,12 +86,14 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
     })
 
     // Implementation of app.on(method, path, ...handlers[])
-    this.on = (method: string, path: string, ...handlers: H[]) => {
+    this.on = (method: string | string[], path: string, ...handlers: H[]) => {
       if (!method) return this
       this.path = path
-      handlers.map((handler) => {
-        this.addRoute(method.toUpperCase(), this.path, handler)
-      })
+      for (const m of [method].flat()) {
+        handlers.map((handler) => {
+          this.addRoute(m.toUpperCase(), this.path, handler)
+        })
+      }
       return this
     }
 

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -193,6 +193,13 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
     path: P,
     ...handlers: H<E, P, I, O>[]
   ): Hono<E, S & Schema<M, P, I, O>>
+
+  // app.on(method[], path, ...handler)
+  <P extends string, O extends {} = {}, I = {}>(
+    methods: string[],
+    path: P,
+    ...handlers: H<E, P, I, O>[]
+  ): Hono<E, S & Schema<string, P, I, O>>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1126,6 +1126,48 @@ describe('Using other methods with `app.on`', () => {
   })
 })
 
+describe('Multiple methods with `app.on`', () => {
+  const app = new Hono()
+  app.on(['PUT', 'DELETE'], '/posts/:id', (c) => {
+    return c.json({
+      postId: c.req.param('id'),
+      method: c.req.method,
+    })
+  })
+
+  it('Should return 200 with PUT', async () => {
+    const req = new Request('http://localhost/posts/123', {
+      method: 'PUT',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      postId: '123',
+      method: 'PUT',
+    })
+  })
+
+  it('Should return 200 with DELETE', async () => {
+    const req = new Request('http://localhost/posts/123', {
+      method: 'DELETE',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      postId: '123',
+      method: 'DELETE',
+    })
+  })
+
+  it('Should return 404 with POST', async () => {
+    const req = new Request('http://localhost/posts/123', {
+      method: 'POST',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(404)
+  })
+})
+
 describe('Multiple handler', () => {
   describe('handler + handler', () => {
     const app = new Hono()

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -86,12 +86,21 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
     })
 
     // Implementation of app.on(method, path, ...handlers[])
-    this.on = (method: string, path: string, ...handlers: H[]) => {
+    this.on = (method: string | string[], path: string, ...handlers: H[]) => {
       if (!method) return this
+      let methods: string[] = []
+      if (Array.isArray(method)) {
+        methods = method
+      } else {
+        methods = [method]
+      }
       this.path = path
-      handlers.map((handler) => {
-        this.addRoute(method.toUpperCase(), this.path, handler)
-      })
+
+      for (const m of methods) {
+        handlers.map((handler) => {
+          this.addRoute(m.toUpperCase(), this.path, handler)
+        })
+      }
       return this
     }
 

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -88,15 +88,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
     // Implementation of app.on(method, path, ...handlers[])
     this.on = (method: string | string[], path: string, ...handlers: H[]) => {
       if (!method) return this
-      let methods: string[] = []
-      if (Array.isArray(method)) {
-        methods = method
-      } else {
-        methods = [method]
-      }
       this.path = path
-
-      for (const m of methods) {
+      for (const m of [method].flat()) {
         handlers.map((handler) => {
           this.addRoute(m.toUpperCase(), this.path, handler)
         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,13 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
     path: P,
     ...handlers: H<E, P, I, O>[]
   ): Hono<E, S & Schema<M, P, I, O>>
+
+  // app.on(method[], path, ...handler)
+  <P extends string, O extends {} = {}, I = {}>(
+    methods: string[],
+    path: P,
+    ...handlers: H<E, P, I, O>[]
+  ): Hono<E, S & Schema<string, P, I, O>>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>


### PR DESCRIPTION
This PR enables handling multiple methods with `app.on()` method.

```ts
app.on(['PUT', 'DELETE'], '/posts/:id', (c) => {
  //...
  return c.text(`Your method is ${c.req.method}`)
})
```