### PR TITLE
feat(page/nextjs): show "deprecated" for 2nd arg of `handle()`

### DIFF
--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -20,10 +20,16 @@ export type EventContext<Env = {}, P extends string = any, Data = {}> = {
 }
 
 interface HandleInterface {
-  <E extends Env, S extends {}, BasePath extends string>(
-    app: Hono<E, S, BasePath>,
-    path?: string
-  ): (eventContext: EventContext) => Response | Promise<Response>
+  <E extends Env, S extends {}, BasePath extends string>(app: Hono<E, S, BasePath>): (
+    eventContext: EventContext
+  ) => Response | Promise<Response>
+  /** @deprecated
+   * Use `app.basePath()` to set a sub path instead of passing the second argument.
+   * The `handle` will have only one argument in v4.
+   */
+  <E extends Env, S extends {}, BasePath extends string>(app: Hono<E, S, BasePath>, path: string): (
+    eventContext: EventContext
+  ) => Response | Promise<Response>
 }
 
 export const handle: HandleInterface =

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -3,9 +3,16 @@ import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
 interface HandleInterface {
+  <E extends Env, S extends {}, BasePath extends string>(subApp: Hono<E, S, BasePath>): (
+    req: Request
+  ) => Response | Promise<Response>
+  /** @deprecated
+   * Use `app.basePath()` to set a sub path instead of passing the second argument.
+   * The `handle` will have only one argument in v4.
+   */
   <E extends Env, S extends {}, BasePath extends string>(
     subApp: Hono<E, S, BasePath>,
-    path?: string
+    path: string
   ): (req: Request) => Response | Promise<Response>
 }
 


### PR DESCRIPTION
This PR is for the Cloudflare Pages adapter and the Next.js adapter. Now, we recommend using `app.basePath()` to set the base path instead of passing a second argument to `handle()`. With this PR showing the "deprecated" message:

<img width="561" alt="SS" src="https://user-images.githubusercontent.com/10682/224855331-1cc293a7-e406-421d-9eb8-7414e1374f55.png">
