### PR TITLE
feat: Returns the parent's app from `route(path, subApp)`.

### DIFF
--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -9,14 +9,18 @@ type EventContext = {
 }
 
 interface HandleInterface {
-  <E extends Env>(app: Hono<E>, path?: string): (
-    eventContext: EventContext
-  ) => Response | Promise<Response>
+  <E extends Env, S extends {}, BasePath extends string>(
+    app: Hono<E, S, BasePath>,
+    path?: string
+  ): (eventContext: EventContext) => Response | Promise<Response>
 }
 
 export const handle: HandleInterface =
-  <E extends Env>(subApp: Hono<E>, path?: string) =>
+  <E extends Env, S extends {}, BasePath extends string>(
+    subApp: Hono<E, S, BasePath>,
+    path?: string
+  ) =>
   ({ request, env, waitUntil }) => {
-    const app = path ? new Hono<E>().route(path, subApp) : subApp
+    const app = path ? new Hono<E, S, BasePath>().route(path, subApp as any) : subApp
     return app.fetch(request, env, { waitUntil, passThroughOnException: () => {} })
   }

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -3,12 +3,17 @@ import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
 interface HandleInterface {
-  <E extends Env>(subApp: Hono<E>, path?: string): (req: Request) => Response | Promise<Response>
+  <E extends Env, S extends {}, BasePath extends string>(subApp: Hono<E, S, BasePath>, path?: string): (
+    req: Request
+  ) => Response | Promise<Response>
 }
 
 export const handle: HandleInterface =
-  <E extends Env>(subApp: Hono<E>, path?: string) =>
+  <E extends Env, S extends {}, BasePath extends string>(
+    subApp: Hono<E, S, BasePath>,
+    path?: string
+  ) =>
   (req) => {
-    const app = path ? new Hono<E>().route(path, subApp) : subApp
+    const app = path ? new Hono<E, S, BasePath>().route(path, subApp as any) : subApp
     return app.fetch(req)
   }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -213,6 +213,26 @@ describe('Routing', () => {
     expect(await res.text()).toBe('get /add-path-after-route-call')
   })
 
+  it('Multiple route', async () => {
+    const app = new Hono()
+
+    const book = new Hono()
+    book.get('/hello', (c) => c.text('get /book/hello'))
+
+    const user = new Hono()
+    user.get('/hello', (c) => c.text('get /user/hello'))
+
+    app.route('/book', book).route('/user', user)
+
+    let res = await app.request('http://localhost/book/hello', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /book/hello')
+
+    res = await app.request('http://localhost/user/hello', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /user/hello')
+  })
+
   describe('Nested route with middleware', () => {
     const api = new Hono()
     const api2 = api.use('*', async (_c, next) => await next())

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -134,13 +134,25 @@ export class Hono<
   private notFoundHandler: NotFoundHandler = notFoundHandler
   private errorHandler: ErrorHandler = errorHandler
 
+  route<SubPath extends string, SubSchema>(
+    path: SubPath
+  ): Hono<
+    E,
+    RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>,
+    MergePath<BasePath, SubPath>
+  >
+  route<SubPath extends string, SubEnv extends Env, SubSchema>(
+    path: SubPath,
+    app: Hono<SubEnv, SubSchema>
+  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath>
   route<SubPath extends string, SubEnv extends Env, SubSchema>(
     path: SubPath,
     app?: Hono<SubEnv, SubSchema>
   ): Hono<
     E,
     RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>,
-    MergePath<BasePath, SubPath>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
   > {
     const subApp = this.clone()
     subApp.basePath = mergePath(this.basePath, path)
@@ -154,6 +166,8 @@ export class Hono<
                 (await compose<Context>([r.handler], app.errorHandler)(c, next)).res
         subApp.addRoute(r.method, r.path, handler)
       })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return this as any
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
#947

As for `route()`, in general, I think the expected type depends on the arguments given.

If no subApp is given, then of course an app with path as basePath should be returned.
```
const subApp = app.route('/api')
```

However, if a subApp is given, the app that has it in the basePath is usually not necessary.
```
const probablyNeverBeUsed = app.route('/api', subApp)
```
If so, it would be more convenient to return `this` when a subApp is specified. This PR includes such a change.


### Is this a good API?

However, it is generally not a good API to have the return type change depending on the argument. I think we can avoid this confusion by renaming the single argument `route()` as `basePath()` and make the return value intuitive as well.
https://github.com/honojs/hono/compare/main...usualoma:hono:feat/basePath-method


### Other options

I don't think the current behavior of main branch is so bad, so I think there is an option not to change it.

@yusukebe 
What do you think?