### PR TITLE
Allow validator to apply validation to path param.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -366,6 +366,7 @@ export type ValidationTargets = {
   form: Record<string, string | File>
   query: Record<string, string>
   queries: Record<string, string[]>
+  param: Record<string, string>
 }
 
 ////////////////////////////////////////

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -58,6 +58,9 @@ export const validator = <
       case 'queries':
         value = c.req.queries()
         break
+      case 'param':
+        value = c.req.param() as Record<string, string>
+        break
     }
 
     const res = validationFunc(value as InputType, c)


### PR DESCRIPTION
How about allowing the validator to also apply validation to the path param?

We can still write the following, which is a helpful way to do it.
```
app.get('/users/:id{[0-9]+}/books/:title', handler);
```

However, validating with a validator in the following cases would be good.
* Should use 400 instead of 404.
* Should be validated by something that regular expressions cannot express.
* Should be changed to Number type.

### Type?

I tried the following changes but couldn't get the https://github.com/usualoma/hono/blob/1a3f2f62d6dece59e4c5e90b5ed21f0388d8b4d9/src/validator/validator.test.ts#L96-L150 test to pass and gave up. Although we cannot reference the path parameter type (generated from `:id`) in ValidationFunction, this PR change would be a useful enough feature.

```diff
diff --git a/src/validator/validator.ts b/src/validator/validator.ts
index c38ad05..b5d27a5 100644
--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -7,9 +7,9 @@ type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD requ
   ? Exclude<keyof ValidationTargets, ValidationTargetKeysWithBody>
   : keyof ValidationTargets
 
-export type ValidationFunction<InputType, OutputType, E extends Env = {}> = (
+export type ValidationFunction<InputType, OutputType, E extends Env = {}, P extends string = any> = (
   value: InputType,
-  c: Context<E>
+  c: Context<E, P>
 ) => OutputType | Response | Promise<Response>
 
 export const validator = <
@@ -29,7 +29,7 @@ export const validator = <
   E extends Env = any
 >(
   target: U,
-  validationFunc: ValidationFunction<InputType, OutputType, E>
+  validationFunc: ValidationFunction<InputType, OutputType, E, P>
 ): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
```