### PR TITLE
feat(types): keep schema info with `app.route()`

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -100,7 +100,8 @@ class ClientRequestImpl {
   }
 }
 
-export const hc = <T extends Hono>(baseUrl: string, options?: RequestOptions) =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const hc = <T extends Hono<any>>(baseUrl: string, options?: RequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -1,5 +1,5 @@
 import type { Hono } from '../hono.ts'
-import type { ValidationTargets, Env } from '../types.ts'
+import type { ValidationTargets } from '../types.ts'
 
 type MethodName = `$${string}`
 
@@ -50,7 +50,8 @@ type PathToChain<
       >
     }
 
-export type Client<T> = T extends Hono<Env, infer S>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Client<T> = T extends Hono<any, infer S>
   ? S extends Record<infer K, Endpoint>
     ? K extends string
       ? PathToChain<K, S>

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -18,6 +18,8 @@ import type {
   NotFoundHandler,
   OnHandlerInterface,
   TypedResponse,
+  MergeSchemaPath,
+  RemoveBlankRecord,
 } from './types.ts'
 import { getPathFromURL, mergePath } from './utils/url.ts'
 
@@ -116,8 +118,10 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
   private notFoundHandler: NotFoundHandler = notFoundHandler
   private errorHandler: ErrorHandler = errorHandler
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  route(path: string, app?: Hono<any, any>) {
+  route<SubPath extends string, SubSchema>(
+    path: SubPath,
+    app?: Hono<E, SubSchema>
+  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>> {
     this._tempPath = path
     if (app) {
       app.routes.map((r) => {
@@ -130,7 +134,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
       })
       this._tempPath = ''
     }
-    return this
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this as any
   }
 
   onError(handler: ErrorHandler<E>) {

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -228,6 +228,16 @@ export type AddDollar<T> = T extends Record<infer K, infer R>
     : never
   : never
 
+export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, infer T>
+  ? Key extends string
+    ? Record<MergePath<P, Key>, T>
+    : never
+  : never
+
+export type MergePath<A extends string, B extends string> = A extends `${infer P}/`
+  ? `${P}${B}`
+  : `${A}${B}`
+
 ////////////////////////////////////////
 //////                            //////
 //////        TypedResponse       //////
@@ -302,3 +312,9 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 ////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
+
+export type RemoveBlankRecord<T> = T extends Record<infer K, unknown>
+  ? K extends string
+    ? T
+    : never
+  : never

--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -17,6 +17,6 @@ interface HandleInterface {
 export const handle: HandleInterface =
   <E extends Env>(subApp: Hono<E>, path: string = '/') =>
   ({ request, env, waitUntil }) =>
-    new Hono()
+    new Hono<E>()
       .route(path, subApp)
       .fetch(request, env, { waitUntil, passThroughOnException: () => {} })

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -9,4 +9,4 @@ interface HandleInterface {
 export const handle: HandleInterface =
   <E extends Env>(subApp: Hono<E>, path: string = '/') =>
   async (req) =>
-    new Hono().route(path, subApp).fetch(req)
+    new Hono<E>().route(path, subApp).fetch(req)

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -100,7 +100,8 @@ class ClientRequestImpl {
   }
 }
 
-export const hc = <T extends Hono>(baseUrl: string, options?: RequestOptions) =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const hc = <T extends Hono<any>>(baseUrl: string, options?: RequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,5 @@
 import type { Hono } from '../hono'
-import type { ValidationTargets, Env } from '../types'
+import type { ValidationTargets } from '../types'
 
 type MethodName = `$${string}`
 
@@ -50,7 +50,8 @@ type PathToChain<
       >
     }
 
-export type Client<T> = T extends Hono<Env, infer S>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Client<T> = T extends Hono<any, infer S>
   ? S extends Record<infer K, Endpoint>
     ? K extends string
       ? PathToChain<K, S>

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -18,6 +18,8 @@ import type {
   NotFoundHandler,
   OnHandlerInterface,
   TypedResponse,
+  MergeSchemaPath,
+  RemoveBlankRecord,
 } from './types'
 import { getPathFromURL, mergePath } from './utils/url'
 
@@ -116,8 +118,10 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
   private notFoundHandler: NotFoundHandler = notFoundHandler
   private errorHandler: ErrorHandler = errorHandler
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  route(path: string, app?: Hono<any, any>) {
+  route<SubPath extends string, SubSchema>(
+    path: SubPath,
+    app?: Hono<E, SubSchema>
+  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>> {
     this._tempPath = path
     if (app) {
       app.routes.map((r) => {
@@ -130,7 +134,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
       })
       this._tempPath = ''
     }
-    return this
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this as any
   }
 
   onError(handler: ErrorHandler<E>) {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -8,6 +8,8 @@ import type {
   ExtractSchema,
   Handler,
   InputToDataByTarget,
+  MergePath,
+  MergeSchemaPath,
   MiddlewareHandler,
   ParamKeys,
   ParamKeyToRecord,
@@ -333,5 +335,67 @@ describe('For HonoRequest', () => {
       type Actual = UndefinedIfHavingQuestion<'/animal/type'>
       type verify = Expect<Equal<string, Actual>>
     })
+  })
+})
+
+describe('merge path', () => {
+  test('MergePath', () => {
+    type path1 = MergePath<'/api', '/book'>
+    type verify1 = Expect<Equal<'/api/book', path1>>
+    type path2 = MergePath<'/api/', '/book'>
+    type verify2 = Expect<Equal<'/api/book', path2>>
+    type path3 = MergePath<'/api/', '/'>
+    type verify3 = Expect<Equal<'/api/', path3>>
+  })
+
+  test('MergeSchemaPath', () => {
+    type Sub = Schema<
+      'post',
+      '/posts',
+      {
+        json: {
+          id: number
+          title: string
+        }
+      },
+      {
+        message: string
+      }
+    > &
+      Schema<
+        'get',
+        '/posts',
+        {},
+        {
+          ok: boolean
+        }
+      >
+
+    type Actual = MergeSchemaPath<Sub, '/api'>
+
+    type Expected = {
+      '/api/posts': {
+        $post: {
+          input: {
+            json: {
+              id: number
+              title: string
+            }
+          }
+          output: {
+            message: string
+          }
+        }
+      } & {
+        $get: {
+          input: {}
+          output: {
+            ok: boolean
+          }
+        }
+      }
+    }
+
+    type verify = Expect<Equal<Expected, Actual>>
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,16 @@ export type AddDollar<T> = T extends Record<infer K, infer R>
     : never
   : never
 
+export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, infer T>
+  ? Key extends string
+    ? Record<MergePath<P, Key>, T>
+    : never
+  : never
+
+export type MergePath<A extends string, B extends string> = A extends `${infer P}/`
+  ? `${P}${B}`
+  : `${A}${B}`
+
 ////////////////////////////////////////
 //////                            //////
 //////        TypedResponse       //////
@@ -302,3 +312,9 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 ////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
+
+export type RemoveBlankRecord<T> = T extends Record<infer K, unknown>
+  ? K extends string
+    ? T
+    : never
+  : never


### PR DESCRIPTION
This PR will fix the matter of #907 .

When using `app.route()`, the schema information is missing but made it so that it is kept.

<img width="753" alt="SS" src="https://user-images.githubusercontent.com/10682/219934403-edb429ca-3d99-440f-b49e-d66223133145.png">
