### PR TITLE
fix(types): make `MergePath<'/api', '/'>` work well

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -338,7 +338,9 @@ export type MergePath<A extends string, B extends string> = A extends ''
     ? `${P}/${Q}`
     : `${P}/${B}`
   : B extends `/${infer Q}`
-  ? `${A}/${Q}`
+  ? Q extends ''
+    ? A
+    : `${A}/${Q}`
   : `${A}/${B}`
 
 ////////////////////////////////////////

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -46,6 +46,20 @@ export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientRes
   ? NonNullable<R>
   : never
 
+type Foo<Path extends string> = Path extends `${infer P}/` ? P : Path
+type v = Foo<'/foo/bar'>
+type v2 = PathToChain<
+  '/foo/bar',
+  {
+    $get: {
+      input: {}
+      output: {
+        name: string
+      }[]
+    }
+  }
+>
+
 type PathToChain<
   Path extends string,
   E extends Endpoint,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -46,20 +46,6 @@ export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientRes
   ? NonNullable<R>
   : never
 
-type Foo<Path extends string> = Path extends `${infer P}/` ? P : Path
-type v = Foo<'/foo/bar'>
-type v2 = PathToChain<
-  '/foo/bar',
-  {
-    $get: {
-      input: {}
-      output: {
-        name: string
-      }[]
-    }
-  }
->
-
 type PathToChain<
   Path extends string,
   E extends Endpoint,

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -359,6 +359,8 @@ describe('merge path', () => {
     type verify2 = Expect<Equal<'/api/book', path2>>
     type path3 = MergePath<'/api/', '/'>
     type verify3 = Expect<Equal<'/api/', path3>>
+    type path4 = MergePath<'/api', '/'>
+    type verify4 = Expect<Equal<'/api', path4>>
   })
 
   test('MergeSchemaPath', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,8 @@ export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, i
     : never
   : never
 
+type path4 = MergePath<'/api', '/'>
+
 export type MergePath<A extends string, B extends string> = A extends ''
   ? B
   : A extends `${infer P}/`
@@ -338,7 +340,9 @@ export type MergePath<A extends string, B extends string> = A extends ''
     ? `${P}/${Q}`
     : `${P}/${B}`
   : B extends `/${infer Q}`
-  ? `${A}/${Q}`
+  ? Q extends ''
+    ? A
+    : `${A}/${Q}`
   : `${A}/${B}`
 
 ////////////////////////////////////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,8 +331,6 @@ export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, i
     : never
   : never
 
-type path4 = MergePath<'/api', '/'>
-
 export type MergePath<A extends string, B extends string> = A extends ''
   ? B
   : A extends `${infer P}/`


### PR DESCRIPTION
This PR fixes the `MergePath` type definition.

Before this PR if you write the following:

```ts
type path = MergePath<'/api', '/'>
```

`path` will be `/api/`. But this is not correct because the actual value with `mergePath()` is the different. The trailing slash is removed:

https://github.com/honojs/hono/blob/fea78f29bd681350ce61dd71b33042aa6ec7db5c/src/utils/url.test.ts#L113

So, I've fixed it:

```ts
type path = MergePath<'/api', '/'>
// path will be /api
```

Whit this PR, the matters mentioned at #962 may be resolved.

<img width="768" alt="SS" src="https://user-images.githubusercontent.com/10682/224492645-57cbb58f-a2f0-47ad-b051-f75071fb48aa.png">

