### PR TITLE
feat(middleware): support overwriting response after `next()`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -131,8 +131,8 @@ export class Context<
     return (this._res ||= new Response('404 Not Found', { status: 404 }))
   }
 
-  set res(_res: Response) {
-    if (this._res) {
+  set res(_res: Response | undefined) {
+    if (this._res && _res) {
       this._res.headers.delete('content-type')
       this._res.headers.forEach((v, k) => {
         _res.headers.set(k, v)


### PR DESCRIPTION
This PR enables completely overwriting the response from middleware after `next()`. This matter is mentioned at #960 .

We can do it by putting `undefined`:

```ts
app.use('*', async (c, next) => {
  await next()
  c.res = undefined
  c.res = new Response('New Response')
})
```

Good PR, as this is done with very few codes.

Fix #960