### PR TITLE
[POC] Introduce LinearRouter

### DIFF
--- a/benchmarks/routers/package.json
+++ b/benchmarks/routers/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "bench:node": "tsx ./src/bench.mts",
-    "bench:bun": "bun run ./src/bench.mts"
+    "bench:bun": "bun run ./src/bench.mts",
+    "bench-spinup:node": "tsx ./src/bench-spinup.mts",
+    "bench-spinup:bun": "bun run ./src/bench-spinup.mts"
   },
   "license": "MIT",
   "devDependencies": {

--- a/benchmarks/routers/src/bench-spinup.mts
+++ b/benchmarks/routers/src/bench-spinup.mts
@@ -1,0 +1,108 @@
+import MedleyRouter from '@medley/router'
+import type { HTTPMethod } from 'find-my-way'
+import findMyWay from 'find-my-way'
+import KoaRouter from 'koa-tree-router'
+import { run, bench, group } from 'mitata'
+import TrekRouter from 'trek-router'
+import { LinearRouter } from '../../../src/router/linear-router/index.ts'
+import { RegExpRouter } from '../../../src/router/reg-exp-router/index.ts'
+import { TrieRouter } from '../../../src/router/trie-router/index.ts'
+import type { Route } from './tool.mts'
+import { routes } from './tool.mts'
+
+const benchRoutes: (Route & { name: string })[] = [
+  {
+    name: 'short static',
+    method: 'GET',
+    path: '/user',
+  },
+  {
+    name: 'static with same radix',
+    method: 'GET',
+    path: '/user/comments',
+  },
+  {
+    name: 'dynamic route',
+    method: 'GET',
+    path: '/user/lookup/username/hey',
+  },
+  {
+    name: 'mixed static dynamic',
+    method: 'GET',
+    path: '/event/abcd1234/comments',
+  },
+  {
+    name: 'post',
+    method: 'POST',
+    path: '/event/abcd1234/comment',
+  },
+  {
+    name: 'long static',
+    method: 'GET',
+    path: '/very/deeply/nested/route/hello/there',
+  },
+  {
+    name: 'wildcard',
+    method: 'GET',
+    path: '/static/index.html',
+  },
+]
+
+for (const benchRoute of benchRoutes) {
+  group(`${benchRoute.method} ${benchRoute.path}`, () => {
+    bench('RegExpRouter', () => {
+      const router = new RegExpRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.match(benchRoute.method, benchRoute.path)
+    })
+    bench('TrieRouter', () => {
+      const router = new TrieRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.match(benchRoute.method, benchRoute.path)
+    })
+    bench('LinearRouter', () => {
+      const router = new LinearRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.match(benchRoute.method, benchRoute.path)
+    })
+    bench('MedleyRouter', () => {
+      const router = new MedleyRouter()
+      for (const route of routes) {
+        const store = router.register(route.path)
+        store[route.method] = () => {}
+      }
+      const match = router.find(benchRoute.path)
+      match.store[benchRoute.method] // get handler
+    })
+    bench('FindMyWay', () => {
+      const router = findMyWay()
+      for (const route of routes) {
+        router.on(route.method as HTTPMethod, route.path, () => {})
+      }
+      router.find(benchRoute.method as HTTPMethod, benchRoute.path)
+    })
+    bench('KoaTreeRouter', () => {
+      const router = new KoaRouter()
+      for (const route of routes) {
+        router.on(route.method, route.path.replace('*', '*foo'), () => {})
+      }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      router.find(benchRoute.method, benchRoute.path)
+    })
+    bench('TrekRouter', () => {
+      const router = new TrekRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.find(benchRoute.method, benchRoute.path)
+    })
+  })
+}
+await run()

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -4,6 +4,7 @@ import type { ExecutionContext } from './context'
 import { HTTPException } from './http-exception'
 import type { Router } from './router'
 import { METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE, METHODS } from './router'
+import { LinearRouter } from './router/linear-router'
 import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { TrieRouter } from './router/trie-router'
@@ -63,6 +64,7 @@ export class Hono<
   BasePath extends string = ''
 > extends defineDynamicClass()<E, S, BasePath> {
   readonly router: Router<H> = new SmartRouter({
+    firstRequestRouter: new LinearRouter(),
     routers: [new RegExpRouter(), new TrieRouter()],
   })
   readonly strict: boolean = true // strict routing - default is true

--- a/src/router/linear-router/index.ts
+++ b/src/router/linear-router/index.ts
@@ -1,0 +1,1 @@
+export { LinearRouter } from './router'

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -1,0 +1,90 @@
+import { LinearRouter } from './router'
+
+describe('Basic Usage', () => {
+  const router = new LinearRouter<string>()
+
+  router.add('GET', '/hello', 'get hello')
+  router.add('POST', '/hello', 'post hello')
+  router.add('PURGE', '/hello', 'purge hello')
+
+  it('get, post hello', async () => {
+    let res = router.match('GET', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get hello'])
+
+    res = router.match('POST', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['post hello'])
+
+    res = router.match('PURGE', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['purge hello'])
+
+    res = router.match('PUT', '/hello')
+    expect(res).toBeNull()
+
+    res = router.match('GET', '/')
+    expect(res).toBeNull()
+  })
+})
+
+describe('Complex', () => {
+  let router: LinearRouter<string>
+  beforeEach(() => {
+    router = new LinearRouter<string>()
+  })
+
+  it('Named Param', async () => {
+    router.add('GET', '/entry/:id', 'get entry')
+    const res = router.match('GET', '/entry/123')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get entry'])
+    expect(res?.params['id']).toBe('123')
+  })
+
+  it('Wildcard', async () => {
+    router.add('GET', '/wild/*/card', 'get wildcard')
+    const res = router.match('GET', '/wild/xxx/card')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get wildcard'])
+  })
+
+  it('Default', async () => {
+    router.add('GET', '/api/abc', 'get api')
+    router.add('GET', '/api/*', 'fallback')
+    let res = router.match('GET', '/api/abc')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get api', 'fallback'])
+    res = router.match('GET', '/api/def')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['fallback'])
+  })
+
+  it('Regexp', async () => {
+    router.add('GET', '/post/:date{[0-9]+}/:title{[a-z]+}', 'get post')
+    let res = router.match('GET', '/post/20210101/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get post'])
+    expect(res?.params['date']).toBe('20210101')
+    expect(res?.params['title']).toBe('hello')
+    res = router.match('GET', '/post/onetwothree')
+    expect(res).toBeNull()
+    res = router.match('GET', '/post/123/123')
+    expect(res).toBeNull()
+  })
+
+  it('/*', async () => {
+    router.add('GET', '/api/*', 'auth middleware')
+    router.add('GET', '/api', 'top')
+    router.add('GET', '/api/posts', 'posts')
+    router.add('GET', '/api/*', 'fallback')
+
+    let res = router.match('GET', '/api')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['auth middleware', 'top', 'fallback'])
+
+    res = router.match('GET', '/api/posts')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['auth middleware', 'posts', 'fallback'])
+  })
+})

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { Router, Result } from '../../router'
+import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
+
+const hasStarRe = /\*/
+const hasLabelRe = /:/
+const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
+const splitByStarRe = /\*/
+export class LinearRouter<T> implements Router<T> {
+  routes: [string, string, T][] = []
+
+  add(method: string, path: string, handler: T) {
+    if (path.charCodeAt(path.length - 1) === 63) {
+      this.routes.push([method, path.slice(0, -1), handler])
+      this.routes.push([method, path.replace(/\/[^/]+$/, ''), handler])
+    } else {
+      this.routes.push([method, path, handler])
+    }
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    const handlers: T[] = []
+    const params: Record<string, string> = {}
+    ROUTES_LOOP: for (let i = 0; i < this.routes.length; i++) {
+      const [routeMethod, routePath, handler] = this.routes[i]
+      if (routeMethod !== method && routeMethod !== METHOD_NAME_ALL) {
+        continue
+      }
+      if (routePath === '*' || routePath === '/*') {
+        handlers.push(handler)
+        continue
+      }
+
+      const hasStar = hasStarRe.test(routePath)
+      const hasLabel = hasLabelRe.test(routePath)
+      if (!hasStar && !hasLabel) {
+        if (routePath === path) {
+          handlers.push(handler)
+        }
+      } else if (hasStar && !hasLabel) {
+        let parts
+        if (routePath.charCodeAt(routePath.length - 1) === 42) {
+          // ends with star
+          parts = routePath.slice(0, -2).split(splitByStarRe)
+        } else {
+          parts = routePath.split(splitByStarRe)
+        }
+
+        const lastIndex = parts.length - 1
+        for (let j = 0, pos = 0; j < parts.length; j++) {
+          const part = parts[j]
+          const index = path.indexOf(part, pos)
+          if (index !== pos) {
+            continue ROUTES_LOOP
+          }
+          pos = part.length
+          if (j !== lastIndex) {
+            const index = path.indexOf('/', pos)
+            if (index === -1) {
+              continue ROUTES_LOOP
+            }
+            pos = index
+          }
+        }
+        handlers.push(handler)
+      } else if (hasLabel && !hasStar) {
+        const localParams: Record<string, string> = {}
+        const parts = routePath.match(splitPathRe) as string[]
+        for (let j = 0, pos = 0; j < parts.length; j++) {
+          const part = parts[j]
+          if (part.charCodeAt(1) === 58) {
+            let name = part.slice(2)
+            const index = path.indexOf('/', pos + 1)
+            const value = path.slice(pos + 1, index === -1 ? undefined : index)
+            if (name.charCodeAt(name.length - 1) === 125) {
+              const index = name.indexOf('{')
+              const pattern = name.slice(index + 1, -1)
+              if (!new RegExp(pattern).test(value)) {
+                continue ROUTES_LOOP
+              }
+              name = name.slice(0, index)
+            }
+            localParams[name] = value
+            pos = index
+          } else {
+            const index = path.indexOf(part, pos)
+            if (index !== pos) {
+              continue ROUTES_LOOP
+            }
+            pos += part.length
+          }
+        }
+        Object.assign(params, localParams)
+        handlers.push(handler)
+      } else if (hasLabel && hasStar) {
+        // TODO: implement
+        throw new UnsupportedPathError()
+      }
+    }
+    return handlers.length
+      ? {
+          handlers,
+          params,
+        }
+      : null
+  }
+}

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -2,8 +2,6 @@
 import type { Router, Result } from '../../router'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
 
-const hasStarRe = /\*/
-const hasLabelRe = /:/
 const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
 const splitByStarRe = /\*/
 export class LinearRouter<T> implements Router<T> {
@@ -31,8 +29,8 @@ export class LinearRouter<T> implements Router<T> {
         continue
       }
 
-      const hasStar = hasStarRe.test(routePath)
-      const hasLabel = hasLabelRe.test(routePath)
+      const hasStar = routePath.indexOf('*') !== -1
+      const hasLabel = routePath.indexOf(':') !== -1
       if (!hasStar && !hasLabel) {
         if (routePath === path) {
           handlers.push(handler)

--- a/src/router/smart-router/router.ts
+++ b/src/router/smart-router/router.ts
@@ -3,10 +3,11 @@ import type { Router, Result } from '../../router'
 import { UnsupportedPathError } from '../../router'
 
 export class SmartRouter<T> implements Router<T> {
+  firstRequestRouter: Router<T> | undefined
   routers: Router<T>[] = []
   routes?: [string, string, T][] = []
 
-  constructor(init: Pick<SmartRouter<T>, 'routers'>) {
+  constructor(init: Pick<SmartRouter<T>, 'firstRequestRouter' | 'routers'>) {
     Object.assign(this, init)
   }
 
@@ -24,6 +25,20 @@ export class SmartRouter<T> implements Router<T> {
     }
 
     const { routers, routes } = this
+
+    if (this.firstRequestRouter) {
+      const router = this.firstRequestRouter
+      this.firstRequestRouter = undefined
+      try {
+        routes.forEach((args) => {
+          router.add(...args)
+        })
+        return router.match(method, path)
+      } catch (e) {
+        // ignore
+      }
+    }
+
     const len = routers.length
     let i = 0
     let res


### PR DESCRIPTION
This PR introduces a router that can return results faster on the first request.

### benchmark

```
% yarn bench-spinup:node
yarn run v1.22.19
$ tsx ./src/bench-spinup.mts
cpu: Apple M2 Pro
runtime: node v18.14.0 (arm64-darwin)

benchmark          time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------- -----------------------------
• GET /user
----------------------------------------------------- -----------------------------
RegExpRouter    30.87 µs/iter    (25.08 µs … 2.05 ms)     28 µs  88.54 µs 342.58 µs
TrieRouter       8.19 µs/iter    (7.5 µs … 289.96 µs)      8 µs  11.54 µs  15.04 µs
LinearRouter   929.75 ns/iter  (910.6 ns … 967.65 ns) 936.97 ns 967.65 ns 967.65 ns
MedleyRouter     2.79 µs/iter     (2.74 µs … 3.01 µs)   2.79 µs   3.01 µs   3.01 µs
FindMyWay       64.36 µs/iter  (59.25 µs … 392.92 µs)  62.75 µs 102.13 µs 163.13 µs
KoaTreeRouter    2.33 µs/iter      (2.3 µs … 2.43 µs)   2.33 µs   2.43 µs   2.43 µs
TrekRouter        4.9 µs/iter     (4.82 µs … 5.05 µs)   4.94 µs   5.05 µs   5.05 µs

summary for GET /user
  LinearRouter
   2.5x faster than KoaTreeRouter
   3x faster than MedleyRouter
   5.27x faster than TrekRouter
   8.81x faster than TrieRouter
   33.2x faster than RegExpRouter
   69.23x faster than FindMyWay

• GET /user/comments
----------------------------------------------------- -----------------------------
RegExpRouter    29.42 µs/iter    (25.13 µs … 2.23 ms)  27.04 µs  44.38 µs    333 µs
TrieRouter       8.19 µs/iter   (7.54 µs … 478.29 µs)   7.96 µs  11.79 µs  15.13 µs
LinearRouter   990.42 ns/iter   (968.97 ns … 1.03 µs) 996.34 ns   1.03 µs   1.03 µs
MedleyRouter     2.84 µs/iter     (2.78 µs … 3.06 µs)   2.86 µs   3.06 µs   3.06 µs
FindMyWay       62.76 µs/iter  (59.54 µs … 288.96 µs)  62.67 µs  79.42 µs 150.42 µs
KoaTreeRouter    2.36 µs/iter     (2.33 µs … 2.42 µs)   2.37 µs   2.42 µs   2.42 µs
TrekRouter       4.89 µs/iter     (4.85 µs … 4.97 µs)    4.9 µs   4.97 µs   4.97 µs

summary for GET /user/comments
  LinearRouter
   2.38x faster than KoaTreeRouter
   2.87x faster than MedleyRouter
   4.94x faster than TrekRouter
   8.27x faster than TrieRouter
   29.7x faster than RegExpRouter
   63.37x faster than FindMyWay

• GET /user/lookup/username/hey
----------------------------------------------------- -----------------------------
RegExpRouter    29.39 µs/iter       (25.29 µs … 2 ms)  27.29 µs  43.21 µs 330.08 µs
TrieRouter       8.21 µs/iter   (7.67 µs … 146.04 µs)   8.04 µs  10.96 µs  13.21 µs
LinearRouter     1.13 µs/iter     (1.12 µs … 1.19 µs)   1.14 µs   1.19 µs   1.19 µs
MedleyRouter     2.88 µs/iter     (2.85 µs … 2.96 µs)   2.89 µs   2.96 µs   2.96 µs
FindMyWay       62.05 µs/iter  (59.58 µs … 316.17 µs)  61.25 µs  79.75 µs 146.17 µs
KoaTreeRouter    2.43 µs/iter     (2.39 µs … 2.67 µs)   2.44 µs   2.67 µs   2.67 µs
TrekRouter       5.02 µs/iter     (4.96 µs … 5.18 µs)   5.04 µs   5.18 µs   5.18 µs

summary for GET /user/lookup/username/hey
  LinearRouter
   2.15x faster than KoaTreeRouter
   2.54x faster than MedleyRouter
   4.43x faster than TrekRouter
   7.23x faster than TrieRouter
   25.91x faster than RegExpRouter
   54.71x faster than FindMyWay

• GET /event/abcd1234/comments
----------------------------------------------------- -----------------------------
RegExpRouter    29.28 µs/iter    (25.29 µs … 2.38 ms)  27.04 µs  42.13 µs 330.42 µs
TrieRouter       8.38 µs/iter     (8.25 µs … 8.45 µs)    8.4 µs   8.45 µs   8.45 µs
LinearRouter     1.16 µs/iter     (1.14 µs … 1.24 µs)   1.17 µs   1.24 µs   1.24 µs
MedleyRouter     2.87 µs/iter     (2.84 µs … 2.96 µs)   2.89 µs   2.96 µs   2.96 µs
FindMyWay       62.22 µs/iter  (59.46 µs … 481.71 µs)  61.25 µs  78.08 µs 159.29 µs
KoaTreeRouter    2.42 µs/iter     (2.37 µs … 2.68 µs)   2.45 µs   2.68 µs   2.68 µs
TrekRouter       4.97 µs/iter      (4.93 µs … 5.1 µs)      5 µs    5.1 µs    5.1 µs

summary for GET /event/abcd1234/comments
  LinearRouter
   2.08x faster than KoaTreeRouter
   2.47x faster than MedleyRouter
   4.28x faster than TrekRouter
   7.2x faster than TrieRouter
   25.17x faster than RegExpRouter
   53.48x faster than FindMyWay

• POST /event/abcd1234/comment
----------------------------------------------------- -----------------------------
RegExpRouter    29.26 µs/iter    (25.21 µs … 2.12 ms)  26.88 µs  40.79 µs 318.54 µs
TrieRouter       8.27 µs/iter     (8.13 µs … 8.46 µs)   8.35 µs   8.46 µs   8.46 µs
LinearRouter   378.52 ns/iter (364.51 ns … 416.77 ns) 383.04 ns 403.42 ns 416.77 ns
MedleyRouter     2.85 µs/iter     (2.84 µs … 2.88 µs)   2.86 µs   2.88 µs   2.88 µs
FindMyWay       63.16 µs/iter  (59.67 µs … 229.25 µs)  63.33 µs  81.17 µs  147.5 µs
KoaTreeRouter    2.41 µs/iter     (2.38 µs … 2.52 µs)   2.41 µs   2.52 µs   2.52 µs
TrekRouter       4.93 µs/iter      (4.9 µs … 4.96 µs)   4.94 µs   4.96 µs   4.96 µs

summary for POST /event/abcd1234/comment
  LinearRouter
   6.37x faster than KoaTreeRouter
   7.54x faster than MedleyRouter
   13.03x faster than TrekRouter
   21.85x faster than TrieRouter
   77.31x faster than RegExpRouter
   166.85x faster than FindMyWay

• GET /very/deeply/nested/route/hello/there
----------------------------------------------------- -----------------------------
RegExpRouter    29.17 µs/iter     (25.17 µs … 1.8 ms)     27 µs  42.38 µs 330.79 µs
TrieRouter       8.36 µs/iter     (8.27 µs … 8.47 µs)   8.38 µs   8.47 µs   8.47 µs
LinearRouter     1.15 µs/iter     (1.14 µs … 1.22 µs)   1.16 µs   1.22 µs   1.22 µs
MedleyRouter     2.81 µs/iter     (2.76 µs … 3.04 µs)   2.81 µs   3.04 µs   3.04 µs
FindMyWay       62.38 µs/iter  (59.46 µs … 273.33 µs)  61.29 µs  80.29 µs 158.29 µs
KoaTreeRouter    2.42 µs/iter     (2.35 µs … 2.45 µs)   2.43 µs   2.45 µs   2.45 µs
TrekRouter       4.88 µs/iter     (4.84 µs … 4.92 µs)    4.9 µs   4.92 µs   4.92 µs

summary for GET /very/deeply/nested/route/hello/there
  LinearRouter
   2.1x faster than KoaTreeRouter
   2.44x faster than MedleyRouter
   4.23x faster than TrekRouter
   7.25x faster than TrieRouter
   25.27x faster than RegExpRouter
   54.05x faster than FindMyWay

• GET /static/index.html
----------------------------------------------------- -----------------------------
RegExpRouter    29.39 µs/iter    (25.13 µs … 2.33 ms)  26.96 µs  44.88 µs 330.25 µs
TrieRouter       8.28 µs/iter     (8.17 µs … 8.43 µs)   8.31 µs   8.43 µs   8.43 µs
LinearRouter   992.22 ns/iter   (960.64 ns … 1.03 µs) 997.72 ns   1.03 µs   1.03 µs
MedleyRouter     2.86 µs/iter     (2.81 µs … 3.11 µs)   2.87 µs   3.11 µs   3.11 µs
FindMyWay       62.54 µs/iter  (59.63 µs … 216.25 µs)  61.42 µs  80.58 µs 145.96 µs
KoaTreeRouter    2.48 µs/iter     (2.42 µs … 2.53 µs)   2.51 µs   2.53 µs   2.53 µs
TrekRouter       5.05 µs/iter     (4.95 µs … 5.15 µs)    5.1 µs   5.15 µs   5.15 µs

summary for GET /static/index.html
  LinearRouter
   2.5x faster than KoaTreeRouter
   2.88x faster than MedleyRouter
   5.09x faster than TrekRouter
   8.35x faster than TrieRouter
   29.62x faster than RegExpRouter
   63.03x faster than FindMyWay
✨  Done in 38.02s.
```

```
% yarn bench-spinup:bun
yarn run v1.22.19
$ bun run ./src/bench-spinup.mts
cpu: Apple M2 Pro
runtime: bun 0.5.8 (arm64-darwin)

benchmark          time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------- -----------------------------
• GET /user
----------------------------------------------------- -----------------------------
RegExpRouter    31.55 µs/iter     (25.46 µs … 3.4 ms)  31.33 µs  50.75 µs  62.71 µs
TrieRouter       7.76 µs/iter   (6.33 µs … 628.67 µs)   7.46 µs  14.08 µs  16.46 µs
LinearRouter     1.32 µs/iter      (1.24 µs … 1.6 µs)   1.33 µs    1.6 µs    1.6 µs
MedleyRouter     4.07 µs/iter      (3.9 µs … 4.51 µs)   4.09 µs   4.51 µs   4.51 µs
FindMyWay          58 µs/iter    (42.79 µs … 1.74 ms)  58.21 µs  77.54 µs  86.08 µs
KoaTreeRouter    3.29 µs/iter     (3.14 µs … 3.54 µs)   3.33 µs   3.54 µs   3.54 µs
TrekRouter        5.2 µs/iter     (5.07 µs … 5.38 µs)   5.24 µs   5.38 µs   5.38 µs

summary for GET /user
  LinearRouter
   2.5x faster than KoaTreeRouter
   3.08x faster than MedleyRouter
   3.94x faster than TrekRouter
   5.88x faster than TrieRouter
   23.91x faster than RegExpRouter
   43.96x faster than FindMyWay

• GET /user/comments
----------------------------------------------------- -----------------------------
RegExpRouter    33.23 µs/iter     (25.71 µs … 727 µs)  33.67 µs  49.79 µs  61.17 µs
TrieRouter          8 µs/iter     (7.87 µs … 8.13 µs)   8.06 µs   8.13 µs   8.13 µs
LinearRouter     1.39 µs/iter     (1.32 µs … 1.53 µs)   1.42 µs   1.53 µs   1.53 µs
MedleyRouter      4.1 µs/iter      (3.98 µs … 4.2 µs)   4.13 µs    4.2 µs    4.2 µs
FindMyWay       57.99 µs/iter    (43.83 µs … 1.73 ms)  57.75 µs  75.04 µs  79.42 µs
KoaTreeRouter    3.47 µs/iter     (3.29 µs … 3.57 µs)   3.53 µs   3.57 µs   3.57 µs
TrekRouter        5.4 µs/iter     (5.31 µs … 5.48 µs)   5.42 µs   5.48 µs   5.48 µs

summary for GET /user/comments
  LinearRouter
   2.49x faster than KoaTreeRouter
   2.95x faster than MedleyRouter
   3.88x faster than TrekRouter
   5.74x faster than TrieRouter
   23.86x faster than RegExpRouter
   41.65x faster than FindMyWay

• GET /user/lookup/username/hey
----------------------------------------------------- -----------------------------
RegExpRouter    33.15 µs/iter  (26.21 µs … 571.08 µs)  33.58 µs  49.04 µs  60.25 µs
TrieRouter       8.48 µs/iter     (8.35 µs … 8.57 µs)   8.53 µs   8.57 µs   8.57 µs
LinearRouter     1.72 µs/iter     (1.63 µs … 1.99 µs)   1.73 µs   1.99 µs   1.99 µs
MedleyRouter      4.3 µs/iter      (4.17 µs … 4.4 µs)   4.33 µs    4.4 µs    4.4 µs
FindMyWay       61.07 µs/iter        (45.5 µs … 2 ms)  60.63 µs  77.71 µs  84.71 µs
KoaTreeRouter    3.65 µs/iter     (3.51 µs … 3.78 µs)   3.68 µs   3.78 µs   3.78 µs
TrekRouter       5.62 µs/iter      (5.49 µs … 5.7 µs)   5.66 µs    5.7 µs    5.7 µs

summary for GET /user/lookup/username/hey
  LinearRouter
   2.13x faster than KoaTreeRouter
   2.5x faster than MedleyRouter
   3.27x faster than TrekRouter
   4.94x faster than TrieRouter
   19.3x faster than RegExpRouter
   35.56x faster than FindMyWay

• GET /event/abcd1234/comments
----------------------------------------------------- -----------------------------
RegExpRouter    33.54 µs/iter  (26.17 µs … 669.08 µs)  33.79 µs  49.46 µs  59.63 µs
TrieRouter       8.57 µs/iter      (8.33 µs … 8.7 µs)   8.62 µs    8.7 µs    8.7 µs
LinearRouter     1.71 µs/iter     (1.59 µs … 1.87 µs)   1.76 µs   1.87 µs   1.87 µs
MedleyRouter     4.33 µs/iter      (4.2 µs … 4.56 µs)   4.34 µs   4.56 µs   4.56 µs
FindMyWay       60.84 µs/iter     (44.5 µs … 1.78 ms)  60.63 µs  78.38 µs  87.33 µs
KoaTreeRouter    3.54 µs/iter     (3.42 µs … 3.68 µs)   3.59 µs   3.68 µs   3.68 µs
TrekRouter       5.66 µs/iter     (5.53 µs … 5.85 µs)   5.72 µs   5.85 µs   5.85 µs

summary for GET /event/abcd1234/comments
  LinearRouter
   2.06x faster than KoaTreeRouter
   2.53x faster than MedleyRouter
   3.31x faster than TrekRouter
   5x faster than TrieRouter
   19.58x faster than RegExpRouter
   35.53x faster than FindMyWay

• POST /event/abcd1234/comment
----------------------------------------------------- -----------------------------
RegExpRouter    33.54 µs/iter  (26.17 µs … 625.88 µs)  33.83 µs   48.5 µs  55.79 µs
TrieRouter       8.67 µs/iter      (8.5 µs … 9.03 µs)   8.68 µs   9.03 µs   9.03 µs
LinearRouter   568.46 ns/iter  (507.97 ns … 651.4 ns) 589.97 ns  651.4 ns  651.4 ns
MedleyRouter     4.33 µs/iter     (4.24 µs … 4.46 µs)   4.36 µs   4.46 µs   4.46 µs
FindMyWay          59 µs/iter    (44.58 µs … 2.08 ms)   58.5 µs   75.5 µs  82.21 µs
KoaTreeRouter    3.57 µs/iter      (3.41 µs … 3.7 µs)    3.6 µs    3.7 µs    3.7 µs
TrekRouter       5.68 µs/iter      (5.53 µs … 5.8 µs)   5.75 µs    5.8 µs    5.8 µs

summary for POST /event/abcd1234/comment
  LinearRouter
   6.27x faster than KoaTreeRouter
   7.62x faster than MedleyRouter
   10x faster than TrekRouter
   15.25x faster than TrieRouter
   59.01x faster than RegExpRouter
   103.8x faster than FindMyWay

• GET /very/deeply/nested/route/hello/there
----------------------------------------------------- -----------------------------
RegExpRouter    34.03 µs/iter  (26.04 µs … 635.92 µs)   34.5 µs  49.58 µs  60.63 µs
TrieRouter       8.89 µs/iter     (8.79 µs … 9.09 µs)   8.93 µs   9.09 µs   9.09 µs
LinearRouter     1.49 µs/iter      (1.41 µs … 1.6 µs)   1.51 µs    1.6 µs    1.6 µs
MedleyRouter      4.3 µs/iter      (4.2 µs … 4.39 µs)   4.33 µs   4.39 µs   4.39 µs
FindMyWay       61.38 µs/iter    (45.67 µs … 1.61 ms)  60.96 µs  77.71 µs  84.58 µs
KoaTreeRouter     3.6 µs/iter     (3.51 µs … 3.74 µs)   3.63 µs   3.74 µs   3.74 µs
TrekRouter       5.62 µs/iter     (5.46 µs … 5.76 µs)   5.68 µs   5.76 µs   5.76 µs

summary for GET /very/deeply/nested/route/hello/there
  LinearRouter
   2.42x faster than KoaTreeRouter
   2.89x faster than MedleyRouter
   3.78x faster than TrekRouter
   5.98x faster than TrieRouter
   22.9x faster than RegExpRouter
   41.29x faster than FindMyWay

• GET /static/index.html
----------------------------------------------------- -----------------------------
RegExpRouter    34.18 µs/iter  (26.29 µs … 618.88 µs)  34.63 µs  50.58 µs  59.79 µs
TrieRouter        8.7 µs/iter     (8.51 µs … 8.94 µs)   8.74 µs   8.94 µs   8.94 µs
LinearRouter     1.45 µs/iter     (1.36 µs … 1.63 µs)   1.46 µs   1.63 µs   1.63 µs
MedleyRouter      4.4 µs/iter     (4.29 µs … 4.46 µs)   4.44 µs   4.46 µs   4.46 µs
FindMyWay       60.44 µs/iter       (44 µs … 1.97 ms)   60.5 µs  78.96 µs   84.5 µs
KoaTreeRouter    3.76 µs/iter     (3.62 µs … 3.94 µs)   3.79 µs   3.94 µs   3.94 µs
TrekRouter       5.86 µs/iter     (5.76 µs … 5.92 µs)   5.89 µs   5.92 µs   5.92 µs

summary for GET /static/index.html
  LinearRouter
   2.59x faster than KoaTreeRouter
   3.02x faster than MedleyRouter
   4.03x faster than TrekRouter
   5.98x faster than TrieRouter
   23.5x faster than RegExpRouter
   41.55x faster than FindMyWay
✨  Done in 41.42s.
```

### If we are ok with the increased bundle size

I think that by incorporating it into SmartRouter, as shown in ee5b26d12badc66b5a6e46aa8c0b74eb7d1b94a4, we can make hono's default router a fast router for one-shot requests and for repeated requests.