### PR TITLE
Custom fetch method for Hono Client options

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -92,7 +92,7 @@ class ClientRequestImpl {
     setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
 
     // Pass URL string to 1st arg for testing with MSW and node-fetch
-    return fetch(url, {
+    return (opt?.fetch || fetch)(url, {
       body: setBody ? this.rBody : undefined,
       method: methodUpperCase,
       headers: headers,

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -14,6 +14,7 @@ type Data = {
 
 export type RequestOptions = {
   headers?: Record<string, string>
+  fetch?: typeof fetch
 }
 
 type ClientRequest<S extends Data> = {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -306,3 +306,30 @@ describe('Merge path with `app.route()`', () => {
     expect(data.ok).toBe(true)
   })
 })
+
+describe('Use custom fetch method', () => {
+  it('Should call the custom fetch method when provided', async () => {
+    const fetchMock = jest.fn()
+
+    const api = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
+    const app = new Hono().route('/api', api)
+    type AppType = typeof app
+    const client = hc<AppType>('http://localhost', { fetch: fetchMock })
+    await client.api.search.$get()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Should return Response from custom fetch method', async () => {
+    const fetchMock = jest.fn()
+    const returnValue = new Response(null, { status: 200 })
+    fetchMock.mockReturnValueOnce(returnValue)
+
+    const api = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
+    const app = new Hono().route('/api', api)
+    type AppType = typeof app
+    const client = hc<AppType>('http://localhost', { fetch: fetchMock })
+    const res = await client.api.search.$get()
+    expect(res.ok).toBe(true)
+    expect(res).toEqual(returnValue)
+  })
+})

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -92,7 +92,7 @@ class ClientRequestImpl {
     setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
 
     // Pass URL string to 1st arg for testing with MSW and node-fetch
-    return fetch(url, {
+    return (opt?.fetch || fetch)(url, {
       body: setBody ? this.rBody : undefined,
       method: methodUpperCase,
       headers: headers,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -14,6 +14,7 @@ type Data = {
 
 export type RequestOptions = {
   headers?: Record<string, string>
+  fetch?: typeof fetch
 }
 
 type ClientRequest<S extends Data> = {


### PR DESCRIPTION
As described in my issue https://github.com/honojs/hono/issues/917 it would be great to be able to pass a custom fetch method to Hono Client to be able to call Service Bindings through Hono Client.

I have just added an optional `fetch` method to the `RequestOptions` so that the `fetch` method of a Service Binding can be used instead of the default `fetch` API when it's set in the options.

See this example on how it would be used:
```
services = [
  { binding = "AUTH", service = "auth-service" },
]
```
```typescript
const client = hc<CreateProfileType>('/', { fetch: c.env. AUTH.fetch });
...
// use client normally
```