### PR TITLE
fix(middleware): don't use `headers.append()`, use `headers.set()`

### DIFF
--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -10,7 +10,7 @@ export const cache = (options: {
   }
 
   const addHeader = (response: Response) => {
-    if (options.cacheControl) response.headers.append('Cache-Control', options.cacheControl)
+    if (options.cacheControl) response.headers.set('Cache-Control', options.cacheControl)
   }
 
   return async (c, next) => {

--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -33,7 +33,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
   return async (c, next) => {
     function set(key: string, value: string) {
-      c.res.headers.append(key, value)
+      c.res.headers.set(key, value)
     }
 
     const allowOrigin = findAllowOrigin(c.req.headers.get('origin') || '')
@@ -77,7 +77,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       }
       if (headers?.length) {
         set('Access-Control-Allow-Headers', headers.join(','))
-        set('Vary', 'Access-Control-Request-Headers')
+        c.res.headers.append('Vary', 'Access-Control-Request-Headers')
       }
 
       c.res.headers.delete('Content-Length')

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -29,7 +29,7 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
       c.res.headers.delete('Content-Length')
     } else {
       c.res = new Response(clone.body, clone)
-      c.res.headers.append('ETag', etag)
+      c.res.headers.set('ETag', etag)
     }
   }
 }

--- a/deno_dist/middleware/powered-by/index.ts
+++ b/deno_dist/middleware/powered-by/index.ts
@@ -3,6 +3,6 @@ import type { MiddlewareHandler } from '../../types.ts'
 export const poweredBy = (): MiddlewareHandler => {
   return async (c, next) => {
     await next()
-    c.res.headers.append('X-Powered-By', 'Hono')
+    c.res.headers.set('X-Powered-By', 'Hono')
   }
 }

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -30,6 +30,12 @@ describe('Cache Middleware', () => {
     return c.text('not cached')
   })
 
+  app.use('/wait2/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.use('/wait2/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.get('/wait2/', (c) => {
+    return c.text('cached')
+  })
+
   const ctx = new Context()
 
   it('Should return cached response', async () => {
@@ -49,5 +55,12 @@ describe('Cache Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe('max-age=10')
     expect(res.headers.get('cf-cache-status')).toBeNull()
+  })
+
+  it('Should not return duplicate header values', async () => {
+    const res = await app.request('/wait2/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('max-age=10')
   })
 })

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -10,7 +10,7 @@ export const cache = (options: {
   }
 
   const addHeader = (response: Response) => {
-    if (options.cacheControl) response.headers.append('Cache-Control', options.cacheControl)
+    if (options.cacheControl) response.headers.set('Cache-Control', options.cacheControl)
   }
 
   return async (c, next) => {

--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -33,6 +33,19 @@ describe('CORS by Middleware', () => {
 
   app.use('/api5/*', cors())
 
+  app.use(
+    '/api6/*',
+    cors({
+      origin: 'http://example.com',
+    })
+  )
+  app.use(
+    '/api6/*',
+    cors({
+      origin: 'http://example.com',
+    })
+  )
+
   app.get('/api/abc', (c) => {
     return c.json({ success: true })
   })
@@ -141,5 +154,11 @@ describe('CORS by Middleware', () => {
 
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
     expect(res.headers.get('Vary')).toBeNull()
+  })
+
+  it('Should not return duplicate header values', async () => {
+    const res = await app.request('http://localhost/api6/abc')
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
   })
 })

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -33,7 +33,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
   return async (c, next) => {
     function set(key: string, value: string) {
-      c.res.headers.append(key, value)
+      c.res.headers.set(key, value)
     }
 
     const allowOrigin = findAllowOrigin(c.req.headers.get('origin') || '')
@@ -77,7 +77,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       }
       if (headers?.length) {
         set('Access-Control-Allow-Headers', headers.join(','))
-        set('Vary', 'Access-Control-Request-Headers')
+        c.res.headers.append('Vary', 'Access-Control-Request-Headers')
       }
 
       c.res.headers.delete('Content-Length')

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -36,6 +36,10 @@ describe('Etag Middleware', () => {
     return c.body(new Uint8Array([1, 2, 3, 4]))
   })
 
+  app.use('/etag2/*', etag())
+  app.use('/etag2/*', etag())
+  app.get('/etag2/abc', (c) => c.text('Hono is cool'))
+
   it('Should return etag header', async () => {
     let res = await app.request('http://localhost/etag/abc')
     expect(res.headers.get('ETag')).not.toBeFalsy()
@@ -88,5 +92,11 @@ describe('Etag Middleware', () => {
     expect(res.status).toBe(304)
     expect(res.headers.get('Etag')).toBe(etag)
     expect(await res.text()).toBe('')
+  })
+
+  it('Should not return duplicate etag header values', async () => {
+    const res = await app.request('http://localhost/etag2/abc')
+    expect(res.headers.get('ETag')).not.toBeFalsy()
+    expect(res.headers.get('ETag')).toBe('"4e32298b1cb4edc595237405e5b696e105c2399a"')
   })
 })

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -29,7 +29,7 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
       c.res.headers.delete('Content-Length')
     } else {
       c.res = new Response(clone.body, clone)
-      c.res.headers.append('ETag', etag)
+      c.res.headers.set('ETag', etag)
     }
   }
 }

--- a/src/middleware/powered-by/index.test.ts
+++ b/src/middleware/powered-by/index.test.ts
@@ -4,11 +4,22 @@ import { poweredBy } from '.'
 describe('Powered by Middleware', () => {
   const app = new Hono()
 
-  app.use('*', poweredBy())
-  app.get('/', (c) => c.text('root'))
+  app.use('/poweredBy/*', poweredBy())
+  app.get('/poweredBy', (c) => c.text('root'))
+
+  app.use('/poweredBy2/*', poweredBy())
+  app.use('/poweredBy2/*', poweredBy())
+  app.get('/poweredBy2', (c) => c.text('root'))
 
   it('Should return with X-Powered-By header', async () => {
-    const res = await app.request('http://localhost/')
+    const res = await app.request('http://localhost/poweredBy')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Powered-By')).toBe('Hono')
+  })
+
+  it('Should not return duplicate values', async () => {
+    const res = await app.request('http://localhost/poweredBy2')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('X-Powered-By')).toBe('Hono')

--- a/src/middleware/powered-by/index.ts
+++ b/src/middleware/powered-by/index.ts
@@ -3,6 +3,6 @@ import type { MiddlewareHandler } from '../../types'
 export const poweredBy = (): MiddlewareHandler => {
   return async (c, next) => {
     await next()
-    c.res.headers.append('X-Powered-By', 'Hono')
+    c.res.headers.set('X-Powered-By', 'Hono')
   }
 }


### PR DESCRIPTION
Some middleware are using `response.headers.append()` when setting header values. With this method, it's possible to set duplicate values if the middleware is called twice.

```ts
app.use(
  '/api/*',
  cors({
    origin: 'http://example.com',
  })
)
app.use(
  '/api/*',
  cors({
    origin: 'http://example.com',
  })
)
```

In this PR, `response.headers.set()` is used to fix this issue.