### PR TITLE
feat(`jsonT`): check JSON type

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -4,7 +4,7 @@ import type { Env, NotFoundHandler, Input } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
-import type { PrettyJSON, JSONObject } from './utils/types.ts'
+import type { PrettyJSON, JSONValue } from './utils/types.ts'
 
 type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'lagon' | 'other'
 type HeaderRecord = Record<string, string | string[]>
@@ -239,12 +239,10 @@ export class Context<
   }
 
   jsonT = <T>(
-    object: T extends JSONObject ? T : JSONObject,
+    object: T extends JSONValue ? T : JSONValue,
     status: StatusCode = this._status,
     headers?: HeaderRecord
-  ): TypedResponse<
-    T extends JSONObject ? (JSONObject extends T ? never : PrettyJSON<T>) : never
-  > => {
+  ): TypedResponse<T extends JSONValue ? (JSONValue extends T ? never : PrettyJSON<T>) : never> => {
     return {
       response: this.json(object, status, headers),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -4,6 +4,7 @@ import type { Env, NotFoundHandler, Input } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
+import type { PrettyJSON, JSONObject } from './utils/types.ts'
 
 type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'lagon' | 'other'
 type HeaderRecord = Record<string, string | string[]>
@@ -237,14 +238,17 @@ export class Context<
     return this.newResponse(body, status, headers)
   }
 
-  jsonT = <T = object>(
-    object: T,
+  jsonT = <T>(
+    object: T extends JSONObject ? T : JSONObject,
     status: StatusCode = this._status,
     headers?: HeaderRecord
-  ): TypedResponse<T> => {
+  ): TypedResponse<
+    T extends JSONObject ? (JSONObject extends T ? never : PrettyJSON<T>) : never
+  > => {
     return {
       response: this.json(object, status, headers),
-      data: object,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: object as any,
       format: 'json',
     }
   }

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -10,3 +10,18 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 ) => void
   ? I
   : never
+
+export type JSONPrimitive = string | boolean | number | null | undefined
+export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
+export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
+export type PrettyJSON<T> = T extends true
+  ? boolean
+  : T extends false
+  ? boolean
+  : T extends JSONPrimitive
+  ? T
+  : T extends JSONArray
+  ? PrettyJSON<T[number]>
+  : T extends JSONObject
+  ? { [K in keyof T]: PrettyJSON<T[K]> }
+  : never

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -15,12 +15,14 @@ export type JSONPrimitive = string | boolean | number | null | undefined
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
 export type JSONValue = JSONObject | JSONArray | JSONPrimitive
-export type PrettyJSON<T> = T extends true
-  ? boolean
-  : T extends false
-  ? boolean
-  : T extends JSONPrimitive
-  ? T
+
+// `boolean` will be `true` or `false` because it's an alias of them.
+// See: https://github.com/microsoft/TypeScript/issues/22596
+// This type converts `true | false` to `boolean` that we expect.
+type TrueAndFalseToBoolean<T> = T extends true ? boolean : T extends false ? boolean : T
+
+export type PrettyJSON<T> = T extends JSONPrimitive
+  ? TrueAndFalseToBoolean<T>
   : T extends JSONArray
   ? PrettyJSON<T[number]>
   : T extends JSONObject

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -14,6 +14,7 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 export type JSONPrimitive = string | boolean | number | null | undefined
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
+export type JSONValue = JSONObject | JSONArray | JSONPrimitive
 export type PrettyJSON<T> = T extends true
   ? boolean
   : T extends false

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -332,6 +332,17 @@ describe('Merge path with `app.route()`', () => {
     expect(data.ok).toBe(true)
   })
 
+  it('Should not allow the incorrect JSON type', async () => {
+    const app = new Hono()
+    // @ts-ignore
+    const route = app.get('/api/foo', (c) => c.jsonT({ datetime: new Date() }))
+    type AppType = typeof route
+    const client = hc<AppType>('http://localhost')
+    const res = await client.api.foo.$get()
+    const data = await res.json()
+    type verify = Expect<Equal<never, typeof data>>
+  })
+
   describe('Multiple endpoints', () => {
     const api = new Hono()
       .get('/foo', (c) => c.jsonT({ foo: '' }))

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import type { Env, NotFoundHandler, Input } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
+import type { PrettyJSON, JSONObject } from './utils/types'
 
 type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'lagon' | 'other'
 type HeaderRecord = Record<string, string | string[]>
@@ -237,14 +238,17 @@ export class Context<
     return this.newResponse(body, status, headers)
   }
 
-  jsonT = <T = object>(
-    object: T,
+  jsonT = <T>(
+    object: T extends JSONObject ? T : JSONObject,
     status: StatusCode = this._status,
     headers?: HeaderRecord
-  ): TypedResponse<T> => {
+  ): TypedResponse<
+    T extends JSONObject ? (JSONObject extends T ? never : PrettyJSON<T>) : never
+  > => {
     return {
       response: this.json(object, status, headers),
-      data: object,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: object as any,
       format: 'json',
     }
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import type { Env, NotFoundHandler, Input } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
-import type { PrettyJSON, JSONObject } from './utils/types'
+import type { PrettyJSON, JSONValue } from './utils/types'
 
 type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'lagon' | 'other'
 type HeaderRecord = Record<string, string | string[]>
@@ -239,12 +239,10 @@ export class Context<
   }
 
   jsonT = <T>(
-    object: T extends JSONObject ? T : JSONObject,
+    object: T extends JSONValue ? T : JSONValue,
     status: StatusCode = this._status,
     headers?: HeaderRecord
-  ): TypedResponse<
-    T extends JSONObject ? (JSONObject extends T ? never : PrettyJSON<T>) : never
-  > => {
+  ): TypedResponse<T extends JSONValue ? (JSONValue extends T ? never : PrettyJSON<T>) : never> => {
     return {
       response: this.json(object, status, headers),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,3 +10,18 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 ) => void
   ? I
   : never
+
+export type JSONPrimitive = string | boolean | number | null | undefined
+export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
+export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
+export type PrettyJSON<T> = T extends true
+  ? boolean
+  : T extends false
+  ? boolean
+  : T extends JSONPrimitive
+  ? T
+  : T extends JSONArray
+  ? PrettyJSON<T[number]>
+  : T extends JSONObject
+  ? { [K in keyof T]: PrettyJSON<T[K]> }
+  : never

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -15,12 +15,14 @@ export type JSONPrimitive = string | boolean | number | null | undefined
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
 export type JSONValue = JSONObject | JSONArray | JSONPrimitive
-export type PrettyJSON<T> = T extends true
-  ? boolean
-  : T extends false
-  ? boolean
-  : T extends JSONPrimitive
-  ? T
+
+// `boolean` will be `true` or `false` because it's an alias of them.
+// See: https://github.com/microsoft/TypeScript/issues/22596
+// This type converts `true | false` to `boolean` that we expect.
+type TrueAndFalseToBoolean<T> = T extends true ? boolean : T extends false ? boolean : T
+
+export type PrettyJSON<T> = T extends JSONPrimitive
+  ? TrueAndFalseToBoolean<T>
   : T extends JSONArray
   ? PrettyJSON<T[number]>
   : T extends JSONObject

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -14,6 +14,7 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 export type JSONPrimitive = string | boolean | number | null | undefined
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
+export type JSONValue = JSONObject | JSONArray | JSONPrimitive
 export type PrettyJSON<T> = T extends true
   ? boolean
   : T extends false


### PR DESCRIPTION
`jsonT()` returns a JSON object composed of primitive types. For example, a `Date` object is converted to a string. But currently, `jsonT()` allows the `Date` type.

```ts
app.get('/hello', (c) => {
  return c.jsonT({
    messge: 'Hello',
    datetime: new Date(), // does not show the error
  })
})
```

And the Client will get the `Date` type even though the actual value is a string.

<img width="303" alt="SS" src="https://user-images.githubusercontent.com/10682/221574375-f761fc98-107e-4fa6-97aa-a170bacf678a.png">

Allowing the types of objects other than primitives to be loose can be confusing.

In this PR, I've made it provides a JSON type and limits the object that `jsonT()` would receive, and if they are not JSON type, it throws an error.

<img width="319" alt="SS" src="https://user-images.githubusercontent.com/10682/221573552-d14d61e8-4f9c-4e68-99d6-9a1c3a055446.png">

On the client side, the return type of `res.json()` is `never`.

<img width="318" alt="SS" src="https://user-images.githubusercontent.com/10682/221573584-8e185c12-12fb-4045-bf28-f0549a37155a.png">

This feature was inspired by the following article.

<https://zenn.dev/kosei28/articles/f4bac1ed2b64a7#date%E5%9E%8B%E3%81%AF%E6%96%87%E5%AD%97%E5%88%97%E3%81%AB%E3%81%AA%E3%82%8B>

By restricting the types that `jsonT()` accepts to JSON types composed of primitives, we can make it more type-safe.