### PR TITLE
fix(app): don't remove slash form `/` if strict is false

### DIFF
--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -74,7 +74,7 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
-  if (strict === false && result.endsWith('/')) {
+  if (strict === false && /.+\/$/.test(result)) {
     return result.slice(0, -1)
   }
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -90,7 +90,7 @@ describe('url', () => {
       expect(path).toBe('/hello/hey')
     })
 
-    it('getPathFromURL - return `/` whether strict is false', () => {
+    it('getPathFromURL - return `/` even if strict is false', () => {
       const path = getPathFromURL('https://example.com/', false)
       expect(path).toBe('/')
     })

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -89,6 +89,11 @@ describe('url', () => {
       path = getPathFromURL('https://example.com/hello/hey/', false)
       expect(path).toBe('/hello/hey')
     })
+
+    it('getPathFromURL - return `/` whether strict is false', () => {
+      const path = getPathFromURL('https://example.com/', false)
+      expect(path).toBe('/')
+    })
   })
 
   describe('getQueryStringFromURL', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -74,7 +74,7 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
   // default is true
-  if (strict === false && result.endsWith('/')) {
+  if (strict === false && /.+\/$/.test(result)) {
     return result.slice(0, -1)
   }
 


### PR DESCRIPTION
Do not remove slashes when the strict option is `false` and the path is `/`.

Fix https://github.com/honojs/hono/issues/1000