### PR TITLE
feat: change the arg `InferResponseType` receives

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -26,11 +26,7 @@ export interface ClientResponse<T> extends Response {
   json(): Promise<T>
 }
 
-export type InferResponseType<T> = T extends Record<MethodName, infer R>
-  ? R extends () => Promise<ClientResponse<infer O>>
-    ? O
-    : never
-  : never
+export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
 
 type PathToChain<
   Path extends string,

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -238,8 +238,9 @@ describe('Infer the request type', () => {
 
   it('Should infer the type correctly', () => {
     const client = hc<AppType>('/')
+    const req = client.index.$get
 
-    type Actual = InferResponseType<typeof client.index>
+    type Actual = InferResponseType<typeof req>
     type Expected = {
       id: number
       title: string

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -26,11 +26,7 @@ export interface ClientResponse<T> extends Response {
   json(): Promise<T>
 }
 
-export type InferResponseType<T> = T extends Record<MethodName, infer R>
-  ? R extends () => Promise<ClientResponse<infer O>>
-    ? O
-    : never
-  : never
+export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
 
 type PathToChain<
   Path extends string,


### PR DESCRIPTION
```ts
const req = client.index
type Actual = InferResponseType<typeof req>
```

will be:

```ts
const req = client.index.$get
type Actual = InferResponseType<typeof req>
```