### PR TITLE
[POC] feat: `contentLength` middleware

### DIFF
--- a/src/middleware/content-length/index.test.ts
+++ b/src/middleware/content-length/index.test.ts
@@ -1,0 +1,26 @@
+import { Hono } from '../../hono'
+import { contentLength } from '.'
+
+describe('Content Length Middleware', () => {
+  const app = new Hono()
+
+  app.use('*', contentLength())
+  app.get('/', (c) => {
+    return c.text('Hono')
+  })
+  app.get('/kanji', (c) => {
+    return c.text('炎')
+  })
+
+  it('Should return the correct content length', async () => {
+    let res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Length')).toBe('4')
+    expect(await res.text()).toBe('Hono')
+
+    res = await app.request('/kanji')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Length')).toBe('3')
+    expect(await res.text()).toBe('炎')
+  })
+})

--- a/src/middleware/content-length/index.ts
+++ b/src/middleware/content-length/index.ts
@@ -1,0 +1,11 @@
+import type { MiddlewareHandler } from '../../types'
+
+export const contentLength = (): MiddlewareHandler => {
+  return async (c, next) => {
+    await next()
+    const res = new Response(c.res.clone().body)
+    const data = await res.arrayBuffer()
+    const length = data.byteLength
+    c.res.headers.set('Content-Length', length.toString())
+  }
+}


### PR DESCRIPTION
This PR introduces the "Content Length Middleware", which calculates content length and adds the `Content-Length` header to the response.

```ts
import { contentLength } from 'hono/content-length'

// ...

app.use('*', contentLength())

app.get('/', (c) => {
  return c.text('Hello!')
})
```

```
curl -XGET -I http://localhost:8787/

HTTP/1.1 200 OK
Content-Length: 6
Content-Type: text/plain;charset=UTF-8
```

While this seems beneficial, we generally do not recommend using it.

This is because it's not necessary for edge environments such as Cloudflare, Deno, Compute@Edge, or Bun. In these environments, the `Content-Length` header will be automatically added. Moreover, this middleware calculates length by handling the content in memory, which is not ideal.

So, first, we need to discuss whether we should accept this PR or not.