### PR TITLE
fix(utils/url): Replace "+" in the query string with " ".

### DIFF
--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -133,6 +133,10 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   return [base === '' ? '/' : base.replace(/\/$/, ''), optional]
 }
 
+const _decodeURI = (value: string): string => {
+  return /[%+]/.test(value) ? decodeURIComponent(value.replace(/\+/g, ' ')) : value
+}
+
 // Optimized
 export const getQueryParam = (
   queryString: string,
@@ -155,7 +159,7 @@ export const getQueryParam = (
       const v = strings.substring(eqIndex + 1)
       const k = strings.substring(0, eqIndex)
       if (key === k) {
-        return /\%/.test(v) ? decodeURIComponent(v) : v
+        return _decodeURI(v)
       } else {
         results[k] ||= v
       }
@@ -181,7 +185,7 @@ export const getQueryParams = (
     let [k, v] = strings.split('=')
     if (v === undefined) v = ''
     results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
+    results[k].push(_decodeURI(v))
   }
 
   if (key) return results[key] ? results[key] : null

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -160,6 +160,7 @@ describe('url', () => {
   describe('getQueryParam', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParam('name=hey', 'name')).toBe('hey')
+      expect(getQueryParam('title=Hono+is+a+web+framework', 'title')).toBe('Hono is a web framework')
       expect(getQueryParam('name=hey#fragment', 'name')).toBe('hey#fragment')
       expect(getQueryParam('name=hey&age=20&tall=170', 'age')).toBe('20')
       let searchParams = new URLSearchParams({ name: '炎' })
@@ -184,6 +185,7 @@ describe('url', () => {
   describe('getQueryParams', () => {
     it('Parse URL query strings', () => {
       expect(getQueryParams('name=hey', 'name')).toEqual(['hey'])
+      expect(getQueryParams('title=Hono+is+a+web+framework', 'title')).toEqual(['Hono is a web framework'])
       expect(getQueryParams('name=hey#fragment', 'name')).toEqual(['hey#fragment'])
       expect(getQueryParams('name=hey&name=foo', 'name')).toEqual(['hey', 'foo'])
       expect(getQueryParams('name=hey&age=20&tall=170', 'age')).toEqual(['20'])

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -133,6 +133,10 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   return [base === '' ? '/' : base.replace(/\/$/, ''), optional]
 }
 
+const _decodeURI = (value: string): string => {
+  return /[%+]/.test(value) ? decodeURIComponent(value.replace(/\+/g, ' ')) : value
+}
+
 // Optimized
 export const getQueryParam = (
   queryString: string,
@@ -155,7 +159,7 @@ export const getQueryParam = (
       const v = strings.substring(eqIndex + 1)
       const k = strings.substring(0, eqIndex)
       if (key === k) {
-        return /\%/.test(v) ? decodeURIComponent(v) : v
+        return _decodeURI(v)
       } else {
         results[k] ||= v
       }
@@ -181,7 +185,7 @@ export const getQueryParams = (
     let [k, v] = strings.split('=')
     if (v === undefined) v = ''
     results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
+    results[k].push(_decodeURI(v))
   }
 
   if (key) return results[key] ? results[key] : null


### PR DESCRIPTION
We should replace "+" with " " for the query string.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#decoding_query_parameters_from_a_url