### PR TITLE
fix: check `global.fastly` instead of `require('fastly:env')`

### DIFF
--- a/deno_dist/adapter.ts
+++ b/deno_dist/adapter.ts
@@ -19,18 +19,12 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
     // @ts-ignore
     return Deno.env.toObject()
   }
-  if (c.runtime === 'fastly') {
-    let env = {}
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      const data = require('fastly:env')
-      env = data.env
-    } catch {}
-    return env as T
-  }
   if (c.runtime === 'workerd') {
     return c.env
+  }
+  if (c.runtime === 'fastly') {
+    // On Fastly Compute@Edge, you can use the ConfigStore to manage user-defined data.
+    return {} as T
   }
   return {} as T
 }

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -360,14 +360,7 @@ export class Context<
       return 'edge-light'
     }
 
-    let onFastly = false
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      const { env } = require('fastly:env')
-      if (env instanceof Function) onFastly = true
-    } catch {}
-    if (onFastly) {
+    if (global?.fastly !== undefined) {
       return 'fastly'
     }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -19,18 +19,12 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
     // @ts-ignore
     return Deno.env.toObject()
   }
-  if (c.runtime === 'fastly') {
-    let env = {}
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      const data = require('fastly:env')
-      env = data.env
-    } catch {}
-    return env as T
-  }
   if (c.runtime === 'workerd') {
     return c.env
+  }
+  if (c.runtime === 'fastly') {
+    // On Fastly Compute@Edge, you can use the ConfigStore to manage user-defined data.
+    return {} as T
   }
   return {} as T
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -360,14 +360,7 @@ export class Context<
       return 'edge-light'
     }
 
-    let onFastly = false
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      const { env } = require('fastly:env')
-      if (env instanceof Function) onFastly = true
-    } catch {}
-    if (onFastly) {
+    if (global?.fastly !== undefined) {
       return 'fastly'
     }
 

--- a/test_fastly/index.test.ts
+++ b/test_fastly/index.test.ts
@@ -1,8 +1,11 @@
 import { SHA256 } from 'crypto-js'
-import { env } from '../src/adapter'
 import { Hono } from '../src/index'
 import { basicAuth } from '../src/middleware/basic-auth'
 import { jwt } from '../src/middleware/jwt'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+globalThis.fastly = true
 
 const app = new Hono()
 


### PR DESCRIPTION
This PR fixes the method for detecting whether the code is running on Fastly Compute@Edge or not.

Previously, it used `require('fastly:env')` and checked whether it could access the variables. With this PR, it checks for `global.fastly` instead. Additionally, in `adapter.ts`, the `env` function used dynamic require, but this caused errors in environments like `webpack`, so it has been removed. We can use `ConfigStore` to manage user-defined data on Fastly.

Resolve #1052