### PR TITLE
fix(req): decode special chars in URL params

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -1,10 +1,10 @@
 import { HonoRequest } from './request'
 
 describe('Query', () => {
-  const rawRequest = new Request('http://localhost?page=2&tag=A&tag=B')
-  const req = new HonoRequest(rawRequest)
-
   test('req.query() and req.queries()', () => {
+    const rawRequest = new Request('http://localhost?page=2&tag=A&tag=B')
+    const req = new HonoRequest(rawRequest)
+
     const page = req.query('page')
     expect(page).not.toBeUndefined()
     expect(page).toBe('2')
@@ -18,6 +18,17 @@ describe('Query', () => {
 
     const q2 = req.queries('q2')
     expect(q2).toBeUndefined()
+  })
+
+  test('decode special chars', () => {
+    const rawRequest = new Request('http://localhost?mail=framework%40hono.dev&tag=%401&tag=%402')
+    const req = new HonoRequest(rawRequest)
+
+    const mail = req.query('mail')
+    expect(mail).toBe('framework@hono.dev')
+
+    const tags = req.queries('tag')
+    expect(tags).toEqual(['@1', '@2'])
   })
 })
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -155,7 +155,7 @@ export const getQueryParam = (
       const v = strings.substring(eqIndex + 1)
       const k = strings.substring(0, eqIndex)
       if (key === k) {
-        return /\%/.test(v) ? decodeURI(v) : v
+        return /\%/.test(v) ? decodeURIComponent(v) : v
       } else {
         results[k] ||= v
       }
@@ -181,7 +181,7 @@ export const getQueryParams = (
     let [k, v] = strings.split('=')
     if (v === undefined) v = ''
     results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURI(v) : v)
+    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
   }
 
   if (key) return results[key] ? results[key] : null


### PR DESCRIPTION
This PR enables `c.req.query` and `c.req.queries` to decode special characters in URL parameters.

This will fix #1006