### PR TITLE
fix(type): remove unnecessary distribution

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -283,7 +283,7 @@ describe('Infer the response/request type', () => {
       const req = client.index.$get
 
       type Actual = InferResponseType<typeof req>
-      type Expected = { ok: boolean }
+      type Expected = { ok: true }
       type verify = Expect<Equal<Expected, Actual>>
     })
 
@@ -340,7 +340,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
     const data = await res.json()
-    type verify = Expect<Equal<boolean, typeof data.ok>>
+    type verify = Expect<Equal<true, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 
@@ -351,7 +351,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
     const data = await res.json()
-    type verify = Expect<Equal<boolean, typeof data.ok>>
+    type verify = Expect<Equal<true, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -36,6 +36,7 @@ export type Fetch<T> = (
 ) => Promise<ClientResponse<InferResponseType<T>>>
 
 export type InferResponseType<T> = T extends (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any | undefined
 ) => Promise<ClientResponse<infer O>>
   ? O

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import type { Env, NotFoundHandler, Input } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
-import type { PrettyJSON, JSONValue } from './utils/types'
+import type { JSONValue } from './utils/types'
 
 type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'lagon' | 'other'
 type HeaderRecord = Record<string, string | string[]>
@@ -242,7 +242,7 @@ export class Context<
     object: T extends JSONValue ? T : JSONValue,
     status: StatusCode = this._status,
     headers?: HeaderRecord
-  ): TypedResponse<T extends JSONValue ? (JSONValue extends T ? never : PrettyJSON<T>) : never> => {
+  ): TypedResponse<T extends JSONValue ? (JSONValue extends T ? never : T) : never> => {
     return {
       response: this.json(object, status, headers),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -135,7 +135,7 @@ describe('OnHandlerInterface', () => {
             }
           }
           output: {
-            success: boolean
+            success: true
           }
         }
       }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,16 +21,3 @@ export type JSONPrimitive = string | boolean | number | null | undefined
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
 export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject }
 export type JSONValue = JSONObject | JSONArray | JSONPrimitive
-
-// `boolean` will be `true` or `false` because it's an alias of them.
-// See: https://github.com/microsoft/TypeScript/issues/22596
-// This type converts `true | false` to `boolean` that we expect.
-type TrueAndFalseToBoolean<T> = T extends true ? boolean : T extends false ? boolean : T
-
-export type PrettyJSON<T> = T extends JSONPrimitive
-  ? TrueAndFalseToBoolean<T>
-  : T extends JSONArray
-  ? PrettyJSON<T[number]>
-  : T extends JSONObject
-  ? { [K in keyof T]: PrettyJSON<T[K]> }
-  : never

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -426,7 +426,7 @@ describe('`on`', () => {
           }
         }
         output: {
-          success: boolean
+          success: true
         }
       }
     }


### PR DESCRIPTION
Do not use `PrettyJSON<T>` because it causes unnecessary distributions. As a side effect, `boolean` is inferred to `true | false`. But I think there is no problem in practical use.

This will fix #950 