### PR TITLE
feat(client): introduce `Fetch` type

### DIFF
--- a/deno_dist/client/index.ts
+++ b/deno_dist/client/index.ts
@@ -1,2 +1,2 @@
 export { hc } from './client.ts'
-export type { InferResponseType, InferRequestType } from './types.ts'
+export type { InferResponseType, InferRequestType, Fetch } from './types.ts'

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -26,6 +26,11 @@ export interface ClientResponse<T> extends Response {
   json(): Promise<T>
 }
 
+export type Fetch<T> = (
+  args?: InferRequestType<T>,
+  opt?: RequestOption
+) => Promise<ClientResponse<InferResponseType<T>>>
+
 export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
 export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientResponse<unknown>>
   ? NonNullable<R>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,2 +1,2 @@
 export { hc } from './client'
-export type { InferResponseType, InferRequestType } from './types'
+export type { InferResponseType, InferRequestType, Fetch } from './types'

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -26,6 +26,11 @@ export interface ClientResponse<T> extends Response {
   json(): Promise<T>
 }
 
+export type Fetch<T> = (
+  args?: InferRequestType<T>,
+  opt?: RequestOption
+) => Promise<ClientResponse<InferResponseType<T>>>
+
 export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
 export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientResponse<unknown>>
   ? NonNullable<R>


### PR DESCRIPTION
With `Fetch`, you can write `fetcher` for [SWR](https://swr.vercel.app/ja) type-safety.

```ts
import useSWR from 'swr'
import { hc, InferRequestType, Fetch } from 'hono/client'
import { AppType } from '../functions/api/[[route]]'

const App = () => {
  const client = hc<AppType>('/api')
  const $get = client.hello.$get

  const fetcher = (method: Fetch<typeof $get>) => (arg: InferRequestType<typeof $get>) => {
    return async () => {
      const res = await method(arg)
      return await res.json()
    }
  }

  const { data, error, isLoading } = useSWR(
    'api-hello',
    fetcher($get)({
      query: {
        name: 'SWR',
      },
    })
  )

  if (error) return <div>failed to load</div>
  if (isLoading) return <div>loading...</div>

  return <h1>{data.message}</h1>
}
```

