### PR TITLE
fix(client): show type error if `$get()` needs args

### DIFF
--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -20,8 +20,8 @@ import type {
   TypedResponse,
   MergePath,
   MergeSchemaPath,
-  RemoveBlankRecord,
 } from './types.ts'
+import type { RemoveBlankRecord } from './utils/types.ts'
 import { getPathFromURL, mergePath } from './utils/url.ts'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context.ts'
 import type { Hono } from './hono.ts'
-import type { UnionToIntersection } from './utils/types.ts'
+import type { UnionToIntersection, RemoveBlankRecord } from './utils/types.ts'
 
 ////////////////////////////////////////
 //////                            //////
@@ -361,9 +361,3 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 ////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
-
-export type RemoveBlankRecord<T> = T extends Record<infer K, unknown>
-  ? K extends string
-    ? T
-    : never
-  : never

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -10,3 +10,9 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 ) => void
   ? I
   : never
+
+export type RemoveBlankRecord<T> = T extends Record<infer K, unknown>
+  ? K extends string
+    ? T
+    : never
+  : never

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -231,7 +231,7 @@ describe('Basic - query, queries, form, and path params', () => {
   })
 })
 
-describe('Infer the request type', () => {
+describe('Infer the response/request type', () => {
   const app = new Hono()
   const route = app.get(
     '/',
@@ -272,6 +272,29 @@ describe('Infer the request type', () => {
       name: string
     }
     type verify = Expect<Equal<Expected, Actual['query']>>
+  })
+
+  describe('Without input', () => {
+    const route = app.get('/', (c) => c.jsonT({ ok: true }))
+    type AppType = typeof route
+
+    it('Should infer response type the type correctly', () => {
+      const client = hc<AppType>('/')
+      const req = client.index.$get
+
+      type Actual = InferResponseType<typeof req>
+      type Expected = { ok: boolean }
+      type verify = Expect<Equal<Expected, Actual>>
+    })
+
+    it('Should infer request type the type correctly', () => {
+      const client = hc<AppType>('/')
+      const req = client.index.$get
+
+      type Actual = InferRequestType<typeof req>
+      type Expected = {}
+      type verify = Expect<Equal<Expected, Actual>>
+    })
   })
 })
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,6 @@
 import type { Hono } from '../hono'
 import type { ValidationTargets } from '../types'
+import type { RemoveBlankRecord } from '../utils/types'
 
 type MethodName = `$${string}`
 
@@ -19,7 +20,9 @@ export type RequestOptions = {
 
 type ClientRequest<S extends Data> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
-    ? (args?: R, options?: RequestOptions) => Promise<ClientResponse<O>>
+    ? RemoveBlankRecord<R> extends never
+      ? (args?: {}, options?: RequestOptions) => Promise<ClientResponse<O>>
+      : (args: R, options?: RequestOptions) => Promise<ClientResponse<O>>
     : never
 }
 
@@ -32,7 +35,12 @@ export type Fetch<T> = (
   opt?: RequestOptions
 ) => Promise<ClientResponse<InferResponseType<T>>>
 
-export type InferResponseType<T> = T extends () => Promise<ClientResponse<infer O>> ? O : never
+export type InferResponseType<T> = T extends (
+  args: any | undefined
+) => Promise<ClientResponse<infer O>>
+  ? O
+  : never
+
 export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientResponse<unknown>>
   ? NonNullable<R>
   : never

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -20,8 +20,8 @@ import type {
   TypedResponse,
   MergePath,
   MergeSchemaPath,
-  RemoveBlankRecord,
 } from './types'
+import type { RemoveBlankRecord } from './utils/types'
 import { getPathFromURL, mergePath } from './utils/url'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context'
 import type { Hono } from './hono'
-import type { UnionToIntersection } from './utils/types'
+import type { UnionToIntersection, RemoveBlankRecord } from './utils/types'
 
 ////////////////////////////////////////
 //////                            //////
@@ -361,9 +361,3 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 ////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
-
-export type RemoveBlankRecord<T> = T extends Record<infer K, unknown>
-  ? K extends string
-    ? T
-    : never
-  : never

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,3 +10,9 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 ) => void
   ? I
   : never
+
+export type RemoveBlankRecord<T> = T extends Record<infer K, unknown>
+  ? K extends string
+    ? T
+    : never
+  : never


### PR DESCRIPTION
Made it throws the type error if `client.path.$method()` needs arguments:

<img width="592" alt="SS" src="https://user-images.githubusercontent.com/10682/221541313-13858e40-4df4-4f67-a54d-fad448aea020.png">

This fix will make the Client more type-safety.