### PR TITLE
fix: Add missing client types and TypedResponse type

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -1,7 +1,7 @@
 import type { Hono } from '../hono.ts'
 import type { ValidationTargets } from '../types.ts'
 import type { UnionToIntersection } from '../utils/types.ts'
-import type { Callback, Client, RequestOptions } from './types.ts'
+import type { Callback, Client, ClientRequestOptions } from './types.ts'
 import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils.ts'
 
 const createProxy = (callback: Callback, path: string[]) => {
@@ -36,7 +36,7 @@ class ClientRequestImpl {
     args?: ValidationTargets & {
       param?: Record<string, string>
     },
-    opt?: RequestOptions
+    opt?: ClientRequestOptions
   ) => {
     if (args) {
       if (args.query) {
@@ -107,7 +107,7 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: RequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: ClientRequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 
@@ -124,7 +124,7 @@ export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: Req
     const req = new ClientRequestImpl(url, method)
     if (method) {
       options ??= {}
-      const args = deepMerge<RequestOptions>(options, { ...(opts.args[1] ?? {}) })
+      const args = deepMerge<ClientRequestOptions>(options, { ...(opts.args[1] ?? {}) })
       return req.fetch(opts.args[0], args)
     }
     return req

--- a/deno_dist/client/index.ts
+++ b/deno_dist/client/index.ts
@@ -1,2 +1,2 @@
 export { hc } from './client.ts'
-export type { InferResponseType, InferRequestType, Fetch } from './types.ts'
+export type { InferResponseType, InferRequestType, Fetch, ClientRequestOptions } from './types.ts'

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -13,7 +13,7 @@ type Data = {
   output: {}
 }
 
-export type RequestOptions = {
+export type ClientRequestOptions = {
   headers?: Record<string, string>
   fetch?: typeof fetch
 }
@@ -21,8 +21,8 @@ export type RequestOptions = {
 type ClientRequest<S extends Data> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
     ? RemoveBlankRecord<R> extends never
-      ? (args?: {}, options?: RequestOptions) => Promise<ClientResponse<O>>
-      : (args: R, options?: RequestOptions) => Promise<ClientResponse<O>>
+      ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
+      : (args: R, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
     : never
 }
 
@@ -32,7 +32,7 @@ export interface ClientResponse<T> extends Response {
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,
-  opt?: RequestOptions
+  opt?: ClientRequestOptions
 ) => Promise<ClientResponse<InferResponseType<T>>>
 
 export type InferResponseType<T> = T extends (

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,7 +1,7 @@
 import type { Hono } from '../hono'
 import type { ValidationTargets } from '../types'
 import type { UnionToIntersection } from '../utils/types'
-import type { Callback, Client, RequestOptions } from './types'
+import type { Callback, Client, ClientRequestOptions } from './types'
 import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils'
 
 const createProxy = (callback: Callback, path: string[]) => {
@@ -36,7 +36,7 @@ class ClientRequestImpl {
     args?: ValidationTargets & {
       param?: Record<string, string>
     },
-    opt?: RequestOptions
+    opt?: ClientRequestOptions
   ) => {
     if (args) {
       if (args.query) {
@@ -107,7 +107,7 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: RequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: ClientRequestOptions) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 
@@ -124,7 +124,7 @@ export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: Req
     const req = new ClientRequestImpl(url, method)
     if (method) {
       options ??= {}
-      const args = deepMerge<RequestOptions>(options, { ...(opts.args[1] ?? {}) })
+      const args = deepMerge<ClientRequestOptions>(options, { ...(opts.args[1] ?? {}) })
       return req.fetch(opts.args[0], args)
     }
     return req

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,2 +1,2 @@
 export { hc } from './client'
-export type { InferResponseType, InferRequestType, Fetch } from './types'
+export type { InferResponseType, InferRequestType, Fetch, ClientRequestOptions } from './types'

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -13,7 +13,7 @@ type Data = {
   output: {}
 }
 
-export type RequestOptions = {
+export type ClientRequestOptions = {
   headers?: Record<string, string>
   fetch?: typeof fetch
 }
@@ -21,8 +21,8 @@ export type RequestOptions = {
 type ClientRequest<S extends Data> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
     ? RemoveBlankRecord<R> extends never
-      ? (args?: {}, options?: RequestOptions) => Promise<ClientResponse<O>>
-      : (args: R, options?: RequestOptions) => Promise<ClientResponse<O>>
+      ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
+      : (args: R, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
     : never
 }
 
@@ -32,7 +32,7 @@ export interface ClientResponse<T> extends Response {
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,
-  opt?: RequestOptions
+  opt?: ClientRequestOptions
 ) => Promise<ClientResponse<InferResponseType<T>>>
 
 export type InferResponseType<T> = T extends (

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,10 @@ export type {
   NotFoundHandler,
   ValidationTargets,
   Input,
+  TypedResponse,
 } from './types'
 export type { Context, ContextVariableMap } from './context'
 export type { HonoRequest } from './request'
+export type { InferRequestType, InferResponseType, ClientRequestOptions } from './client'
 
 export { Hono }


### PR DESCRIPTION
Hi @yusukebe we have an issue with `hc` – we'd like to publish typed hono client from our Hono app as a library with zero dependencies, but since hono package.json has `"types": "dist/types/index.d.ts",` and this file doesn't contain client types we can't make it standalone – without `import from 'hono/dist...'` (see screenshots now/after change).

We have such entry point (client.ts) that we build separately from Hono app worker itself:
```
import { hc } from 'hono/client';

import { AppType } from '.';

export type { InferRequestType, InferResponseType } from 'hono/client';

export const client = hc<AppType>;
```

This is what we have now after build:
<img width="908" alt="Screen Shot 2566-05-27 at 20 32 41" src="https://github.com/honojs/hono/assets/116948/8a90094d-2cf4-4721-98d2-12e8788af660">

This is what we want to have with this changes:
<img width="920" alt="Screen Shot 2566-05-27 at 20 29 39" src="https://github.com/honojs/hono/assets/116948/8d81466a-bcc8-430e-8a09-0300b2772052">

So i exported few hono client types that we 
need for that. Changed RequestOptions => ClientRequestOptions to avoid possible type name collisions. As it uses only internally now that should not be a breaking change for anybody.
As well I exported the TypedResponse bcs we don't want use jsonT but instead to return Response | TypedResponse from handler and we need this type to be exposed as well.

I'm not sure if I need to change files in deno_dist as well. so please let me know if i need to roll them back