### PR TITLE
feat: Introduce LinearRouter.

### DIFF
--- a/benchmarks/routers/package.json
+++ b/benchmarks/routers/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "bench:node": "tsx ./src/bench.mts",
-    "bench:bun": "bun run ./src/bench.mts"
+    "bench:bun": "bun run ./src/bench.mts",
+    "bench-includes-init:node": "tsx ./src/bench-includes-init.mts",
+    "bench-includes-init:bun": "bun run ./src/bench-includes-init.mts"
   },
   "license": "MIT",
   "devDependencies": {

--- a/benchmarks/routers/src/bench-includes-init.mts
+++ b/benchmarks/routers/src/bench-includes-init.mts
@@ -1,0 +1,108 @@
+import MedleyRouter from '@medley/router'
+import type { HTTPMethod } from 'find-my-way'
+import findMyWay from 'find-my-way'
+import KoaRouter from 'koa-tree-router'
+import { run, bench, group } from 'mitata'
+import TrekRouter from 'trek-router'
+import { LinearRouter } from '../../../src/router/linear-router/index.ts'
+import { RegExpRouter } from '../../../src/router/reg-exp-router/index.ts'
+import { TrieRouter } from '../../../src/router/trie-router/index.ts'
+import type { Route } from './tool.mts'
+import { routes } from './tool.mts'
+
+const benchRoutes: (Route & { name: string })[] = [
+  {
+    name: 'short static',
+    method: 'GET',
+    path: '/user',
+  },
+  {
+    name: 'static with same radix',
+    method: 'GET',
+    path: '/user/comments',
+  },
+  {
+    name: 'dynamic route',
+    method: 'GET',
+    path: '/user/lookup/username/hey',
+  },
+  {
+    name: 'mixed static dynamic',
+    method: 'GET',
+    path: '/event/abcd1234/comments',
+  },
+  {
+    name: 'post',
+    method: 'POST',
+    path: '/event/abcd1234/comment',
+  },
+  {
+    name: 'long static',
+    method: 'GET',
+    path: '/very/deeply/nested/route/hello/there',
+  },
+  {
+    name: 'wildcard',
+    method: 'GET',
+    path: '/static/index.html',
+  },
+]
+
+for (const benchRoute of benchRoutes) {
+  group(`${benchRoute.method} ${benchRoute.path}`, () => {
+    bench('RegExpRouter', () => {
+      const router = new RegExpRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.match(benchRoute.method, benchRoute.path)
+    })
+    bench('TrieRouter', () => {
+      const router = new TrieRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.match(benchRoute.method, benchRoute.path)
+    })
+    bench('LinearRouter', () => {
+      const router = new LinearRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.match(benchRoute.method, benchRoute.path)
+    })
+    bench('MedleyRouter', () => {
+      const router = new MedleyRouter()
+      for (const route of routes) {
+        const store = router.register(route.path)
+        store[route.method] = () => {}
+      }
+      const match = router.find(benchRoute.path)
+      match.store[benchRoute.method] // get handler
+    })
+    bench('FindMyWay', () => {
+      const router = findMyWay()
+      for (const route of routes) {
+        router.on(route.method as HTTPMethod, route.path, () => {})
+      }
+      router.find(benchRoute.method as HTTPMethod, benchRoute.path)
+    })
+    bench('KoaTreeRouter', () => {
+      const router = new KoaRouter()
+      for (const route of routes) {
+        router.on(route.method, route.path.replace('*', '*foo'), () => {})
+      }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      router.find(benchRoute.method, benchRoute.path)
+    })
+    bench('TrekRouter', () => {
+      const router = new TrekRouter()
+      for (const route of routes) {
+        router.add(route.method, route.path, () => {})
+      }
+      router.find(benchRoute.method, benchRoute.path)
+    })
+  })
+}
+await run()

--- a/deno_dist/router/linear-router/index.ts
+++ b/deno_dist/router/linear-router/index.ts
@@ -1,0 +1,1 @@
+export { LinearRouter } from './router.ts'

--- a/deno_dist/router/linear-router/router.ts
+++ b/deno_dist/router/linear-router/router.ts
@@ -1,0 +1,143 @@
+import type { Router, Result } from '../../router.ts'
+import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router.ts'
+
+type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] };
+
+const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
+const splitByStarRe = /\*/
+export class LinearRouter<T> implements Router<T> {
+  routes: [string, string, T][] = []
+
+  add(method: string, path: string, handler: T) {
+    if (path.charCodeAt(path.length - 1) === 63) {
+      // /path/to/:label? means /path/to/:label or /path/to
+      this.routes.push([method, path.slice(0, -1), handler])
+      this.routes.push([method, path.replace(/\/[^/]+$/, ''), handler])
+    } else {
+      this.routes.push([method, path, handler])
+    }
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    const handlers: T[] = []
+    const params: Record<string, string> = {}
+    ROUTES_LOOP: for (let i = 0; i < this.routes.length; i++) {
+      const [routeMethod, routePath, handler] = this.routes[i]
+      if (routeMethod !== method && routeMethod !== METHOD_NAME_ALL) {
+        continue
+      }
+      if (routePath === '*' || routePath === '/*') {
+        handlers.push(handler)
+        continue
+      }
+
+      const hasStar = routePath.indexOf('*') !== -1
+      const hasLabel = routePath.indexOf(':') !== -1
+      if (!hasStar && !hasLabel) {
+        if (routePath === path || routePath + '/' === path) {
+          handlers.push(handler)
+        }
+      } else if (hasStar && !hasLabel) {
+        const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
+        const parts = (endsWithStar ? routePath.slice(0, -2) : routePath).split(splitByStarRe)
+
+        const lastIndex = parts.length - 1
+        for (let j = 0, pos = 0; j < parts.length; j++) {
+          const part = parts[j]
+          const index = path.indexOf(part, pos)
+          if (index !== pos) {
+            continue ROUTES_LOOP
+          }
+          pos += part.length
+          if (j === lastIndex) {
+            if (
+              !endsWithStar &&
+              pos !== path.length &&
+              !(pos === path.length - 1 && path.charCodeAt(pos) === 47)
+            ) {
+              continue ROUTES_LOOP
+            }
+          } else {
+            const index = path.indexOf('/', pos)
+            if (index === -1) {
+              continue ROUTES_LOOP
+            }
+            pos = index
+          }
+        }
+        handlers.push(handler)
+      } else if (hasLabel && !hasStar) {
+        const localParams: Record<string, string> = {}
+        const parts = routePath.match(splitPathRe) as string[]
+
+        const lastIndex = parts.length - 1
+        for (let j = 0, pos = 0; j < parts.length; j++) {
+          if (pos === -1 || pos >= path.length) {
+            continue ROUTES_LOOP
+          }
+
+          const part = parts[j]
+          if (part.charCodeAt(1) === 58) {
+            // /:label
+            let name = part.slice(2)
+            let value
+
+            if (name.charCodeAt(name.length - 1) === 125) {
+              // :label{pattern}
+              const openBracePos = name.indexOf('{')
+              const pattern = name.slice(openBracePos + 1, -1)
+              const restPath = path.slice(pos + 1)
+              const match = new RegExp(pattern, 'd').exec(restPath) as RegExpMatchArrayWithIndices
+              if (!match || match.indices[0][0] !== 0 || match.indices[0][1] === 0) {
+                continue ROUTES_LOOP
+              }
+              name = name.slice(0, openBracePos)
+              value = restPath.slice(...match.indices[0])
+              pos += match.indices[0][1] + 1
+            } else {
+              let endValuePos = path.indexOf('/', pos + 1)
+              if (endValuePos === -1) {
+                if (pos + 1 === path.length) {
+                  continue ROUTES_LOOP
+                }
+                endValuePos = path.length
+              }
+              value = path.slice(pos + 1, endValuePos)
+              pos = endValuePos
+            }
+
+            if (
+              (params[name] && params[name] !== value) ||
+              (localParams[name] && localParams[name] !== value)
+            ) {
+              throw new Error('Duplicate param name')
+            }
+            localParams[name] = value as string
+          } else {
+            const index = path.indexOf(part, pos)
+            if (index !== pos) {
+              continue ROUTES_LOOP
+            }
+            pos += part.length
+          }
+
+          if (j === lastIndex) {
+            if (pos !== path.length && !(pos === path.length - 1 && path.charCodeAt(pos) === 47)) {
+              continue ROUTES_LOOP
+            }
+          }
+        }
+        Object.assign(params, localParams)
+        handlers.push(handler)
+      } else if (hasLabel && hasStar) {
+        throw new UnsupportedPathError()
+      }
+    }
+    return handlers.length
+      ? {
+          handlers,
+          params,
+        }
+      : null
+  }
+}

--- a/src/router/linear-router/index.ts
+++ b/src/router/linear-router/index.ts
@@ -1,0 +1,1 @@
+export { LinearRouter } from './router'

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -1,0 +1,277 @@
+import { LinearRouter } from './router'
+
+describe('Basic Usage', () => {
+  const router = new LinearRouter<string>()
+
+  router.add('GET', '/hello', 'get hello')
+  router.add('POST', '/hello', 'post hello')
+  router.add('PURGE', '/hello', 'purge hello')
+
+  it('get, post hello', async () => {
+    let res = router.match('GET', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get hello'])
+
+    res = router.match('POST', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['post hello'])
+
+    res = router.match('PURGE', '/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['purge hello'])
+
+    res = router.match('PUT', '/hello')
+    expect(res).toBeNull()
+
+    res = router.match('GET', '/')
+    expect(res).toBeNull()
+  })
+})
+
+describe('Complex', () => {
+  let router: LinearRouter<string>
+  beforeEach(() => {
+    router = new LinearRouter<string>()
+  })
+
+  it('Named Param', async () => {
+    router.add('GET', '/entry/:id', 'get entry')
+    const res = router.match('GET', '/entry/123')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get entry'])
+    expect(res?.params['id']).toBe('123')
+  })
+
+  it('Wildcard', async () => {
+    router.add('GET', '/wild/*/card', 'get wildcard')
+
+    let res = router.match('GET', '/wild/xxx/card')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get wildcard'])
+
+    res = router.match('GET', '/wild/xxx/card/yyy')
+    expect(res).toBeNull()
+  })
+
+  it('Default', async () => {
+    router.add('GET', '/api/abc', 'get api')
+    router.add('GET', '/api/*', 'fallback')
+    let res = router.match('GET', '/api/abc')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get api', 'fallback'])
+    res = router.match('GET', '/api/def')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['fallback'])
+  })
+
+  it('Regexp', async () => {
+    router.add('GET', '/post/:date{[0-9]+}/:title{[a-z]+}', 'get post')
+    let res = router.match('GET', '/post/20210101/hello')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['get post'])
+    expect(res?.params['date']).toBe('20210101')
+    expect(res?.params['title']).toBe('hello')
+    res = router.match('GET', '/post/onetwothree')
+    expect(res).toBeNull()
+    res = router.match('GET', '/post/123/123')
+    expect(res).toBeNull()
+  })
+
+  it('/*', async () => {
+    router.add('GET', '/api/*', 'auth middleware')
+    router.add('GET', '/api', 'top')
+    router.add('GET', '/api/posts', 'posts')
+    router.add('GET', '/api/*', 'fallback')
+
+    let res = router.match('GET', '/api')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['auth middleware', 'top', 'fallback'])
+
+    res = router.match('GET', '/api/posts')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['auth middleware', 'posts', 'fallback'])
+  })
+})
+
+describe('Multi match', () => {
+  const router = new LinearRouter<string>()
+
+  describe('Blog', () => {
+    router.add('ALL', '*', 'middleware a')
+    router.add('GET', '*', 'middleware b')
+    router.add('GET', '/entry', 'get entries')
+    router.add('POST', '/entry/*', 'middleware c')
+    router.add('POST', '/entry', 'post entry')
+    router.add('GET', '/entry/:id', 'get entry')
+    router.add('GET', '/entry/:id/comment/:comment_id', 'get comment')
+    it('GET /', async () => {
+      const res = router.match('GET', '/')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a', 'middleware b'])
+    })
+    it('GET /entry/123', async () => {
+      const res = router.match('GET', '/entry/123')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a', 'middleware b', 'get entry'])
+      expect(res?.params['id']).toBe('123')
+    })
+    it('GET /entry/123/comment/456', async () => {
+      const res = router.match('GET', '/entry/123/comment/456')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a', 'middleware b', 'get comment'])
+      expect(res?.params['id']).toBe('123')
+      expect(res?.params['comment_id']).toBe('456')
+    })
+    it('POST /entry', async () => {
+      const res = router.match('POST', '/entry')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a', 'middleware c', 'post entry'])
+    })
+    it('DELETE /entry', async () => {
+      const res = router.match('DELETE', '/entry')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['middleware a'])
+    })
+  })
+})
+
+describe('page', () => {
+  const router = new LinearRouter<string>()
+  router.add('GET', '/page', 'page')
+  router.add('ALL', '*', 'fallback') // or '*'
+  it('GET /page', async () => {
+    const res = router.match('GET', '/page')
+    expect(res?.handlers).toEqual(['page', 'fallback'])
+  })
+})
+
+describe('Optional route', () => {
+  const router = new LinearRouter<string>()
+  router.add('GET', '/api/animals/:type?', 'animals')
+  it('GET /api/animals/dog', async () => {
+    const res = router.match('GET', '/api/animals/dog')
+    expect(res?.handlers).toEqual(['animals'])
+    expect(res?.params['type']).toBe('dog')
+  })
+  it('GET /api/animals', async () => {
+    const res = router.match('GET', '/api/animals')
+    expect(res?.handlers).toEqual(['animals'])
+    expect(res?.params['type']).toBeUndefined()
+  })
+})
+
+describe('Trailing slash', () => {
+  const router = new LinearRouter<string>()
+  router.add('GET', '/book', 'GET /book')
+  router.add('GET', '/book/:id', 'GET /book/:id')
+  it('GET /book', () => {
+    const res = router.match('GET', '/book')
+    expect(res?.handlers).toEqual(['GET /book'])
+  })
+  it('GET /book/', () => {
+    const res = router.match('GET', '/book/')
+    expect(res?.handlers).toEqual(['GET /book'])
+  })
+})
+
+describe('Same path', () => {
+  const router = new LinearRouter<string>()
+  router.add('GET', '/hey', 'Middleware A')
+  router.add('GET', '/hey', 'Middleware B')
+  it('GET /hey', () => {
+    const res = router.match('GET', '/hey')
+    expect(res?.handlers).toEqual(['Middleware A', 'Middleware B'])
+  })
+})
+
+describe('Including slashes', () => {
+  const router = new LinearRouter<string>()
+  router.add('GET', '/js/:filename{[a-z0-9/]+.js}', 'any file')
+  router.add('GET', '/js/main.js', 'main.js')
+
+  it('GET /js/main.js', () => {
+    const res = router.match('GET', '/js/main.js')
+    expect(res?.handlers).toEqual(['any file', 'main.js'])
+    expect(res?.params).toEqual({ filename: 'main.js' })
+  })
+
+  it('get /js/chunk/123.js', () => {
+    const res = router.match('GET', '/js/chunk/123.js')
+    expect(res?.handlers).toEqual(['any file'])
+    expect(res?.params).toEqual({ filename: 'chunk/123.js' })
+  })
+
+  it('get /js/chunk/nest/123.js', () => {
+    const res = router.match('GET', '/js/chunk/nest/123.js')
+    expect(res?.handlers).toEqual(['any file'])
+    expect(res?.params).toEqual({ filename: 'chunk/nest/123.js' })
+  })
+})
+
+describe('REST API', () => {
+  const router = new LinearRouter<string>()
+  router.add('GET', '/users/:username{[a-z]+}', 'profile')
+  router.add('GET', '/users/:username{[a-z]+}/posts', 'posts')
+
+  it('GET /users/hono', () => {
+    const res = router.match('GET', '/users/hono')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['profile'])
+  })
+
+  it('GET /users/hono/posts', () => {
+    const res = router.match('GET', '/users/hono/posts')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['posts'])
+  })
+})
+
+describe('star', () => {
+  const router = new LinearRouter<string>()
+  router.add('get', '/', '/')
+  router.add('get', '/*', '/*')
+  router.add('get', '*', '*')
+
+  router.add('get', '/x', '/x')
+  router.add('get', '/x/*', '/x/*')
+
+  it('top', async () => {
+    const res = router.match('get', '/')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['/', '/*', '*']) // =>  failed ['*', '/*', '/']
+  })
+
+  it('Under a certain path', async () => {
+    const res = router.match('get', '/x')
+    expect(res).not.toBeNull()
+    expect(res?.handlers).toEqual(['/*', '*', '/x', '/x/*'])
+  })
+})
+
+describe('Duplicate param name', () => {
+  it('self', () => {
+    const router = new LinearRouter<string>()
+    router.add('GET', '/:id/:id', 'foo')
+    expect(() => {
+      router.match('GET', '/123/456')
+    }).toThrowError(/Duplicate param name/)
+  })
+
+  it('parent', () => {
+    const router = new LinearRouter<string>()
+    router.add('GET', '/:id/:action', 'foo')
+    router.add('GET', '/posts/:id', 'bar')
+    expect(() => {
+      router.match('GET', '/posts/get')
+    }).toThrowError(/Duplicate param name/)
+  })
+
+  it('child', () => {
+    const router = new LinearRouter<string>()
+    router.add('GET', '/posts/:id', 'foo')
+    router.add('GET', '/:id/:action', 'bar')
+    expect(() => {
+      router.match('GET', '/posts/get')
+    }).toThrowError(/Duplicate param name/)
+  })
+})

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -1,0 +1,143 @@
+import type { Router, Result } from '../../router'
+import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
+
+type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] };
+
+const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
+const splitByStarRe = /\*/
+export class LinearRouter<T> implements Router<T> {
+  routes: [string, string, T][] = []
+
+  add(method: string, path: string, handler: T) {
+    if (path.charCodeAt(path.length - 1) === 63) {
+      // /path/to/:label? means /path/to/:label or /path/to
+      this.routes.push([method, path.slice(0, -1), handler])
+      this.routes.push([method, path.replace(/\/[^/]+$/, ''), handler])
+    } else {
+      this.routes.push([method, path, handler])
+    }
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    const handlers: T[] = []
+    const params: Record<string, string> = {}
+    ROUTES_LOOP: for (let i = 0; i < this.routes.length; i++) {
+      const [routeMethod, routePath, handler] = this.routes[i]
+      if (routeMethod !== method && routeMethod !== METHOD_NAME_ALL) {
+        continue
+      }
+      if (routePath === '*' || routePath === '/*') {
+        handlers.push(handler)
+        continue
+      }
+
+      const hasStar = routePath.indexOf('*') !== -1
+      const hasLabel = routePath.indexOf(':') !== -1
+      if (!hasStar && !hasLabel) {
+        if (routePath === path || routePath + '/' === path) {
+          handlers.push(handler)
+        }
+      } else if (hasStar && !hasLabel) {
+        const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
+        const parts = (endsWithStar ? routePath.slice(0, -2) : routePath).split(splitByStarRe)
+
+        const lastIndex = parts.length - 1
+        for (let j = 0, pos = 0; j < parts.length; j++) {
+          const part = parts[j]
+          const index = path.indexOf(part, pos)
+          if (index !== pos) {
+            continue ROUTES_LOOP
+          }
+          pos += part.length
+          if (j === lastIndex) {
+            if (
+              !endsWithStar &&
+              pos !== path.length &&
+              !(pos === path.length - 1 && path.charCodeAt(pos) === 47)
+            ) {
+              continue ROUTES_LOOP
+            }
+          } else {
+            const index = path.indexOf('/', pos)
+            if (index === -1) {
+              continue ROUTES_LOOP
+            }
+            pos = index
+          }
+        }
+        handlers.push(handler)
+      } else if (hasLabel && !hasStar) {
+        const localParams: Record<string, string> = {}
+        const parts = routePath.match(splitPathRe) as string[]
+
+        const lastIndex = parts.length - 1
+        for (let j = 0, pos = 0; j < parts.length; j++) {
+          if (pos === -1 || pos >= path.length) {
+            continue ROUTES_LOOP
+          }
+
+          const part = parts[j]
+          if (part.charCodeAt(1) === 58) {
+            // /:label
+            let name = part.slice(2)
+            let value
+
+            if (name.charCodeAt(name.length - 1) === 125) {
+              // :label{pattern}
+              const openBracePos = name.indexOf('{')
+              const pattern = name.slice(openBracePos + 1, -1)
+              const restPath = path.slice(pos + 1)
+              const match = new RegExp(pattern, 'd').exec(restPath) as RegExpMatchArrayWithIndices
+              if (!match || match.indices[0][0] !== 0 || match.indices[0][1] === 0) {
+                continue ROUTES_LOOP
+              }
+              name = name.slice(0, openBracePos)
+              value = restPath.slice(...match.indices[0])
+              pos += match.indices[0][1] + 1
+            } else {
+              let endValuePos = path.indexOf('/', pos + 1)
+              if (endValuePos === -1) {
+                if (pos + 1 === path.length) {
+                  continue ROUTES_LOOP
+                }
+                endValuePos = path.length
+              }
+              value = path.slice(pos + 1, endValuePos)
+              pos = endValuePos
+            }
+
+            if (
+              (params[name] && params[name] !== value) ||
+              (localParams[name] && localParams[name] !== value)
+            ) {
+              throw new Error('Duplicate param name')
+            }
+            localParams[name] = value as string
+          } else {
+            const index = path.indexOf(part, pos)
+            if (index !== pos) {
+              continue ROUTES_LOOP
+            }
+            pos += part.length
+          }
+
+          if (j === lastIndex) {
+            if (pos !== path.length && !(pos === path.length - 1 && path.charCodeAt(pos) === 47)) {
+              continue ROUTES_LOOP
+            }
+          }
+        }
+        Object.assign(params, localParams)
+        handlers.push(handler)
+      } else if (hasLabel && hasStar) {
+        throw new UnsupportedPathError()
+      }
+    }
+    return handlers.length
+      ? {
+          handlers,
+          params,
+        }
+      : null
+  }
+}


### PR DESCRIPTION
It is slightly slower than #1041, but the bugs have been fixed, and it covers most use cases.


```
% npm run bench-includes-init:node

> bench-includes-init:node
> tsx ./src/bench-includes-init.mts

cpu: Apple M2 Pro
runtime: node v18.14.0 (arm64-darwin)

benchmark          time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------- -----------------------------
• GET /user
----------------------------------------------------- -----------------------------
RegExpRouter    30.71 µs/iter    (24.88 µs … 1.84 ms)  28.54 µs  86.63 µs 335.17 µs
TrieRouter       8.16 µs/iter    (7.5 µs … 155.54 µs)   7.88 µs   12.5 µs  16.83 µs
LinearRouter   946.25 ns/iter (932.29 ns … 985.59 ns) 950.19 ns 985.59 ns 985.59 ns
MedleyRouter      2.8 µs/iter     (2.73 µs … 2.91 µs)   2.81 µs   2.91 µs   2.91 µs
FindMyWay       63.95 µs/iter  (58.63 µs … 293.75 µs)  62.92 µs 100.92 µs 164.17 µs
KoaTreeRouter    2.35 µs/iter     (2.32 µs … 2.43 µs)   2.35 µs   2.43 µs   2.43 µs
TrekRouter       4.88 µs/iter     (4.83 µs … 5.06 µs)   4.89 µs   5.06 µs   5.06 µs

summary for GET /user
  LinearRouter
   2.48x faster than KoaTreeRouter
   2.96x faster than MedleyRouter
   5.16x faster than TrekRouter
   8.62x faster than TrieRouter
   32.45x faster than RegExpRouter
   67.59x faster than FindMyWay

• GET /user/comments
----------------------------------------------------- -----------------------------
RegExpRouter    29.26 µs/iter     (24.83 µs … 1.9 ms)  27.04 µs  41.67 µs 332.67 µs
TrieRouter        8.1 µs/iter    (7.5 µs … 136.13 µs)   7.88 µs  12.04 µs  15.17 µs
LinearRouter     1.03 µs/iter     (1.01 µs … 1.08 µs)   1.03 µs   1.08 µs   1.08 µs
MedleyRouter     2.81 µs/iter     (2.76 µs … 2.95 µs)   2.83 µs   2.95 µs   2.95 µs
FindMyWay       62.06 µs/iter  (58.67 µs … 279.13 µs)  61.25 µs  80.25 µs 147.38 µs
KoaTreeRouter    2.37 µs/iter     (2.34 µs … 2.43 µs)   2.37 µs   2.43 µs   2.43 µs
TrekRouter       4.94 µs/iter      (4.9 µs … 5.07 µs)   4.95 µs   5.07 µs   5.07 µs

summary for GET /user/comments
  LinearRouter
   2.3x faster than KoaTreeRouter
   2.73x faster than MedleyRouter
   4.8x faster than TrekRouter
   7.86x faster than TrieRouter
   28.41x faster than RegExpRouter
   60.25x faster than FindMyWay

• GET /user/lookup/username/hey
----------------------------------------------------- -----------------------------
RegExpRouter    29.24 µs/iter    (24.88 µs … 1.89 ms)  27.33 µs  39.17 µs 334.21 µs
TrieRouter       8.31 µs/iter   (7.63 µs … 239.58 µs)   8.04 µs  12.25 µs  15.58 µs
LinearRouter     1.18 µs/iter     (1.16 µs … 1.21 µs)   1.19 µs   1.21 µs   1.21 µs
MedleyRouter     2.88 µs/iter     (2.86 µs … 3.05 µs)   2.88 µs   3.05 µs   3.05 µs
FindMyWay       61.43 µs/iter  (58.71 µs … 199.67 µs)  60.63 µs  75.29 µs 150.13 µs
KoaTreeRouter    2.43 µs/iter     (2.39 µs … 2.61 µs)   2.43 µs   2.61 µs   2.61 µs
TrekRouter       5.06 µs/iter     (5.01 µs … 5.19 µs)   5.06 µs   5.19 µs   5.19 µs

summary for GET /user/lookup/username/hey
  LinearRouter
   2.06x faster than KoaTreeRouter
   2.44x faster than MedleyRouter
   4.29x faster than TrekRouter
   7.04x faster than TrieRouter
   24.78x faster than RegExpRouter
   52.06x faster than FindMyWay

• GET /event/abcd1234/comments
----------------------------------------------------- -----------------------------
RegExpRouter    29.11 µs/iter    (24.88 µs … 2.26 ms)  27.08 µs  39.54 µs 332.71 µs
TrieRouter       8.29 µs/iter   (7.67 µs … 270.25 µs)   8.04 µs  12.38 µs  16.38 µs
LinearRouter     1.21 µs/iter     (1.18 µs … 1.23 µs)   1.22 µs   1.23 µs   1.23 µs
MedleyRouter     2.88 µs/iter     (2.85 µs … 2.99 µs)   2.89 µs   2.99 µs   2.99 µs
FindMyWay       61.73 µs/iter  (58.63 µs … 239.71 µs)  60.83 µs  76.54 µs 155.38 µs
KoaTreeRouter    2.39 µs/iter     (2.35 µs … 2.48 µs)    2.4 µs   2.48 µs   2.48 µs
TrekRouter       5.03 µs/iter     (4.99 µs … 5.09 µs)   5.04 µs   5.09 µs   5.09 µs

summary for GET /event/abcd1234/comments
  LinearRouter
   1.98x faster than KoaTreeRouter
   2.38x faster than MedleyRouter
   4.16x faster than TrekRouter
   6.86x faster than TrieRouter
   24.07x faster than RegExpRouter
   51.06x faster than FindMyWay

• POST /event/abcd1234/comment
----------------------------------------------------- -----------------------------
RegExpRouter    29.39 µs/iter    (24.88 µs … 1.99 ms)  27.25 µs  40.54 µs 324.63 µs
TrieRouter       8.22 µs/iter     (8.11 µs … 8.54 µs)   8.19 µs   8.54 µs   8.54 µs
LinearRouter   393.35 ns/iter (382.09 ns … 418.51 ns) 397.38 ns  410.8 ns 418.51 ns
MedleyRouter     2.85 µs/iter     (2.81 µs … 2.91 µs)   2.85 µs   2.91 µs   2.91 µs
FindMyWay       61.63 µs/iter  (58.71 µs … 276.88 µs)  60.83 µs  74.92 µs 147.96 µs
KoaTreeRouter    2.39 µs/iter     (2.34 µs … 2.44 µs)   2.41 µs   2.44 µs   2.44 µs
TrekRouter       5.02 µs/iter     (4.95 µs … 5.17 µs)   5.04 µs   5.17 µs   5.17 µs

summary for POST /event/abcd1234/comment
  LinearRouter
   6.07x faster than KoaTreeRouter
   7.25x faster than MedleyRouter
   12.76x faster than TrekRouter
   20.89x faster than TrieRouter
   74.72x faster than RegExpRouter
   156.67x faster than FindMyWay

• GET /very/deeply/nested/route/hello/there
----------------------------------------------------- -----------------------------
RegExpRouter    28.95 µs/iter     (24.79 µs … 1.9 ms)  26.92 µs  38.96 µs 332.25 µs
TrieRouter       8.21 µs/iter     (8.15 µs … 8.39 µs)   8.18 µs   8.39 µs   8.39 µs
LinearRouter     1.19 µs/iter     (1.16 µs … 1.24 µs)    1.2 µs   1.24 µs   1.24 µs
MedleyRouter     2.79 µs/iter     (2.77 µs … 2.91 µs)   2.79 µs   2.91 µs   2.91 µs
FindMyWay       61.33 µs/iter  (58.67 µs … 311.71 µs)  60.29 µs  73.67 µs 156.92 µs
KoaTreeRouter    2.38 µs/iter     (2.34 µs … 2.47 µs)   2.39 µs   2.47 µs   2.47 µs
TrekRouter       4.92 µs/iter        (4.87 µs … 5 µs)   4.94 µs      5 µs      5 µs

summary for GET /very/deeply/nested/route/hello/there
  LinearRouter
   2x faster than KoaTreeRouter
   2.34x faster than MedleyRouter
   4.13x faster than TrekRouter
   6.9x faster than TrieRouter
   24.31x faster than RegExpRouter
   51.5x faster than FindMyWay

• GET /static/index.html
----------------------------------------------------- -----------------------------
RegExpRouter    29.22 µs/iter    (24.83 µs … 2.25 ms)  26.88 µs  42.63 µs 326.67 µs
TrieRouter       8.09 µs/iter         (8 µs … 8.2 µs)    8.1 µs    8.2 µs    8.2 µs
LinearRouter        1 µs/iter   (987.87 ns … 1.03 µs)   1.01 µs   1.03 µs   1.03 µs
MedleyRouter     2.78 µs/iter     (2.73 µs … 2.86 µs)   2.79 µs   2.86 µs   2.86 µs
FindMyWay       62.44 µs/iter  (58.88 µs … 546.79 µs)  63.33 µs  76.79 µs 150.63 µs
KoaTreeRouter    2.41 µs/iter     (2.37 µs … 2.69 µs)    2.4 µs   2.69 µs   2.69 µs
TrekRouter       5.16 µs/iter     (4.94 µs … 5.66 µs)   5.31 µs   5.66 µs   5.66 µs

summary for GET /static/index.html
  LinearRouter
   2.4x faster than KoaTreeRouter
   2.77x faster than MedleyRouter
   5.14x faster than TrekRouter
   8.06x faster than TrieRouter
   29.11x faster than RegExpRouter
   62.2x faster than FindMyWay
```

```
% npm run bench-includes-init:bun

> bench-includes-init:bun
> bun run ./src/bench-includes-init.mts

cpu: Apple M2 Pro
runtime: bun 0.5.8 (arm64-darwin)

benchmark          time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------- -----------------------------
• GET /user
----------------------------------------------------- -----------------------------
RegExpRouter    31.61 µs/iter    (25.54 µs … 1.74 ms)  31.38 µs  51.71 µs  69.83 µs
TrieRouter       7.86 µs/iter   (6.42 µs … 577.46 µs)   7.58 µs  14.04 µs  16.42 µs
LinearRouter     1.44 µs/iter     (1.28 µs … 4.31 µs)   1.38 µs   4.31 µs   4.31 µs
MedleyRouter     4.21 µs/iter     (4.07 µs … 4.58 µs)   4.23 µs   4.58 µs   4.58 µs
FindMyWay       59.52 µs/iter     (43.71 µs … 1.9 ms)  59.96 µs  79.13 µs  89.96 µs
KoaTreeRouter    3.43 µs/iter     (3.31 µs … 3.73 µs)   3.44 µs   3.73 µs   3.73 µs
TrekRouter       5.34 µs/iter     (5.23 µs … 5.47 µs)   5.38 µs   5.47 µs   5.47 µs

summary for GET /user
  LinearRouter
   2.39x faster than KoaTreeRouter
   2.93x faster than MedleyRouter
   3.72x faster than TrekRouter
   5.47x faster than TrieRouter
   22x faster than RegExpRouter
   41.42x faster than FindMyWay

• GET /user/comments
----------------------------------------------------- -----------------------------
RegExpRouter    33.39 µs/iter  (26.25 µs … 784.08 µs)  33.75 µs   48.5 µs  64.38 µs
TrieRouter       8.16 µs/iter     (8.03 µs … 8.36 µs)   8.21 µs   8.36 µs   8.36 µs
LinearRouter     1.51 µs/iter     (1.44 µs … 1.62 µs)   1.54 µs   1.62 µs   1.62 µs
MedleyRouter     4.29 µs/iter     (4.17 µs … 4.39 µs)   4.32 µs   4.39 µs   4.39 µs
FindMyWay       58.89 µs/iter    (44.46 µs … 1.92 ms)  58.88 µs  76.63 µs   82.5 µs
KoaTreeRouter    3.59 µs/iter     (3.42 µs … 3.71 µs)   3.63 µs   3.71 µs   3.71 µs
TrekRouter       5.55 µs/iter     (5.46 µs … 5.66 µs)    5.6 µs   5.66 µs   5.66 µs

summary for GET /user/comments
  LinearRouter
   2.37x faster than KoaTreeRouter
   2.83x faster than MedleyRouter
   3.67x faster than TrekRouter
   5.39x faster than TrieRouter
   22.06x faster than RegExpRouter
   38.9x faster than FindMyWay

• GET /user/lookup/username/hey
----------------------------------------------------- -----------------------------
RegExpRouter    33.52 µs/iter  (26.42 µs … 646.21 µs)     34 µs  47.96 µs  55.92 µs
TrieRouter       8.58 µs/iter     (8.28 µs … 8.83 µs)   8.65 µs   8.83 µs   8.83 µs
LinearRouter     1.82 µs/iter      (1.7 µs … 2.04 µs)   1.84 µs   2.04 µs   2.04 µs
MedleyRouter     4.44 µs/iter     (4.34 µs … 4.54 µs)   4.48 µs   4.54 µs   4.54 µs
FindMyWay       60.36 µs/iter      (45.5 µs … 1.9 ms)  59.88 µs  78.13 µs  82.92 µs
KoaTreeRouter    3.81 µs/iter     (3.73 µs … 3.87 µs)   3.84 µs   3.87 µs   3.87 µs
TrekRouter       5.84 µs/iter     (5.75 µs … 6.04 µs)   5.86 µs   6.04 µs   6.04 µs

summary for GET /user/lookup/username/hey
  LinearRouter
   2.1x faster than KoaTreeRouter
   2.45x faster than MedleyRouter
   3.21x faster than TrekRouter
   4.73x faster than TrieRouter
   18.46x faster than RegExpRouter
   33.24x faster than FindMyWay

• GET /event/abcd1234/comments
----------------------------------------------------- -----------------------------
RegExpRouter    33.66 µs/iter  (26.21 µs … 639.79 µs)  34.08 µs  48.08 µs  53.46 µs
TrieRouter       8.68 µs/iter     (8.54 µs … 8.89 µs)   8.72 µs   8.89 µs   8.89 µs
LinearRouter     1.83 µs/iter      (1.7 µs … 2.03 µs)   1.85 µs   2.03 µs   2.03 µs
MedleyRouter     4.43 µs/iter     (4.31 µs … 4.53 µs)   4.47 µs   4.53 µs   4.53 µs
FindMyWay       61.88 µs/iter    (45.38 µs … 2.12 ms)  61.88 µs  78.58 µs  84.71 µs
KoaTreeRouter    3.69 µs/iter     (3.61 µs … 3.76 µs)   3.72 µs   3.76 µs   3.76 µs
TrekRouter       5.83 µs/iter      (5.7 µs … 5.92 µs)   5.89 µs   5.92 µs   5.92 µs

summary for GET /event/abcd1234/comments
  LinearRouter
   2.02x faster than KoaTreeRouter
   2.42x faster than MedleyRouter
   3.19x faster than TrekRouter
   4.74x faster than TrieRouter
   18.38x faster than RegExpRouter
   33.78x faster than FindMyWay

• POST /event/abcd1234/comment
----------------------------------------------------- -----------------------------
RegExpRouter    34.12 µs/iter  (26.58 µs … 606.17 µs)  34.54 µs  48.13 µs  55.25 µs
TrieRouter       8.82 µs/iter     (8.62 µs … 9.24 µs)   8.83 µs   9.24 µs   9.24 µs
LinearRouter   592.78 ns/iter (539.86 ns … 665.46 ns)  617.7 ns 665.46 ns 665.46 ns
MedleyRouter      4.5 µs/iter     (4.43 µs … 4.63 µs)   4.53 µs   4.63 µs   4.63 µs
FindMyWay       61.51 µs/iter    (45.46 µs … 2.04 ms)  61.29 µs  78.75 µs   84.5 µs
KoaTreeRouter    3.68 µs/iter     (3.58 µs … 3.83 µs)   3.72 µs   3.83 µs   3.83 µs
TrekRouter       5.87 µs/iter      (5.7 µs … 6.01 µs)   5.93 µs   6.01 µs   6.01 µs

summary for POST /event/abcd1234/comment
  LinearRouter
   6.22x faster than KoaTreeRouter
   7.59x faster than MedleyRouter
   9.9x faster than TrekRouter
   14.88x faster than TrieRouter
   57.56x faster than RegExpRouter
   103.76x faster than FindMyWay

• GET /very/deeply/nested/route/hello/there
----------------------------------------------------- -----------------------------
RegExpRouter    34.25 µs/iter  (26.29 µs … 670.17 µs)  34.58 µs  49.13 µs   56.5 µs
TrieRouter       9.05 µs/iter      (8.91 µs … 9.2 µs)   9.09 µs    9.2 µs    9.2 µs
LinearRouter      1.6 µs/iter     (1.53 µs … 1.75 µs)   1.61 µs   1.75 µs   1.75 µs
MedleyRouter     4.43 µs/iter     (4.33 µs … 4.54 µs)   4.45 µs   4.54 µs   4.54 µs
FindMyWay       62.36 µs/iter    (46.25 µs … 1.69 ms)  61.79 µs  78.67 µs  87.42 µs
KoaTreeRouter    3.69 µs/iter      (3.53 µs … 3.9 µs)   3.72 µs    3.9 µs    3.9 µs
TrekRouter       5.79 µs/iter     (5.64 µs … 5.93 µs)   5.83 µs   5.93 µs   5.93 µs

summary for GET /very/deeply/nested/route/hello/there
  LinearRouter
   2.31x faster than KoaTreeRouter
   2.77x faster than MedleyRouter
   3.63x faster than TrekRouter
   5.67x faster than TrieRouter
   21.46x faster than RegExpRouter
   39.08x faster than FindMyWay

• GET /static/index.html
----------------------------------------------------- -----------------------------
RegExpRouter    34.96 µs/iter  (26.71 µs … 758.42 µs)  35.42 µs     50 µs  58.79 µs
TrieRouter       8.89 µs/iter     (8.58 µs … 9.06 µs)   8.94 µs   9.06 µs   9.06 µs
LinearRouter     1.59 µs/iter     (1.48 µs … 1.81 µs)   1.62 µs   1.81 µs   1.81 µs
MedleyRouter     4.52 µs/iter     (4.38 µs … 4.66 µs)   4.55 µs   4.66 µs   4.66 µs
FindMyWay       61.53 µs/iter    (43.75 µs … 2.12 ms)  61.71 µs  77.88 µs  84.71 µs
KoaTreeRouter    3.87 µs/iter     (3.72 µs … 3.99 µs)   3.93 µs   3.99 µs   3.99 µs
TrekRouter       6.04 µs/iter     (5.89 µs … 6.22 µs)   6.07 µs   6.22 µs   6.22 µs

summary for GET /static/index.html
  LinearRouter
   2.44x faster than KoaTreeRouter
   2.85x faster than MedleyRouter
   3.8x faster than TrekRouter
   5.6x faster than TrieRouter
   22.01x faster than RegExpRouter
   38.74x faster than FindMyWay
```