### PR TITLE
feat(adapter): AWS Lambda Adapter supports requests via Lambda Function URLs.

### DIFF
--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -40,6 +40,28 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(response.isBase64Encoded).toBe(true)
   })
 
+  it('Should handle a GET request and return a 200 response (LambdaFunctionUrlEvent)', async () => {
+    const event = {
+      headers: { 'content-type': 'text/plain' },
+      rawPath: '/',
+      rawQueryString: '',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: {
+        domainName: 'example.com',
+        http: {
+          method: 'GET',
+        },
+      },
+    };
+  
+    const response = await handler(event);
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('SGVsbG8gTGFtYmRhIQ==');
+    expect(response.headers['content-type']).toMatch(/^text\/plain/);
+    expect(response.isBase64Encoded).toBe(true);
+  });
+
   it('Should handle a GET request and return a 404 response', async () => {
     const event = {
       httpMethod: 'GET',
@@ -77,6 +99,30 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(response.body).toBe('R29vZCBNb3JuaW5nIExhbWJkYSE=')
   })
 
+  it('Should handle a POST request and return a 200 response (LambdaFunctionUrlEvent)', async () => {
+    const searchParam = new URLSearchParams();
+    searchParam.append('message', 'Good Morning Lambda!');
+    const event = {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      rawPath: '/post',
+      rawQueryString: '',
+      body: btoa(searchParam.toString()),
+      isBase64Encoded: true,
+      requestContext: {
+        domainName: 'example.com',
+        http: {
+          method: 'POST',
+        },
+      },
+    };
+  
+    const response = await handler(event);
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('R29vZCBNb3JuaW5nIExhbWJkYSE=');
+  });
+  
   it('Should handle a request and return a 401 response with Basic auth', async () => {
     const event = {
       httpMethod: 'GET',

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -32,8 +32,8 @@ interface APIGatewayProxyEvent {
   }
 }
 
+// When calling Lambda through an Lambda Function URLs
 interface LambdaFunctionUrlEvent {
-  // httpMethod: string
   headers: Record<string, string | undefined>
   rawPath: string
   rawQueryString: string

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -85,8 +85,8 @@ const createResult = async (res: Response): Promise<APIGatewayProxyResult> => {
 
 const createRequest = (event: APIGatewayProxyEvent | APIGatewayProxyEventV2 | LambdaFunctionUrlEvent) => {
   const queryString = extractQueryString(event)
-  const urlPath = `https://${event.requestContext.domainName}${isProxyEvent(event) ? event.path : event.rawPath}`;
-  const url = queryString ? `${urlPath}?${queryString}` : urlPath;
+  const urlPath = `https://${event.requestContext.domainName}${isProxyEvent(event) ? event.path : event.rawPath}`
+  const url = queryString ? `${urlPath}?${queryString}` : urlPath
 
   const headers = new Headers()
   for (const [k, v] of Object.entries(event.headers)) {
@@ -111,16 +111,16 @@ const extractQueryString = (event: APIGatewayProxyEvent | APIGatewayProxyEventV2
     return Object.entries(event.queryStringParameters || {})
       .filter(([, value]) => value)
       .map(([key, value]) => `${key}=${value}`)
-      .join('&');
+      .join('&')
   }
 
-  return isProxyEventV2(event) ? event.rawQueryString : event.rawQueryString;
+  return isProxyEventV2(event) ? event.rawQueryString : event.rawQueryString
 }
 
 const isProxyEvent = (
   event: APIGatewayProxyEvent | APIGatewayProxyEventV2 | LambdaFunctionUrlEvent
 ): event is APIGatewayProxyEvent => {
-  return Object.prototype.hasOwnProperty.call(event, 'path');
+  return Object.prototype.hasOwnProperty.call(event, 'path')
 }
 
 const isProxyEventV2 = (


### PR DESCRIPTION
Lambda Function URLs are endpoints that allow for simple requests to be passed to Lambda without an API Gateway. 

https://aws.amazon.com/jp/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/

Most of the event is compatible with API Gateway, but the location of the method is different, which is why, as mentioned in https://github.com/honojs/hono/issues/1075, we specified the behavior of GET during a POST request. This patch attempts to fix that issue.