### PR TITLE
feat(context): clear the header with `c.header(key, undefined)`

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -81,6 +81,17 @@ describe('Context', () => {
     expect(res.headers.get('content-type')).toMatch(/^text\/html/)
   })
 
+  it('c.header() - clear the header', async () => {
+    c.header('X-Foo', 'Bar')
+    c.header('X-Foo', undefined)
+    c.header('X-Foo2', 'Bar')
+    let res = c.body('Hi')
+    expect(res.headers.get('X-Foo')).toBe(null)
+    c.header('X-Foo2', undefined)
+    res = c.res
+    expect(res.headers.get('X-Foo2')).toBe(null)
+  })
+
   it('c.body() - multiple header', async () => {
     const res = c.body('Hi', 200, {
       'X-Foo': ['Bar', 'Buzz'],

--- a/src/context.ts
+++ b/src/context.ts
@@ -145,7 +145,20 @@ export class Context<
     this.finalized = true
   }
 
-  header = (name: string, value: string, options?: { append?: boolean }): void => {
+  header = (name: string, value: string | undefined, options?: { append?: boolean }): void => {
+    // Clear the header
+    if (value === undefined) {
+      if (this._headers) {
+        this._headers.delete(name)
+      } else if (this._preparedHeaders) {
+        delete this._preparedHeaders[name.toLocaleLowerCase()]
+      }
+      if (this.finalized) {
+        this.res.headers.delete(name)
+      }
+      return
+    }
+
     if (options?.append) {
       if (!this._headers) {
         this._headers = new Headers(this._preparedHeaders)


### PR DESCRIPTION
This PR allows the Context to clear a header using `c.header(key, undefined)` because previously, we didn't have a way to clear headers.