### PR TITLE
fix(tire-router/pattern-router): fixed the named capture issue

### DIFF
--- a/deno_dist/router/pattern-router/router.ts
+++ b/deno_dist/router/pattern-router/router.ts
@@ -1,7 +1,7 @@
 import type { Result, Router } from '../../router.ts'
 import { METHOD_NAME_ALL } from '../../router.ts'
 
-type Route<T> = [RegExp, string, T] // [pattern, method, handler]
+type Route<T> = [RegExp, string, T, string] // [pattern, method, handler, path]
 
 export class PatternRouter<T> implements Router<T> {
   name: string = 'PatternRouter'
@@ -43,23 +43,36 @@ export class PatternRouter<T> implements Router<T> {
       new RegExp(`^${parts.join('')}${endsWithWildcard ? '' : '/?$'}`),
       method,
       handler,
+      path,
     ])
   }
 
   match(method: string, path: string): Result<T> | null {
     const handlers: T[] = []
     let params: Record<string, string> | undefined = undefined
-    for (const [pattern, routeMethod, handler] of this.routes) {
+    const matchedRoutes: Route<T>[] = []
+
+    for (const route of this.routes) {
+      const [pattern, routeMethod, handler] = route
+      const isRegExp = pattern.source.charCodeAt(pattern.source.length - 1) === 36
       if (routeMethod === METHOD_NAME_ALL || routeMethod === method) {
         const match = pattern.exec(path)
         if (match) {
           handlers.push(handler)
-          if (pattern.source.charCodeAt(pattern.source.length - 1) === 36) {
+          for (const r of matchedRoutes) {
+            const m = pattern.exec(r[3])
+            if (m && isRegExp) {
+              params = Object.assign({}, m.groups)
+            }
+          }
+          if (isRegExp) {
             params ??= match.groups || {}
           }
+          matchedRoutes.push(route)
         }
       }
     }
+
     return handlers.length
       ? {
           handlers,

--- a/deno_dist/router/pattern-router/router.ts
+++ b/deno_dist/router/pattern-router/router.ts
@@ -1,7 +1,7 @@
 import type { Result, Router } from '../../router.ts'
 import { METHOD_NAME_ALL } from '../../router.ts'
 
-type Route<T> = [RegExp, string, T, string] // [pattern, method, handler, path]
+type Route<T> = [RegExp, string, T] // [pattern, method, handler, path]
 
 export class PatternRouter<T> implements Router<T> {
   name: string = 'PatternRouter'
@@ -43,32 +43,22 @@ export class PatternRouter<T> implements Router<T> {
       new RegExp(`^${parts.join('')}${endsWithWildcard ? '' : '/?$'}`),
       method,
       handler,
-      path,
     ])
   }
 
   match(method: string, path: string): Result<T> | null {
     const handlers: T[] = []
-    let params: Record<string, string> | undefined = undefined
-    const matchedRoutes: Route<T>[] = []
+    const params: Record<string, string> = {}
 
-    for (const route of this.routes) {
-      const [pattern, routeMethod, handler] = route
+    for (const [pattern, routeMethod, handler] of this.routes) {
       const isRegExp = pattern.source.charCodeAt(pattern.source.length - 1) === 36
       if (routeMethod === METHOD_NAME_ALL || routeMethod === method) {
         const match = pattern.exec(path)
         if (match) {
           handlers.push(handler)
-          for (const r of matchedRoutes) {
-            const m = pattern.exec(r[3])
-            if (m && isRegExp) {
-              params = Object.assign({}, m.groups)
-            }
-          }
           if (isRegExp) {
-            params ??= match.groups || {}
+            Object.assign(params, match.groups)
           }
-          matchedRoutes.push(route)
         }
       }
     }
@@ -76,7 +66,7 @@ export class PatternRouter<T> implements Router<T> {
     return handlers.length
       ? {
           handlers,
-          params: params || {},
+          params,
         }
       : null
   }

--- a/deno_dist/router/trie-router/node.ts
+++ b/deno_dist/router/trie-router/node.ts
@@ -33,7 +33,6 @@ export class Node<T> {
   order: number = 0
   name: string
   handlerSetCache: Record<string, HandlerSet<T>[]>
-  shouldCapture: boolean = false
 
   constructor(method?: string, handler?: T, children?: Record<string, Node<T>>) {
     this.children = children || {}
@@ -75,7 +74,6 @@ export class Node<T> {
       const pattern = getPattern(p)
       if (pattern) {
         if (typeof pattern === 'object') {
-          this.shouldCapture = true
           for (let j = 0, len = parentPatterns.length; j < len; j++) {
             if (typeof parentPatterns[j] === 'object' && parentPatterns[j][1] === pattern[1]) {
               throw new Error(errorMessage(pattern[1]))
@@ -90,7 +88,6 @@ export class Node<T> {
       }
       parentPatterns.push(...curNode.patterns)
       curNode = curNode.children[p]
-      curNode.shouldCapture = this.shouldCapture
     }
 
     if (!curNode.methods.length) {
@@ -200,7 +197,7 @@ export class Node<T> {
             if (typeof name === 'string' && !matched) {
               params[name] = part
             } else {
-              if (node.children[part] && node.children[part].shouldCapture) {
+              if (node.children[part]) {
                 params[name] = part
               }
             }

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -604,7 +604,7 @@ describe('Routing order With named parameters', () => {
     const res = node.search('get', '/book/a')
     expect(res).not.toBeNull()
     expect(res?.handlers).toEqual(['no-slug', 'slug'])
-    expect(res?.params['slug']).toBeUndefined()
+    expect(res?.params['slug']).toBe('a')
   })
   it('/book/foo', () => {
     const res = node.search('get', '/book/foo')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -33,7 +33,6 @@ export class Node<T> {
   order: number = 0
   name: string
   handlerSetCache: Record<string, HandlerSet<T>[]>
-  shouldCapture: boolean = false
 
   constructor(method?: string, handler?: T, children?: Record<string, Node<T>>) {
     this.children = children || {}
@@ -75,7 +74,6 @@ export class Node<T> {
       const pattern = getPattern(p)
       if (pattern) {
         if (typeof pattern === 'object') {
-          this.shouldCapture = true
           for (let j = 0, len = parentPatterns.length; j < len; j++) {
             if (typeof parentPatterns[j] === 'object' && parentPatterns[j][1] === pattern[1]) {
               throw new Error(errorMessage(pattern[1]))
@@ -90,7 +88,6 @@ export class Node<T> {
       }
       parentPatterns.push(...curNode.patterns)
       curNode = curNode.children[p]
-      curNode.shouldCapture = this.shouldCapture
     }
 
     if (!curNode.methods.length) {
@@ -200,7 +197,7 @@ export class Node<T> {
             if (typeof name === 'string' && !matched) {
               params[name] = part
             } else {
-              if (node.children[part] && node.children[part].shouldCapture) {
+              if (node.children[part]) {
                 params[name] = part
               }
             }

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -158,7 +158,7 @@ describe('routing order with named parameters', () => {
   it('GET /book/a', async () => {
     const res = router.match('GET', '/book/a')
     expect(res?.handlers).toEqual(['no-slug', 'slug'])
-    expect(res?.params['slug']).toBeUndefined()
+    expect(res?.params['slug']).toBe('a')
   })
   it('GET /book/foo', async () => {
     const res = router.match('GET', '/book/foo')


### PR DESCRIPTION
This PR will fix the issue of capturing named parameters in TrieRouter and PatternRouter.

If we have the following routes:

```ts
app.get('/webhooks/github', async (c, next) => {
  await next()
})

app.get('/webhooks/:service', (c) => {
  return c.text(`service: ${c.req.param('service')}`)
})
```

Then, when accessing `GET /webhooks/github`, it currently can't handle the named parameter as `github`:

```
GET /webhooks/github => service: undefined
```

With this fix, it can capture `github`:

```
GET /webhooks/github => service: github
```

Resolves #1141