### PR TITLE
feat(jwt): support for getting payload from `c.get('jwtPayload')`

### DIFF
--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -2,6 +2,7 @@ import { HTTPException } from '../../http-exception.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
+import '../../context.ts'
 
 declare module '../../context.ts' {
   interface ContextVariableMap {

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -3,6 +3,13 @@ import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { AlgorithmTypes } from '../../utils/jwt/types.ts'
 
+declare module '../../context.ts' {
+  interface ContextVariableMap {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jwtPayload: any
+  }
+}
+
 export const jwt = (options: {
   secret: string
   cookie?: string
@@ -46,14 +53,14 @@ export const jwt = (options: {
       throw new HTTPException(401, { res })
     }
 
-    let authorized = false
+    let payload
     let msg = ''
     try {
-      authorized = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
+      payload = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
     } catch (e) {
       msg = `${e}`
     }
-    if (!authorized) {
+    if (!payload) {
       const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,
@@ -63,6 +70,8 @@ export const jwt = (options: {
       })
       throw new HTTPException(401, { res })
     }
+
+    ctx.set('jwtPayload', payload)
 
     await next()
   }

--- a/deno_dist/utils/jwt/jwt.ts
+++ b/deno_dist/utils/jwt/jwt.ts
@@ -112,7 +112,8 @@ export const verify = async (
   token: string,
   secret: string,
   alg: AlgorithmTypes = AlgorithmTypes.HS256
-): Promise<boolean> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> => {
   const tokenParts = token.split('.')
   if (tokenParts.length !== 3) {
     throw new JwtTokenInvalid(token)
@@ -137,7 +138,7 @@ export const verify = async (
     throw new JwtTokenSignatureMismatched(token)
   }
 
-  return true
+  return payload
 }
 
 // eslint-disable-next-line

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -155,7 +155,7 @@ export const getQueryParam = (
       const v = strings.substring(eqIndex + 1)
       const k = strings.substring(0, eqIndex)
       if (key === k) {
-        return /\%/.test(v) ? decodeURI(v) : v
+        return /\%/.test(v) ? decodeURIComponent(v) : v
       } else {
         results[k] ||= v
       }
@@ -181,7 +181,7 @@ export const getQueryParams = (
     let [k, v] = strings.split('=')
     if (v === undefined) v = ''
     results[k] ||= []
-    results[k].push(v.indexOf('%') !== -1 ? decodeURI(v) : v)
+    results[k].push(v.indexOf('%') !== -1 ? decodeURIComponent(v) : v)
   }
 
   if (key) return results[key] ? results[key] : null

--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -20,15 +20,18 @@ describe('JWT', () => {
 
     app.get('/auth/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
     app.get('/auth-unicode/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
     app.get('/nested/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
 
     it('Should not authorize', async () => {
@@ -48,7 +51,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
 
@@ -61,7 +64,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
 
@@ -112,7 +115,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
   })
@@ -131,11 +134,13 @@ describe('JWT', () => {
 
     app.get('/auth/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
     app.get('/auth-unicode/*', (c) => {
       handlerExecuted = true
-      return c.text('auth')
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
     })
 
     it('Should not authorize', async () => {
@@ -158,7 +163,7 @@ describe('JWT', () => {
       })
       const res = await app.request(req)
       expect(res).not.toBeNull()
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(res.status).toBe(200)
       expect(handlerExecuted).toBeTruthy()
     })
@@ -175,7 +180,7 @@ describe('JWT', () => {
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('auth')
+      expect(await res.json()).toEqual({ message: 'hello world' })
       expect(handlerExecuted).toBeTruthy()
     })
 

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -2,6 +2,7 @@ import { HTTPException } from '../../http-exception'
 import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
 import type { AlgorithmTypes } from '../../utils/jwt/types'
+import '../../context'
 
 declare module '../../context' {
   interface ContextVariableMap {

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -3,6 +3,13 @@ import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
 import type { AlgorithmTypes } from '../../utils/jwt/types'
 
+declare module '../../context' {
+  interface ContextVariableMap {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jwtPayload: any
+  }
+}
+
 export const jwt = (options: {
   secret: string
   cookie?: string
@@ -46,14 +53,14 @@ export const jwt = (options: {
       throw new HTTPException(401, { res })
     }
 
-    let authorized = false
+    let payload
     let msg = ''
     try {
-      authorized = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
+      payload = await Jwt.verify(token, options.secret, options.alg as AlgorithmTypes)
     } catch (e) {
       msg = `${e}`
     }
-    if (!authorized) {
+    if (!payload) {
       const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,
@@ -63,6 +70,8 @@ export const jwt = (options: {
       })
       throw new HTTPException(401, { res })
     }
+
+    ctx.set('jwtPayload', payload)
 
     await next()
   }

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -31,7 +31,7 @@ describe('JWT', () => {
     const tok = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ'
     const secret = 'a-secret'
     let err: JwtTokenInvalid
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
@@ -39,7 +39,7 @@ describe('JWT', () => {
     }
     // @ts-ignore
     expect(err).toEqual(new JwtTokenInvalid(tok))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('JwtTokenNotBefore', async () => {
@@ -47,7 +47,7 @@ describe('JWT', () => {
       'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjQ2MDYzMzQsImV4cCI6MTY2NDYwOTkzNCwibmJmIjoiMzEwNDYwNjI2NCJ9.hpSDT_cfkxeiLWEpWVT8TDxFP3dFi27q1K7CcMcLXHc'
     const secret = 'a-secret'
     let err: JwtTokenNotBefore
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
@@ -55,7 +55,7 @@ describe('JWT', () => {
     }
     // @ts-ignore
     expect(err).toEqual(new JwtTokenNotBefore(tok))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('JwtTokenExpired', async () => {
@@ -63,14 +63,14 @@ describe('JWT', () => {
       'eyJraWQiOiJFemF6bVZWbnd0TUpUNEFveFVtT0dILWJ0Y2VUVFM3djBYcEJuMm5ZZ2VjIiwiYWxnIjoiSFMyNTYifQ.eyJyb2xlIjoiYXBpX3JvbGUiLCJleHAiOjE2MzMwNDY0MDB9.Gmq_dozOnwzqkMUMEm7uny7cMZuF1d0QkCnmRXAbTEk'
     const secret = 'a-secret'
     let err
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
     expect(err).toEqual(new JwtTokenExpired(tok))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('JwtTokenIssuedAt', async () => {
@@ -83,14 +83,14 @@ describe('JWT', () => {
     const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
 
     let err
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
     expect(err).toEqual(new JwtTokenIssuedAt(now, iat))
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
   })
 
   it('HS256 sign & verify & decode', async () => {
@@ -101,7 +101,9 @@ describe('JWT', () => {
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
     expect(tok).toEqual(expected)
 
-    expect(await JWT.verify(tok, secret, AlgorithmTypes.HS256)).toBe(true)
+    const verifiedPayload = await JWT.verify(tok, secret, AlgorithmTypes.HS256)
+    expect(verifiedPayload).not.toBeUndefined()
+    expect(verifiedPayload).toEqual(payload)
 
     expect(JWT.decode(tok)).toEqual({
       header: {
@@ -123,13 +125,13 @@ describe('JWT', () => {
     expect(tok).toEqual(expected)
 
     let err = null
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret + 'invalid', AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
     expect(err instanceof JwtTokenSignatureMismatched).toBe(true)
   })
 
@@ -141,7 +143,9 @@ describe('JWT', () => {
       'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.RqVLgExB_GXF1-9T-k4V4HjFmiuQKTEjVSiZd-YL0WERIlywZ7PfzAuTZSJU4gg8cscGamQa030cieEWrYcywg'
     expect(tok).toEqual(expected)
 
-    expect(await JWT.verify(tok, secret, AlgorithmTypes.HS512)).toBe(true)
+    const verifiedPayload = await JWT.verify(tok, secret, AlgorithmTypes.HS512)
+    expect(verifiedPayload).not.toBeUndefined()
+    expect(verifiedPayload).toEqual(payload)
 
     expect(JWT.decode(tok)).toEqual({
       header: {
@@ -163,13 +167,13 @@ describe('JWT', () => {
     expect(tok).toEqual(expected)
 
     let err = null
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret + 'invalid', AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
     expect(err instanceof JwtTokenSignatureMismatched).toBe(true)
   })
 
@@ -182,13 +186,13 @@ describe('JWT', () => {
     expect(tok).toEqual(expected)
 
     let err = null
-    let authorized = false
+    let authorized
     try {
       authorized = await JWT.verify(tok, secret + 'invalid', AlgorithmTypes.HS256)
     } catch (e) {
       err = e
     }
-    expect(authorized).toBe(false)
+    expect(authorized).toBeUndefined()
     expect(err instanceof JwtTokenSignatureMismatched).toBe(true)
   })
 })

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -112,7 +112,8 @@ export const verify = async (
   token: string,
   secret: string,
   alg: AlgorithmTypes = AlgorithmTypes.HS256
-): Promise<boolean> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> => {
   const tokenParts = token.split('.')
   if (tokenParts.length !== 3) {
     throw new JwtTokenInvalid(token)
@@ -137,7 +138,7 @@ export const verify = async (
     throw new JwtTokenSignatureMismatched(token)
   }
 
-  return true
+  return payload
 }
 
 // eslint-disable-next-line


### PR DESCRIPTION
Copied from #1013.

---

This PR will add support for getting the decoded payload from `c.get('jwtPaload')` for JWT Auth Middleware.

```ts
app.post(
  '/auth/abc',
  jwt({
    secret: 'a-secret',
  }),
  (c) => {
    const payload = c.get('jwtPayload')
    //...
  }
)
```

This will resolve #810 #1005 

### Does it include breaking changes?

The `verify()` API in `utils/jwt/jwt.ts` has been changed. It will return `any` instead of `boolean`. This seems to be  a breaking change, but this function is mainly "utility" used in the Hono internal. We should release the fix, including breaking changes as major version up, but this change will not affect end users. EDIT ~~I'd like to release it as a minor version up "3.2.0".~~


EDIT:

We can release this with a patch release.

* Utilities such as `utils/url.ts` are broken and changed without notice. utilities are intended to be used internally and may be changed in patch releases. Same for `utils/jwt/jwt.ts.
* It is not a major feature addition, and we don't have to include it in the Minor or Major release.