### PR TITLE
feat(client): introduce "after" hook

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -369,3 +369,30 @@ describe('Use custom fetch method', () => {
     expect(res).toEqual(returnValue)
   })
 })
+
+describe('After Hook', () => {
+  const server = setupServer(
+    rest.get('http://localhost/hello', (_, res, ctx) => {
+      return res(ctx.text('OK'))
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  const app = new Hono().get('/hello', (c) => c.text('OK'))
+  type AppType = typeof app
+  const client = hc<AppType>('http://localhost', {
+    after: (res) => {
+      res.headers.append('X-Custom', 'Hono!')
+    },
+  })
+
+  it('Should return Response with the X-Custom header', async () => {
+    const res = await client.hello.$get()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Custom')).toBe('Hono!')
+    expect(await res.text()).toBe('OK')
+  })
+})

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -32,7 +32,7 @@ class ClientRequestImpl {
     this.url = url
     this.method = method
   }
-  fetch = (
+  fetch = async (
     args?: ValidationTargets & {
       param?: Record<string, string>
     },
@@ -92,11 +92,21 @@ class ClientRequestImpl {
     setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
 
     // Pass URL string to 1st arg for testing with MSW and node-fetch
-    return (opt?.fetch || fetch)(url, {
+    const res = (opt?.fetch || fetch)(url, {
       body: setBody ? this.rBody : undefined,
       method: methodUpperCase,
       headers: headers,
     })
+
+    if (opt?.after) {
+      const hookedResponse = await opt.after(await res)
+      if (hookedResponse) {
+        return hookedResponse
+      } else {
+        return res
+      }
+    }
+    return res
   }
 }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -100,11 +100,7 @@ class ClientRequestImpl {
 
     if (opt?.after) {
       const hookedResponse = await opt.after(await res)
-      if (hookedResponse) {
-        return hookedResponse
-      } else {
-        return res
-      }
+      return hookedResponse ?? res
     }
     return res
   }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -12,12 +12,12 @@ type Data = {
   output: {}
 }
 
-type AfterHook = (res: Response) => Promise<Response | void> | Response | void
+type AfterResponseHook = (res: Response) => Promise<Response | void> | Response | void
 
 export type RequestOptions = {
   headers?: Record<string, string>
   fetch?: typeof fetch
-  after?: AfterHook
+  after?: AfterResponseHook
 }
 
 type ClientRequest<S extends Data> = {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -12,9 +12,12 @@ type Data = {
   output: {}
 }
 
+type AfterHook = (res: Response) => Promise<Response | void> | Response | void
+
 export type RequestOptions = {
   headers?: Record<string, string>
   fetch?: typeof fetch
+  after?: AfterHook
 }
 
 type ClientRequest<S extends Data> = {


### PR DESCRIPTION
This PR introduces the new feature "after" hook for Hono Client.

As mentioned in #928, writing the same steps for each response is tedious.

In this PR, `after` hook allows us to write common actions after getting the response.For example, to output logs, we can write the following:

```ts
const client = hc<AppType>('http://localhost:8787', {
  after: (res) => {
    console.log(`${Date.now()}: Response status is ${res.status}`)
  },
})
```

I would like to keep the Hono Client to a minimum, but this `after` Hook is good because it allows for so much with so little implementation.

This will resolve #928 