### PR TITLE
feat: `route()` with one argument is renamed `basePath()`.

### DIFF
--- a/src/adapter/cloudflare-pages/handler.test.ts
+++ b/src/adapter/cloudflare-pages/handler.test.ts
@@ -39,9 +39,9 @@ describe('Adapter for Cloudflare Pages', () => {
     expect(await res.text()).toBe('/api/foo')
   })
 
-  it('Should not use `route()` if path argument is not passed', async () => {
+  it('Should not use `basePath()` if path argument is not passed', async () => {
     const request = new Request('http://localhost/api/error')
-    const app = new Hono().route('/api')
+    const app = new Hono().basePath('/api')
 
     app.onError((e) => {
       throw e

--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -9,14 +9,18 @@ type EventContext = {
 }
 
 interface HandleInterface {
-  <E extends Env>(app: Hono<E>, path?: string): (
-    eventContext: EventContext
-  ) => Response | Promise<Response>
+  <E extends Env, S extends {}, BasePath extends string>(
+    app: Hono<E, S, BasePath>,
+    path?: string
+  ): (eventContext: EventContext) => Response | Promise<Response>
 }
 
 export const handle: HandleInterface =
-  <E extends Env>(subApp: Hono<E>, path?: string) =>
+  <E extends Env, S extends {}, BasePath extends string>(
+    subApp: Hono<E, S, BasePath>,
+    path?: string
+  ) =>
   ({ request, env, waitUntil }) => {
-    const app = path ? new Hono<E>().route(path, subApp) : subApp
+    const app = path ? new Hono<E, S, BasePath>().route(path, subApp as any) : subApp
     return app.fetch(request, env, { waitUntil, passThroughOnException: () => {} })
   }

--- a/src/adapter/nextjs/handler.test.ts
+++ b/src/adapter/nextjs/handler.test.ts
@@ -27,7 +27,7 @@ describe('Adapter for Next.js', () => {
   })
 
   it('Should not use `route()` if path argument is not passed', async () => {
-    const app = new Hono().route('/api')
+    const app = new Hono().basePath('/api')
 
     app.onError((e) => {
       throw e

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -3,12 +3,17 @@ import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
 interface HandleInterface {
-  <E extends Env>(subApp: Hono<E>, path?: string): (req: Request) => Response | Promise<Response>
+  <E extends Env, S extends {}, BasePath extends string>(subApp: Hono<E, S, BasePath>, path?: string): (
+    req: Request
+  ) => Response | Promise<Response>
 }
 
 export const handle: HandleInterface =
-  <E extends Env>(subApp: Hono<E>, path?: string) =>
+  <E extends Env, S extends {}, BasePath extends string>(
+    subApp: Hono<E, S, BasePath>,
+    path?: string
+  ) =>
   (req) => {
-    const app = path ? new Hono<E>().route(path, subApp) : subApp
+    const app = path ? new Hono<E, S, BasePath>().route(path, subApp as any) : subApp
     return app.fetch(req)
   }

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -344,8 +344,8 @@ describe('Merge path with `app.route()`', () => {
     expect(data.ok).toBe(true)
   })
 
-  it('Should have correct types - route() then get()', async () => {
-    const base = new Hono<Env>().route('/api')
+  it('Should have correct types - basePath() then get()', async () => {
+    const base = new Hono<Env>().basePath('/api')
     const app = base.get('/search', (c) => c.jsonT({ ok: true }))
     type AppType = typeof app
     const client = hc<AppType>('http://localhost')

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -166,18 +166,18 @@ describe('Routing', () => {
   it('Nested route', async () => {
     const app = new Hono()
 
-    const book = app.route('/book')
+    const book = app.basePath('/book')
     book.get('/', (c) => c.text('get /book'))
     book.get('/:id', (c) => {
       return c.text('get /book/' + c.req.param('id'))
     })
     book.post('/', (c) => c.text('post /book'))
 
-    const user = app.route('/user')
+    const user = app.basePath('/user')
     user.get('/login', (c) => c.text('get /user/login'))
     user.post('/register', (c) => c.text('post /user/register'))
 
-    const appForEachUser = user.route(':id')
+    const appForEachUser = user.basePath(':id')
     appForEachUser.get('/profile', (c) => c.text('get /user/' + c.req.param('id') + '/profile'))
 
     app.get('/add-path-after-route-call', (c) => c.text('get /add-path-after-route-call'))
@@ -212,6 +212,26 @@ describe('Routing', () => {
     res = await app.request('http://localhost/add-path-after-route-call', { method: 'GET' })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('get /add-path-after-route-call')
+  })
+
+  it('Multiple route', async () => {
+    const app = new Hono()
+
+    const book = new Hono()
+    book.get('/hello', (c) => c.text('get /book/hello'))
+
+    const user = new Hono()
+    user.get('/hello', (c) => c.text('get /user/hello'))
+
+    app.route('/book', book).route('/user', user)
+
+    let res = await app.request('http://localhost/book/hello', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /book/hello')
+
+    res = await app.request('http://localhost/user/hello', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /user/hello')
   })
 
   describe('Nested route with middleware', () => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -137,8 +137,22 @@ export class Hono<
   route<SubPath extends string, SubEnv extends Env, SubSchema>(
     path: SubPath,
     app: Hono<SubEnv, SubSchema>
+  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath>
+  /** @deprecated
+   * Use `basePath` instead of `route` with one argument.
+   * The `route` with one argument has been removed in v4.
+   */
+  route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
+  route<SubPath extends string, SubEnv extends Env, SubSchema>(
+    path: SubPath,
+    app?: Hono<SubEnv, SubSchema>
   ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath> {
     const subApp = this.basePath(path)
+
+    if (!app) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return subApp as any
+    }
 
     app.routes.map((r) => {
       const handler =

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -66,7 +66,7 @@ export class Hono<
     routers: [new RegExpRouter(), new TrieRouter()],
   })
   readonly strict: boolean = true // strict routing - default is true
-  #basePath: string = ''
+  private _basePath: string = ''
   private path: string = '*'
 
   routes: RouterRoute[] = []
@@ -154,7 +154,7 @@ export class Hono<
 
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    subApp._basePath = mergePath(this._basePath, path)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return subApp as any
   }
@@ -180,8 +180,8 @@ export class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    if (this.#basePath) {
-      path = mergePath(this.#basePath, path)
+    if (this._basePath) {
+      path = mergePath(this._basePath, path)
     }
     this.router.add(method, path, handler)
     const r: RouterRoute = { path: path, method: method, handler: handler }


### PR DESCRIPTION
#948 basePath() version

One difference from https://github.com/honojs/hono/pull/948#issuecomment-1455115090 is that we replaced `private _basePath` with `#basePath`. This should make it more straightforward that it is a local member.

### Compatibility

To reduce confusion caused by compatibility issues, it would be possible to allow `route(path)` to be used in 3.x and then remove it in 4.x.

```diff
diff --git a/src/hono.ts b/src/hono.ts
index 72380c8..3238c35 100644
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -137,9 +137,23 @@ export class Hono<
   route<SubPath extends string, SubEnv extends Env, SubSchema>(
     path: SubPath,
     app: Hono<SubEnv, SubSchema>
+  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath>
+  /** @deprecated
+   * Use `basePath` instead of `route` with one argument.
+   * The `route` with one argument has been removed in v4.
+   */
+  route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
+  route<SubPath extends string, SubEnv extends Env, SubSchema>(
+    path: SubPath,
+    app?: Hono<SubEnv, SubSchema>
   ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath> {
     const subApp = this.basePath(path)
 
+    if (!app) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return subApp as any
+    }
+
     app.routes.map((r) => {
       const handler =
         app.errorHandler === errorHandler
```

![image](https://user-images.githubusercontent.com/30598/223580511-35d5e183-35e1-4259-86b5-8f111bf9044a.png)
