### PR TITLE
fix(basic-auth): handle passing invalid value to `atob()`

### DIFF
--- a/deno_dist/middleware/basic-auth/index.ts
+++ b/deno_dist/middleware/basic-auth/index.ts
@@ -13,7 +13,11 @@ const auth = (req: HonoRequest) => {
     return undefined
   }
 
-  const userPass = USER_PASS_REGEXP.exec(utf8Decoder.decode(decodeBase64(match[1])))
+  let userPass = undefined
+  // If an invalid string is passed to atob(), it throws a `DOMException`.
+  try {
+    userPass = USER_PASS_REGEXP.exec(utf8Decoder.decode(decodeBase64(match[1])))
+  } catch {} // Do nothing
 
   if (!userPass) {
     return undefined

--- a/runtime_tests/deno/middleware.test.tsx
+++ b/runtime_tests/deno/middleware.test.tsx
@@ -10,8 +10,8 @@ import { assertEquals, assertMatch } from './deps.ts'
 Deno.test('Basic Auth Middleware', async () => {
   const app = new Hono()
 
-  const username = 'hono-user-a'
-  const password = 'hono-password-a'
+  const username = 'hono'
+  const password = 'acoolproject'
 
   app.use(
     '/auth/*',
@@ -27,13 +27,21 @@ Deno.test('Basic Auth Middleware', async () => {
   assertEquals(res.status, 401)
   assertEquals(await res.text(), 'Unauthorized')
 
-  const credential = 'aG9uby11c2VyLWE6aG9uby1wYXNzd29yZC1h'
+  const credential = 'aG9ubzphY29vbHByb2plY3Q='
 
   const req = new Request('http://localhost/auth/a')
   req.headers.set('Authorization', `Basic ${credential}`)
   const resOK = await app.request(req)
   assertEquals(resOK.status, 200)
   assertEquals(await resOK.text(), 'auth')
+
+  const invalidCredential = 'G9ubzphY29vbHByb2plY3Q='
+
+  const req2 = new Request('http://localhost/auth/a')
+  req2.headers.set('Authorization', `Basic ${invalidCredential}`)
+  const resNG = await app.request(req2)
+  assertEquals(resNG.status, 401)
+  assertEquals(await resNG.text(), 'Unauthorized')
 })
 
 Deno.test('JSX middleware', async () => {

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -13,7 +13,11 @@ const auth = (req: HonoRequest) => {
     return undefined
   }
 
-  const userPass = USER_PASS_REGEXP.exec(utf8Decoder.decode(decodeBase64(match[1])))
+  let userPass = undefined
+  // If an invalid string is passed to atob(), it throws a `DOMException`.
+  try {
+    userPass = USER_PASS_REGEXP.exec(utf8Decoder.decode(decodeBase64(match[1])))
+  } catch {} // Do nothing
 
   if (!userPass) {
     return undefined


### PR DESCRIPTION
This PR will fix #1121.

If an invalid value like `G9ubzphY29vbHByb2plY3Q=` is passed to `atob()`, it should throw a `DOMException`. However, the existing Basic Auth middleware cannot handle this, resulting in a "500 Internal Error" when an invalid string is sent.

The `jest-environment-miniflare` testing environment does not throw an exception from `atob()`. Therefore, this PR includes a test for this in `runtime_tests/deno/middleware.test.tsx`. The implementation in Deno is correct according to the spec.

Regarding the implementation, it uses `try`, even though we can check if the string is valid or invalid for Base64. This is because testing is difficult due to the above reasons, so I believe we need to keep the implementation as simple as possible.