### PR TITLE
fix(types): `app.route` with multiple endpoints returns types correctly

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -120,9 +120,9 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
   private notFoundHandler: NotFoundHandler = notFoundHandler
   private errorHandler: ErrorHandler = errorHandler
 
-  route<SubPath extends string, SubSchema>(
+  route<SubPath extends string, SubEnv extends Env, SubSchema>(
     path: SubPath,
-    app?: Hono<E, SubSchema>
+    app?: Hono<SubEnv, SubSchema>
   ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>> {
     this._tempPath = path
     if (app) {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -83,7 +83,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
             this.addRoute(method, this.path, handler)
           }
         })
-        return this
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return this as any
       }
     })
 
@@ -96,7 +97,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
           this.addRoute(m.toUpperCase(), this.path, handler)
         })
       }
-      return this
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return this as any
     }
 
     // Implementation of app.use(...handlers[]) or app.get(path, ...handlers[])

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -63,13 +63,13 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   // app.get(handler, handler)
   <I = {}, O = {}>(...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]): Hono<
     E,
-    S & Schema<M, ExtractKey<S>, I, O>
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>
   >
 
   // app.get(handler x 3)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I2, O>, H<E, ExtractKey<S>, I3, O>]
-  ): Hono<E, S & Schema<M, ExtractKey<S>, I3, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3, O>>>
 
   // app.get(handler x 4)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
@@ -79,7 +79,7 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
       H<E, ExtractKey<S>, I3, O>,
       H<E, ExtractKey<S>, I4, O>
     ]
-  ): Hono<E, S & Schema<M, ExtractKey<S>, I4, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4, O>>>
 
   // app.get(handler x 5)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
@@ -90,12 +90,12 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
       H<E, ExtractKey<S>, I4, O>,
       H<E, ExtractKey<S>, I5, O>
     ]
-  ): Hono<E, S & Schema<M, ExtractKey<S>, I5, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5, O>>>
 
   // app.get(...handlers[])
   <I = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
     E,
-    S & Schema<M, ExtractKey<S>, I, O>
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>
   >
 
   ////  app.get(path, ...handlers[])
@@ -103,31 +103,31 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   // app.get(path, handler, handler)
   <P extends string, O = {}, I = {}>(path: P, ...handlers: [H<E, P, I, O>, H<E, P, I, O>]): Hono<
     E,
-    S & Schema<M, P, I, O>
+    RemoveBlankRecord<S | Schema<M, P, I, O>>
   >
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, S & Schema<M, P, I3, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
 
   // app.get(path, handler x4)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, S & Schema<M, P, I4, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
 
   // app.get(path, handler x5)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S & Schema<M, P, I5, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I5, O>>>
 
   // app.get(path, ...handlers[])
   <P extends string, I = {}, O = {}>(path: P, ...handlers: H<E, P, I, O>[]): Hono<
     E,
-    S & Schema<M, P, I, O>
+    RemoveBlankRecord<S | Schema<M, P, I, O>>
   >
 }
 
@@ -156,21 +156,21 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, S & Schema<M, P, I, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
 
   // app.get(method, path, handler x3)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, S & Schema<M, P, I3, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
 
   // app.get(method, path, handler x4)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, S & Schema<M, P, I4, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
 
   // app.get(method, path, handler x5)
   <
@@ -186,20 +186,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S & Schema<M, P, I5, O>>
+  ): Hono<E, S | Schema<M, P, I5, O>>
 
   <M extends string, P extends string, O extends {} = {}, I = {}>(
     method: M,
     path: P,
     ...handlers: H<E, P, I, O>[]
-  ): Hono<E, S & Schema<M, P, I, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, P, I, O>[]
-  ): Hono<E, S & Schema<string, P, I, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, P, I, O>>>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -330,17 +330,15 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<typeof app>('http://localhost')
 
     it('Should return correct types - GET /api/foo', async () => {
-      type verify1 = Expect<NotEqual<typeof client.api.foo.$get, any>>
       const res = await client.api.foo.$get()
       const data = await res.json()
-      type verify2 = Expect<Equal<string, typeof data.foo>>
+      type verify = Expect<Equal<string, typeof data.foo>>
     })
 
     it('Should return correct types - POST /api/bar', async () => {
-      type verify1 = Expect<NotEqual<typeof client.api.bar.$post, any>>
       const res = await client.api.bar.$post()
       const data = await res.json()
-      type verify2 = Expect<Equal<number, typeof data.bar>>
+      type verify = Expect<Equal<number, typeof data.bar>>
     })
   })
 })

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import FormData from 'form-data'
@@ -5,7 +6,8 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import _fetch, { Request as NodeFetchRequest } from 'node-fetch'
 import { Hono } from '../hono'
-import type { Equal, Expect } from '../utils/types'
+import type { Expect } from '../utils/types'
+import type { Equal, NotEqual } from '../utils/types'
 import { validator } from '../validator'
 import { hc } from './client'
 import type { InferRequestType, InferResponseType } from './types'
@@ -277,7 +279,20 @@ describe('Merge path with `app.route()`', () => {
   const server = setupServer(
     rest.get('http://localhost/api/search', async (req, res, ctx) => {
       return res(
-        ctx.status(200),
+        ctx.json({
+          ok: true,
+        })
+      )
+    }),
+    rest.get('http://localhost/api/foo', async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          ok: true,
+        })
+      )
+    }),
+    rest.post('http://localhost/api/bar', async (req, res, ctx) => {
+      return res(
         ctx.json({
           ok: true,
         })
@@ -304,5 +319,28 @@ describe('Merge path with `app.route()`', () => {
     const data = await res.json()
     type verify = Expect<Equal<boolean, typeof data.ok>>
     expect(data.ok).toBe(true)
+  })
+
+  describe('Multiple endpoints', () => {
+    const api = new Hono()
+      .get('/foo', (c) => c.jsonT({ foo: '' }))
+      .post('/bar', (c) => c.jsonT({ bar: 0 }))
+    const app = new Hono().route('/api', api)
+    type AppType = typeof app
+    const client = hc<typeof app>('http://localhost')
+
+    it('Should return correct types - GET /api/foo', async () => {
+      type verify1 = Expect<NotEqual<typeof client.api.foo.$get, any>>
+      const res = await client.api.foo.$get()
+      const data = await res.json()
+      type verify2 = Expect<Equal<string, typeof data.foo>>
+    })
+
+    it('Should return correct types - POST /api/bar', async () => {
+      type verify1 = Expect<NotEqual<typeof client.api.bar.$post, any>>
+      const res = await client.api.bar.$post()
+      const data = await res.json()
+      type verify2 = Expect<Equal<number, typeof data.bar>>
+    })
   })
 })

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -120,9 +120,9 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
   private notFoundHandler: NotFoundHandler = notFoundHandler
   private errorHandler: ErrorHandler = errorHandler
 
-  route<SubPath extends string, SubSchema>(
+  route<SubPath extends string, SubEnv extends Env, SubSchema>(
     path: SubPath,
-    app?: Hono<E, SubSchema>
+    app?: Hono<SubEnv, SubSchema>
   ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>> {
     this._tempPath = path
     if (app) {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -97,7 +97,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
           this.addRoute(m.toUpperCase(), this.path, handler)
         })
       }
-      return this
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return this as any
     }
 
     // Implementation of app.use(...handlers[]) or app.get(path, ...handlers[])

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -83,7 +83,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
             this.addRoute(method, this.path, handler)
           }
         })
-        return this
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return this as any
       }
     })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,13 +63,13 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   // app.get(handler, handler)
   <I = {}, O = {}>(...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]): Hono<
     E,
-    S & Schema<M, ExtractKey<S>, I, O>
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>
   >
 
   // app.get(handler x 3)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I2, O>, H<E, ExtractKey<S>, I3, O>]
-  ): Hono<E, S & Schema<M, ExtractKey<S>, I3, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3, O>>>
 
   // app.get(handler x 4)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
@@ -79,7 +79,7 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
       H<E, ExtractKey<S>, I3, O>,
       H<E, ExtractKey<S>, I4, O>
     ]
-  ): Hono<E, S & Schema<M, ExtractKey<S>, I4, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4, O>>>
 
   // app.get(handler x 5)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
@@ -90,12 +90,12 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
       H<E, ExtractKey<S>, I4, O>,
       H<E, ExtractKey<S>, I5, O>
     ]
-  ): Hono<E, S & Schema<M, ExtractKey<S>, I5, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5, O>>>
 
   // app.get(...handlers[])
   <I = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
     E,
-    S & Schema<M, ExtractKey<S>, I, O>
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>
   >
 
   ////  app.get(path, ...handlers[])
@@ -103,31 +103,31 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   // app.get(path, handler, handler)
   <P extends string, O = {}, I = {}>(path: P, ...handlers: [H<E, P, I, O>, H<E, P, I, O>]): Hono<
     E,
-    S & Schema<M, P, I, O>
+    RemoveBlankRecord<S | Schema<M, P, I, O>>
   >
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, S & Schema<M, P, I3, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
 
   // app.get(path, handler x4)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, S & Schema<M, P, I4, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
 
   // app.get(path, handler x5)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S & Schema<M, P, I5, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I5, O>>>
 
   // app.get(path, ...handlers[])
   <P extends string, I = {}, O = {}>(path: P, ...handlers: H<E, P, I, O>[]): Hono<
     E,
-    S & Schema<M, P, I, O>
+    RemoveBlankRecord<S | Schema<M, P, I, O>>
   >
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,21 +156,21 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, S & Schema<M, P, I, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
 
   // app.get(method, path, handler x3)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, S & Schema<M, P, I3, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
 
   // app.get(method, path, handler x4)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, S & Schema<M, P, I4, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
 
   // app.get(method, path, handler x5)
   <
@@ -186,20 +186,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
     method: M,
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S & Schema<M, P, I5, O>>
+  ): Hono<E, S | Schema<M, P, I5, O>>
 
   <M extends string, P extends string, O extends {} = {}, I = {}>(
     method: M,
     path: P,
     ...handlers: H<E, P, I, O>[]
-  ): Hono<E, S & Schema<M, P, I, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, P, I, O>[]
-  ): Hono<E, S & Schema<string, P, I, O>>
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, P, I, O>>>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>


### PR DESCRIPTION
As pointed out in #915, the type was incorrectly inferred when mounting an app with multiple `jsonT()` endpoints using `app.route()`.

<img width="457" alt="SS" src="https://user-images.githubusercontent.com/10682/220639134-6d99d497-d9ab-4842-ac1c-f34d6bc1cf02.png">

This PR will fix #915