### PR TITLE
fix(route): support a root-level optional parameter

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -148,6 +148,7 @@ describe('url', () => {
       expect(checkOptionalParameter('/api/animals')).toBeNull()
       expect(checkOptionalParameter('/api/:animals?/type')).toBeNull()
       expect(checkOptionalParameter('/api/animals/:type?/')).toBeNull()
+      expect(checkOptionalParameter('/:optional?')).toEqual(['/', '/:optional'])
     })
   })
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -125,12 +125,12 @@ export const checkOptionalParameter = (path: string): string[] | null => {
    [`/api/animals`, `/api/animals/:type`]
    in other cases it will return null
    */
-  const match = path.match(/(^.+)(\/\:[^\/]+)\?$/)
+  const match = path.match(/^(.+|)(\/\:[^\/]+)\?$/)
   if (!match) return null
 
   const base = match[1]
   const optional = base + match[2]
-  return [base, optional]
+  return [base === '' ? '/' : base.replace(/\/$/, ''), optional]
 }
 
 const removeFragment = (queryString: string): string => {


### PR DESCRIPTION
I've implemented a root-level optional parameter `/:optional?` which was not provided.

This will fix #974 