### PR TITLE
feat(app): `onError()` supports async

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -68,10 +68,10 @@ export const compose = <C extends ComposeContext, E extends Env = Env>(
             }
             return context
           })
-          .catch((err) => {
+          .catch(async (err) => {
             if (err instanceof Error && context instanceof Context && onError) {
               context.error = err
-              context.res = onError(err, context)
+              context.res = await onError(err, context)
               return context
             }
             throw err

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -52,7 +52,10 @@ export type H<E extends Env = any, P extends string = any, I extends Input = {},
   | MiddlewareHandler<E, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
-export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
+export type ErrorHandler<E extends Env = any> = (
+  err: Error,
+  c: Context<E>
+) => Response | Promise<Response>
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -68,10 +68,10 @@ export const compose = <C extends ComposeContext, E extends Env = Env>(
             }
             return context
           })
-          .catch((err) => {
+          .catch(async (err) => {
             if (err instanceof Error && context instanceof Context && onError) {
               context.error = err
-              context.res = onError(err, context)
+              context.res = await onError(err, context)
               return context
             }
             throw err

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,10 @@ export type H<E extends Env = any, P extends string = any, I extends Input = {},
   | MiddlewareHandler<E, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
-export type ErrorHandler<E extends Env = any> = (err: Error, c: Context<E>) => Response
+export type ErrorHandler<E extends Env = any> = (
+  err: Error,
+  c: Context<E>
+) => Response | Promise<Response>
 
 ////////////////////////////////////////
 //////                            //////


### PR DESCRIPTION
As mentioned by @AliKaanT in #1088, `app.onError()` can be an asynchronous function.

```ts
app.onError(async (e, c) => {
  //...
})
```

This PR enables support for an asynchronous function in `app.onError()`. It is based on #1088, I added tests and a small fix. If this is merged, I will need to add @AliKaanT as a co-author.