### PR TITLE
feat(context): allow passing `RequestInit` to `c.json()` etc.

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -197,3 +197,66 @@ describe('Context header', () => {
     expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
   })
 })
+
+describe('Pass a ResponseInit to respond methods', () => {
+  const req = new Request('http://localhost/')
+  let c: Context
+  beforeEach(() => {
+    c = new Context(req)
+  })
+
+  it('c.json()', async () => {
+    const originalResponse = new Response('Unauthorized', {
+      headers: {
+        'content-type': 'text/plain',
+        'x-custom': 'custom message',
+      },
+      status: 401,
+    })
+    const res = c.json(
+      {
+        message: 'Unauthorized',
+      },
+      originalResponse
+    )
+    expect(res.status).toBe(401)
+    expect(res.headers.get('content-type')).toMatch(/^application\/json/)
+    expect(res.headers.get('x-custom')).toBe('custom message')
+    expect(await res.json()).toEqual({
+      message: 'Unauthorized',
+    })
+  })
+
+  it('c.body()', async () => {
+    const originalResponse = new Response('<h1>Hello</h1>', {
+      headers: {
+        'content-type': 'text/html',
+      },
+    })
+    const res = c.body('<h2>Hello</h2>', originalResponse)
+    expect(res.headers.get('content-type')).toMatch(/^text\/html/)
+    expect(await res.text()).toBe('<h2>Hello</h2>')
+  })
+
+  it('c.text()', async () => {
+    const originalResponse = new Response(JSON.stringify({ foo: 'bar' }))
+    const res = c.text('foo', originalResponse)
+    expect(res.headers.get('content-type')).toMatch(/^text\/plain/)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('c.jsonT()', async () => {
+    const originalResponse = new Response('foo')
+    const tRes = c.jsonT({ foo: 'bar' }, originalResponse)
+    const res = tRes['response'] as Response
+    expect(res.headers.get('content-type')).toMatch(/^application\/json/)
+    expect(await res.json()).toEqual({ foo: 'bar' })
+  })
+
+  it('c.html()', async () => {
+    const originalResponse = new Response('foo')
+    const res = c.html('<h1>foo</h1>', originalResponse)
+    expect(res.headers.get('content-type')).toMatch(/^text\/html/)
+    expect(await res.text()).toBe('<h1>foo</h1>')
+  })
+})


### PR DESCRIPTION
This PR proposes allowing us to pass `InitResponse` as the second argument to `c.text()` or `c.json()`. It will overload these methods.

```ts
interface TextRespond {
  (text: string, status?: StatusCode, headers?: HeaderRecord): Response
  (text: string, init?: ResponseInit): Response
}
```

This is inspired by Issue #952. Now, it is very tedious to customize Basic Auth errors.

```ts
app.onError((e, c) => {
  if (e instanceof HTTPException) {
    const res = e.getResponse()
    res.headers.set('content-type', 'application/json')
    return new Response(
      JSON.stringify({
        message: 'Unauthorized!',
      }),
      res
    )
// ...
```

So I thought it would be easier if we can pass `ResponseInit`, i.e. meta information such as headers, to `c.json()`.

```ts
app.onError((e, c) => {
  if (e instanceof HTTPException) {
    return c.json(
      {
        message: Unauthorized!',
      },
      e.getResponse()
    )
  }
```

This feature is not only used in the above cases, but can also be used when we want to modify and return the content retrieved from the outside using `fetch`.

```ts
app.get('/mirror', async (c) => {
  const res = await fetch('http://example.com')
  return c.json({ foo: 'bar' }, res)
})
```

## Side effects

* The code size will increase. But they are almost types definitions.
* Overload is often confusing to users. But, I think it is intuitive to pass `ResponseInit` in this case.
* The implementation becomes more complex. There is no way around this :(

---

It would be a good feature, except that the code would be complicated. In addition, I think it's not a bad idea to allow overloads since one of the big features of Hono is flexible to write code.

If you have any other good ideas, please let me know.