### PR TITLE
feat(hc): add `InferRequestType`

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -27,6 +27,9 @@ export interface ClientResponse<T> extends Response {
 }
 
 export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
+export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientResponse<unknown>>
+  ? NonNullable<R>
+  : never
 
 type PathToChain<
   Path extends string,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -27,6 +27,9 @@ export interface ClientResponse<T> extends Response {
 }
 
 export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
+export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientResponse<unknown>>
+  ? NonNullable<R>
+  : never
 
 type PathToChain<
   Path extends string,


### PR DESCRIPTION
We can write like below:

```ts
const client = hc<AppType>('/')
const $get = client.index.$get

type ReqType = InferRequestType<typeof $get>
type T = ReqType['query']
```
