### PR TITLE
feat: `headMethod` middleware

### DIFF
--- a/src/middleware/head-method/index.test.ts
+++ b/src/middleware/head-method/index.test.ts
@@ -1,0 +1,35 @@
+import { Hono } from '../../hono'
+import { headMethod } from './index'
+
+describe('Head Method Middleware', () => {
+  const app = new Hono()
+
+  app.use('/page/*', headMethod({ app }))
+  app.use('*', async (c, next) => {
+    await next()
+    c.header('foo2', 'bar2')
+  })
+
+  app.get('/page', (c) => {
+    c.header('foo', 'bar')
+    return c.text('page')
+  })
+
+  it('Should return 200 response with body - GET /page', async () => {
+    const res = await app.request('/page')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('foo')).toBe('bar')
+    expect(res.headers.get('foo2')).toBe('bar2')
+    expect(await res.text()).toBe('page')
+  })
+
+  it('Should return 200 response without body - HEAD /page', async () => {
+    const res = await app.request('/page', {
+      method: 'HEAD',
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('foo')).toBe('bar')
+    expect(res.headers.get('foo2')).toBe('bar2')
+    expect(res.body).toBeNull()
+  })
+})

--- a/src/middleware/head-method/index.ts
+++ b/src/middleware/head-method/index.ts
@@ -1,0 +1,21 @@
+import type { Hono } from '../../hono'
+import type { MiddlewareHandler } from '../../types'
+
+type HeadMethodOptions = {
+  app: Hono
+}
+
+export const headMethod = ({ app }: HeadMethodOptions): MiddlewareHandler => {
+  return async (c, next) => {
+    if (c.req.method === 'HEAD') {
+      const res = await app.fetch(
+        new Request(c.req.url, {
+          ...c.req.raw,
+          method: 'GET',
+        })
+      )
+      return new Response(null, res)
+    }
+    await next()
+  }
+}


### PR DESCRIPTION
This PR introduces the "HEAD Method middleware". This middleware handles `HEAD` method requests.

```ts
import { headMethod } from 'hono/head-method'

// ...

app.use('*', headMethod({ app }))

app.get('/', (c) => {
  return c.text('Hello!')
})
```

Incoming `HEAD` requests will be handled by `app.get()` and it will return a response without the body.

```
curl --head http://localhost:8787/

HTTP/1.1 200 OK
Content-Type: text/plain;charset=UTF-8
```

The advantage of this approach is that it's implemented as middleware. Therefore, users can choose whether to allow HEAD requests or not.

This will resolve #1130 , alternative to #1142