### PR TITLE
fix: let the app.request behave the same as fetch

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -264,10 +264,14 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
     return this.dispatch(request, executionCtx, Env)
   }
 
-  request = async (input: Request | string, requestInit?: RequestInit) => {
+  request = async (input: Request | string | URL, requestInit?: RequestInit) => {
     if (input instanceof Request) {
+      if (requestInit !== undefined) {
+        input = new Request(input, requestInit)
+      }
       return await this.fetch(input)
     }
+    input = input.toString()
     const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
     const req = new Request(path, requestInit)
     return await this.fetch(req)

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -264,10 +264,14 @@ export class Hono<E extends Env = Env, S = {}> extends defineDynamicClass()<E, S
     return this.dispatch(request, executionCtx, Env)
   }
 
-  request = async (input: Request | string, requestInit?: RequestInit) => {
+  request = async (input: Request | string | URL, requestInit?: RequestInit) => {
     if (input instanceof Request) {
+      if (requestInit !== undefined) {
+        input = new Request(input, requestInit)
+      }
       return await this.fetch(input)
     }
+    input = input.toString()
     const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
     const req = new Request(path, requestInit)
     return await this.fetch(req)


### PR DESCRIPTION
This pr is to extend `app.request` usage range.

We test app by fetching directly via `app.request` without a setup of an app server, but the request parameters can only accept string or request, while fetch's can accept string, request or URL for the first parameter.

Moreover, when the input is request, then the second paramter `RequestInit` dose not worked as fetch dose.