### PR TITLE
feat(adapter): add `hono/vercel` / deprecate `hono/nextjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,11 @@
       "types": "./dist/types/adapter/aws-lambda/index.d.ts",
       "import": "./dist/adapter/aws-lambda/index.js",
       "require": "./dist/cjs/adapter/aws-lambda/index.js"
+    },
+    "./vercel": {
+      "types": "./dist/types/adapter/vercel/index.d.ts",
+      "import": "./dist/adapter/vercel/index.js",
+      "require": "./dist/cjs/adapter/vercel/index.js"
     }
   },
   "typesVersions": {
@@ -285,6 +290,9 @@
       ],
       "aws-lambda": [
         "./dist/types/adapter/aws-lambda"
+      ],
+      "vercel": [
+        "./dist/types/adapter/vercel"
       ]
     }
   },

--- a/src/adapter/nextjs/handler.ts
+++ b/src/adapter/nextjs/handler.ts
@@ -3,6 +3,10 @@ import { Hono } from '../../hono'
 import type { Env } from '../../types'
 
 interface HandleInterface {
+  /** @deprecated
+   * `hono/nextjs` will become obsolete in v4.
+   * Use `hono/vercel` instead.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (subApp: Hono<any, any, any>): (req: Request) => Response | Promise<Response>
   /** @deprecated

--- a/src/adapter/vercel/handler.test.ts
+++ b/src/adapter/vercel/handler.test.ts
@@ -1,0 +1,31 @@
+import { Hono } from '../../hono'
+import { handle } from './handler'
+
+describe('Adapter for Next.js', () => {
+  it('Should return 200 response', async () => {
+    const app = new Hono()
+    app.get('/api/foo', (c) => {
+      return c.text('/api/foo')
+    })
+    const handler = handle(app)
+    const req = new Request('http://localhost/api/foo')
+    const res = await handler(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('/api/foo')
+  })
+
+  it('Should not use `route()` if path argument is not passed', async () => {
+    const app = new Hono().basePath('/api')
+
+    app.onError((e) => {
+      throw e
+    })
+    app.get('/error', () => {
+      throw new Error('Custom Error')
+    })
+
+    const handler = handle(app)
+    const req = new Request('http://localhost/api/error')
+    expect(() => handler(req)).toThrowError('Custom Error')
+  })
+})

--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -1,0 +1,7 @@
+// @denoify-ignore
+import type { Hono } from '../../hono'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handle = (app: Hono<any, any, any>) => (req: Request) => {
+  return app.fetch(req)
+}

--- a/src/adapter/vercel/index.ts
+++ b/src/adapter/vercel/index.ts
@@ -1,0 +1,2 @@
+// @denoify-ignore
+export { handle } from './handler'


### PR DESCRIPTION
I realized that Hono works on Vercel, not only with Next.js. Therefore, I create `hono/vercel` and deprecate `hono/nextjs`. `hono/nextjs` will become obsolete in v4.