### PR TITLE
feat(client): Inject common headers

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -1,8 +1,8 @@
 import type { Hono } from '../hono.ts'
 import type { ValidationTargets } from '../types.ts'
 import type { UnionToIntersection } from '../utils/types.ts'
-import type { Callback, Client, RequestOption } from './types.ts'
-import { replaceUrlParam, mergePath, removeIndexString } from './utils.ts'
+import type { Callback, Client, RequestOptions } from './types.ts'
+import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils.ts'
 
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
@@ -36,7 +36,7 @@ class ClientRequestImpl {
     args?: ValidationTargets & {
       param?: Record<string, string>
     },
-    opt?: RequestOption
+    opt?: RequestOptions
   ) => {
     if (args) {
       if (args.query) {
@@ -100,7 +100,7 @@ class ClientRequestImpl {
   }
 }
 
-export const hc = <T extends Hono>(baseUrl: string) =>
+export const hc = <T extends Hono>(baseUrl: string, options?: RequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 
@@ -116,7 +116,9 @@ export const hc = <T extends Hono>(baseUrl: string) =>
     const url = mergePath(baseUrl, path)
     const req = new ClientRequestImpl(url, method)
     if (method) {
-      return req.fetch(opts.args[0], opts.args[1])
+      options ??= {}
+      const args = deepMerge<RequestOptions>(options, { ...(opts.args[1] ?? {}) })
+      return req.fetch(opts.args[0], args)
     }
     return req
   }, []) as UnionToIntersection<Client<T>>

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -12,13 +12,13 @@ type Data = {
   output: {}
 }
 
-export type RequestOption = {
+export type RequestOptions = {
   headers?: Record<string, string>
 }
 
 type ClientRequest<S extends Data> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
-    ? (args?: R, options?: RequestOption) => Promise<ClientResponse<O>>
+    ? (args?: R, options?: RequestOptions) => Promise<ClientResponse<O>>
     : never
 }
 
@@ -28,7 +28,7 @@ export interface ClientResponse<T> extends Response {
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,
-  opt?: RequestOption
+  opt?: RequestOptions
 ) => Promise<ClientResponse<InferResponseType<T>>>
 
 export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
@@ -64,4 +64,8 @@ interface CallbackOptions {
   path: string[]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[]
+}
+
+export type ObjectType<T = unknown> = {
+  [key: string]: T
 }

--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -1,4 +1,5 @@
 import { getPathFromURL } from '../utils/url.ts'
+import type { ObjectType } from './types.ts'
 
 export const mergePath = (base: string, path: string) => {
   base = base.replace(/\/+$/, '')
@@ -22,4 +23,26 @@ export const removeIndexString = (urlSting: string) => {
     return urlSting.replace(/index$/, '')
   }
   return urlSting
+}
+
+function isObject(item: unknown): item is ObjectType {
+  return typeof item === 'object' && item !== null && !Array.isArray(item)
+}
+
+export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
+  if (!isObject(target) && !isObject(source)) {
+    return source as T
+  }
+  const merged = { ...target } as ObjectType<T>
+
+  for (const key in source) {
+    const value = source[key]
+    if (isObject(merged[key]) && isObject(value)) {
+      merged[key] = deepMerge(merged[key], value)
+    } else {
+      merged[key] = value as T[keyof T] & T
+    }
+  }
+
+  return merged as T
 }

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -34,6 +34,7 @@ describe('Basic - JSON', () => {
           success: true,
           message: 'dummy',
           requestContentType: 'dummy',
+          requestHono: 'dummy',
           requestMessage: 'dummy',
           requestBody: {
             id: 123,
@@ -49,12 +50,14 @@ describe('Basic - JSON', () => {
   const server = setupServer(
     rest.post('http://localhost/posts', async (req, res, ctx) => {
       const requestContentType = req.headers.get('content-type')
+      const requestHono = req.headers.get('x-hono')
       const requestMessage = req.headers.get('x-message')
       const requestBody = await req.json()
       const payload = {
         message: 'Hello!',
         success: true,
         requestContentType,
+        requestHono,
         requestMessage,
         requestBody,
       }
@@ -74,7 +77,7 @@ describe('Basic - JSON', () => {
     title: 'Hello! Hono!',
   }
 
-  const client = hc<AppType>('http://localhost')
+  const client = hc<AppType>('http://localhost', { 'x-hono': 'hono' })
 
   it('Should get 200 response', async () => {
     const res = await client.posts.$post(
@@ -93,6 +96,7 @@ describe('Basic - JSON', () => {
     expect(data.success).toBe(true)
     expect(data.message).toBe('Hello!')
     expect(data.requestContentType).toBe('application/json')
+    expect(data.requestHono).toBe('hono')
     expect(data.requestMessage).toBe('foobar')
     expect(data.requestBody).toEqual(payload)
   })

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -77,7 +77,7 @@ describe('Basic - JSON', () => {
     title: 'Hello! Hono!',
   }
 
-  const client = hc<AppType>('http://localhost', { 'x-hono': 'hono' })
+  const client = hc<AppType>('http://localhost', { headers: { 'x-hono': 'hono' } })
 
   it('Should get 200 response', async () => {
     const res = await client.posts.$post(

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,7 +1,7 @@
 import type { Hono } from '../hono'
 import type { ValidationTargets } from '../types'
 import type { UnionToIntersection } from '../utils/types'
-import type { Callback, Client, RequestOption } from './types'
+import type { Callback, Client, RequestOptions } from './types'
 import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils'
 
 const createProxy = (callback: Callback, path: string[]) => {
@@ -36,7 +36,7 @@ class ClientRequestImpl {
     args?: ValidationTargets & {
       param?: Record<string, string>
     },
-    opt?: RequestOption
+    opt?: RequestOptions
   ) => {
     if (args) {
       if (args.query) {
@@ -100,7 +100,7 @@ class ClientRequestImpl {
   }
 }
 
-export const hc = <T extends Hono>(baseUrl: string, options?: RequestOption) =>
+export const hc = <T extends Hono>(baseUrl: string, options?: RequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 
@@ -117,7 +117,7 @@ export const hc = <T extends Hono>(baseUrl: string, options?: RequestOption) =>
     const req = new ClientRequestImpl(url, method)
     if (method) {
       options ??= {}
-      const args = deepMerge<RequestOption>(options, { ...(opts.args[1] ?? {}) })
+      const args = deepMerge<RequestOptions>(options, { ...(opts.args[1] ?? {}) })
       return req.fetch(opts.args[0], args)
     }
     return req

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import type { Hono } from '../hono'
 import type { ValidationTargets } from '../types'
 import type { UnionToIntersection } from '../utils/types'
 import type { Callback, Client, RequestOption } from './types'
-import { replaceUrlParam, mergePath, removeIndexString } from './utils'
+import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils'
 
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
@@ -100,7 +100,7 @@ class ClientRequestImpl {
   }
 }
 
-export const hc = <T extends Hono>(baseUrl: string, headers?: RequestOption['headers']) =>
+export const hc = <T extends Hono>(baseUrl: string, options?: RequestOption) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 
@@ -115,10 +115,9 @@ export const hc = <T extends Hono>(baseUrl: string, headers?: RequestOption['hea
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
     const req = new ClientRequestImpl(url, method)
-    console.log(method)
     if (method) {
-      headers ??= {}
-      const args = {...opts.args[1], headers: opts.args[1]?.headers ? {...headers, ...opts.args[1].headers }: headers}
+      options ??= {}
+      const args = deepMerge<RequestOption>(options, { ...(opts.args[1] ?? {}) })
       return req.fetch(opts.args[0], args)
     }
     return req

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -100,7 +100,7 @@ class ClientRequestImpl {
   }
 }
 
-export const hc = <T extends Hono>(baseUrl: string) =>
+export const hc = <T extends Hono>(baseUrl: string, headers?: RequestOption['headers']) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 
@@ -115,8 +115,11 @@ export const hc = <T extends Hono>(baseUrl: string) =>
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
     const req = new ClientRequestImpl(url, method)
+    console.log(method)
     if (method) {
-      return req.fetch(opts.args[0], opts.args[1])
+      headers ??= {}
+      const args = {...opts.args[1], headers: opts.args[1]?.headers ? {...headers, ...opts.args[1].headers }: headers}
+      return req.fetch(opts.args[0], args)
     }
     return req
   }, []) as UnionToIntersection<Client<T>>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -65,3 +65,7 @@ interface CallbackOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[]
 }
+
+export type ObjectType<T = unknown> = {
+  [key: string]: T
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -12,13 +12,13 @@ type Data = {
   output: {}
 }
 
-export type RequestOption = {
+export type RequestOptions = {
   headers?: Record<string, string>
 }
 
 type ClientRequest<S extends Data> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
-    ? (args?: R, options?: RequestOption) => Promise<ClientResponse<O>>
+    ? (args?: R, options?: RequestOptions) => Promise<ClientResponse<O>>
     : never
 }
 
@@ -28,7 +28,7 @@ export interface ClientResponse<T> extends Response {
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,
-  opt?: RequestOption
+  opt?: RequestOptions
 ) => Promise<ClientResponse<InferResponseType<T>>>
 
 export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,4 +1,4 @@
-import { mergePath, removeIndexString, replaceUrlParam } from './utils'
+import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './utils'
 
 describe('mergePath', () => {
   it('Should merge paths correctly', () => {
@@ -31,5 +31,27 @@ describe('removeIndexString', () => {
     url = '/index'
     newUrl = removeIndexString(url)
     expect(newUrl).toBe('/')
+  })
+})
+
+describe('deepMerge', () => {
+  it('should return the source object if the target object is not an object', () => {
+    const target = null
+    const source = { a: 1 }
+    const result = deepMerge(target, source)
+    expect(result).toEqual(source)
+  })
+
+  it('should merge two objects with object properties', () => {
+    expect(
+      deepMerge(
+        { headers: { hono: '1' }, timeout: 2, params: {} },
+        { headers: { hono: '2', demo: 2 }, params: undefined }
+      )
+    ).toStrictEqual({
+      params: undefined,
+      headers: { hono: '2', demo: 2 },
+      timeout: 2,
+    })
   })
 })

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,4 +1,5 @@
 import { getPathFromURL } from '../utils/url'
+import type { ObjectType } from './types'
 
 export const mergePath = (base: string, path: string) => {
   base = base.replace(/\/+$/, '')
@@ -22,4 +23,26 @@ export const removeIndexString = (urlSting: string) => {
     return urlSting.replace(/index$/, '')
   }
   return urlSting
+}
+
+function isObject(item: unknown): item is ObjectType {
+  return typeof item === 'object' && item !== null && !Array.isArray(item)
+}
+
+export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
+  if (!isObject(target) && !isObject(source)) {
+    return source as T
+  }
+  const merged = { ...target } as ObjectType<T>
+
+  for (const key in source) {
+    const value = source[key]
+    if (isObject(merged[key]) && isObject(value)) {
+      merged[key] = deepMerge(merged[key], value)
+    } else {
+      merged[key] = value as T[keyof T] & T
+    }
+  }
+
+  return merged as T
 }


### PR DESCRIPTION
Enabled passing the commonly used site header as an argument during HonoClient instance generation.