### PR TITLE
feat(pages): enable getting `eventContext`

### DIFF
--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -2,10 +2,21 @@
 import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
-type EventContext = {
+// Ref: https://github.com/cloudflare/workerd/blob/main/types/defines/pages.d.ts
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Params<P extends string = any> = Record<P, string | string[]>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type EventContext<Env = {}, P extends string = any, Data = {}> = {
   request: Request
+  functionPath: string
   waitUntil: (promise: Promise<unknown>) => void
-  env: {} & { ASSETS: { fetch: typeof fetch } }
+  passThroughOnException: () => void
+  next: (input?: Request | string, init?: RequestInit) => Response
+  env: Env & { ASSETS: { fetch: typeof fetch } }
+  params: Params<P>
+  data: Data
 }
 
 interface HandleInterface {
@@ -20,7 +31,14 @@ export const handle: HandleInterface =
     subApp: Hono<E, S, BasePath>,
     path?: string
   ) =>
-  ({ request, env, waitUntil }) => {
+  (eventContext) => {
     const app = path ? new Hono<E, S, BasePath>().route(path, subApp as never) : subApp
-    return app.fetch(request, env, { waitUntil, passThroughOnException: () => {} })
+    return app.fetch(
+      eventContext.request,
+      { ...eventContext.env, eventContext },
+      {
+        waitUntil: eventContext.waitUntil,
+        passThroughOnException: eventContext.passThroughOnException,
+      }
+    )
   }

--- a/src/adapter/cloudflare-pages/index.ts
+++ b/src/adapter/cloudflare-pages/index.ts
@@ -1,2 +1,3 @@
 // @denoify-ignore
 export { handle } from './handler'
+export type { EventContext } from './handler'


### PR DESCRIPTION
This PR is for an adapter of Cloudflare Pages. Now we can get "EventContext" from `env`. It's useful for adding Basic Auth to your page's site with the middleware.

```ts
// functions/_middleware.ts
import { Hono } from 'hono'
import { basicAuth } from 'hono/basic-auth'
import { handle } from 'hono/cloudflare-pages'
import type { EventContext } from 'hono/cloudflare-pages'

type Bindings = {
  eventContext: EventContext
}

const app = new Hono<{ Bindings: Bindings }>()

app.get(
  '*',
  basicAuth({
    username: 'hoge',
    password: 'bar',
  }),
  async (c) => {
    return c.env.eventContext.next()
  }
)

export const onRequest = handle(app)
```