### PR TITLE
feat: allow pathname argument

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -263,7 +263,11 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
   }
 
   request = async (input: Request | string, requestInit?: RequestInit) => {
-    const req = input instanceof Request ? input : new Request(input, requestInit)
+    if (input instanceof Request) {
+      return await this.fetch(input)
+    }
+    const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
+    const req = new Request(path, requestInit)
     return await this.fetch(req)
   }
 }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -38,8 +38,21 @@ describe('GET Request', () => {
     expect(await res.text()).toBe('hello')
   })
 
+  it('GET httphello is ng', async () => {
+    const res = await app.request('httphello')
+    expect(res.status).toBe(404)
+  })
+
   it('GET /hello is ok', async () => {
     const res = await app.request('/hello')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.statusText).toBe('Hono is OK')
+    expect(await res.text()).toBe('hello')
+  })
+
+  it('GET hello is ok', async () => {
+    const res = await app.request('hello')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.statusText).toBe('Hono is OK')

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -30,8 +30,16 @@ describe('GET Request', () => {
     return c.html('<h1>Hono!!!</h1>')
   })
 
-  it('GET /hello is ok', async () => {
+  it('GET http://localhost/hello is ok', async () => {
     const res = await app.request('http://localhost/hello')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.statusText).toBe('Hono is OK')
+    expect(await res.text()).toBe('hello')
+  })
+
+  it('GET /hello is ok', async () => {
+    const res = await app.request('/hello')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.statusText).toBe('Hono is OK')

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -266,7 +266,8 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
     if (input instanceof Request) {
       return await this.fetch(input)
     }
-    const req = new Request(/^http/.test(input) ? input : `http://localhost${input}`, requestInit)
+    const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
+    const req = new Request(path, requestInit)
     return await this.fetch(req)
   }
 }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -263,7 +263,10 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
   }
 
   request = async (input: Request | string, requestInit?: RequestInit) => {
-    const req = input instanceof Request ? input : new Request(input, requestInit)
+    if (input instanceof Request) {
+      return await this.fetch(input)
+    }
+    const req = new Request(/^http/.test(input) ? input : `http://localhost${input}`, requestInit)
     return await this.fetch(req)
   }
 }


### PR DESCRIPTION
In order to avoid having to write the full URL every time when writing tests, 
we implemented a feature to implicitly format the URL and generate the request object when the pathname argument is entered.