### PR TITLE
fix(pages/nextjs): don't use `route()` if path is not passed

### DIFF
--- a/src/adapter/cloudflare-pages/handler.test.ts
+++ b/src/adapter/cloudflare-pages/handler.test.ts
@@ -38,4 +38,22 @@ describe('Adapter for Cloudflare Pages', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('/api/foo')
   })
+
+  it('Should not use `route()` if path argument is not passed', async () => {
+    const request = new Request('http://localhost/api/error')
+    const app = new Hono().route('/api')
+
+    app.onError((e) => {
+      throw e
+    })
+    app.get('/error', () => {
+      throw new Error('Custom Error')
+    })
+
+    const handler = handle(app)
+    // It does throw the error if app is NOT "subApp"
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(() => handler({ request })).toThrowError('Custom Error')
+  })
 })

--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -15,8 +15,8 @@ interface HandleInterface {
 }
 
 export const handle: HandleInterface =
-  <E extends Env>(subApp: Hono<E>, path: string = '/') =>
-  ({ request, env, waitUntil }) =>
-    new Hono<E>()
-      .route(path, subApp)
-      .fetch(request, env, { waitUntil, passThroughOnException: () => {} })
+  <E extends Env>(subApp: Hono<E>, path?: string) =>
+  ({ request, env, waitUntil }) => {
+    const app = path ? new Hono<E>().route(path, subApp) : subApp
+    return app.fetch(request, env, { waitUntil, passThroughOnException: () => {} })
+  }

--- a/src/adapter/nextjs/handler.test.ts
+++ b/src/adapter/nextjs/handler.test.ts
@@ -25,4 +25,19 @@ describe('Adapter for Next.js', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('/api/foo')
   })
+
+  it('Should not use `route()` if path argument is not passed', async () => {
+    const app = new Hono().route('/api')
+
+    app.onError((e) => {
+      throw e
+    })
+    app.get('/error', () => {
+      throw new Error('Custom Error')
+    })
+
+    const handler = handle(app)
+    const req = new Request('http://localhost/api/error')
+    expect(() => handler(req)).toThrowError('Custom Error')
+  })
 })

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -3,10 +3,12 @@ import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
 interface HandleInterface {
-  <E extends Env>(subApp: Hono<E>, path?: string): (req: Request) => Promise<Response>
+  <E extends Env>(subApp: Hono<E>, path?: string): (req: Request) => Response | Promise<Response>
 }
 
 export const handle: HandleInterface =
-  <E extends Env>(subApp: Hono<E>, path: string = '/') =>
-  async (req) =>
-    new Hono<E>().route(path, subApp).fetch(req)
+  <E extends Env>(subApp: Hono<E>, path?: string) =>
+  (req) => {
+    const app = path ? new Hono<E>().route(path, subApp) : subApp
+    return app.fetch(req)
+  }


### PR DESCRIPTION
If we use `handle` in the Cloudflare Pages adapter with no second argument:

```ts
export const onRequest = handle(app)
```

With the current implementation,  `app` will be passed to `route()`

https://github.com/honojs/hono/blob/b1c50597088c2e4e1d3666f53f3f9de171cbd506/src/adapter/cloudflare-pages/handler.ts#L17-L22

If we do so, the error thrown from `app` can't be re-thrown:

```ts
const app = new Hono().route('/api')

app.get('/hello', (c) => {
  throw new Error('Capture this error in Sentry!')
})

app.onError((e) => {
  throw e // <--- This will not be a real "error", will return 500 response.
})

export const onRequest = handle(app)
```

This PR fixes this issue.

This will resolve #938