### PR TITLE
feat(preset): add `hono/quick`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,14 @@
       "require": "./dist/cjs/index.js"
     },
     "./tiny": {
-      "types": "./dist/types/tiny.d.ts",
-      "import": "./dist/tiny.js",
-      "require": "./dist/cjs/tiny.js"
+      "types": "./dist/types/preset/tiny.d.ts",
+      "import": "./dist/preset/tiny.js",
+      "require": "./dist/cjs/preset/tiny.js"
+    },
+    "./quick": {
+      "types": "./dist/types/preset/quick.d.ts",
+      "import": "./dist/preset/quick.js",
+      "require": "./dist/cjs/preset/quick.js"
     },
     "./http-exception": {
       "types": "./dist/types/http-exception.d.ts",
@@ -194,7 +199,10 @@
   "typesVersions": {
     "*": {
       "tiny": [
-        "./dist/types/tiny"
+        "./dist/types/preset/tiny"
+      ],
+      "quick": [
+        "./dist/types/preset/quick"
       ],
       "http-exception": [
         "./dist/types/http-exception"

--- a/src/preset/quick.ts
+++ b/src/preset/quick.ts
@@ -1,0 +1,14 @@
+import { HonoBase } from '../hono-base'
+import { LinearRouter } from '../router/linear-router'
+import type { Env } from '../types'
+
+export class Hono<E extends Env = Env, S = {}, BasePath extends string = ''> extends HonoBase<
+  E,
+  S,
+  BasePath
+> {
+  constructor() {
+    super()
+    this.router = new LinearRouter()
+  }
+}

--- a/src/preset/tiny.ts
+++ b/src/preset/tiny.ts
@@ -1,6 +1,6 @@
-import { HonoBase } from './hono-base'
-import { PatternRouter } from './router/pattern-router'
-import type { Env } from './types'
+import { HonoBase } from '../hono-base'
+import { PatternRouter } from '../router/pattern-router'
+import type { Env } from '../types'
 
 export class Hono<E extends Env = Env, S = {}, BasePath extends string = ''> extends HonoBase<
   E,


### PR DESCRIPTION
This PR introduces `hono/quick` and a `preset` directory to manage `hono/tiny` and `hono/quick`.

`hono/quick` uses only the **LinearRouter**. It has the fastest boot time, making it suitable for Fastly Compute@Edge.

You can use `hono/quick` just like `hono`:

```ts
import { Hono } from 'hono/quick'
```