### PR TITLE
feat: handle HEAD method

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -267,19 +267,16 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   private dispatch(
     request: Request,
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
-    env?: E['Bindings']
+    env?: E['Bindings'],
+    method?: string,
   ): Response | Promise<Response> {
     const path = this.getPath(request)
-    const method = request.method
+    method ||= request.method
 
     // Handle HEAD method
     if (method === 'HEAD') {
-      request = new Request(request.url, {
-        ...request,
-        method: 'GET',
-      })
       return (async () => {
-        const response = await this.dispatch(request, eventOrExecutionCtx, env)
+        const response = await this.dispatch(request, eventOrExecutionCtx, env, 'GET')
         return new Response(null, response)
       })()
     }

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -274,7 +274,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
     // Handle HEAD method
     if (method === 'HEAD') {
-      request = new Request(request, {
+      request = new Request(request.url, {
         ...request,
         method: 'GET',
       })

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -29,12 +29,6 @@ interface RouterRoute {
   handler: H
 }
 
-interface DispatchOptions<Env> {
-  eventOrExecutionCtx?: ExecutionContext | FetchEvent
-  env?: Env
-  method?: string
-}
-
 function defineDynamicClass(): {
   new <E extends Env = Env, S = {}, BasePath extends string = '/'>(): {
     [M in Methods]: HandlerInterface<E, M, S, BasePath>
@@ -272,28 +266,24 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
   private dispatch(
     request: Request,
-    options?: DispatchOptions<E['Bindings']>
+    eventOrExecutionCtx: ExecutionContext | FetchEvent | undefined,
+    env: E['Bindings'],
+    method: string
   ): Response | Promise<Response> {
     const path = this.getPath(request)
-    const method = options?.method ?? request.method
 
     // Handle HEAD method
     if (method === 'HEAD') {
-      return (async () => {
-        const response = await this.dispatch(request, {
-          ...options,
-          method: 'GET',
-        })
-        return new Response(null, response)
-      })()
+      return (async () =>
+        new Response(null, await this.dispatch(request, eventOrExecutionCtx, env, 'GET')))()
     }
 
     const result = this.matchRoute(method, path)
     const paramData = result?.params
 
     const c = new Context(request, {
-      env: options?.env,
-      executionCtx: options?.eventOrExecutionCtx,
+      env,
+      executionCtx: eventOrExecutionCtx,
       notFoundHandler: this.notFoundHandler,
       path,
       paramData,
@@ -358,16 +348,11 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   }
 
   handleEvent = (event: FetchEvent) => {
-    return this.dispatch(event.request, {
-      eventOrExecutionCtx: event,
-    })
+    return this.dispatch(event.request, event, undefined, event.request.method)
   }
 
   fetch = (request: Request, Env?: E['Bindings'] | {}, executionCtx?: ExecutionContext) => {
-    return this.dispatch(request, {
-      eventOrExecutionCtx: executionCtx,
-      env: Env,
-    })
+    return this.dispatch(request, executionCtx, Env, request.method)
   }
 
   request = async (input: Request | string | URL, requestInit?: RequestInit) => {

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -233,6 +233,16 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     return this.router.name
   }
 
+  /**
+   * @deprecate
+   * `app.head()` is no longer used.
+   * `app.get()` implicitly handles the HEAD method.
+   */
+  head = () => {
+    console.warn('`app.head()` is no longer used. `app.get()` implicitly handles the HEAD method.')
+    return this
+  }
+
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
     if (this._basePath) {
@@ -261,6 +271,18 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   ): Response | Promise<Response> {
     const path = this.getPath(request)
     const method = request.method
+
+    // Handle HEAD method
+    if (method === 'HEAD') {
+      request = new Request(request, {
+        ...request,
+        method: 'GET',
+      })
+      return (async () => {
+        const response = await this.dispatch(request, eventOrExecutionCtx, env)
+        return new Response(null, response)
+      })()
+    }
 
     const result = this.matchRoute(method, path)
     const paramData = result?.params

--- a/deno_dist/router.ts
+++ b/deno_dist/router.ts
@@ -1,6 +1,6 @@
 export const METHOD_NAME_ALL = 'ALL' as const
 export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
-export const METHODS = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
+export const METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch'] as const
 
 export interface Router<T> {
   name: string

--- a/runtime_tests/lagon/index.ts
+++ b/runtime_tests/lagon/index.ts
@@ -61,8 +61,6 @@ app.onError((err, c) => {
   return c.text('Custom Error Message', 500)
 })
 
-app.head('/', (c) => c.text('OK'))
-
 // Routing
 app.get('/', (c) => c.text('Hono!!'))
 // Use Response object directly

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -262,6 +262,18 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     const path = this.getPath(request)
     const method = request.method
 
+    // Handle HEAD method
+    if (method === 'HEAD') {
+      request = new Request(request, {
+        ...request,
+        method: 'GET',
+      })
+      return (async () => {
+        const response = await this.dispatch(request, eventOrExecutionCtx, env)
+        return new Response(null, response)
+      })()
+    }
+
     const result = this.matchRoute(method, path)
     const paramData = result?.params
 

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -267,19 +267,16 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   private dispatch(
     request: Request,
     eventOrExecutionCtx?: ExecutionContext | FetchEvent,
-    env?: E['Bindings']
+    env?: E['Bindings'],
+    method?: string,
   ): Response | Promise<Response> {
     const path = this.getPath(request)
-    const method = request.method
+    method ||= request.method
 
     // Handle HEAD method
     if (method === 'HEAD') {
-      request = new Request(request.url, {
-        ...request,
-        method: 'GET',
-      })
       return (async () => {
-        const response = await this.dispatch(request, eventOrExecutionCtx, env)
+        const response = await this.dispatch(request, eventOrExecutionCtx, env, 'GET')
         return new Response(null, response)
       })()
     }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -274,7 +274,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
     // Handle HEAD method
     if (method === 'HEAD') {
-      request = new Request(request, {
+      request = new Request(request.url, {
         ...request,
         method: 'GET',
       })

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -233,6 +233,16 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     return this.router.name
   }
 
+  /**
+   * @deprecate
+   * `app.head()` is no longer used.
+   * `app.get()` implicitly handles the HEAD method.
+   */
+  head = () => {
+    console.warn('`app.head()` is no longer used. `app.get()` implicitly handles the HEAD method.')
+    return this
+  }
+
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
     if (this._basePath) {

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -29,12 +29,6 @@ interface RouterRoute {
   handler: H
 }
 
-interface DispatchOptions<Env> {
-  eventOrExecutionCtx?: ExecutionContext | FetchEvent
-  env?: Env
-  method?: string
-}
-
 function defineDynamicClass(): {
   new <E extends Env = Env, S = {}, BasePath extends string = '/'>(): {
     [M in Methods]: HandlerInterface<E, M, S, BasePath>
@@ -272,28 +266,24 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
   private dispatch(
     request: Request,
-    options?: DispatchOptions<E['Bindings']>
+    eventOrExecutionCtx: ExecutionContext | FetchEvent | undefined,
+    env: E['Bindings'],
+    method: string
   ): Response | Promise<Response> {
     const path = this.getPath(request)
-    const method = options?.method ?? request.method
 
     // Handle HEAD method
     if (method === 'HEAD') {
-      return (async () => {
-        const response = await this.dispatch(request, {
-          ...options,
-          method: 'GET',
-        })
-        return new Response(null, response)
-      })()
+      return (async () =>
+        new Response(null, await this.dispatch(request, eventOrExecutionCtx, env, 'GET')))()
     }
 
     const result = this.matchRoute(method, path)
     const paramData = result?.params
 
     const c = new Context(request, {
-      env: options?.env,
-      executionCtx: options?.eventOrExecutionCtx,
+      env,
+      executionCtx: eventOrExecutionCtx,
       notFoundHandler: this.notFoundHandler,
       path,
       paramData,
@@ -358,16 +348,11 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   }
 
   handleEvent = (event: FetchEvent) => {
-    return this.dispatch(event.request, {
-      eventOrExecutionCtx: event,
-    })
+    return this.dispatch(event.request, event, undefined, event.request.method)
   }
 
   fetch = (request: Request, Env?: E['Bindings'] | {}, executionCtx?: ExecutionContext) => {
-    return this.dispatch(request, {
-      eventOrExecutionCtx: executionCtx,
-      env: Env,
-    })
+    return this.dispatch(request, executionCtx, Env, request.method)
   }
 
   request = async (input: Request | string | URL, requestInit?: RequestInit) => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2119,6 +2119,7 @@ describe('HEAD method', () => {
 
   app.get('/page', (c) => {
     c.header('X-Message', 'Foo')
+    c.header('X-Method', c.req.method)
     return c.text('/page')
   })
 
@@ -2126,6 +2127,7 @@ describe('HEAD method', () => {
     const res = await app.request('/page')
     expect(res.status).toBe(200)
     expect(res.headers.get('X-Message')).toBe('Foo')
+    expect(res.headers.get('X-Method')).toBe('GET')
     expect(await res.text()).toBe('/page')
   })
 
@@ -2136,6 +2138,7 @@ describe('HEAD method', () => {
     const res = await app.request(req)
     expect(res.status).toBe(200)
     expect(res.headers.get('X-Message')).toBe('Foo')
+    expect(res.headers.get('X-Method')).toBe('HEAD')
     expect(res.body).toBe(null)
   })
 })

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2113,3 +2113,29 @@ describe('Router Name', () => {
     expect(await res.text()).toBe('RegExpRouter')
   })
 })
+
+describe('HEAD method', () => {
+  const app = new Hono()
+
+  app.get('/page', (c) => {
+    c.header('X-Message', 'Foo')
+    return c.text('/page')
+  })
+
+  it('Should return 200 response with body - GET /page', async () => {
+    const res = await app.request('/page')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Message')).toBe('Foo')
+    expect(await res.text()).toBe('/page')
+  })
+
+  it('Should return 200 response without body - HEAD /page', async () => {
+    const req = new Request('http://localhost/page', {
+      method: 'HEAD',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Message')).toBe('Foo')
+    expect(res.body).toBe(null)
+  })
+})

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,6 @@
 export const METHOD_NAME_ALL = 'ALL' as const
 export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
-export const METHODS = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
+export const METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch'] as const
 
 export interface Router<T> {
   name: string


### PR DESCRIPTION
This PR allows `app.get()` to handle the HEAD method, resolving issue #1130.

Currently, we have to define the process in `app.head()` if a HEAD method request comes in. However, the HEAD method is essentially "the response of GET without the body". Therefore, `HEAD /foo` will be handled by `app.get('/foo')` and return the response without the body. Users will not be able to define `app.head()`.

While this is a feature change, on the other hand, it simply corrects the handling of HEAD. Therefore, I believe it's acceptable to release it as a patch.