### PR TITLE
feat(validator): support type transformation

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -66,7 +66,7 @@ export class Context<
     }
   }
 
-  get req(): HonoRequest<P, I> {
+  get req(): HonoRequest<P, I['output']> {
     if (this._req) {
       return this._req
     } else {

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -99,7 +99,7 @@ export class Context<
     }
   }
 
-  get req(): HonoRequest<P, I['output']> {
+  get req(): HonoRequest<P, I['out']> {
     if (this._req) {
       return this._req
     } else {

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -14,7 +14,7 @@ import { parse } from './utils/cookie.ts'
 import type { UnionToIntersection } from './utils/types.ts'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url.ts'
 
-export class HonoRequest<P extends string = '/', I extends Input['output'] = {}> {
+export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -14,7 +14,7 @@ import { parse } from './utils/cookie.ts'
 import type { UnionToIntersection } from './utils/types.ts'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url.ts'
 
-export class HonoRequest<P extends string = '/', I extends Input = {}> {
+export class HonoRequest<P extends string = '/', I extends Input['output'] = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -22,8 +22,8 @@ export type Env = {
 export type Next = () => Promise<void>
 
 export type Input = {
-  input?: Partial<ValidationTargets>
-  output?: Partial<{ [K in keyof ValidationTargets]: unknown }>
+  in?: Partial<ValidationTargets>
+  out?: Partial<{ [K in keyof ValidationTargets]: unknown }>
 }
 
 ////////////////////////////////////////
@@ -71,12 +71,12 @@ export interface HandlerInterface<
   // app.get(handler, handler)
   <I extends Input = {}, O = {}>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['in'], O>>, BasePath>
 
   // app.get(handler x 3)
   <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I2, O>, H<E, ExtractKey<S>, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3['in'], O>>, BasePath>
 
   // app.get(handler x 4)
   <
@@ -93,7 +93,7 @@ export interface HandlerInterface<
       H<E, ExtractKey<S>, I3, O>,
       H<E, ExtractKey<S>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4['in'], O>>, BasePath>
 
   // app.get(handler x 5)
   <
@@ -112,12 +112,12 @@ export interface HandlerInterface<
       H<E, ExtractKey<S>, I4, O>,
       H<E, ExtractKey<S>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5['in'], O>>, BasePath>
 
   // app.get(...handlers[])
   <I extends Input = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
     E,
-    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>,
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['in'], O>>,
     BasePath
   >
 
@@ -128,7 +128,7 @@ export interface HandlerInterface<
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
@@ -138,7 +138,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
 
   // app.get(path, handler x4)
   <
@@ -156,7 +156,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
 
   // app.get(path, handler x5)
   <
@@ -176,13 +176,13 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['in'], O>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = {}, O = {}>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -218,7 +218,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
     method: M,
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(method, path, handler x3)
   <
@@ -236,7 +236,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
 
   // app.get(method, path, handler x4)
   <
@@ -256,7 +256,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
@@ -278,20 +278,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['input'], O>, BasePath>
+  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
 
   <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I extends Input = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -306,7 +306,7 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type Schema<M extends string, P extends string, I extends Input['input'], O> = {
+export type Schema<M extends string, P extends string, I extends Input['in'], O> = {
   [K in P]: AddDollar<{
     [K2 in M]: {
       input: unknown extends I ? {} : AddParam<I, P>
@@ -396,7 +396,7 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
 ////////////////////////////////////////
 
 export type InputToDataByTarget<
-  T extends Input['output'],
+  T extends Input['out'],
   Target extends keyof ValidationTargets
 > = T extends {
   [K in Target]: infer R

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -21,7 +21,10 @@ export type Env = {
 
 export type Next = () => Promise<void>
 
-export type Input = unknown
+export type Input = {
+  input?: Partial<ValidationTargets>
+  output?: Partial<{ [K in keyof ValidationTargets]: unknown }>
+}
 
 ////////////////////////////////////////
 //////                            //////
@@ -66,29 +69,42 @@ export interface HandlerInterface<
   //// app.get(...handlers[])
 
   // app.get(handler, handler)
-  <I = {}, O = {}>(...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>,
-    BasePath
-  >
+  <I extends Input = {}, O = {}>(
+    ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>, BasePath>
 
   // app.get(handler x 3)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+  <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I2, O>, H<E, ExtractKey<S>, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3['input'], O>>, BasePath>
 
   // app.get(handler x 4)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
     ...handlers: [
       H<E, ExtractKey<S>, I, O>,
       H<E, ExtractKey<S>, I2, O>,
       H<E, ExtractKey<S>, I3, O>,
       H<E, ExtractKey<S>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4['input'], O>>, BasePath>
 
   // app.get(handler x 5)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
+  >(
     ...handlers: [
       H<E, ExtractKey<S>, I, O>,
       H<E, ExtractKey<S>, I2, O>,
@@ -96,36 +112,43 @@ export interface HandlerInterface<
       H<E, ExtractKey<S>, I4, O>,
       H<E, ExtractKey<S>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5['input'], O>>, BasePath>
 
   // app.get(...handlers[])
-  <I = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
+  <I extends Input = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
     E,
-    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>,
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>,
     BasePath
   >
 
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler, handler)
-  <P extends string, O = {}, I = {}>(path: P, ...handlers: [H<E, P, I, O>, H<E, P, I, O>]): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>,
-    BasePath
-  >
+
+  <P extends string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 
   // app.get(path, handler x3)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+  <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
     path: P,
     ...handlers: [
       H<E, MergePath<BasePath, P>, I, O>,
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
 
   // app.get(path, handler x4)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
     path: P,
     ...handlers: [
       H<E, MergePath<BasePath, P>, I, O>,
@@ -133,10 +156,18 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
 
   // app.get(path, handler x5)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
+  >(
     path: P,
     ...handlers: [
       H<E, MergePath<BasePath, P>, I, O>,
@@ -145,13 +176,13 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['input'], O>>, BasePath>
 
   // app.get(path, ...handlers[])
-  <P extends string, I = {}, O = {}>(
+  <P extends string, I extends Input = {}, O = {}>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -183,14 +214,21 @@ export interface MiddlewareHandlerInterface<
 
 export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extends string = ''> {
   // app.on(method, path, handler, handler)
-  <M extends string, P extends string, O = {}, I = {}>(
+  <M extends string, P extends string, O = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 
   // app.get(method, path, handler x3)
-  <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2
+  >(
     method: M,
     path: P,
     ...handlers: [
@@ -198,10 +236,18 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
 
   // app.get(method, path, handler x4)
-  <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
     method: M,
     path: P,
     ...handlers: [
@@ -210,18 +256,18 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
     M extends string,
     P extends string,
     O = {},
-    I = {},
-    I2 = I,
-    I3 = I & I2,
-    I4 = I2 & I3,
-    I5 = I3 & I4
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
   >(
     method: M,
     path: P,
@@ -232,20 +278,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5, O>, BasePath>
+  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['input'], O>, BasePath>
 
-  <M extends string, P extends string, O extends {} = {}, I = {}>(
+  <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 
   // app.on(method[], path, ...handler)
-  <P extends string, O extends {} = {}, I = {}>(
+  <P extends string, O extends {} = {}, I extends Input = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -260,8 +306,13 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type Schema<M extends string, P extends string, I extends Input, O> = {
-  [K in P]: AddDollar<{ [K2 in M]: { input: AddParam<I, P>; output: O } }>
+export type Schema<M extends string, P extends string, I extends Input['input'], O> = {
+  [K in P]: AddDollar<{
+    [K2 in M]: {
+      input: unknown extends I ? {} : AddParam<I, P>
+      output: unknown extends O ? {} : O
+    }
+  }>
 }
 
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
@@ -345,7 +396,7 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
 ////////////////////////////////////////
 
 export type InputToDataByTarget<
-  T extends Input,
+  T extends Input['output'],
   Target extends keyof ValidationTargets
 > = T extends {
   [K in Target]: infer R

--- a/deno_dist/validator/index.ts
+++ b/deno_dist/validator/index.ts
@@ -1,1 +1,2 @@
 export { validator } from './validator.ts'
+export type { ValidationFunction } from './validator.ts'

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -12,7 +12,7 @@ export const validator = <
   P extends string,
   M extends string,
   U extends ValidationTargetByMethod<M>,
-  V extends { [K in U]: T },
+  V extends { input: { [K in U]: T }; output: { [K in U]: T } },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -19,11 +19,11 @@ export const validator = <
   U extends ValidationTargetByMethod<M>,
   OutputType = ValidationTargets[U],
   V extends {
-    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    output: { [K in U]: OutputType }
+    in: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    out: { [K in U]: OutputType }
   } = {
-    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    output: { [K in U]: OutputType }
+    in: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    out: { [K in U]: OutputType }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -7,17 +7,29 @@ type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD requ
   ? Exclude<keyof ValidationTargets, ValidationTargetKeysWithBody>
   : keyof ValidationTargets
 
+export type ValidationFunction<InputType, OutputType, E extends Env = {}> = (
+  value: InputType,
+  c: Context<E>
+) => OutputType | Response | Promise<Response>
+
 export const validator = <
-  T,
+  InputType,
   P extends string,
   M extends string,
   U extends ValidationTargetByMethod<M>,
-  V extends { input: { [K in U]: T }; output: { [K in U]: T } },
+  OutputType = ValidationTargets[U],
+  V extends {
+    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    output: { [K in U]: OutputType }
+  } = {
+    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    output: { [K in U]: OutputType }
+  },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
   target: U,
-  validationFunc: (value: ValidationTargets[U], c: Context<E>) => T | Response | Promise<Response>
+  validationFunc: ValidationFunction<InputType, OutputType, E>
 ): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
@@ -48,7 +60,7 @@ export const validator = <
         break
     }
 
-    const res = validationFunc(value, c)
+    const res = validationFunc(value as InputType, c)
 
     if (res instanceof Response || res instanceof Promise) {
       return res

--- a/src/context.ts
+++ b/src/context.ts
@@ -66,7 +66,7 @@ export class Context<
     }
   }
 
-  get req(): HonoRequest<P, I> {
+  get req(): HonoRequest<P, I['output']> {
     if (this._req) {
       return this._req
     } else {

--- a/src/context.ts
+++ b/src/context.ts
@@ -99,7 +99,7 @@ export class Context<
     }
   }
 
-  get req(): HonoRequest<P, I['output']> {
+  get req(): HonoRequest<P, I['out']> {
     if (this._req) {
       return this._req
     } else {

--- a/src/request.ts
+++ b/src/request.ts
@@ -14,7 +14,7 @@ import { parse } from './utils/cookie'
 import type { UnionToIntersection } from './utils/types'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url'
 
-export class HonoRequest<P extends string = '/', I extends Input['output'] = {}> {
+export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined

--- a/src/request.ts
+++ b/src/request.ts
@@ -14,7 +14,7 @@ import { parse } from './utils/cookie'
 import type { UnionToIntersection } from './utils/types'
 import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url'
 
-export class HonoRequest<P extends string = '/', I extends Input = {}> {
+export class HonoRequest<P extends string = '/', I extends Input['output'] = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -52,8 +52,8 @@ describe('HandlerInterface', () => {
       Env,
       never,
       {
-        input: { json: Payload }
-        output: { json: Payload }
+        in: { json: Payload }
+        out: { json: Payload }
       }
     > = async (_c, next) => {
       await next()
@@ -64,8 +64,8 @@ describe('HandlerInterface', () => {
           Env,
           never,
           {
-            input: { json: Payload }
-            output: { json: Payload }
+            in: { json: Payload }
+            out: { json: Payload }
           }
         >
         type verify = Expect<Equal<Expected, typeof c>>
@@ -88,17 +88,13 @@ describe('HandlerInterface', () => {
     const middleware: MiddlewareHandler<
       Env,
       '/foo',
-      { input: { json: Payload }; output: { json: Payload } }
+      { in: { json: Payload }; out: { json: Payload } }
     > = async (_c, next) => {
       await next()
     }
     test('Context and AppType', () => {
       const route = app.get('/foo', middleware, (c) => {
-        type Expected = Context<
-          Env,
-          '/foo',
-          { input: { json: Payload }; output: { json: Payload } }
-        >
+        type Expected = Context<Env, '/foo', { in: { json: Payload }; out: { json: Payload } }>
         type verify = Expect<Equal<Expected, typeof c>>
         return c.jsonT({
           message: 'Hello!',
@@ -131,7 +127,7 @@ describe('OnHandlerInterface', () => {
     const middleware: MiddlewareHandler<
       Env,
       '/purge',
-      { input: { form: { id: string } }; output: { form: { id: number } } }
+      { in: { form: { id: string } }; out: { form: { id: number } } }
     > = async (_c, next) => {
       await next()
     }
@@ -249,7 +245,7 @@ describe('Test types of Handler', () => {
 
   test('Env, Path, Type', async () => {
     const app = new Hono<E>()
-    const handler: Handler<E, '/', { input: { json: User }; output: { json: User } }> = (c) => {
+    const handler: Handler<E, '/', { in: { json: User }; out: { json: User } }> = (c) => {
       const foo = c.get('foo')
       type verifyEnv = Expect<Equal<number, typeof foo>>
       const { name } = c.req.valid('json')

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export type Env = {
 export type Next = () => Promise<void>
 
 export type Input = {
-  input?: Partial<ValidationTargets>
-  output?: Partial<{ [K in keyof ValidationTargets]: unknown }>
+  in?: Partial<ValidationTargets>
+  out?: Partial<{ [K in keyof ValidationTargets]: unknown }>
 }
 
 ////////////////////////////////////////
@@ -71,12 +71,12 @@ export interface HandlerInterface<
   // app.get(handler, handler)
   <I extends Input = {}, O = {}>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['in'], O>>, BasePath>
 
   // app.get(handler x 3)
   <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I2, O>, H<E, ExtractKey<S>, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3['in'], O>>, BasePath>
 
   // app.get(handler x 4)
   <
@@ -93,7 +93,7 @@ export interface HandlerInterface<
       H<E, ExtractKey<S>, I3, O>,
       H<E, ExtractKey<S>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4['in'], O>>, BasePath>
 
   // app.get(handler x 5)
   <
@@ -112,12 +112,12 @@ export interface HandlerInterface<
       H<E, ExtractKey<S>, I4, O>,
       H<E, ExtractKey<S>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5['in'], O>>, BasePath>
 
   // app.get(...handlers[])
   <I extends Input = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
     E,
-    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>,
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['in'], O>>,
     BasePath
   >
 
@@ -128,7 +128,7 @@ export interface HandlerInterface<
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
@@ -138,7 +138,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
 
   // app.get(path, handler x4)
   <
@@ -156,7 +156,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
 
   // app.get(path, handler x5)
   <
@@ -176,13 +176,13 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['in'], O>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = {}, O = {}>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -218,7 +218,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
     method: M,
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(method, path, handler x3)
   <
@@ -236,7 +236,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
 
   // app.get(method, path, handler x4)
   <
@@ -256,7 +256,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
@@ -278,20 +278,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['input'], O>, BasePath>
+  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
 
   <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I extends Input = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['input'], O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -306,7 +306,7 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type Schema<M extends string, P extends string, I extends Input['input'], O> = {
+export type Schema<M extends string, P extends string, I extends Input['in'], O> = {
   [K in P]: AddDollar<{
     [K2 in M]: {
       input: unknown extends I ? {} : AddParam<I, P>
@@ -396,7 +396,7 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
 ////////////////////////////////////////
 
 export type InputToDataByTarget<
-  T extends Input['output'],
+  T extends Input['out'],
   Target extends keyof ValidationTargets
 > = T extends {
   [K in Target]: infer R

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,10 @@ export type Env = {
 
 export type Next = () => Promise<void>
 
-export type Input = unknown
+export type Input = {
+  input?: Partial<ValidationTargets>
+  output?: Partial<{ [K in keyof ValidationTargets]: unknown }>
+}
 
 ////////////////////////////////////////
 //////                            //////
@@ -66,29 +69,42 @@ export interface HandlerInterface<
   //// app.get(...handlers[])
 
   // app.get(handler, handler)
-  <I = {}, O = {}>(...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>,
-    BasePath
-  >
+  <I extends Input = {}, O = {}>(
+    ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I, O>]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>, BasePath>
 
   // app.get(handler x 3)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+  <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
     ...handlers: [H<E, ExtractKey<S>, I, O>, H<E, ExtractKey<S>, I2, O>, H<E, ExtractKey<S>, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I3['input'], O>>, BasePath>
 
   // app.get(handler x 4)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
     ...handlers: [
       H<E, ExtractKey<S>, I, O>,
       H<E, ExtractKey<S>, I2, O>,
       H<E, ExtractKey<S>, I3, O>,
       H<E, ExtractKey<S>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I4['input'], O>>, BasePath>
 
   // app.get(handler x 5)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
+  >(
     ...handlers: [
       H<E, ExtractKey<S>, I, O>,
       H<E, ExtractKey<S>, I2, O>,
@@ -96,36 +112,43 @@ export interface HandlerInterface<
       H<E, ExtractKey<S>, I4, O>,
       H<E, ExtractKey<S>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I5['input'], O>>, BasePath>
 
   // app.get(...handlers[])
-  <I = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
+  <I extends Input = {}, O = {}>(...handlers: Handler<E, ExtractKey<S>, I, O>[]): Hono<
     E,
-    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I, O>>,
+    RemoveBlankRecord<S | Schema<M, ExtractKey<S>, I['input'], O>>,
     BasePath
   >
 
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler, handler)
-  <P extends string, O = {}, I = {}>(path: P, ...handlers: [H<E, P, I, O>, H<E, P, I, O>]): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>,
-    BasePath
-  >
+
+  <P extends string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 
   // app.get(path, handler x3)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+  <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
     path: P,
     ...handlers: [
       H<E, MergePath<BasePath, P>, I, O>,
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
 
   // app.get(path, handler x4)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
     path: P,
     ...handlers: [
       H<E, MergePath<BasePath, P>, I, O>,
@@ -133,10 +156,18 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
 
   // app.get(path, handler x5)
-  <P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3, I5 = I3 & I4>(
+  <
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
+  >(
     path: P,
     ...handlers: [
       H<E, MergePath<BasePath, P>, I, O>,
@@ -145,13 +176,13 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['input'], O>>, BasePath>
 
   // app.get(path, ...handlers[])
-  <P extends string, I = {}, O = {}>(
+  <P extends string, I extends Input = {}, O = {}>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -183,14 +214,21 @@ export interface MiddlewareHandlerInterface<
 
 export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extends string = ''> {
   // app.on(method, path, handler, handler)
-  <M extends string, P extends string, O = {}, I = {}>(
+  <M extends string, P extends string, O = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 
   // app.get(method, path, handler x3)
-  <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2>(
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2
+  >(
     method: M,
     path: P,
     ...handlers: [
@@ -198,10 +236,18 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['input'], O>>, BasePath>
 
   // app.get(method, path, handler x4)
-  <M extends string, P extends string, O = {}, I = {}, I2 = I, I3 = I & I2, I4 = I2 & I3>(
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
     method: M,
     path: P,
     ...handlers: [
@@ -210,18 +256,18 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['input'], O>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
     M extends string,
     P extends string,
     O = {},
-    I = {},
-    I2 = I,
-    I3 = I & I2,
-    I4 = I2 & I3,
-    I5 = I3 & I4
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
   >(
     method: M,
     path: P,
@@ -232,20 +278,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5, O>, BasePath>
+  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['input'], O>, BasePath>
 
-  <M extends string, P extends string, O extends {} = {}, I = {}>(
+  <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 
   // app.on(method[], path, ...handler)
-  <P extends string, O extends {} = {}, I = {}>(
+  <P extends string, O extends {} = {}, I extends Input = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I, O>>, BasePath>
+  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['input'], O>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -260,8 +306,13 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type Schema<M extends string, P extends string, I extends Input, O> = {
-  [K in P]: AddDollar<{ [K2 in M]: { input: AddParam<I, P>; output: O } }>
+export type Schema<M extends string, P extends string, I extends Input['input'], O> = {
+  [K in P]: AddDollar<{
+    [K2 in M]: {
+      input: unknown extends I ? {} : AddParam<I, P>
+      output: unknown extends O ? {} : O
+    }
+  }>
 }
 
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
@@ -345,7 +396,7 @@ export type ParamKeyToRecord<T extends string> = T extends `${infer R}?`
 ////////////////////////////////////////
 
 export type InputToDataByTarget<
-  T extends Input,
+  T extends Input['output'],
   Target extends keyof ValidationTargets
 > = T extends {
   [K in Target]: infer R

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,1 +1,2 @@
 export { validator } from './validator'
+export type { ValidationFunction } from './validator'

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -19,7 +19,7 @@ const zodValidator = <
 ): MiddlewareHandler<
   E,
   P,
-  { input: { [K in Target]: z.input<T> }; output: { [K in Target]: z.output<T> } }
+  { in: { [K in Target]: z.input<T> }; out: { [K in Target]: z.output<T> } }
 > =>
   validator(target, (value, c) => {
     const result = schema.safeParse(value)

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -12,7 +12,7 @@ export const validator = <
   P extends string,
   M extends string,
   U extends ValidationTargetByMethod<M>,
-  V extends { [K in U]: T },
+  V extends { input: { [K in U]: T }; output: { [K in U]: T } },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -19,11 +19,11 @@ export const validator = <
   U extends ValidationTargetByMethod<M>,
   OutputType = ValidationTargets[U],
   V extends {
-    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    output: { [K in U]: OutputType }
+    in: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    out: { [K in U]: OutputType }
   } = {
-    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    output: { [K in U]: OutputType }
+    in: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    out: { [K in U]: OutputType }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -7,17 +7,29 @@ type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD requ
   ? Exclude<keyof ValidationTargets, ValidationTargetKeysWithBody>
   : keyof ValidationTargets
 
+export type ValidationFunction<InputType, OutputType, E extends Env = {}> = (
+  value: InputType,
+  c: Context<E>
+) => OutputType | Response | Promise<Response>
+
 export const validator = <
-  T,
+  InputType,
   P extends string,
   M extends string,
   U extends ValidationTargetByMethod<M>,
-  V extends { input: { [K in U]: T }; output: { [K in U]: T } },
+  OutputType = ValidationTargets[U],
+  V extends {
+    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    output: { [K in U]: OutputType }
+  } = {
+    input: { [K in U]: unknown extends InputType ? OutputType : InputType }
+    output: { [K in U]: OutputType }
+  },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
   target: U,
-  validationFunc: (value: ValidationTargets[U], c: Context<E>) => T | Response | Promise<Response>
+  validationFunc: ValidationFunction<InputType, OutputType, E>
 ): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
@@ -48,7 +60,7 @@ export const validator = <
         break
     }
 
-    const res = validationFunc(value, c)
+    const res = validationFunc(value as InputType, c)
 
     if (res instanceof Response || res instanceof Promise) {
       return res


### PR DESCRIPTION
This PR provides supporting "type transformation" for the validator.

For example, Zod has a "transform" feature.

```ts
z.string()
  .regex(/^[0-9]+$/)
  .transform(Number)
```

This means that the input type(`string`) and output type(`number`) are different. But, Hono does not support different input and output types. If we use "transform" in Zod Validator Middleware, the value from `c.req.valid()` will be "input type" not "output type":

```ts
const app = new Hono().post(
  '/foo',
  zValidator(
    'json',
    z.object({
      id: z
        .string()
        .regex(/^[0-9]+$/)
        .transform(Number),
    })
  ),
  (c) => {
    c.req.valid('json').id // expected to be `number`
```

<img width="643" alt="SS" src="https://user-images.githubusercontent.com/10682/224057616-69bd5ef2-f8cd-4929-bc85-c2461482db9e.png">

This is mentioned at #946 

With this PR, the validator treats input and output types as different, so it will suport Zod's transform.

<img width="577" alt="SS" src="https://user-images.githubusercontent.com/10682/224058868-927497f1-3ed5-46b7-90b9-983f8926ae58.png">

Without this feature, Validation using Zod and others would be very inconvenient to use. So, if there are no problems, would like to include it in the next minor version upgrade "v3.1.0.

This will fix #946