### PR TITLE
feat(jwt): support for getting payload from `c.get('jwtPayload')`

### DIFF
--- a/benchmarks/query-param/package-lock.json
+++ b/benchmarks/query-param/package-lock.json
@@ -1,0 +1,519 @@
+{
+  "name": "query-param",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "license": "MIT",
+      "dependencies": {
+        "fast-querystring": "^1.1.1",
+        "mitata": "^0.1.6"
+      },
+      "devDependencies": {
+        "tsx": "^3.12.2"
+      }
+    },
+    "node_modules/@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.14.tgz",
+      "integrity": "sha512-0CnlwnjDU8cks0yJLXfkaU/uoLyRf9VZJs4p1PskBr2AlAHeEsFEwJEo0of/Z3g+ilw5mpyDwThlxzNEIxOE4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.14.tgz",
+      "integrity": "sha512-eLOpPO1RvtsP71afiFTvS7tVFShJBCT0txiv/xjFBo5a7R7Gjw7X0IgIaFoLKhqXYAXhahoXm7qAmRXhY4guJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.14.tgz",
+      "integrity": "sha512-nrfQYWBfLGfSGLvRVlt6xi63B5IbfHm3tZCdu/82zuFPQ7zez4XjmRtF/wIRYbJQ/DsZrxJdEvYFE67avYXyng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.14.tgz",
+      "integrity": "sha512-eoSjEuDsU1ROwgBH/c+fZzuSyJUVXQTOIN9xuLs9dE/9HbV/A5IqdXHU1p2OfIMwBwOYJ9SFVGGldxeRCUJFyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.14.tgz",
+      "integrity": "sha512-zN0U8RWfrDttdFNkHqFYZtOH8hdi22z0pFm0aIJPsNC4QQZv7je8DWCX5iA4Zx6tRhS0CCc0XC2m7wKsbWEo5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.14.tgz",
+      "integrity": "sha512-z0VcD4ibeZWVQCW1O7szaLxGsx54gcCnajEJMdYoYjLiq4g1jrP2lMq6pk71dbS5+7op/L2Aod+erw+EUr28/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.14.tgz",
+      "integrity": "sha512-hd9mPcxfTgJlolrPlcXkQk9BMwNBvNBsVaUe5eNUqXut6weDQH8whcNaKNF2RO8NbpT6GY8rHOK2A9y++s+ehw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.14.tgz",
+      "integrity": "sha512-BNTl+wSJ1omsH8s3TkQmIIIQHwvwJrU9u1ggb9XU2KTVM4TmthRIVyxSp2qxROJHhZuW/r8fht46/QE8hU8Qvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.14.tgz",
+      "integrity": "sha512-FhAMNYOq3Iblcj9i+K0l1Fp/MHt+zBeRu/Qkf0LtrcFu3T45jcwB6A1iMsemQ42vR3GBhjNZJZTaCe3VFPbn9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.14.tgz",
+      "integrity": "sha512-91OK/lQ5y2v7AsmnFT+0EyxdPTNhov3y2CWMdizyMfxSxRqHazXdzgBKtlmkU2KYIc+9ZK3Vwp2KyXogEATYxQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.14.tgz",
+      "integrity": "sha512-vp15H+5NR6hubNgMluqqKza85HcGJgq7t6rMH7O3Y6ApiOWPkvW2AJfNojUQimfTp6OUrACUXfR4hmpcENXoMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.14.tgz",
+      "integrity": "sha512-90TOdFV7N+fgi6c2+GO9ochEkmm9kBAKnuD5e08GQMgMINOdOFHuYLPQ91RYVrnWwQ5683sJKuLi9l4SsbJ7Hg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.14.tgz",
+      "integrity": "sha512-NnBGeoqKkTugpBOBZZoktQQ1Yqb7aHKmHxsw43NddPB2YWLAlpb7THZIzsRsTr0Xw3nqiPxbA1H31ZMOG+VVPQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.14.tgz",
+      "integrity": "sha512-0qdlKScLXA8MGVy21JUKvMzCYWovctuP8KKqhtE5A6IVPq4onxXhSuhwDd2g5sRCzNDlDjitc5sX31BzDoL5Fw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.14.tgz",
+      "integrity": "sha512-Hdm2Jo1yaaOro4v3+6/zJk6ygCqIZuSDJHdHaf8nVH/tfOuoEX5Riv03Ka15LmQBYJObUTNS1UdyoMk0WUn9Ww==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.14.tgz",
+      "integrity": "sha512-8KHF17OstlK4DuzeF/KmSgzrTWQrkWj5boluiiq7kvJCiQVzUrmSkaBvcLB2UgHpKENO2i6BthPkmUhNDaJsVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.14.tgz",
+      "integrity": "sha512-nVwpqvb3yyXztxIT2+VsxJhB5GCgzPdk1n0HHSnchRAcxqKO6ghXwHhJnr0j/B+5FSyEqSxF4q03rbA2fKXtUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.14.tgz",
+      "integrity": "sha512-1RZ7uQQ9zcy/GSAJL1xPdN7NDdOOtNEGiJalg/MOzeakZeTrgH/DoCkbq7TaPDiPhWqnDF+4bnydxRqQD7il6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.14.tgz",
+      "integrity": "sha512-nqMjDsFwv7vp7msrwWRysnM38Sd44PKmW8EzV01YzDBTcTWUpczQg6mGao9VLicXSgW/iookNK6AxeogNVNDZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.14.tgz",
+      "integrity": "sha512-xrD0mccTKRBBIotrITV7WVQAwNJ5+1va6L0H9zN92v2yEdjfAN7864cUaZwJS7JPEs53bDTzKFbfqVlG2HhyKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.14.tgz",
+      "integrity": "sha512-nXpkz9bbJrLLyUTYtRotSS3t5b+FOuljg8LgLdINWFs3FfqZMtbnBCZFUmBzQPyxqU87F8Av+3Nco/M3hEcu1w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.14.tgz",
+      "integrity": "sha512-gPQmsi2DKTaEgG14hc3CHXHp62k8g6qr0Pas+I4lUxRMugGSATh/Bi8Dgusoz9IQ0IfdrvLpco6kujEIBoaogA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.14.tgz",
+      "integrity": "sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.14",
+        "@esbuild/android-arm64": "0.17.14",
+        "@esbuild/android-x64": "0.17.14",
+        "@esbuild/darwin-arm64": "0.17.14",
+        "@esbuild/darwin-x64": "0.17.14",
+        "@esbuild/freebsd-arm64": "0.17.14",
+        "@esbuild/freebsd-x64": "0.17.14",
+        "@esbuild/linux-arm": "0.17.14",
+        "@esbuild/linux-arm64": "0.17.14",
+        "@esbuild/linux-ia32": "0.17.14",
+        "@esbuild/linux-loong64": "0.17.14",
+        "@esbuild/linux-mips64el": "0.17.14",
+        "@esbuild/linux-ppc64": "0.17.14",
+        "@esbuild/linux-riscv64": "0.17.14",
+        "@esbuild/linux-s390x": "0.17.14",
+        "@esbuild/linux-x64": "0.17.14",
+        "@esbuild/netbsd-x64": "0.17.14",
+        "@esbuild/openbsd-x64": "0.17.14",
+        "@esbuild/sunos-x64": "0.17.14",
+        "@esbuild/win32-arm64": "0.17.14",
+        "@esbuild/win32-ia32": "0.17.14",
+        "@esbuild/win32-x64": "0.17.14"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.1.tgz",
+      "integrity": "sha512-qR2r+e3HvhEFmpdHMv//U8FnFlnYjaC6QKDuaXALDkw2kvHO8WDjxH+f/rHGR4Me4pnk8p9JAkRNTjYHAKRn2Q==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
+      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/mitata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mitata/-/mitata-0.1.6.tgz",
+      "integrity": "sha512-VKQ0r3jriTOU9E2Z+mwbZrUmbg4Li4QyFfi7kfHKl6reZhGzL0AYlu3wE0VPXzIwA5xnFzmEQoBwCcNT8stUkA=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.6.tgz",
+      "integrity": "sha512-q93WgS3lBdHlPgS0h1i+87Pt6n9K/qULIMNYZo07nSeu2z5QE2CellcAZfofVXBo2tQg9av2ZcRMQ2S2i5oadQ==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    }
+  }
+}

--- a/benchmarks/query-param/package.json
+++ b/benchmarks/query-param/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "bench:node": "tsx ./src/bench.mts",
+    "bench:bun": "bun run ./src/bench.mts"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "tsx": "^3.12.2"
+  },
+  "dependencies": {
+    "fast-querystring": "^1.1.1",
+    "mitata": "^0.1.6"
+  }
+}

--- a/benchmarks/query-param/src/bench.mts
+++ b/benchmarks/query-param/src/bench.mts
@@ -1,0 +1,42 @@
+import { run, group, bench } from 'mitata'
+import fastQuerystring from './fast-querystring.mts'
+import hono from './hono.mts'
+;[
+  {
+    url: 'http://example.com/?page=1',
+    key: 'page',
+  },
+  {
+    url: 'http://example.com/?url=http://example.com&page=1',
+    key: 'page',
+  },
+  {
+    url: 'http://example.com/?page=1',
+    key: undefined,
+  },
+  {
+    url: 'http://example.com/?url=http://example.com&page=1',
+    key: undefined,
+  },
+  {
+    url: 'http://example.com/?url=http://example.com/very/very/deep/path/to/something&search=very-long-search-string',
+    key: undefined,
+  },
+  {
+    url: 'http://example.com/?search=Hono+is+a+small,+simple,+and+ultrafast+web+framework+for+the+Edge.&page=1',
+    key: undefined,
+  },
+  {
+    url: 'http://example.com/?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9&j=10',
+    key: undefined,
+  },
+].forEach((data) => {
+  const { url, key } = data
+
+  group(JSON.stringify(data), () => {
+    bench('hono', () => hono(url, key))
+    bench('fastQuerystring', () => fastQuerystring(url, key))
+  })
+})
+
+run()

--- a/benchmarks/query-param/src/fast-querystring.mts
+++ b/benchmarks/query-param/src/fast-querystring.mts
@@ -1,0 +1,12 @@
+import { parse } from 'fast-querystring'
+
+const getQueryStringFromURL = (url: string): string => {
+  const queryIndex = url.indexOf('?', 8)
+  const result = queryIndex !== -1 ? url.slice(queryIndex + 1) : ''
+  return result
+}
+
+export default (url, key?) => {
+  const data = parse(getQueryStringFromURL(url))
+  return key !== undefined ? data[key] : data 
+}

--- a/benchmarks/query-param/src/hono.mts
+++ b/benchmarks/query-param/src/hono.mts
@@ -1,0 +1,5 @@
+import { getQueryParam } from '../../../src/utils/url'
+
+export default (url, key?) => {
+  return getQueryParam(url, key)
+}

--- a/deno_dist/adapter.ts
+++ b/deno_dist/adapter.ts
@@ -1,6 +1,8 @@
 import type { Context } from './context.ts'
 
-export const env = <T = Record<string, string>>(c: Context): T => {
+export const env = <T extends Record<string, string>, C extends Context = Context<{}>>(
+  c: C
+): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -2,6 +2,7 @@ import { HTTPException } from '../../http-exception.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
+import '../../context.ts'
 
 declare module '../../context.ts' {
   interface ContextVariableMap {

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -3,6 +3,13 @@ import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
 
+declare module '../../context.ts' {
+  interface ContextVariableMap {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jwtPayload: any
+  }
+}
+
 export const jwt = (options: {
   secret: string
   cookie?: string
@@ -46,14 +53,14 @@ export const jwt = (options: {
       throw new HTTPException(401, { res })
     }
 
-    let authorized = false
+    let payload
     let msg = ''
     try {
-      authorized = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
+      payload = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
     } catch (e) {
       msg = `${e}`
     }
-    if (!authorized) {
+    if (!payload) {
       const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,
@@ -63,6 +70,8 @@ export const jwt = (options: {
       })
       throw new HTTPException(401, { res })
     }
+
+    ctx.set('jwtPayload', payload)
 
     await next()
   }

--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -28,6 +28,7 @@ export type {
   Next,
   NotFoundHandler,
   ValidationTargets,
+  Input,
 } from './types.ts'
 export type { Context, ContextVariableMap } from './context.ts'
 export type { HonoRequest } from './request.ts'

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -12,7 +12,7 @@ import type { BodyData } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 import type { UnionToIntersection } from './utils/types.ts'
-import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url.ts'
+import { getQueryParam, getQueryParams } from './utils/url.ts'
 
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   raw: Request
@@ -57,19 +57,13 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   query(key: string): string | undefined
   query(): Record<string, string>
   query(key?: string) {
-    const queryString = getQueryStringFromURL(this.url)
-    const result = getQueryParam(queryString, key)
-    if (result === null) return undefined
-    return result
+    return getQueryParam(this.url, key)
   }
 
   queries(key: string): string[] | undefined
   queries(): Record<string, string[]>
   queries(key?: string) {
-    const queryString = getQueryStringFromURL(this.url)
-    const result = getQueryParams(queryString, key)
-    if (result === null) return undefined
-    return result
+    return getQueryParams(this.url, key)
   }
 
   header(name: string): string | undefined

--- a/deno_dist/utils/jwt/jwt.ts
+++ b/deno_dist/utils/jwt/jwt.ts
@@ -112,7 +112,8 @@ export const verify = async (
   token: string,
   secret: string,
   alg: AlgorithmTypes = AlgorithmTypes.HS256
-): Promise<boolean> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> => {
   const tokenParts = token.split('.')
   if (tokenParts.length !== 3) {
     throw new JwtTokenInvalid(token)
@@ -137,7 +138,7 @@ export const verify = async (
     throw new JwtTokenSignatureMismatched(token)
   }
 
-  return true
+  return payload
 }
 
 // eslint-disable-next-line

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -155,7 +155,7 @@ export const getQueryParam = (
       const v = strings.substring(eqIndex + 1)
       const k = strings.substring(0, eqIndex)
       if (key === k) {
-        return /\%/.test(v) ? decodeURI(v) : v
+        return /\%/.test(v) ? decodeURIComponent(v) : v
       } else {
         results[k] ||= v
       }
@@ -181,7 +181,7 @@ export const getQueryParams = (
     let [k, v] = strings.split('=')
     if (v === undefined) v = ''
     results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURI(v) : v)
+    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
   }
 
   if (key) return results[key] ? results[key] : null

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -81,12 +81,6 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
   return result
 }
 
-export const getQueryStringFromURL = (url: string): string => {
-  const queryIndex = url.indexOf('?', 8)
-  const result = queryIndex !== -1 ? url.slice(queryIndex + 1) : ''
-  return result
-}
-
 export const mergePath = (...paths: string[]): string => {
   let p: string = ''
   let endsWithSlash = false
@@ -134,57 +128,104 @@ export const checkOptionalParameter = (path: string): string[] | null => {
 }
 
 // Optimized
-export const getQueryParam = (
-  queryString: string,
-  key?: string
-): string | null | Record<string, string> => {
-  const results: Record<string, string> = {}
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const andIndex = queryString.indexOf('&')
-    let strings = ''
-    if (andIndex === -1) {
-      strings = queryString
-    } else {
-      strings = queryString.substring(0, andIndex)
-    }
-
-    const eqIndex = strings.indexOf('=')
-    if (eqIndex !== -1) {
-      const v = strings.substring(eqIndex + 1)
-      const k = strings.substring(0, eqIndex)
-      if (key === k) {
-        return /\%/.test(v) ? decodeURIComponent(v) : v
-      } else {
-        results[k] ||= v
-      }
-    } else if (strings === key) {
-      return ''
-    }
-
-    if (andIndex === -1) break
-    queryString = queryString.substring(andIndex + 1, queryString.length)
+const _decodeURI = (value: string) => {
+  if (!/[%+]/.test(value)) {
+    return value
   }
-
-  if (key) return null
-  return results
+  if (value.includes('+')) {
+    value = value.replace(/\+/g, ' ')
+  }
+  return value.includes('%') ? decodeURIComponent(value) : value
 }
 
-export const getQueryParams = (
-  queryString: string,
-  key?: string
-): string[] | null | Record<string, string[]> => {
-  const results: Record<string, string[]> = {}
+const _getQueryParam = (
+  url: string,
+  key?: string,
+  multiple?: boolean
+): string | undefined | Record<string, string> | string[] | Record<string, string[]> => {
+  let encoded
 
-  for (const strings of queryString.split('&')) {
-    let [k, v] = strings.split('=')
-    if (v === undefined) v = ''
-    results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
+  if (!multiple && key && !/[%+]/.test(key)) {
+    // optimized for unencoded key
+
+    let keyIndex = url.indexOf(`?${key}`, 8)
+    if (keyIndex === -1) {
+      keyIndex = url.indexOf(`&${key}`, 8)
+    }
+    while (keyIndex !== -1) {
+      const trailingKeyCode = url.charCodeAt(keyIndex + key.length + 1)
+      if (trailingKeyCode === 61) {
+        const valueIndex = keyIndex + key.length + 2
+        const endIndex = url.indexOf('&', valueIndex)
+        return _decodeURI(url.slice(valueIndex, endIndex === -1 ? undefined : endIndex))
+      } else if (trailingKeyCode == 38 || isNaN(trailingKeyCode)) {
+        return ''
+      }
+      keyIndex = url.indexOf(`&${key}`, keyIndex)
+    }
+
+    encoded = /[%+]/.test(url)
+    if (!encoded) {
+      return undefined
+    }
+    // fallback to default routine
   }
 
-  if (key) return results[key] ? results[key] : null
+  const results: Record<string, string> | Record<string, string[]> = {}
+  encoded ??= /[%+]/.test(url)
 
-  return results
+  let keyIndex = url.indexOf('?', 8)
+  while (keyIndex !== -1) {
+    const nextKeyIndex = url.indexOf('&', keyIndex + 1)
+    let valueIndex = url.indexOf('=', keyIndex)
+    if (valueIndex > nextKeyIndex && nextKeyIndex !== -1) {
+      valueIndex = -1
+    }
+    let name = url.slice(
+      keyIndex + 1,
+      valueIndex === -1 ? (nextKeyIndex === -1 ? undefined : nextKeyIndex) : valueIndex
+    )
+    if (encoded) {
+      name = _decodeURI(name)
+    }
+
+    keyIndex = nextKeyIndex
+
+    if (name === '') {
+      continue
+    }
+
+    let value
+    if (valueIndex === -1) {
+      value = ''
+    } else {
+      value = url.slice(valueIndex + 1, nextKeyIndex === -1 ? undefined : nextKeyIndex)
+      if (encoded) {
+        value = _decodeURI(value)
+      }
+    }
+
+    if (multiple) {
+      ;((results[name] ??= []) as string[]).push(value)
+    } else {
+      results[name] ??= value
+    }
+  }
+
+  return key ? results[key] : results
+}
+
+export const getQueryParam: (
+  url: string,
+  key?: string
+) => string | undefined | Record<string, string> = _getQueryParam as (
+  url: string,
+  key?: string
+) => string | undefined | Record<string, string>
+
+export const getQueryParams = (
+  url: string,
+  key?: string
+): string[] | undefined | Record<string, string[]> => {
+  return _getQueryParam(url, key, true) as string[] | undefined | Record<string, string[]>
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Ultrafast web framework for the Edge",
   "main": "dist/cjs/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Ultrafast web framework for the Edge",
   "main": "dist/cjs/index.js",
   "type": "module",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,6 +1,8 @@
 import type { Context } from './context'
 
-export const env = <T = Record<string, string>>(c: Context): T => {
+export const env = <T extends Record<string, string>, C extends Context = Context<{}>>(
+  c: C
+): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   Next,
   NotFoundHandler,
   ValidationTargets,
+  Input,
 } from './types'
 export type { Context, ContextVariableMap } from './context'
 export type { HonoRequest } from './request'

--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -20,15 +20,18 @@ describe('JWT', () => {
 
     app.get('/auth/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
     app.get('/auth-unicode/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
     app.get('/nested/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
 
     it('Should not authorize', async () => {
@@ -48,7 +51,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
 
@@ -61,7 +64,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
 
@@ -112,7 +115,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
   })
@@ -131,11 +134,13 @@ describe('JWT', () => {
 
     app.get('/auth/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
     app.get('/auth-unicode/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
 
     it('Should not authorize', async () => {
@@ -158,7 +163,7 @@ describe('JWT', () => {
       })
       const res = await app.request(req)
       expect(res).not.toBeNull()
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(res.status).toBe(200)
       expect(handlerExecuted).toBeTruthy()
     })
@@ -175,7 +180,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
 

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -2,6 +2,7 @@ import { HTTPException } from '../../http-exception'
 import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
 import type { AlgorithmTypes } from '../../utils/jwt/types'
+import '../../context'
 
 declare module '../../context' {
   interface ContextVariableMap {

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -3,6 +3,13 @@ import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
 import type { AlgorithmTypes } from '../../utils/jwt/types'
 
+declare module '../../context' {
+  interface ContextVariableMap {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jwtPayload: any
+  }
+}
+
 export const jwt = (options: {
   secret: string
   cookie?: string
@@ -46,14 +53,14 @@ export const jwt = (options: {
       throw new HTTPException(401, { res })
     }
 
-    let authorized = false
+    let payload
     let msg = ''
     try {
-      authorized = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
+      payload = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
     } catch (e) {
       msg = `${e}`
     }
-    if (!authorized) {
+    if (!payload) {
       const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,
@@ -63,6 +70,8 @@ export const jwt = (options: {
       })
       throw new HTTPException(401, { res })
     }
+
+    ctx.set('jwtPayload', payload)
 
     await next()
   }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -28,6 +28,7 @@ export type {
   Next,
   NotFoundHandler,
   ValidationTargets,
+  Input,
 } from './types'
 export type { Context, ContextVariableMap } from './context'
 export type { HonoRequest } from './request'

--- a/src/request.ts
+++ b/src/request.ts
@@ -12,7 +12,7 @@ import type { BodyData } from './utils/body'
 import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
 import type { UnionToIntersection } from './utils/types'
-import { getQueryStringFromURL, getQueryParam, getQueryParams } from './utils/url'
+import { getQueryParam, getQueryParams } from './utils/url'
 
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   raw: Request
@@ -57,19 +57,13 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   query(key: string): string | undefined
   query(): Record<string, string>
   query(key?: string) {
-    const queryString = getQueryStringFromURL(this.url)
-    const result = getQueryParam(queryString, key)
-    if (result === null) return undefined
-    return result
+    return getQueryParam(this.url, key)
   }
 
   queries(key: string): string[] | undefined
   queries(): Record<string, string[]>
   queries(key?: string) {
-    const queryString = getQueryStringFromURL(this.url)
-    const result = getQueryParams(queryString, key)
-    if (result === null) return undefined
-    return result
+    return getQueryParams(this.url, key)
   }
 
   header(name: string): string | undefined

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -31,7 +31,7 @@ describe('JWT', () => {
     const tok = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ'
     const secret = 'a-secret'
     let err: JwtTokenInvalid
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
@@ -39,7 +39,7 @@ describe('JWT', () => {
     }
     // @ts-ignore
     expect(err).toEqual(new JwtTokenInvalid(tok))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('JwtTokenNotBefore', async () => {
@@ -47,7 +47,7 @@ describe('JWT', () => {
       'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjQ2MDYzMzQsImV4cCI6MTY2NDYwOTkzNCwibmJmIjoiMzEwNDYwNjI2NCJ9.hpSDT_cfkxeiLWEpWVT8TDxFP3dFi27q1K7CcMcLXHc'
     const secret = 'a-secret'
     let err: JwtTokenNotBefore
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
@@ -55,7 +55,7 @@ describe('JWT', () => {
     }
     // @ts-ignore
     expect(err).toEqual(new JwtTokenNotBefore(tok))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('JwtTokenExpired', async () => {
@@ -63,14 +63,14 @@ describe('JWT', () => {
       'eyJraWQiOiJFemF6bVZWbnd0TUpUNEFveFVtT0dILWJ0Y2VUVFM3djBYcEJuMm5ZZ2VjIiwiYWxnIjoiSFMyNTYifQ.eyJyb2xlIjoiYXBpX3JvbGUiLCJleHAiOjE2MzMwNDY0MDB9.Gmq_dozOnwzqkMUMEm7uny7cMZuF1d0QkCnmRXAbTEk'
     const secret = 'a-secret'
     let err
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
     expect(err).toEqual(new JwtTokenExpired(tok))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('JwtTokenIssuedAt', async () => {
@@ -83,14 +83,14 @@ describe('JWT', () => {
     const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
 
     let err
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
     expect(err).toEqual(new JwtTokenIssuedAt(now, iat))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('HS256 sign & verify & decode', async () => {
@@ -101,7 +101,9 @@ describe('JWT', () => {
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
     expect(tok).toEqual(expected)
 
-    expect(await JWT.verify(tok, secret, AlgorithmTypes.HS256)).toBe(true)
+    const verifiedPayload = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
+    expect(verifiedPayload).not.toBeUndefined()
+    expect(verifiedPayload).toEqual(payload)
 
     expect(JWT.decode(tok)).toEqual({
       header: {
@@ -123,13 +125,13 @@ describe('JWT', () => {
     expect(tok).toEqual(expected)
 
     let err = null
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret + 'invalid', AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
     expect(err instanceof JwtTokenSignatureMismatched).toBe(true)
   })
 
@@ -141,7 +143,9 @@ describe('JWT', () => {
       'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.RqVLgExB_GXF1-9T-k4V4HjFmiuQKTEjVSiZd-YL0WERIlywZ7PfzAuTZSJU4gg8cscGamQa030cieEWrYcywg'
     expect(tok).toEqual(expected)
 
-    expect(await JWT.verify(tok, secret, AlgorithmTypes.HS512)).toBe(true)
+    const verifiedPayload = await JWT.verify(tok, secret, AlgorithmTypes.HS512)
+    expect(verifiedPayload).not.toBeUndefined()
+    expect(verifiedPayload).toEqual(payload)
 
     expect(JWT.decode(tok)).toEqual({
       header: {
@@ -163,13 +167,13 @@ describe('JWT', () => {
     expect(tok).toEqual(expected)
 
     let err = null
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret + 'invalid', AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
     expect(err instanceof JwtTokenSignatureMismatched).toBe(true)
   })
 
@@ -182,13 +186,13 @@ describe('JWT', () => {
     expect(tok).toEqual(expected)
 
     let err = null
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret + 'invalid', AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
     expect(err instanceof JwtTokenSignatureMismatched).toBe(true)
   })
 })

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -112,7 +112,8 @@ export const verify = async (
   token: string,
   secret: string,
   alg: AlgorithmTypes = AlgorithmTypes.HS256
-): Promise<boolean> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> => {
   const tokenParts = token.split('.')
   if (tokenParts.length !== 3) {
     throw new JwtTokenInvalid(token)
@@ -137,7 +138,7 @@ export const verify = async (
     throw new JwtTokenSignatureMismatched(token)
   }
 
-  return true
+  return payload
 }
 
 // eslint-disable-next-line

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -4,7 +4,6 @@ import {
   getPattern,
   getPathFromURL,
   mergePath,
-  getQueryStringFromURL,
   checkOptionalParameter,
   getQueryParam,
   getQueryParams,
@@ -96,23 +95,6 @@ describe('url', () => {
     })
   })
 
-  describe('getQueryStringFromURL', () => {
-    it('should return strings of query params', () => {
-      let queryString = getQueryStringFromURL('https://example.com/?foo=bar')
-      expect(queryString).toBe('foo=bar')
-      queryString = getQueryStringFromURL('https://example.com/?foo=bar&foo2=bar2')
-      expect(queryString).toBe('foo=bar&foo2=bar2')
-      queryString = getQueryStringFromURL('https://example.com/')
-      expect(queryString).toBe('')
-      // This specification allows the fragments as query strings
-      queryString = getQueryStringFromURL('https://example.com/?#foo=#bar&#foo2=#bar2')
-      expect(queryString).toBe('#foo=#bar&#foo2=#bar2')
-      // This specification allows that the string includes two `?` or more
-      queryString = getQueryStringFromURL('https://example.com/?foo=bar?foo2=bar2')
-      expect(queryString).toBe('foo=bar?foo2=bar2')
-    })
-  })
-
   describe('mergePath', () => {
     it('mergePath', () => {
       expect(mergePath('/book', '/')).toBe('/book')
@@ -159,21 +141,37 @@ describe('url', () => {
 
   describe('getQueryParam', () => {
     it('Parse URL query strings', () => {
-      expect(getQueryParam('name=hey', 'name')).toBe('hey')
-      expect(getQueryParam('name=hey#fragment', 'name')).toBe('hey#fragment')
-      expect(getQueryParam('name=hey&age=20&tall=170', 'age')).toBe('20')
+      expect(getQueryParam('http://example.com/?name=hey', 'name')).toBe('hey')
+      expect(getQueryParam('http://example.com/?name=hey#fragment', 'name')).toBe('hey#fragment')
+      expect(getQueryParam('http://example.com/?name=hey&age=20&tall=170', 'age')).toBe('20')
+      expect(getQueryParam('http://example.com/?Hono+is=a+web+framework', 'Hono is')).toBe(
+        'a web framework'
+      )
       let searchParams = new URLSearchParams({ name: '炎' })
-      expect(getQueryParam(searchParams.toString(), 'name')).toBe('炎')
-      expect(getQueryParam('name=hey&age=20&tall=170', 'weight')).toBe(null)
-      expect(getQueryParam('name=hey&age=20&tall=170')).toEqual({
+      expect(getQueryParam(`http://example.com/?${searchParams.toString()}`, 'name')).toBe('炎')
+      searchParams = new URLSearchParams({ '炎 is': 'a web framework' })
+      expect(
+        getQueryParam(
+          `http://example.com/?${searchParams.toString()}`,
+          searchParams.keys().next().value
+        )
+      ).toBe('a web framework')
+      expect(getQueryParam('http://example.com/?name=hey&age=20&tall=170', 'weight')).toBe(
+        undefined
+      )
+      expect(getQueryParam('http://example.com/?name=hey&age=20&tall=170')).toEqual({
         name: 'hey',
         age: '20',
         tall: '170',
       })
-      expect(getQueryParam('pretty', 'pretty')).toBe('')
-      expect(getQueryParam('pretty', 'prtt')).toBe(null)
-      expect(getQueryParam('name=sam&name=tom', 'name')).toBe('sam')
-      expect(getQueryParam('name=sam&name=tom')).toEqual({
+      expect(getQueryParam('http://example.com/?pretty&&&&q=1%2b1=2')).toEqual({
+        pretty: '',
+        q: '1+1=2',
+      })
+      expect(getQueryParam('http://example.com/?pretty', 'pretty')).toBe('')
+      expect(getQueryParam('http://example.com/?pretty', 'prtt')).toBe(undefined)
+      expect(getQueryParam('http://example.com/?name=sam&name=tom', 'name')).toBe('sam')
+      expect(getQueryParam('http://example.com/?name=sam&name=tom')).toEqual({
         name: 'sam',
       })
       searchParams = new URLSearchParams('?name=sam=tom')
@@ -183,26 +181,53 @@ describe('url', () => {
 
   describe('getQueryParams', () => {
     it('Parse URL query strings', () => {
-      expect(getQueryParams('name=hey', 'name')).toEqual(['hey'])
-      expect(getQueryParams('name=hey#fragment', 'name')).toEqual(['hey#fragment'])
-      expect(getQueryParams('name=hey&name=foo', 'name')).toEqual(['hey', 'foo'])
-      expect(getQueryParams('name=hey&age=20&tall=170', 'age')).toEqual(['20'])
-      expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30', 'age')).toEqual([
-        '20',
-        '30',
+      expect(getQueryParams('http://example.com/?name=hey', 'name')).toEqual(['hey'])
+      expect(getQueryParams('http://example.com/?name=hey#fragment', 'name')).toEqual([
+        'hey#fragment',
       ])
-      const searchParams = new URLSearchParams()
+      expect(getQueryParams('http://example.com/?name=hey&name=foo', 'name')).toEqual([
+        'hey',
+        'foo',
+      ])
+      expect(getQueryParams('http://example.com/?name=hey&age=20&tall=170', 'age')).toEqual(['20'])
+      expect(
+        getQueryParams('http://example.com/?name=hey&age=20&tall=170&name=foo&age=30', 'age')
+      ).toEqual(['20', '30'])
+      expect(getQueryParams('http://example.com/?Hono+is=a+web+framework', 'Hono is')).toEqual([
+        'a web framework',
+      ])
+      let searchParams = new URLSearchParams()
       searchParams.append('tag', '炎')
       searchParams.append('tag', 'ほのお')
-      expect(getQueryParams(searchParams.toString(), 'tag')).toEqual(['炎', 'ほのお'])
-      expect(getQueryParams('name=hey&age=20&tall=170', 'weight')).toEqual(null)
-      expect(getQueryParams('name=hey&age=20&tall=170&name=foo&age=30&tall=180')).toEqual({
+      expect(getQueryParams(`http://example.com/?${searchParams.toString()}`, 'tag')).toEqual([
+        '炎',
+        'ほのお',
+      ])
+      searchParams = new URLSearchParams()
+      searchParams.append('炎 works on', 'Cloudflare Workers')
+      searchParams.append('炎 works on', 'Fastly Compute@Edge')
+      expect(
+        getQueryParams(
+          `http://example.com/?${searchParams.toString()}`,
+          searchParams.keys().next().value
+        )
+      ).toEqual(['Cloudflare Workers', 'Fastly Compute@Edge'])
+      expect(getQueryParams('http://example.com/?name=hey&age=20&tall=170', 'weight')).toEqual(
+        undefined
+      )
+      expect(
+        getQueryParams('http://example.com/?name=hey&age=20&tall=170&name=foo&age=30&tall=180')
+      ).toEqual({
         name: ['hey', 'foo'],
         age: ['20', '30'],
         tall: ['170', '180'],
       })
-      expect(getQueryParams('pretty', 'pretty')).toEqual([''])
-      expect(getQueryParams('pretty', 'prtt')).toBe(null)
+      expect(getQueryParams('http://example.com/?pretty&&&&q=1%2b1=2&q=2%2b2=4')).toEqual({
+        pretty: [''],
+        q: ['1+1=2', '2+2=4'],
+      })
+      expect(getQueryParams('http://example.com/?pretty', 'pretty')).toEqual([''])
+      expect(getQueryParams('http://example.com/?pretty', 'prtt')).toBe(undefined)
     })
   })
 })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -81,12 +81,6 @@ export const getPathFromURL = (url: string, strict: boolean = true): string => {
   return result
 }
 
-export const getQueryStringFromURL = (url: string): string => {
-  const queryIndex = url.indexOf('?', 8)
-  const result = queryIndex !== -1 ? url.slice(queryIndex + 1) : ''
-  return result
-}
-
 export const mergePath = (...paths: string[]): string => {
   let p: string = ''
   let endsWithSlash = false
@@ -134,57 +128,104 @@ export const checkOptionalParameter = (path: string): string[] | null => {
 }
 
 // Optimized
-export const getQueryParam = (
-  queryString: string,
-  key?: string
-): string | null | Record<string, string> => {
-  const results: Record<string, string> = {}
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const andIndex = queryString.indexOf('&')
-    let strings = ''
-    if (andIndex === -1) {
-      strings = queryString
-    } else {
-      strings = queryString.substring(0, andIndex)
-    }
-
-    const eqIndex = strings.indexOf('=')
-    if (eqIndex !== -1) {
-      const v = strings.substring(eqIndex + 1)
-      const k = strings.substring(0, eqIndex)
-      if (key === k) {
-        return /\%/.test(v) ? decodeURIComponent(v) : v
-      } else {
-        results[k] ||= v
-      }
-    } else if (strings === key) {
-      return ''
-    }
-
-    if (andIndex === -1) break
-    queryString = queryString.substring(andIndex + 1, queryString.length)
+const _decodeURI = (value: string) => {
+  if (!/[%+]/.test(value)) {
+    return value
   }
-
-  if (key) return null
-  return results
+  if (value.includes('+')) {
+    value = value.replace(/\+/g, ' ')
+  }
+  return value.includes('%') ? decodeURIComponent(value) : value
 }
 
-export const getQueryParams = (
-  queryString: string,
-  key?: string
-): string[] | null | Record<string, string[]> => {
-  const results: Record<string, string[]> = {}
+const _getQueryParam = (
+  url: string,
+  key?: string,
+  multiple?: boolean
+): string | undefined | Record<string, string> | string[] | Record<string, string[]> => {
+  let encoded
 
-  for (const strings of queryString.split('&')) {
-    let [k, v] = strings.split('=')
-    if (v === undefined) v = ''
-    results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
+  if (!multiple && key && !/[%+]/.test(key)) {
+    // optimized for unencoded key
+
+    let keyIndex = url.indexOf(`?${key}`, 8)
+    if (keyIndex === -1) {
+      keyIndex = url.indexOf(`&${key}`, 8)
+    }
+    while (keyIndex !== -1) {
+      const trailingKeyCode = url.charCodeAt(keyIndex + key.length + 1)
+      if (trailingKeyCode === 61) {
+        const valueIndex = keyIndex + key.length + 2
+        const endIndex = url.indexOf('&', valueIndex)
+        return _decodeURI(url.slice(valueIndex, endIndex === -1 ? undefined : endIndex))
+      } else if (trailingKeyCode == 38 || isNaN(trailingKeyCode)) {
+        return ''
+      }
+      keyIndex = url.indexOf(`&${key}`, keyIndex)
+    }
+
+    encoded = /[%+]/.test(url)
+    if (!encoded) {
+      return undefined
+    }
+    // fallback to default routine
   }
 
-  if (key) return results[key] ? results[key] : null
+  const results: Record<string, string> | Record<string, string[]> = {}
+  encoded ??= /[%+]/.test(url)
 
-  return results
+  let keyIndex = url.indexOf('?', 8)
+  while (keyIndex !== -1) {
+    const nextKeyIndex = url.indexOf('&', keyIndex + 1)
+    let valueIndex = url.indexOf('=', keyIndex)
+    if (valueIndex > nextKeyIndex && nextKeyIndex !== -1) {
+      valueIndex = -1
+    }
+    let name = url.slice(
+      keyIndex + 1,
+      valueIndex === -1 ? (nextKeyIndex === -1 ? undefined : nextKeyIndex) : valueIndex
+    )
+    if (encoded) {
+      name = _decodeURI(name)
+    }
+
+    keyIndex = nextKeyIndex
+
+    if (name === '') {
+      continue
+    }
+
+    let value
+    if (valueIndex === -1) {
+      value = ''
+    } else {
+      value = url.slice(valueIndex + 1, nextKeyIndex === -1 ? undefined : nextKeyIndex)
+      if (encoded) {
+        value = _decodeURI(value)
+      }
+    }
+
+    if (multiple) {
+      ;((results[name] ??= []) as string[]).push(value)
+    } else {
+      results[name] ??= value
+    }
+  }
+
+  return key ? results[key] : results
+}
+
+export const getQueryParam: (
+  url: string,
+  key?: string
+) => string | undefined | Record<string, string> = _getQueryParam as (
+  url: string,
+  key?: string
+) => string | undefined | Record<string, string>
+
+export const getQueryParams = (
+  url: string,
+  key?: string
+): string[] | undefined | Record<string, string[]> => {
+  return _getQueryParam(url, key, true) as string[] | undefined | Record<string, string[]>
 }


### PR DESCRIPTION
This PR will add support for getting the decoded payload from `c.get('jwtPaload')` for JWT Auth Middleware.

```ts
app.post(
  '/auth/abc',
  jwt({
    secret: 'a-secret',
  }),
  (c) => {
    const payload = c.get('jwtPayload')
    //...
  }
)
```

This will resolve #810 #1005 

### Does it include breaking changes?

The `verify()` API in `utils/jwt/jwt.ts` has been changed. It will return `any` instead of `boolean`. This seems to be  a breaking change, but this function is mainly "utility" used in the Hono internal. We should release the fix, including breaking changes as major version up, but this change will not affect end users. EDIT ~~I'd like to release it as a minor version up "3.2.0".~~


EDIT:

We can release this with a patch release.

* Utilities such as `utils/url.ts` are broken and changed without notice. utilities are intended to be used internally and may be changed in patch releases. Same for `utils/jwt/jwt.ts.
* It is not a major feature addition, and we don't have to include it in the Minor or Major release.