### PR TITLE
supported issued_at validation for JWT

### DIFF
--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -7,6 +7,7 @@ import {
   JwtTokenInvalid,
   JwtTokenNotBefore,
   JwtTokenExpired,
+  JwtTokenIssuedAt,
 } from './types'
 
 describe('JWT', () => {
@@ -69,6 +70,26 @@ describe('JWT', () => {
       err = e
     }
     expect(err).toEqual(new JwtTokenExpired(tok))
+    expect(authorized).toBe(false)
+  })
+
+  it('JwtTokenIssuedAt', async () => {
+    const now = 1633046400
+    jest.useFakeTimers().setSystemTime(new Date().setTime(now * 1000))
+
+    const iat = now + 1000 // after 1s
+    const payload = { role: 'api_role', iat }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+
+    let err
+    let authorized = false
+    try {
+      authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
+    } catch (e) {
+      err = e
+    }
+    expect(err).toEqual(new JwtTokenIssuedAt(now, iat))
     expect(authorized).toBe(false)
   })
 

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -1,5 +1,5 @@
 import { encodeBase64Url, decodeBase64Url } from '../../utils/encode'
-import { AlgorithmTypes } from './types'
+import { AlgorithmTypes, JwtTokenIssuedAt } from './types'
 import {
   JwtTokenInvalid,
   JwtTokenNotBefore,
@@ -119,11 +119,15 @@ export const verify = async (
   }
 
   const { payload } = decode(token)
-  if (payload.nbf && payload.nbf > Math.floor(Date.now() / 1000)) {
+  const now = Math.floor(Date.now() / 1000)
+  if (payload.nbf && payload.nbf > now) {
     throw new JwtTokenNotBefore(token)
   }
-  if (payload.exp && payload.exp <= Math.floor(Date.now() / 1000)) {
+  if (payload.exp && payload.exp <= now) {
     throw new JwtTokenExpired(token)
+  }
+  if (payload.iat && now < payload.iat) {
+    throw new JwtTokenIssuedAt(now, payload.iat)
   }
 
   const signaturePart = tokenParts.slice(0, 2).join('.')

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -8,7 +8,7 @@ export class JwtAlgorithmNotImplemented extends Error {
 /**
  * Export for backward compatibility
  * @deprecated Use JwtAlgorithmNotImplemented instead
-**/
+ **/
 export const JwtAlorithmNotImplemented = JwtAlgorithmNotImplemented
 
 export class JwtTokenInvalid extends Error {
@@ -32,6 +32,13 @@ export class JwtTokenExpired extends Error {
   }
 }
 
+export class JwtTokenIssuedAt extends Error {
+  constructor(currentTimestamp: number, iat: number) {
+    super(`Incorrect "iat" claim must be a older than "${currentTimestamp}" (iat: "${iat}")`)
+    this.name = 'JwtTokenIssuedAt'
+  }
+}
+
 export class JwtTokenSignatureMismatched extends Error {
   constructor(token: string) {
     super(`token(${token}) signature mismatched`)
@@ -44,4 +51,3 @@ export enum AlgorithmTypes {
   HS384 = 'HS384',
   HS512 = 'HS512',
 }
-


### PR DESCRIPTION
This validation is allowed `current_time >= iat` if there is iat field.