### PR TITLE
fix(client): `removeIndexString` supports `/sub/index`

### DIFF
--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -19,10 +19,7 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
 export const removeIndexString = (urlSting: string) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const path = getPathFromURL(urlSting)
-  if (path === '/index') {
-    return urlSting.replace(/index$/, '')
-  }
-  return urlSting
+  return urlSting.replace(/\/index$/, '/')
 }
 
 function isObject(item: unknown): item is ObjectType {

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -31,6 +31,14 @@ describe('removeIndexString', () => {
     url = '/index'
     newUrl = removeIndexString(url)
     expect(newUrl).toBe('/')
+
+    url = '/sub/index'
+    newUrl = removeIndexString(url)
+    expect(newUrl).toBe('/sub/')
+
+    url = '/subindex'
+    newUrl = removeIndexString(url)
+    expect(newUrl).toBe('/subindex')
   })
 })
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -19,10 +19,7 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
 export const removeIndexString = (urlSting: string) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const path = getPathFromURL(urlSting)
-  if (path === '/index') {
-    return urlSting.replace(/index$/, '')
-  }
-  return urlSting
+  return urlSting.replace(/\/index$/, '/')
 }
 
 function isObject(item: unknown): item is ObjectType {


### PR DESCRIPTION
`removeIndexString`  was supporting only `/`, so if we have a case like below, it will request to `/foo/index`.

```ts
const res = await client.foo.index.$get()
```
But,  if the endpoint path is `/foo/`, of course, it will return Not Found.

This PR makes `removeIndexString` support `/sub/index` and will fix the issue.

Fix #962 