### PR TITLE
ErrorHandler type fix

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -52,7 +52,7 @@ export type H<E extends Env = any, P extends string = any, I extends Input = {},
   | MiddlewareHandler<E, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
-export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
+export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response | Promise<Response>
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type H<E extends Env = any, P extends string = any, I extends Input = {},
   | MiddlewareHandler<E, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
-export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
+export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response | Promise<Response>
 
 ////////////////////////////////////////
 //////                            //////


### PR DESCRIPTION
We can use async function in app.onError method and it works correctly. But it has type error.
Return type of callback function isn't including Promise so i changed it to: 
`
(err: Error, c: Context<E>) => Response | Promise<Response>
`