### PR TITLE
fix(etag): returns correct headers

### DIFF
--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -22,6 +22,9 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
       c.res = new Response(null, {
         status: 304,
         statusText: 'Not Modified',
+        headers: {
+          Etag: etag,
+        },
       })
       c.res.headers.delete('Content-Length')
     } else {

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -23,7 +23,7 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
         status: 304,
         statusText: 'Not Modified',
         headers: {
-          Etag: etag,
+          ETag: etag,
         },
       })
       c.res.headers.delete('Content-Length')

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -86,6 +86,7 @@ describe('Etag Middleware', () => {
     })
     res = await app.request(req)
     expect(res.status).toBe(304)
+    expect(res.headers.get('Etag')).toBe(etag)
     expect(await res.text()).toBe('')
   })
 })

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -77,7 +77,7 @@ describe('Etag Middleware', () => {
     let res = await app.request('http://localhost/etag/abc')
     expect(res.status).toBe(200)
     expect(res.headers.get('ETag')).not.toBeFalsy()
-    const etag = res.headers.get('Etag') || ''
+    const etag = res.headers.get('ETag') || ''
 
     const req = new Request('http://localhost/etag/abc', {
       headers: {

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -22,6 +22,9 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
       c.res = new Response(null, {
         status: 304,
         statusText: 'Not Modified',
+        headers: {
+          Etag: etag,
+        },
       })
       c.res.headers.delete('Content-Length')
     } else {

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -23,7 +23,7 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
         status: 304,
         statusText: 'Not Modified',
         headers: {
-          Etag: etag,
+          ETag: etag,
         },
       })
       c.res.headers.delete('Content-Length')


### PR DESCRIPTION
In this PR, I've made the Etag Middleware returns the `Etag` header if the response is `304`.

This will fix #972 