### PR TITLE
docs(readme): add creator name of RegExpRouter and SmartRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Thanks to [all contributors](https://github.com/honojs/hono/graphs/contributors)
 
 Yusuke Wada <https://github.com/yusukebe>
 
+"RegExpRouter" and "SmartRouter" are created by Taku Amano <https://github.com/usualoma>
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -97,6 +97,8 @@ Thanks to [all contributors](https://github.com/honojs/hono/graphs/contributors)
 
 Yusuke Wada <https://github.com/yusukebe>
 
+"RegExpRouter" and "SmartRouter" are created by Taku Amano <https://github.com/usualoma>
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
I have wanted to write this for a while; this is important.

One of the features of Hono is the RegExpRouter, but I must not take credit for that.