### PR TITLE
feat(app): introduce `app.bundleHandlers()`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -17,6 +17,7 @@ import type {
   TypedResponse,
   MergePath,
   MergeSchemaPath,
+  BundleHandlersInterface,
 } from './types.ts'
 import type { RemoveBlankRecord } from './utils/types.ts'
 import { getPath, getPathNoStrict, mergePath } from './utils/url.ts'
@@ -36,6 +37,8 @@ function defineDynamicClass(): {
     on: OnHandlerInterface<E, S, BasePath>
   } & {
     use: MiddlewareHandlerInterface<E, S, BasePath>
+  } & {
+    bundleHandlers: BundleHandlersInterface<E, BasePath>
   }
 } {
   return class {} as never
@@ -116,6 +119,12 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = ''> extends de
         this.addRoute(METHOD_NAME_ALL, this.path, handler)
       })
       return this
+    }
+
+    // Implementation of app.bundleHandlers(path, ...handler[])
+    this.bundleHandlers = (path: string, ...handlers: H[]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return [path, ...handlers] as any
     }
 
     const strict = init.strict ?? true

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -302,6 +302,107 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 
 ////////////////////////////////////////
 //////                            //////
+//////      Bundle Handlers       //////
+//////                            //////
+////////////////////////////////////////
+
+export interface BundleHandlersInterface<E extends Env, BasePath extends string> {
+  // app.bundleHandlers(path, handler)
+  /**
+   * @experimental
+   */
+  <P extends string = string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, P, I, O>]
+  ): [P, H<E, MergePath<BasePath, P>, I, O>]
+
+  // app.bundleHandlers(path, handler, handler)
+  /**
+   * @experimental
+   */
+  <P extends string = string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
+  ): [P, H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
+
+  // app.bundleHandlers(path, handler x 3)
+  /**
+   * @experimental
+   */
+  <
+    P extends string = string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2
+  >(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
+  ): [
+    P,
+    H<E, MergePath<BasePath, P>, I, O>,
+    H<E, MergePath<BasePath, P>, I2, O>,
+    H<E, MergePath<BasePath, P>, I3, O>
+  ]
+
+  // app.bundleHandlers(path, handler x 4)
+  /**
+   * @experimental
+   */
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
+  ): [
+    H<E, MergePath<BasePath, P>, I, O>,
+    H<E, MergePath<BasePath, P>, I2, O>,
+    H<E, MergePath<BasePath, P>, I3, O>,
+    H<E, MergePath<BasePath, P>, I4, O>
+  ]
+
+  // app.bundleHandlers(path, handler x 5)
+  /**
+   * @experimental
+   */
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
+  >(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
+  ): [
+    H<E, MergePath<BasePath, P>, I, O>,
+    H<E, MergePath<BasePath, P>, I2, O>,
+    H<E, MergePath<BasePath, P>, I3, O>,
+    H<E, MergePath<BasePath, P>, I4, O>,
+    H<E, MergePath<BasePath, P>, I5, O>
+  ]
+
+  // app.bundleHandlers(path, handler[])
+  /**
+   * @experimental
+   */
+  <P extends string = string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: H<E, P, I, O>[]
+  ): [P, ...H<E, MergePath<BasePath, P>, I, O>[]]
+}
+
+////////////////////////////////////////
+//////                            //////
 //////           Schema           //////
 //////                            //////
 ////////////////////////////////////////
@@ -336,6 +437,8 @@ export type MergePath<A extends string, B extends string> = A extends ''
   : A extends `${infer P}/`
   ? B extends `/${infer Q}`
     ? `${P}/${Q}`
+    : string extends B
+    ? string
     : `${P}/${B}`
   : B extends `/${infer Q}`
   ? Q extends ''

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -17,6 +17,7 @@ import type {
   TypedResponse,
   MergePath,
   MergeSchemaPath,
+  BundleHandlersInterface,
 } from './types'
 import type { RemoveBlankRecord } from './utils/types'
 import { getPath, getPathNoStrict, mergePath } from './utils/url'
@@ -36,6 +37,8 @@ function defineDynamicClass(): {
     on: OnHandlerInterface<E, S, BasePath>
   } & {
     use: MiddlewareHandlerInterface<E, S, BasePath>
+  } & {
+    bundleHandlers: BundleHandlersInterface<E, BasePath>
   }
 } {
   return class {} as never
@@ -116,6 +119,12 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = ''> extends de
         this.addRoute(METHOD_NAME_ALL, this.path, handler)
       })
       return this
+    }
+
+    // Implementation of app.bundleHandlers(path, ...handler[])
+    this.bundleHandlers = (path: string, ...handlers: H[]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return [path, ...handlers] as any
     }
 
     const strict = init.strict ?? true

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,6 +302,107 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 
 ////////////////////////////////////////
 //////                            //////
+//////      Bundle Handlers       //////
+//////                            //////
+////////////////////////////////////////
+
+export interface BundleHandlersInterface<E extends Env, BasePath extends string> {
+  // app.bundleHandlers(path, handler)
+  /**
+   * @experimental
+   */
+  <P extends string = string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, P, I, O>]
+  ): [P, H<E, MergePath<BasePath, P>, I, O>]
+
+  // app.bundleHandlers(path, handler, handler)
+  /**
+   * @experimental
+   */
+  <P extends string = string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
+  ): [P, H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
+
+  // app.bundleHandlers(path, handler x 3)
+  /**
+   * @experimental
+   */
+  <
+    P extends string = string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2
+  >(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
+  ): [
+    P,
+    H<E, MergePath<BasePath, P>, I, O>,
+    H<E, MergePath<BasePath, P>, I2, O>,
+    H<E, MergePath<BasePath, P>, I3, O>
+  ]
+
+  // app.bundleHandlers(path, handler x 4)
+  /**
+   * @experimental
+   */
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3
+  >(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
+  ): [
+    H<E, MergePath<BasePath, P>, I, O>,
+    H<E, MergePath<BasePath, P>, I2, O>,
+    H<E, MergePath<BasePath, P>, I3, O>,
+    H<E, MergePath<BasePath, P>, I4, O>
+  ]
+
+  // app.bundleHandlers(path, handler x 5)
+  /**
+   * @experimental
+   */
+  <
+    M extends string,
+    P extends string,
+    O = {},
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I3 & I4
+  >(
+    path: P,
+    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
+  ): [
+    H<E, MergePath<BasePath, P>, I, O>,
+    H<E, MergePath<BasePath, P>, I2, O>,
+    H<E, MergePath<BasePath, P>, I3, O>,
+    H<E, MergePath<BasePath, P>, I4, O>,
+    H<E, MergePath<BasePath, P>, I5, O>
+  ]
+
+  // app.bundleHandlers(path, handler[])
+  /**
+   * @experimental
+   */
+  <P extends string = string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: H<E, P, I, O>[]
+  ): [P, ...H<E, MergePath<BasePath, P>, I, O>[]]
+}
+
+////////////////////////////////////////
+//////                            //////
 //////           Schema           //////
 //////                            //////
 ////////////////////////////////////////
@@ -336,6 +437,8 @@ export type MergePath<A extends string, B extends string> = A extends ''
   : A extends `${infer P}/`
   ? B extends `/${infer Q}`
     ? `${P}/${Q}`
+    : string extends B
+    ? string
     : `${P}/${B}`
   : B extends `/${infer Q}`
   ? Q extends ''


### PR DESCRIPTION
This PR introduces a `bundleHandlers()` function in `hono-base.ts`. This function will **bundle a path and handlers** into `[path, ...handlers]`. The bundled handler can be used with `app.get()` and other route methods. The `bundleHandlers()` is useful for writing application code when using RPC-mode.

Without `bundleHandlers()`:

```ts
const routes = app
  .get(
    '/list',
    validator('query', () => {
      return { page: '1' }
    }),
    (c) => c.jsonT(c.req.valid('query'))
  )
  .post(
    '/create',
    validator('form', () => {
      return { title: 'Hono is cool!' }
    }),
    (c) => c.jsonT(c.req.valid('form'))
  )
```

With `bundleHandlers()`, you can write like the following:

```ts
const listHandler = app.bundleHandlers(
  '/list',
  validator('query', () => {
    return { page: '1' }
  }),
  (c) => c.jsonT(c.req.valid('query'))
)

const createHandler = app.bundleHandlers(
  '/create',
  validator('form', () => {
    return { title: 'Hono is cool!' }
  }),
  (c) => c.jsonT(c.req.valid('form'))
)

const routes = app.get(...listHandler).post(...createHandler)

//...

export type AppType = typeof routes
```

It may be more verbose, but it makes a better outlook on the code. Users can choose to use `bundleHandlers()` or chaining without it.

This is implemented as a method in `hono-base.ts`. It slightly increases the code volume, but this implementation is quite simple:

```ts
this.bundleHandlers = (path: string, ...handlers: H[]) => {
  return [path, ...handlers]
}
```

I think this API provides simplicity for users.

This will be released as "experimental" in "v3.2", and we'll gather feedback on its usage. If it proves to be effective, it will be made generally available.