### PR TITLE
feat(req): introduce `c.req.path`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -59,6 +59,7 @@ type ContextOptions<E extends Env> = {
   env: E['Bindings']
   executionCtx?: FetchEvent | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
+  path?: string
   paramData?: Record<string, string>
 }
 
@@ -83,6 +84,7 @@ export class Context<
   private _headers: Headers | undefined = undefined
   private _preparedHeaders: Record<string, string> | undefined = undefined
   private _res: Response | undefined
+  private _path: string = '/'
   private _paramData?: Record<string, string> | null
   private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
@@ -91,6 +93,7 @@ export class Context<
     this.rawRequest = req
     if (options) {
       this._executionCtx = options.executionCtx
+      this._path = options.path ?? '/'
       this._paramData = options.paramData
       this.env = options.env
       if (options.notFoundHandler) {
@@ -104,7 +107,7 @@ export class Context<
       return this._req
     } else {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this._req = new HonoRequest(this.rawRequest!, this._paramData!)
+      this._req = new HonoRequest(this.rawRequest!, this._path, this._paramData!)
       this.rawRequest = undefined
       this._paramData = undefined
       return this._req

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -228,6 +228,7 @@ export class Hono<
       env,
       executionCtx: eventOrExecutionCtx,
       notFoundHandler: this.notFoundHandler,
+      path,
       paramData,
     })
 

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -19,9 +19,15 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
 
   private paramData: Record<string, string> | undefined
   private validatedData: { [K in keyof ValidationTargets]?: {} }
+  path: string
 
-  constructor(request: Request, paramData?: Record<string, string> | undefined) {
+  constructor(
+    request: Request,
+    path: string = '/',
+    paramData?: Record<string, string> | undefined
+  ) {
     this.raw = request
+    this.path = path
     this.paramData = paramData
     this.validatedData = {}
   }

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -70,7 +70,8 @@ export const getPattern = (label: string): Pattern | null => {
 
 export const getPathFromURL = (url: string, strict: boolean = true): string => {
   const queryIndex = url.indexOf('?', 8)
-  const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
+  let result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
+  result = removeFragment(result)
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
@@ -146,8 +147,6 @@ export const getQueryParam = (
   queryString: string,
   key?: string
 ): string | null | Record<string, string> => {
-  queryString = removeFragment(queryString)
-
   const results: Record<string, string> = {}
 
   // eslint-disable-next-line no-constant-condition
@@ -185,7 +184,6 @@ export const getQueryParams = (
   queryString: string,
   key?: string
 ): string[] | null | Record<string, string[]> => {
-  queryString = removeFragment(queryString)
   const results: Record<string, string[]> = {}
 
   for (const strings of queryString.split('&')) {

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -70,8 +70,7 @@ export const getPattern = (label: string): Pattern | null => {
 
 export const getPathFromURL = (url: string, strict: boolean = true): string => {
   const queryIndex = url.indexOf('?', 8)
-  let result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
-  result = removeFragment(result)
+  const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
@@ -132,14 +131,6 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   const base = match[1]
   const optional = base + match[2]
   return [base === '' ? '/' : base.replace(/\/$/, ''), optional]
-}
-
-const removeFragment = (queryString: string): string => {
-  const fragIndex = queryString.indexOf('#')
-  if (fragIndex !== -1) {
-    queryString = queryString.slice(0, fragIndex)
-  }
-  return queryString
 }
 
 // Optimized

--- a/src/context.ts
+++ b/src/context.ts
@@ -59,6 +59,7 @@ type ContextOptions<E extends Env> = {
   env: E['Bindings']
   executionCtx?: FetchEvent | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
+  path?: string
   paramData?: Record<string, string>
 }
 
@@ -83,6 +84,7 @@ export class Context<
   private _headers: Headers | undefined = undefined
   private _preparedHeaders: Record<string, string> | undefined = undefined
   private _res: Response | undefined
+  private _path: string = '/'
   private _paramData?: Record<string, string> | null
   private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
@@ -91,6 +93,7 @@ export class Context<
     this.rawRequest = req
     if (options) {
       this._executionCtx = options.executionCtx
+      this._path = options.path ?? '/'
       this._paramData = options.paramData
       this.env = options.env
       if (options.notFoundHandler) {
@@ -104,7 +107,7 @@ export class Context<
       return this._req
     } else {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this._req = new HonoRequest(this.rawRequest!, this._paramData!)
+      this._req = new HonoRequest(this.rawRequest!, this._path, this._paramData!)
       this.rawRequest = undefined
       this._paramData = undefined
       return this._req

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -481,12 +481,6 @@ describe('c.req.path', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('/search')
   })
-
-  it('Should get the path `/search` correctly with a fragment', async () => {
-    const res = await app.request('/search#head1')
-    expect(res.status).toBe(200)
-    expect(await res.text()).toBe('/search')
-  })
 })
 
 describe('Middleware', () => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -465,6 +465,30 @@ describe('param and query', () => {
   })
 })
 
+describe('c.req.path', () => {
+  const app = new Hono()
+  app.get('/', (c) => c.text(c.req.path))
+  app.get('/search', (c) => c.text(c.req.path))
+
+  it('Should get the path `/` correctly', async () => {
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/')
+  })
+
+  it('Should get the path `/search` correctly with a query', async () => {
+    const res = await app.request('/search?query=hono')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/search')
+  })
+
+  it('Should get the path `/search` correctly with a fragment', async () => {
+    const res = await app.request('/search#head1')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/search')
+  })
+})
+
 describe('Middleware', () => {
   describe('Basic', () => {
     const app = new Hono()

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -228,6 +228,7 @@ export class Hono<
       env,
       executionCtx: eventOrExecutionCtx,
       notFoundHandler: this.notFoundHandler,
+      path,
       paramData,
     })
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -19,9 +19,15 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
 
   private paramData: Record<string, string> | undefined
   private validatedData: { [K in keyof ValidationTargets]?: {} }
+  path: string
 
-  constructor(request: Request, paramData?: Record<string, string> | undefined) {
+  constructor(
+    request: Request,
+    path: string = '/',
+    paramData?: Record<string, string> | undefined
+  ) {
     this.raw = request
+    this.path = path
     this.paramData = paramData
     this.validatedData = {}
   }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -89,6 +89,13 @@ describe('url', () => {
       path = getPathFromURL('https://example.com/hello/hey/', false)
       expect(path).toBe('/hello/hey')
     })
+
+    it('getPathFromURL - with fragments', () => {
+      let path = getPathFromURL('https://example.com/hello#fragment')
+      expect(path).toBe('/hello')
+      path = getPathFromURL('https://example.com/hello?name=foo#frament')
+      expect(path).toBe('/hello')
+    })
   })
 
   describe('getQueryStringFromURL', () => {
@@ -178,7 +185,6 @@ describe('url', () => {
   describe('getQueryParams', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParams('name=hey', 'name')).toEqual(['hey'])
-      expect(getQueryParams('name=hey#fragment', 'name')).toEqual(['hey'])
       expect(getQueryParams('name=hey&name=foo', 'name')).toEqual(['hey', 'foo'])
       expect(getQueryParams('name=hey&age=20&tall=170', 'age')).toEqual(['20'])
       expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30', 'age')).toEqual([

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -155,7 +155,7 @@ describe('url', () => {
   describe('getQueryParam', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParam('name=hey', 'name')).toBe('hey')
-      expect(getQueryParam('name=hey#', 'name')).toBe('hey#')
+      expect(getQueryParam('name=hey#fragment', 'name')).toBe('hey#fragment')
       expect(getQueryParam('name=hey&age=20&tall=170', 'age')).toBe('20')
       let searchParams = new URLSearchParams({ name: '炎' })
       expect(getQueryParam(searchParams.toString(), 'name')).toBe('炎')
@@ -179,7 +179,7 @@ describe('url', () => {
   describe('getQueryParams', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParams('name=hey', 'name')).toEqual(['hey'])
-      expect(getQueryParams('name=hey#', 'name')).toEqual(['hey#'])
+      expect(getQueryParams('name=hey#fragment', 'name')).toEqual(['hey#fragment'])
       expect(getQueryParams('name=hey&name=foo', 'name')).toEqual(['hey', 'foo'])
       expect(getQueryParams('name=hey&age=20&tall=170', 'age')).toEqual(['20'])
       expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30', 'age')).toEqual([

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -89,13 +89,6 @@ describe('url', () => {
       path = getPathFromURL('https://example.com/hello/hey/', false)
       expect(path).toBe('/hello/hey')
     })
-
-    it('getPathFromURL - with fragments', () => {
-      let path = getPathFromURL('https://example.com/hello#fragment')
-      expect(path).toBe('/hello')
-      path = getPathFromURL('https://example.com/hello?name=foo#frament')
-      expect(path).toBe('/hello')
-    })
   })
 
   describe('getQueryStringFromURL', () => {
@@ -162,6 +155,7 @@ describe('url', () => {
   describe('getQueryParam', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParam('name=hey', 'name')).toBe('hey')
+      expect(getQueryParam('name=hey#', 'name')).toBe('hey#')
       expect(getQueryParam('name=hey&age=20&tall=170', 'age')).toBe('20')
       let searchParams = new URLSearchParams({ name: '炎' })
       expect(getQueryParam(searchParams.toString(), 'name')).toBe('炎')
@@ -185,6 +179,7 @@ describe('url', () => {
   describe('getQueryParams', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParams('name=hey', 'name')).toEqual(['hey'])
+      expect(getQueryParams('name=hey#', 'name')).toEqual(['hey#'])
       expect(getQueryParams('name=hey&name=foo', 'name')).toEqual(['hey', 'foo'])
       expect(getQueryParams('name=hey&age=20&tall=170', 'age')).toEqual(['20'])
       expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30', 'age')).toEqual([

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -70,7 +70,8 @@ export const getPattern = (label: string): Pattern | null => {
 
 export const getPathFromURL = (url: string, strict: boolean = true): string => {
   const queryIndex = url.indexOf('?', 8)
-  const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
+  let result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
+  result = removeFragment(result)
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
@@ -146,8 +147,6 @@ export const getQueryParam = (
   queryString: string,
   key?: string
 ): string | null | Record<string, string> => {
-  queryString = removeFragment(queryString)
-
   const results: Record<string, string> = {}
 
   // eslint-disable-next-line no-constant-condition
@@ -185,7 +184,6 @@ export const getQueryParams = (
   queryString: string,
   key?: string
 ): string[] | null | Record<string, string[]> => {
-  queryString = removeFragment(queryString)
   const results: Record<string, string[]> = {}
 
   for (const strings of queryString.split('&')) {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -70,8 +70,7 @@ export const getPattern = (label: string): Pattern | null => {
 
 export const getPathFromURL = (url: string, strict: boolean = true): string => {
   const queryIndex = url.indexOf('?', 8)
-  let result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
-  result = removeFragment(result)
+  const result = url.substring(url.indexOf('/', 8), queryIndex === -1 ? url.length : queryIndex)
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
@@ -132,14 +131,6 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   const base = match[1]
   const optional = base + match[2]
   return [base === '' ? '/' : base.replace(/\/$/, ''), optional]
-}
-
-const removeFragment = (queryString: string): string => {
-  const fragIndex = queryString.indexOf('#')
-  if (fragIndex !== -1) {
-    queryString = queryString.slice(0, fragIndex)
-  }
-  return queryString
 }
 
 // Optimized


### PR DESCRIPTION
This PR introduces the property `path` for HonoRequest.

This simple feature allows you to get the URL's path by accessing `c.req.path`.

```ts
app.get('/search', (c) => c.text(c.req.path)) // "search"
```

This feature is what many users wanted. This is good because there is no performance degradation, only a slight increase in file size. There are some API changes, but they are used internally, so there are no problems.