### PR TITLE
fix(utils/url): Fix behavior when parameters with no value specified are mixed.

### DIFF
--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -157,8 +157,7 @@ const _getQueryParam = (
       if (trailingKeyCode === 61) {
         const valueIndex = keyIndex + key.length + 2
         const endIndex = url.indexOf('&', valueIndex)
-        const value = url.slice(valueIndex, endIndex === -1 ? undefined : endIndex)
-        return _decodeURI(value)
+        return _decodeURI(url.slice(valueIndex, endIndex === -1 ? undefined : endIndex))
       } else if (trailingKeyCode == 38 || isNaN(trailingKeyCode)) {
         return ''
       }
@@ -177,19 +176,30 @@ const _getQueryParam = (
 
   let keyIndex = url.indexOf('?', 8)
   while (keyIndex !== -1) {
-    const valueIndex = url.indexOf('=', keyIndex)
-    let name = url.slice(keyIndex + 1, valueIndex === -1 ? undefined : valueIndex)
+    const nextKeyIndex = url.indexOf('&', keyIndex + 1)
+    let valueIndex = url.indexOf('=', keyIndex)
+    if (valueIndex > nextKeyIndex && nextKeyIndex !== -1) {
+      valueIndex = -1
+    }
+    let name = url.slice(
+      keyIndex + 1,
+      valueIndex === -1 ? (nextKeyIndex === -1 ? undefined : nextKeyIndex) : valueIndex
+    )
     if (encoded) {
       name = _decodeURI(name)
     }
 
+    keyIndex = nextKeyIndex
+
+    if (name === '') {
+      continue
+    }
+
     let value
     if (valueIndex === -1) {
-      keyIndex = -1
       value = ''
     } else {
-      keyIndex = url.indexOf('&', valueIndex)
-      value = url.slice(valueIndex + 1, keyIndex === -1 ? undefined : keyIndex)
+      value = url.slice(valueIndex + 1, nextKeyIndex === -1 ? undefined : nextKeyIndex)
       if (encoded) {
         value = _decodeURI(value)
       }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -164,6 +164,10 @@ describe('url', () => {
         age: '20',
         tall: '170',
       })
+      expect(getQueryParam('http://example.com/?pretty&&&&q=1%2b1=2')).toEqual({
+        pretty: '',
+        q: '1+1=2',
+      })
       expect(getQueryParam('http://example.com/?pretty', 'pretty')).toBe('')
       expect(getQueryParam('http://example.com/?pretty', 'prtt')).toBe(undefined)
       expect(getQueryParam('http://example.com/?name=sam&name=tom', 'name')).toBe('sam')
@@ -217,6 +221,10 @@ describe('url', () => {
         name: ['hey', 'foo'],
         age: ['20', '30'],
         tall: ['170', '180'],
+      })
+      expect(getQueryParams('http://example.com/?pretty&&&&q=1%2b1=2&q=2%2b2=4')).toEqual({
+        pretty: [''],
+        q: ['1+1=2', '2+2=4'],
       })
       expect(getQueryParams('http://example.com/?pretty', 'pretty')).toEqual([''])
       expect(getQueryParams('http://example.com/?pretty', 'prtt')).toBe(undefined)

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -157,8 +157,7 @@ const _getQueryParam = (
       if (trailingKeyCode === 61) {
         const valueIndex = keyIndex + key.length + 2
         const endIndex = url.indexOf('&', valueIndex)
-        const value = url.slice(valueIndex, endIndex === -1 ? undefined : endIndex)
-        return _decodeURI(value)
+        return _decodeURI(url.slice(valueIndex, endIndex === -1 ? undefined : endIndex))
       } else if (trailingKeyCode == 38 || isNaN(trailingKeyCode)) {
         return ''
       }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -176,19 +176,30 @@ const _getQueryParam = (
 
   let keyIndex = url.indexOf('?', 8)
   while (keyIndex !== -1) {
-    const valueIndex = url.indexOf('=', keyIndex)
-    let name = url.slice(keyIndex + 1, valueIndex === -1 ? undefined : valueIndex)
+    const nextKeyIndex = url.indexOf('&', keyIndex + 1)
+    let valueIndex = url.indexOf('=', keyIndex)
+    if (valueIndex > nextKeyIndex && nextKeyIndex !== -1) {
+      valueIndex = -1
+    }
+    let name = url.slice(
+      keyIndex + 1,
+      valueIndex === -1 ? (nextKeyIndex === -1 ? undefined : nextKeyIndex) : valueIndex
+    )
     if (encoded) {
       name = _decodeURI(name)
     }
 
+    keyIndex = nextKeyIndex
+
+    if (name === '') {
+      continue
+    }
+
     let value
     if (valueIndex === -1) {
-      keyIndex = -1
       value = ''
     } else {
-      keyIndex = url.indexOf('&', valueIndex)
-      value = url.slice(valueIndex + 1, keyIndex === -1 ? undefined : keyIndex)
+      value = url.slice(valueIndex + 1, nextKeyIndex === -1 ? undefined : nextKeyIndex)
       if (encoded) {
         value = _decodeURI(value)
       }


### PR DESCRIPTION
This PR fixes #1022

There is almost no performance degradation (In particular, there is no degradation for `_getQueryParam(url, key)`.)