### PR TITLE
feat: Cookie Middleware and deprecate `c.req.cookie()` / `c.cookie()`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -329,6 +329,18 @@ export class Context<
     return this.newResponse(null, status)
   }
 
+  /** @deprecated
+   * Use Cookie Middleware instead of `c.cookie()`. The `c.cookie()` will be removed in v4.
+   *
+   * @example
+   *
+   * import { setCookie } from 'hono/cookie'
+   * // ...
+   * app.get('/', (c) => {
+   *   setCookie(c, 'key', 'value')
+   *   //...
+   * })
+   */
   cookie = (name: string, value: string, opt?: CookieOptions): void => {
     const cookie = serialize(name, value, opt)
     this.header('set-cookie', cookie, { append: true })

--- a/deno_dist/middleware.ts
+++ b/deno_dist/middleware.ts
@@ -2,6 +2,7 @@
 export * from './middleware/basic-auth/index.ts'
 export * from './middleware/bearer-auth/index.ts'
 export * from './middleware/cache/index.ts'
+export * from './middleware/cookie/index.ts'
 export * from './middleware/compress/index.ts'
 export * from './middleware/cors/index.ts'
 export * from './middleware/etag/index.ts'

--- a/deno_dist/middleware/cookie/index.ts
+++ b/deno_dist/middleware/cookie/index.ts
@@ -1,0 +1,26 @@
+import type { Context } from '../../context.ts'
+import { parse, serialize } from '../../utils/cookie.ts'
+import type { CookieOptions, Cookie } from '../../utils/cookie.ts'
+
+interface GetCookie {
+  (c: Context, key: string): string | undefined
+  (c: Context): Cookie
+}
+
+export const getCookie: GetCookie = (c, key?) => {
+  const cookie = c.req.raw.headers.get('Cookie')
+  if (typeof key === 'string') {
+    if (!cookie) return undefined
+    const obj = parse(cookie)
+    return obj[key]
+  }
+  if (!cookie) return {}
+  const obj = parse(cookie)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return obj as any
+}
+
+export const setCookie = (c: Context, name: string, value: string, opt?: CookieOptions): void => {
+  const cookie = serialize(name, value, opt)
+  c.header('set-cookie', cookie, { append: true })
+}

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -79,8 +79,28 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return headerData[name.toLowerCase()]
   }
 
+  /** @deprecated
+   * Use Cookie Middleware instead of `c.req.cookie()`. The `c.req.cookie()` will be removed in v4.
+   *
+   * @example
+   *
+   * import { getCookie } from 'hono/cookie'
+   * // ...
+   * app.get('/', (c) => c.text(getCookie(c, 'cookie-name')))
+   */
   cookie(key: string): string | undefined
+
+  /** @deprecated
+   * Use Cookie Middleware instead of `c.req.cookie()`. The `c.req.cookie()` will be removed in v4.
+   *
+   * @example
+   *
+   * import { getCookie } from 'hono/cookie'
+   * // ...
+   * app.get('/', (c) => c.json(getCookie(c)))
+   */
   cookie(): Cookie
+
   cookie(key?: string) {
     const cookie = this.raw.headers.get('Cookie')
     if (!cookie) return

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
       "import": "./dist/middleware/cache/index.js",
       "require": "./dist/cjs/middleware/cache/index.js"
     },
+    "./cookie": {
+      "types": "./dist/types/middleware/cookie/index.d.ts",
+      "import": "./dist/middleware/cookie/index.js",
+      "require": "./dist/cjs/middleware/cookie/index.js"
+    },
     "./compress": {
       "types": "./dist/types/middleware/compress/index.d.ts",
       "import": "./dist/middleware/compress/index.js",
@@ -194,6 +199,9 @@
       ],
       "cache": [
         "./dist/types/middleware/cache"
+      ],
+      "cookie": [
+        "./dist/types/middleware/cookie"
       ],
       "compress": [
         "./dist/types/middleware/compress"

--- a/src/context.ts
+++ b/src/context.ts
@@ -329,6 +329,18 @@ export class Context<
     return this.newResponse(null, status)
   }
 
+  /** @deprecated
+   * Use Cookie Middleware instead of `c.cookie()`. The `c.cookie()` will be removed in v4.
+   *
+   * @example
+   *
+   * import { setCookie } from 'hono/cookie'
+   * // ...
+   * app.get('/', (c) => {
+   *   setCookie(c, 'key', 'value')
+   *   //...
+   * })
+   */
   cookie = (name: string, value: string, opt?: CookieOptions): void => {
     const cookie = serialize(name, value, opt)
     this.header('set-cookie', cookie, { append: true })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@
 export * from './middleware/basic-auth'
 export * from './middleware/bearer-auth'
 export * from './middleware/cache'
+export * from './middleware/cookie'
 export * from './middleware/compress'
 export * from './middleware/cors'
 export * from './middleware/etag'

--- a/src/middleware/cookie/index.test.ts
+++ b/src/middleware/cookie/index.test.ts
@@ -1,0 +1,102 @@
+import { Hono } from '../../hono'
+import { getCookie, setCookie } from '.'
+
+describe('Cookie Middleware', () => {
+  describe('Parse cookie', () => {
+    const apps: Record<string, Hono> = {}
+    apps['get by name'] = (() => {
+      const app = new Hono()
+
+      app.get('/cookie', (c) => {
+        const yummyCookie = getCookie(c, 'yummy_cookie')
+        const tastyCookie = getCookie(c, 'tasty_cookie')
+        const res = new Response('Good cookie')
+        if (yummyCookie && tastyCookie) {
+          res.headers.set('Yummy-Cookie', yummyCookie)
+          res.headers.set('Tasty-Cookie', tastyCookie)
+        }
+        return res
+      })
+
+      return app
+    })()
+
+    apps['get all as an object'] = (() => {
+      const app = new Hono()
+
+      app.get('/cookie', (c) => {
+        const { yummy_cookie: yummyCookie, tasty_cookie: tastyCookie } = getCookie(c)
+        const res = new Response('Good cookie')
+        res.headers.set('Yummy-Cookie', yummyCookie)
+        res.headers.set('Tasty-Cookie', tastyCookie)
+        return res
+      })
+
+      return app
+    })()
+
+    describe.each(Object.keys(apps))('%s', (name) => {
+      const app = apps[name]
+      it('Parse cookie with getCookie()', async () => {
+        const req = new Request('http://localhost/cookie')
+        const cookieString = 'yummy_cookie=choco; tasty_cookie = strawberry'
+        req.headers.set('Cookie', cookieString)
+        const res = await app.request(req)
+
+        expect(res.headers.get('Yummy-Cookie')).toBe('choco')
+        expect(res.headers.get('Tasty-Cookie')).toBe('strawberry')
+      })
+    })
+  })
+
+  describe('Set cookie', () => {
+    const app = new Hono()
+
+    app.get('/set-cookie', (c) => {
+      setCookie(c, 'delicious_cookie', 'macha')
+      return c.text('Give cookie')
+    })
+
+    it('Set cookie with setCookie()', async () => {
+      const res = await app.request('http://localhost/set-cookie')
+      expect(res.status).toBe(200)
+      const header = res.headers.get('Set-Cookie')
+      expect(header).toBe('delicious_cookie=macha')
+    })
+
+    app.get('/set-cookie-complex', (c) => {
+      setCookie(c, 'great_cookie', 'banana', {
+        path: '/',
+        secure: true,
+        domain: 'example.com',
+        httpOnly: true,
+        maxAge: 1000,
+        expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
+        sameSite: 'Strict',
+      })
+      return c.text('Give cookie')
+    })
+
+    it('Complex pattern', async () => {
+      const res = await app.request('http://localhost/set-cookie-complex')
+      expect(res.status).toBe(200)
+      const header = res.headers.get('Set-Cookie')
+      expect(header).toBe(
+        'great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict'
+      )
+    })
+
+    app.get('/set-cookie-multiple', (c) => {
+      setCookie(c, 'delicious_cookie', 'macha')
+      setCookie(c, 'delicious_cookie', 'choco')
+      return c.text('Give cookie')
+    })
+
+    it('Multiple values', async () => {
+      const res = await app.request('http://localhost/set-cookie-multiple')
+      expect(res.status).toBe(200)
+      const header = res.headers.get('Set-Cookie')
+      expect(header).toBe('delicious_cookie=macha, delicious_cookie=choco')
+    })
+  })
+})

--- a/src/middleware/cookie/index.ts
+++ b/src/middleware/cookie/index.ts
@@ -1,0 +1,26 @@
+import type { Context } from '../../context'
+import { parse, serialize } from '../../utils/cookie'
+import type { CookieOptions, Cookie } from '../../utils/cookie'
+
+interface GetCookie {
+  (c: Context, key: string): string | undefined
+  (c: Context): Cookie
+}
+
+export const getCookie: GetCookie = (c, key?) => {
+  const cookie = c.req.raw.headers.get('Cookie')
+  if (typeof key === 'string') {
+    if (!cookie) return undefined
+    const obj = parse(cookie)
+    return obj[key]
+  }
+  if (!cookie) return {}
+  const obj = parse(cookie)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return obj as any
+}
+
+export const setCookie = (c: Context, name: string, value: string, opt?: CookieOptions): void => {
+  const cookie = serialize(name, value, opt)
+  c.header('set-cookie', cookie, { append: true })
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -79,8 +79,28 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return headerData[name.toLowerCase()]
   }
 
+  /** @deprecated
+   * Use Cookie Middleware instead of `c.req.cookie()`. The `c.req.cookie()` will be removed in v4.
+   *
+   * @example
+   *
+   * import { getCookie } from 'hono/cookie'
+   * // ...
+   * app.get('/', (c) => c.text(getCookie(c, 'cookie-name')))
+   */
   cookie(key: string): string | undefined
+
+  /** @deprecated
+   * Use Cookie Middleware instead of `c.req.cookie()`. The `c.req.cookie()` will be removed in v4.
+   *
+   * @example
+   *
+   * import { getCookie } from 'hono/cookie'
+   * // ...
+   * app.get('/', (c) => c.json(getCookie(c)))
+   */
   cookie(): Cookie
+
   cookie(key?: string) {
     const cookie = this.raw.headers.get('Cookie')
     if (!cookie) return


### PR DESCRIPTION
This PR introduces the Cookie Middleware, which includes `getCookie()` and `setCookie()` methods. As a result, `c.req.cookie()` and `c.cookie()` will be deprecated.

```ts
import { getCookie, setCookie } from 'hono/cookie'

// ...

app.get('/cookie', (c) => {
  const yummyCookie = getCookie(c, 'yummy_cookie')
  // ...
  setCookie(c, 'delicious_cookie', 'macha')
  //
}
```

`c.req.cookie()` and `c.header()` will be obsolete in v4.

Related to #965 