### PR TITLE
fix(lambda): don't encode text

### DIFF
--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -9,6 +9,12 @@ describe('AWS Lambda Adapter for Hono', () => {
     return c.text('Hello Lambda!')
   })
 
+  app.get('/binary', (c) => {
+    return c.body('Fake Image', 200, {
+      'Content-Type': 'image/png',
+    })
+  })
+
   app.post('/post', async (c) => {
     const body = (await c.req.parseBody()) as { message: string }
     return c.text(body.message)
@@ -35,8 +41,27 @@ describe('AWS Lambda Adapter for Hono', () => {
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
-    expect(response.body).toBe('SGVsbG8gTGFtYmRhIQ==')
+    expect(response.body).toBe('Hello Lambda!')
     expect(response.headers['content-type']).toMatch(/^text\/plain/)
+    expect(response.isBase64Encoded).toBe(false)
+  })
+
+  it('Should handle a GET request and return a 200 response with binary', async () => {
+    const event = {
+      httpMethod: 'GET',
+      headers: {},
+      path: '/binary',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: {
+        domainName: 'example.com',
+      },
+    }
+
+    const response = await handler(event)
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe('RmFrZSBJbWFnZQ==')
+    expect(response.headers['content-type']).toMatch(/^image\/png/)
     expect(response.isBase64Encoded).toBe(true)
   })
 
@@ -53,14 +78,14 @@ describe('AWS Lambda Adapter for Hono', () => {
           method: 'GET',
         },
       },
-    };
-  
-    const response = await handler(event);
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toBe('SGVsbG8gTGFtYmRhIQ==');
-    expect(response.headers['content-type']).toMatch(/^text\/plain/);
-    expect(response.isBase64Encoded).toBe(true);
-  });
+    }
+
+    const response = await handler(event)
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe('Hello Lambda!')
+    expect(response.headers['content-type']).toMatch(/^text\/plain/)
+    expect(response.isBase64Encoded).toBe(false)
+  })
 
   it('Should handle a GET request and return a 404 response', async () => {
     const event = {
@@ -96,12 +121,12 @@ describe('AWS Lambda Adapter for Hono', () => {
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
-    expect(response.body).toBe('R29vZCBNb3JuaW5nIExhbWJkYSE=')
+    expect(response.body).toBe('Good Morning Lambda!')
   })
 
   it('Should handle a POST request and return a 200 response (LambdaFunctionUrlEvent)', async () => {
-    const searchParam = new URLSearchParams();
-    searchParam.append('message', 'Good Morning Lambda!');
+    const searchParam = new URLSearchParams()
+    searchParam.append('message', 'Good Morning Lambda!')
     const event = {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -116,13 +141,13 @@ describe('AWS Lambda Adapter for Hono', () => {
           method: 'POST',
         },
       },
-    };
-  
-    const response = await handler(event);
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toBe('R29vZCBNb3JuaW5nIExhbWJkYSE=');
-  });
-  
+    }
+
+    const response = await handler(event)
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe('Good Morning Lambda!')
+  })
+
   it('Should handle a request and return a 401 response with Basic auth', async () => {
     const event = {
       httpMethod: 'GET',
@@ -159,6 +184,6 @@ describe('AWS Lambda Adapter for Hono', () => {
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
-    expect(response.body).toBe('R29vZCBOaWdodCBMYW1iZGEh')
+    expect(response.body).toBe('Good Night Lambda!')
   })
 })

--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,0 +1,15 @@
+import { isContentTypeBinary } from './handler'
+
+describe('isContentTypeBinary', () => {
+  it('Should determine whether it is binary', () => {
+    expect(isContentTypeBinary('image/png')).toBe(true)
+    expect(isContentTypeBinary('font/woff2')).toBe(true)
+    expect(isContentTypeBinary('text/plain')).toBe(false)
+    expect(isContentTypeBinary('text/plain; charset=UTF-8')).toBe(false)
+    expect(isContentTypeBinary('text/css')).toBe(false)
+    expect(isContentTypeBinary('text/javascript')).toBe(false)
+    expect(isContentTypeBinary('application/json')).toBe(false)
+    expect(isContentTypeBinary('application/ld+json')).toBe(false)
+    expect(isContentTypeBinary('application/json; charset=UTF-8')).toBe(false)
+  })
+})


### PR DESCRIPTION
This PR concerns the AWS Lambda adapter.

From PR #1009, it encodes any content as Base64.

This works fine on Function URLs, but it does not perform well on Lambda with API Gateway. We don't need to encode text-based content, only binary. In this PR, it determines whether the content is text or not and decides whether encoding is necessary.