### PR TITLE
feat(app): `app.routerName()`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -65,6 +65,7 @@ type ContextOptions<E extends Env> = {
   notFoundHandler?: NotFoundHandler<E>
   path?: string
   paramData?: Record<string, string>
+  routerName?: string
 }
 
 export class Context<
@@ -77,6 +78,7 @@ export class Context<
   env: E['Bindings'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
+  routerName?: string | undefined
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _req?: HonoRequest<any, any>
@@ -99,6 +101,7 @@ export class Context<
       this._exCtx = options.executionCtx
       this._path = options.path ?? '/'
       this._pData = options.paramData
+      this.routerName = options.routerName
       this.env = options.env
       if (options.notFoundHandler) {
         this.notFoundHandler = options.notFoundHandler

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -232,6 +232,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
       notFoundHandler: this.notFoundHandler,
       path,
       paramData,
+      routerName: this.router.name,
     })
 
     // Do not `compose` if it has only one handler

--- a/deno_dist/router.ts
+++ b/deno_dist/router.ts
@@ -3,6 +3,7 @@ export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
 export const METHODS = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
 
 export interface Router<T> {
+  name: string
   add(method: string, path: string, handler: T): void
   match(method: string, path: string): Result<T> | null
 }

--- a/deno_dist/router/linear-router/router.ts
+++ b/deno_dist/router/linear-router/router.ts
@@ -1,11 +1,12 @@
 import type { Router, Result } from '../../router.ts'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router.ts'
 
-type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] };
+type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] }
 
 const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
 const splitByStarRe = /\*/
 export class LinearRouter<T> implements Router<T> {
+  name: string = 'LinearRouter'
   routes: [string, string, T][] = []
 
   add(method: string, path: string, handler: T) {

--- a/deno_dist/router/pattern-router/router.ts
+++ b/deno_dist/router/pattern-router/router.ts
@@ -4,6 +4,7 @@ import { METHOD_NAME_ALL } from '../../router.ts'
 type Route<T> = [RegExp, string, T] // [pattern, method, handler]
 
 export class PatternRouter<T> implements Router<T> {
+  name: string = 'PatternRouter'
   private routes: Route<T>[] = []
   private dNames: Record<string, number> = {} // Short name of duplicatedNames
 

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -101,6 +101,7 @@ function findMiddleware<T>(
 }
 
 export class RegExpRouter<T> implements Router<T> {
+  name: string = 'RegExpRouter'
   middleware?: Record<string, Record<string, T[]>>
   routes?: Record<string, Record<string, T[]>>
 

--- a/deno_dist/router/smart-router/router.ts
+++ b/deno_dist/router/smart-router/router.ts
@@ -3,6 +3,7 @@ import type { Router, Result } from '../../router.ts'
 import { UnsupportedPathError } from '../../router.ts'
 
 export class SmartRouter<T> implements Router<T> {
+  name: string = 'SmartRouter'
   routers: Router<T>[] = []
   routes?: [string, string, T][] = []
 
@@ -51,6 +52,9 @@ export class SmartRouter<T> implements Router<T> {
       // not found
       throw new Error('Fatal error')
     }
+
+    // e.g. "SmartRouter + RegExpRouter"
+    this.name = `SmartRouter + ${this.activeRouter.name}`
 
     return res || null
   }

--- a/deno_dist/router/trie-router/router.ts
+++ b/deno_dist/router/trie-router/router.ts
@@ -3,6 +3,7 @@ import { checkOptionalParameter } from '../../utils/url.ts'
 import { Node } from './node.ts'
 
 export class TrieRouter<T> implements Router<T> {
+  name: string = 'TrieRouter'
   node: Node<T>
 
   constructor() {

--- a/src/context.ts
+++ b/src/context.ts
@@ -65,7 +65,6 @@ type ContextOptions<E extends Env> = {
   notFoundHandler?: NotFoundHandler<E>
   path?: string
   paramData?: Record<string, string>
-  routerName?: string
 }
 
 export class Context<
@@ -78,7 +77,6 @@ export class Context<
   env: E['Bindings'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
-  routerName?: string | undefined
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _req?: HonoRequest<any, any>
@@ -101,7 +99,6 @@ export class Context<
       this._exCtx = options.executionCtx
       this._path = options.path ?? '/'
       this._pData = options.paramData
-      this.routerName = options.routerName
       this.env = options.env
       if (options.notFoundHandler) {
         this.notFoundHandler = options.notFoundHandler

--- a/src/context.ts
+++ b/src/context.ts
@@ -65,6 +65,7 @@ type ContextOptions<E extends Env> = {
   notFoundHandler?: NotFoundHandler<E>
   path?: string
   paramData?: Record<string, string>
+  routerName?: string
 }
 
 export class Context<
@@ -77,6 +78,7 @@ export class Context<
   env: E['Bindings'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
+  routerName?: string | undefined
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _req?: HonoRequest<any, any>
@@ -99,6 +101,7 @@ export class Context<
       this._exCtx = options.executionCtx
       this._path = options.path ?? '/'
       this._pData = options.paramData
+      this.routerName = options.routerName
       this.env = options.env
       if (options.notFoundHandler) {
         this.notFoundHandler = options.notFoundHandler

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -194,6 +194,11 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     })
   }
 
+  get routerName() {
+    this.matchRoute('GET', '/')
+    return this.router.name
+  }
+
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
     if (this._basePath) {
@@ -232,7 +237,6 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
       notFoundHandler: this.notFoundHandler,
       path,
       paramData,
-      routerName: this.router.name,
     })
 
     // Do not `compose` if it has only one handler

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -232,6 +232,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
       notFoundHandler: this.notFoundHandler,
       path,
       paramData,
+      routerName: this.router.name,
     })
 
     // Do not `compose` if it has only one handler

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1910,3 +1910,16 @@ describe('Optional parameters', () => {
     })
   })
 })
+
+describe('Router Name', () => {
+  it('Should return the correct router name', async () => {
+    const app = new Hono({
+      router: new RegExpRouter(),
+    })
+    app.get('/router-name', (c) => {
+      return c.text(c.routerName ?? 'N/A')
+    })
+    const res = await app.request('/router-name')
+    expect(await res.text()).toBe('RegExpRouter')
+  })
+})

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1917,7 +1917,7 @@ describe('Router Name', () => {
       router: new RegExpRouter(),
     })
     app.get('/router-name', (c) => {
-      return c.text(c.routerName ?? 'N/A')
+      return c.text(app.routerName ?? 'N/A')
     })
     const res = await app.request('/router-name')
     expect(await res.text()).toBe('RegExpRouter')

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,6 +3,7 @@ export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
 export const METHODS = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
 
 export interface Router<T> {
+  name: string
   add(method: string, path: string, handler: T): void
   match(method: string, path: string): Result<T> | null
 }

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -1,11 +1,12 @@
 import type { Router, Result } from '../../router'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
 
-type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] };
+type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] }
 
 const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
 const splitByStarRe = /\*/
 export class LinearRouter<T> implements Router<T> {
+  name: string = 'LinearRouter'
   routes: [string, string, T][] = []
 
   add(method: string, path: string, handler: T) {

--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -4,6 +4,7 @@ import { METHOD_NAME_ALL } from '../../router'
 type Route<T> = [RegExp, string, T] // [pattern, method, handler]
 
 export class PatternRouter<T> implements Router<T> {
+  name: string = 'PatternRouter'
   private routes: Route<T>[] = []
   private dNames: Record<string, number> = {} // Short name of duplicatedNames
 

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -101,6 +101,7 @@ function findMiddleware<T>(
 }
 
 export class RegExpRouter<T> implements Router<T> {
+  name: string = 'RegExpRouter'
   middleware?: Record<string, Record<string, T[]>>
   routes?: Record<string, Record<string, T[]>>
 

--- a/src/router/smart-router/router.test.ts
+++ b/src/router/smart-router/router.test.ts
@@ -18,6 +18,7 @@ describe('RegExpRouter', () => {
       expect(res?.handlers).toEqual(['get entry'])
       expect(res?.params['id']).toBe('123')
       expect(router.activeRouter).toBeInstanceOf(RegExpRouter)
+      expect(router.name).toBe('SmartRouter + RegExpRouter')
     })
 
     it('Wildcard', async () => {
@@ -82,5 +83,6 @@ describe('TrieRouter', () => {
     expect(res?.params['user']).toBe('entry')
     expect(res?.params['name']).toBe('entries')
     expect(router.activeRouter).toBeInstanceOf(TrieRouter)
+    expect(router.name).toBe('SmartRouter + TrieRouter')
   })
 })

--- a/src/router/smart-router/router.ts
+++ b/src/router/smart-router/router.ts
@@ -3,6 +3,7 @@ import type { Router, Result } from '../../router'
 import { UnsupportedPathError } from '../../router'
 
 export class SmartRouter<T> implements Router<T> {
+  name: string = 'SmartRouter'
   routers: Router<T>[] = []
   routes?: [string, string, T][] = []
 
@@ -51,6 +52,9 @@ export class SmartRouter<T> implements Router<T> {
       // not found
       throw new Error('Fatal error')
     }
+
+    // e.g. "SmartRouter + RegExpRouter"
+    this.name = `SmartRouter + ${this.activeRouter.name}`
 
     return res || null
   }

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -3,6 +3,7 @@ import { checkOptionalParameter } from '../../utils/url'
 import { Node } from './node'
 
 export class TrieRouter<T> implements Router<T> {
+  name: string = 'TrieRouter'
   node: Node<T>
 
   constructor() {


### PR DESCRIPTION
This PR introduces a `c.routerName()` function in `context.ts`. With this function, we can determine the name of the currently active router. This can be useful for debugging purposes.

```ts
import { Hono } from 'hono'

//...

app.get('/', (c) => {
  return c.text(c.routerName ?? 'N/A') // "SmartRouter + RegExpRouter"
})
```

