### PR TITLE
feat(validator): `query` supports array params

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -116,7 +116,7 @@ describe('Basic - query, queries, form, and path params', () => {
     .get(
       '/search',
       validator('query', () => {
-        return {} as { q: string }
+        return {} as { q: string; tag: string[] }
       }),
       (c) => {
         return c.jsonT({
@@ -157,10 +157,12 @@ describe('Basic - query, queries, form, and path params', () => {
     rest.get('http://localhost/api/search', (req, res, ctx) => {
       const url = new URL(req.url)
       const query = url.searchParams.get('q')
+      const tag = url.searchParams.getAll('tag')
       return res(
         ctx.status(200),
         ctx.json({
           q: query,
+          tag: tag,
         })
       )
     }),
@@ -194,12 +196,14 @@ describe('Basic - query, queries, form, and path params', () => {
     const res = await client.search.$get({
       query: {
         q: 'foobar',
+        tag: ['a', 'b'],
       },
     })
 
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       q: 'foobar',
+      tag: ['a', 'b'],
     })
   })
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -42,7 +42,13 @@ class ClientRequestImpl {
       if (args.query) {
         for (const [k, v] of Object.entries(args.query)) {
           this.queryParams ||= new URLSearchParams()
-          this.queryParams.set(k, v)
+          if (Array.isArray(v)) {
+            for (const v2 of v) {
+              this.queryParams.append(k, v2)
+            }
+          } else {
+            this.queryParams.set(k, v)
+          }
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -364,7 +364,7 @@ export type TypedResponse<T = unknown> = {
 export type ValidationTargets = {
   json: any
   form: Record<string, string | File>
-  query: Record<string, string>
+  query: Record<string, string | string[]>
   queries: Record<string, string[]>
   param: Record<string, string>
 }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -39,7 +39,7 @@ describe('Validator middleware', () => {
       await next()
     },
     validator('query', (value, c) => {
-      type verify = Expect<Equal<Record<string, string>, typeof value>>
+      type verify = Expect<Equal<Record<string, string | string[]>, typeof value>>
       if (!value) {
         return c.text('Invalid!', 400)
       }
@@ -275,20 +275,23 @@ describe('Validator middleware with Zod validates query params', () => {
       .transform((v) => {
         return Number(v)
       }),
+    tag: z.array(z.string()),
   })
 
   app.get('/search', zodValidator('query', schema), (c) => {
     const res = c.req.valid('query')
     return c.jsonT({
       page: res.page,
+      tags: res.tag,
     })
   })
 
   it('Should validate query params and return 200 response', async () => {
-    const res = await app.request('http://localhost/search?page=123')
+    const res = await app.request('http://localhost/search?page=123&tag=a&tag=b')
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       page: 123,
+      tags: ['a', 'b'],
     })
   })
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -57,7 +57,11 @@ export const validator = <
         value = await parseBody(c.req.raw.clone())
         break
       case 'query':
-        value = c.req.query()
+        value = Object.fromEntries(
+          Object.entries(c.req.queries()).map(([k, v]) => {
+            return v.length === 1 ? [k, v[0]] : [k, v]
+          })
+        )
         break
       case 'queries':
         value = c.req.queries()


### PR DESCRIPTION
This PR enables the validator to handle array params with `query`, not using `queries`.

For example, before this PR, we could not validate multiple params like `tag` using `query`:

```
http://localhost/search?page=123&tag=a&tag=b
```

Or we have to use `queries` but if we do so, they all will be `array`.

With this PR, the values we could get from `query` will be `Record<string, string | string[]>`. So we can write the followings:

```ts
const app = new Hono()

const schema = z.object({
  q: z.string(),
  tag: z.array(z.string()),
})

const route = app.get('/post', zValidator('query', schema), (c) => {
  const { q, tag } = c.req.valid('query')
  return c.jsonT({
    queryString: q,
    tags: tag,
  })
})
```

This issue is mentioned by @equt in our Discord. Thanks.