### PR TITLE
fix(validator): clone Request object if `json` or `form`

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -1,5 +1,6 @@
 import type { Context } from '../context.ts'
 import type { Env, ValidationTargets, MiddlewareHandler } from '../types.ts'
+import { parseBody } from '../utils/body.ts'
 
 type ValidationTargetKeysWithBody = 'form' | 'json'
 type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD request must not have a body content.
@@ -24,7 +25,7 @@ export const validator = <
     switch (target) {
       case 'json':
         try {
-          value = await c.req.json()
+          value = await c.req.raw.clone().json()
         } catch {
           console.error('Error: Malformed JSON in request body')
           return c.json(
@@ -37,7 +38,7 @@ export const validator = <
         }
         break
       case 'form':
-        value = await c.req.parseBody()
+        value = await parseBody(c.req.raw.clone())
         break
       case 'query':
         value = c.req.query()

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -478,3 +478,59 @@ describe('`app.on`', () => {
   type Actual = ExtractSchema<typeof route>
   //type verify = Expect<Equal<Expected, Actual>>
 })
+
+describe('Clone Request object', () => {
+  describe('json', () => {
+    const app = new Hono()
+    app.post(
+      '/',
+      validator('json', () => {
+        return {
+          foo: 'bar',
+        }
+      }),
+      async (c) => {
+        // `c.req.json` should not throw the error
+        await c.req.json()
+        return c.text('foo')
+      }
+    )
+
+    it('Should not throw the error with c.req.json()', async () => {
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ foo: 'bar' }),
+      })
+      const res = await app.request(req)
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('form', () => {
+    const app = new Hono()
+    app.post(
+      '/',
+      validator('form', () => {
+        return {
+          foo: 'bar',
+        }
+      }),
+      async (c) => {
+        // `c.req.json` should not throw the error
+        await c.req.parseBody()
+        return c.text('foo')
+      }
+    )
+
+    it('Should not throw the error with c.req.parseBody()', async () => {
+      const body = new FormData()
+      body.append('foo', 'bar')
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: body,
+      })
+      const res = await app.request(req)
+      expect(res.status).toBe(200)
+    })
+  })
+})

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,5 +1,6 @@
 import type { Context } from '../context'
 import type { Env, ValidationTargets, MiddlewareHandler } from '../types'
+import { parseBody } from '../utils/body'
 
 type ValidationTargetKeysWithBody = 'form' | 'json'
 type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD request must not have a body content.
@@ -24,7 +25,7 @@ export const validator = <
     switch (target) {
       case 'json':
         try {
-          value = await c.req.json()
+          value = await c.req.raw.clone().json()
         } catch {
           console.error('Error: Malformed JSON in request body')
           return c.json(
@@ -37,7 +38,7 @@ export const validator = <
         }
         break
       case 'form':
-        value = await c.req.parseBody()
+        value = await parseBody(c.req.raw.clone())
         break
       case 'query':
         value = c.req.query()


### PR DESCRIPTION
It throws the error if we do `c.req.json()` or `c.req.parseBody()` after validating `json` or `form` with `hono/validator`, 

```ts
const app = new Hono()
app.post(
  '/',
  validator('json', () => {
    return {
      foo: 'bar',
    }
  }),
  async (c) => {
    await c.req.json() // throw error!
    return c.text('foo')
  }
)
```

This bug is caused by the Request object being used though the body has been used. So, we should clone it before validation.

Fix #818