### PR TITLE
Expose HonoRequest Type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ export type {
 export type { Context, ContextVariableMap } from './context'
 export type { HonoRequest } from './request'
 
-
 declare module './hono' {
   interface Hono {
     fire(): void

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export type {
   ValidationTargets,
 } from './types'
 export type { Context, ContextVariableMap } from './context'
+export type { HonoRequest } from './request'
+
 
 declare module './hono' {
   interface Hono {


### PR DESCRIPTION
Congrats on the v3, launch. Really liking Hono as a clean and fast framework. 

In my apps, I sometimes build utility functions that are used by multiple handlers and they interact with the Request. Since the request has changed to `HonoRequest`, I think it is valuable to also expose its type, so ppl can write functions and define `HonoRequest` as a parameter.