### PR TITLE
fix(cloudflare-workers): serveStatic `rewriteRequestPath` option

### DIFF
--- a/src/adapter/cloudflare-workers/server-static-module.ts
+++ b/src/adapter/cloudflare-workers/server-static-module.ts
@@ -11,6 +11,7 @@ const module = (options: ServeStaticOptions = { root: '' }) => {
     root: options.root,
     path: options.path,
     manifest: options.manifest ? options.manifest : manifest,
+    rewriteRequestPath: options.rewriteRequestPath,
   })
 }
 


### PR DESCRIPTION
This PR enables the `rewriteRequestPath` option for `serveStatic`.