### PR TITLE
feat(app): add `basePath` option

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -275,6 +275,33 @@ describe('Infer the request type', () => {
   })
 })
 
+describe('With `basePath` option', () => {
+  const server = setupServer(
+    rest.get('http://localhost/api/hello', async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          ok: true,
+        })
+      )
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('Should have correct types', async () => {
+    const app = new Hono({ basePath: '/api' })
+    const route = app.get('/hello', (c) => c.jsonT({ ok: true }))
+    type AppType = typeof route
+    const client = hc<AppType>('http://localhost')
+    const res = await client.api.hello.$get()
+    const data = await res.json()
+    type verify = Expect<Equal<boolean, typeof data.ok>>
+    expect(data.ok).toBe(true)
+  })
+})
+
 describe('Merge path with `app.route()`', () => {
   const server = setupServer(
     rest.get('http://localhost/api/search', async (req, res, ctx) => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -128,6 +128,32 @@ describe('strict parameter', () => {
   })
 })
 
+describe('Specify basePath in the constructor', () => {
+  describe('basic', () => {
+    const app = new Hono({ basePath: '/api' })
+    app.get('/hello', (c) => c.text('/api/hello'))
+
+    it('Should return 200 response - GET /api/hello', async () => {
+      const res = await app.request('/api/hello')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('/api/hello')
+    })
+  })
+
+  describe('with app.route()', () => {
+    const app = new Hono({ basePath: '/api' })
+    app.get('/hello', (c) => c.text('/v1/api/hello'))
+    const v1 = new Hono()
+    v1.route('/v1', app)
+
+    it('Should return 200 response - GET /v1/api/hello', async () => {
+      const res = await v1.request('/v1/api/hello')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('/v1/api/hello')
+    })
+  })
+})
+
 describe('Destruct functions in context', () => {
   it('Should return 200 response - text', async () => {
     const app = new Hono()


### PR DESCRIPTION
With this PR, we can specify the `basePath` in the constructor of `Hono`:

```ts
const app = new Hono({ basePath: '/api' })
```

Also, it has the correct type.

<img width="358" alt="SS" src="https://user-images.githubusercontent.com/10682/222011617-aa00c3b6-e8c2-4938-8868-4e69553c5460.png">

<img width="529" alt="SS" src="https://user-images.githubusercontent.com/10682/222011596-6eae2c68-8f49-44c4-985a-a011d31788d6.png">

Related to #929 