### PR TITLE
feat: Improve route()

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -101,7 +101,7 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any>>(baseUrl: string, options?: RequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: RequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -52,7 +52,7 @@ type PathToChain<
     }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Client<T> = T extends Hono<any, infer S>
+export type Client<T> = T extends Hono<any, infer S, any>
   ? S extends Record<infer K, Endpoint>
     ? K extends string
       ? PathToChain<K, S>

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -57,7 +57,12 @@ export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => R
 //////                            //////
 ////////////////////////////////////////
 
-export interface HandlerInterface<E extends Env = Env, M extends string = any, S = {}> {
+export interface HandlerInterface<
+  E extends Env = Env,
+  M extends string = any,
+  S = {},
+  BasePath extends string = ''
+> {
   //// app.get(...handlers[])
 
   // app.get(handler, handler)
@@ -103,32 +108,47 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   // app.get(path, handler, handler)
   <P extends string, O = {}, I = {}>(path: P, ...handlers: [H<E, P, I, O>, H<E, P, I, O>]): Hono<
     E,
-    RemoveBlankRecord<S | Schema<M, P, I, O>>
+    RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>
   >
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>
+    ]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
 
   // app.get(path, handler x4)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>
+    ]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
 
   // app.get(path, handler x5)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>,
+      H<E, MergePath<BasePath, P>, I5, O>
+    ]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I5, O>>>
 
   // app.get(path, ...handlers[])
-  <P extends string, I = {}, O = {}>(path: P, ...handlers: H<E, P, I, O>[]): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, P, I, O>>
-  >
+  <P extends string, I = {}, O = {}>(
+    path: P,
+    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>>
 }
 
 ////////////////////////////////////////
@@ -137,11 +157,19 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
 //////                            //////
 ////////////////////////////////////////
 
-export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
+export interface MiddlewareHandlerInterface<
+  E extends Env = Env,
+  S = {},
+  BasePath extends string = ''
+> {
   //// app.get(...handlers[])
-  (...handlers: MiddlewareHandler<E, ExtractKey<S>>[]): Hono<E, S>
+  (...handlers: MiddlewareHandler<E, MergePath<BasePath, ExtractKey<S>>>[]): Hono<E, S, BasePath>
   //// app.get(path, ...handlers[])
-  <P extends string>(path: P, ...handlers: MiddlewareHandler<E, P>[]): Hono<E, S>
+  <P extends string>(path: P, ...handlers: MiddlewareHandler<E, MergePath<BasePath, P>>[]): Hono<
+    E,
+    S,
+    BasePath
+  >
 }
 
 ////////////////////////////////////////
@@ -150,27 +178,36 @@ export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
 //////                            //////
 ////////////////////////////////////////
 
-export interface OnHandlerInterface<E extends Env = Env, S = {}> {
+export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extends string = ''> {
   // app.on(method, path, handler, handler)
   <M extends string, P extends string, O = {}, I = {}>(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
+    ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
 
   // app.get(method, path, handler x3)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>
+    ]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3, O>>, BasePath>
 
   // app.get(method, path, handler x4)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>
+    ]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4, O>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
@@ -185,21 +222,27 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
   >(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S | Schema<M, P, I5, O>>
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>,
+      H<E, MergePath<BasePath, P>, I5, O>
+    ]
+  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5, O>, BasePath>
 
   <M extends string, P extends string, O extends {} = {}, I = {}>(
     method: M,
     path: P,
-    ...handlers: H<E, P, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
+    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I = {}>(
     methods: string[],
     path: P,
-    ...handlers: H<E, P, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, P, I, O>>>
+    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I, O>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -234,9 +277,15 @@ export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, i
     : never
   : never
 
-export type MergePath<A extends string, B extends string> = A extends `${infer P}/`
-  ? `${P}${B}`
-  : `${A}${B}`
+export type MergePath<A extends string, B extends string> = A extends ''
+  ? B
+  : A extends `${infer P}/`
+  ? B extends `/${infer Q}`
+    ? `${P}/${Q}`
+    : `${P}/${B}`
+  : B extends `/${infer Q}`
+  ? `${A}/${Q}`
+  : `${A}/${B}`
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -321,6 +321,17 @@ describe('Merge path with `app.route()`', () => {
     expect(data.ok).toBe(true)
   })
 
+  it('Should have correct types - route() then get()', async () => {
+    const base = new Hono<Env>().route('/api')
+    const app = base.get('/search', (c) => c.jsonT({ ok: true }))
+    type AppType = typeof app
+    const client = hc<AppType>('http://localhost')
+    const res = await client.api.search.$get()
+    const data = await res.json()
+    type verify = Expect<Equal<boolean, typeof data.ok>>
+    expect(data.ok).toBe(true)
+  })
+
   describe('Multiple endpoints', () => {
     const api = new Hono()
       .get('/foo', (c) => c.jsonT({ foo: '' }))

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -101,7 +101,7 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any>>(baseUrl: string, options?: RequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: RequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -52,7 +52,7 @@ type PathToChain<
     }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Client<T> = T extends Hono<any, infer S>
+export type Client<T> = T extends Hono<any, infer S, any>
   ? S extends Record<infer K, Endpoint>
     ? K extends string
       ? PathToChain<K, S>

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -176,6 +176,11 @@ describe('Routing', () => {
     user.get('/login', (c) => c.text('get /user/login'))
     user.post('/register', (c) => c.text('post /user/register'))
 
+    const appForEachUser = user.route(':id')
+    appForEachUser.get('/profile', (c) => c.text('get /user/' + c.req.param('id') + '/profile'))
+
+    app.get('/add-path-after-route-call', (c) => c.text('get /add-path-after-route-call'))
+
     let res = await app.request('http://localhost/book', { method: 'GET' })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('get /book')
@@ -198,6 +203,14 @@ describe('Routing', () => {
     res = await app.request('http://localhost/user/register', { method: 'POST' })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('post /user/register')
+
+    res = await app.request('http://localhost/user/123/profile', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /user/123/profile')
+
+    res = await app.request('http://localhost/add-path-after-route-call', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /add-path-after-route-call')
   })
 
   describe('Nested route with middleware', () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -135,7 +135,7 @@ export class Hono<
   private errorHandler: ErrorHandler = errorHandler
 
   route<SubPath extends string, SubEnv extends Env, SubSchema>(
-    path: SubPath = '' as SubPath,
+    path: SubPath,
     app?: Hono<SubEnv, SubSchema>
   ): Hono<
     E,

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -66,7 +66,7 @@ export class Hono<
     routers: [new RegExpRouter(), new TrieRouter()],
   })
   readonly strict: boolean = true // strict routing - default is true
-  private basePath: BasePath = '' as BasePath
+  private basePath: string = ''
   private path: string = '*'
 
   routes: RouterRoute[] = []
@@ -143,8 +143,7 @@ export class Hono<
     MergePath<BasePath, SubPath>
   > {
     const subApp = this.clone()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    subApp.basePath = mergePath(this.basePath, path) as any
+    subApp.basePath = mergePath(this.basePath, path)
 
     if (app) {
       app.routes.map((r) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,12 @@ export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => R
 //////                            //////
 ////////////////////////////////////////
 
-export interface HandlerInterface<E extends Env = Env, M extends string = any, S = {}> {
+export interface HandlerInterface<
+  E extends Env = Env,
+  M extends string = any,
+  S = {},
+  BasePath extends string = ''
+> {
   //// app.get(...handlers[])
 
   // app.get(handler, handler)
@@ -103,32 +108,47 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
   // app.get(path, handler, handler)
   <P extends string, O = {}, I = {}>(path: P, ...handlers: [H<E, P, I, O>, H<E, P, I, O>]): Hono<
     E,
-    RemoveBlankRecord<S | Schema<M, P, I, O>>
+    RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>
   >
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>
+    ]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
 
   // app.get(path, handler x4)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>
+    ]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
 
   // app.get(path, handler x5)
   <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>,
+      H<E, MergePath<BasePath, P>, I5, O>
+    ]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I5, O>>>
 
   // app.get(path, ...handlers[])
-  <P extends string, I = {}, O = {}>(path: P, ...handlers: H<E, P, I, O>[]): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, P, I, O>>
-  >
+  <P extends string, I = {}, O = {}>(
+    path: P,
+    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>>
 }
 
 ////////////////////////////////////////
@@ -137,11 +157,19 @@ export interface HandlerInterface<E extends Env = Env, M extends string = any, S
 //////                            //////
 ////////////////////////////////////////
 
-export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
+export interface MiddlewareHandlerInterface<
+  E extends Env = Env,
+  S = {},
+  BasePath extends string = ''
+> {
   //// app.get(...handlers[])
-  (...handlers: MiddlewareHandler<E, ExtractKey<S>>[]): Hono<E, S>
+  (...handlers: MiddlewareHandler<E, MergePath<BasePath, ExtractKey<S>>>[]): Hono<E, S, BasePath>
   //// app.get(path, ...handlers[])
-  <P extends string>(path: P, ...handlers: MiddlewareHandler<E, P>[]): Hono<E, S>
+  <P extends string>(path: P, ...handlers: MiddlewareHandler<E, MergePath<BasePath, P>>[]): Hono<
+    E,
+    S,
+    BasePath
+  >
 }
 
 ////////////////////////////////////////
@@ -150,27 +178,36 @@ export interface MiddlewareHandlerInterface<E extends Env = Env, S = {}> {
 //////                            //////
 ////////////////////////////////////////
 
-export interface OnHandlerInterface<E extends Env = Env, S = {}> {
+export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extends string = ''> {
   // app.on(method, path, handler, handler)
   <M extends string, P extends string, O = {}, I = {}>(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
+    ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
 
   // app.get(method, path, handler x3)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3, O>>>
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>
+    ]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3, O>>, BasePath>
 
   // app.get(method, path, handler x4)
   <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4, O>>>
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>
+    ]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4, O>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
@@ -185,21 +222,27 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}> {
   >(
     method: M,
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S | Schema<M, P, I5, O>>
+    ...handlers: [
+      H<E, MergePath<BasePath, P>, I, O>,
+      H<E, MergePath<BasePath, P>, I2, O>,
+      H<E, MergePath<BasePath, P>, I3, O>,
+      H<E, MergePath<BasePath, P>, I4, O>,
+      H<E, MergePath<BasePath, P>, I5, O>
+    ]
+  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5, O>, BasePath>
 
   <M extends string, P extends string, O extends {} = {}, I = {}>(
     method: M,
     path: P,
-    ...handlers: H<E, P, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I, O>>>
+    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I = {}>(
     methods: string[],
     path: P,
-    ...handlers: H<E, P, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, P, I, O>>>
+    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I, O>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -234,9 +277,15 @@ export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, i
     : never
   : never
 
-export type MergePath<A extends string, B extends string> = A extends `${infer P}/`
-  ? `${P}${B}`
-  : `${A}${B}`
+export type MergePath<A extends string, B extends string> = A extends ''
+  ? B
+  : A extends `${infer P}/`
+  ? B extends `/${infer Q}`
+    ? `${P}/${Q}`
+    : `${P}/${B}`
+  : B extends `/${infer Q}`
+  ? `${A}/${Q}`
+  : `${A}/${B}`
 
 ////////////////////////////////////////
 //////                            //////


### PR DESCRIPTION
### What is this PR?

This PR implements the following.
* Reduce side-effects of `route()` calls on the parent app
    * https://github.com/honojs/hono/compare/main...usualoma:hono:feat/basepath-2?expand=1#diff-8ac13809c9886e994d1db33943de82df4d6c5d88b73fd0270c0189804ff565c2R182
* Support nested `route()` calls
    * https://github.com/honojs/hono/compare/main...usualoma:hono:feat/basepath-2?expand=1#diff-8ac13809c9886e994d1db33943de82df4d6c5d88b73fd0270c0189804ff565c2R179-R180


### What will this PR allow us to do

`route()` can be used to specify the base path.

```typescript
const hono = new Hono().route('/api')
const api = hono.get('/search', (c) => c.jsonT({ ok: true }))
type AppType = typeof api
```

<img width="703" alt="image" src="https://user-images.githubusercontent.com/30598/221352266-5749c14a-1061-4572-b610-8f305aa59b84.png">


### Why can't we specify our basePath in the constructor in this PR?

I also wrote the following code to try to be able to specify it in the constructor, but I just could not get it to infer correctly.
https://github.com/honojs/hono/compare/main...usualoma:hono:feat/basepath

<img width="726" alt="image" src="https://user-images.githubusercontent.com/30598/221353328-5438f225-3fb1-4401-97b1-22cae612ace7.png">


I know that the following utility method can be prepared and used in place of `new Hono` in the same way as specifying it in the constructor.

```typescript
export const hono = <E extends Env = Env, S = {}, BasePath extends string = ''>(
  init: {
    router?: Router<H>
    strict?: boolean
    basePath?: BasePath
  } = {}
) => {
  return new Hono<E, S, BasePath>(init as any)
}
```

<img width="377" alt="image" src="https://user-images.githubusercontent.com/30598/221353136-ad4a43f4-69da-465b-8e07-8a5cfc7dc0a6.png">

However, I see no need for such a utility method, as it is short enough to be written as follows

```typescript
const hono = new Hono().route('/api')
```