### PR TITLE
perf: use `indexOf()` intead of `includes()`

### DIFF
--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -117,7 +117,7 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error('Can not add a route since the matcher is already built.')
     }
 
-    if (!methodNames.includes(method)) methodNames.push(method)
+    if (methodNames.indexOf(method) === -1) methodNames.push(method)
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
         handlerMap[method] = {}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -132,10 +132,10 @@ const _decodeURI = (value: string) => {
   if (!/[%+]/.test(value)) {
     return value
   }
-  if (value.includes('+')) {
+  if (value.indexOf('+') !== -1) {
     value = value.replace(/\+/g, ' ')
   }
-  return value.includes('%') ? decodeURIComponent_(value) : value
+  return value.indexOf('%') === -1 ? value : decodeURIComponent_(value)
 }
 
 const _getQueryParam = (


### PR DESCRIPTION
`indexOf()` is faster than `includes()`.

Benchmark script:

```ts
bench('noop', () => {})

bench('includes', async () => {
  'abc+defg'.includes('+')
})

bench('indexOf', async () => {
  'abc+defg'.indexOf('+') !== -1
})

await run()
```

Results:

```
yusuke $ bun run src/benchmark-includes.mts
cpu: Apple M1 Pro
runtime: bun 0.6.6 (arm64-darwin)

benchmark      time (avg)             (min … max)       p75       p99      p995
------------------------------------------------- -----------------------------
noop       319.56 ps/iter      (300 ps … 9.97 ns)  312.5 ps  370.9 ps  379.1 ps
includes     86.1 ns/iter  (82.47 ns … 208.26 ns)   84.9 ns 122.15 ns 126.49 ns
indexOf     81.83 ns/iter  (78.61 ns … 126.58 ns)  81.25 ns 115.38 ns 116.34 ns
```

```
yusuke $ tsx src/benchmark-includes.mts
cpu: Apple M1 Pro
runtime: node v18.16.0 (arm64-darwin)

benchmark      time (avg)             (min … max)       p75       p99      p995
------------------------------------------------- -----------------------------
noop       318.36 ps/iter  (304.1 ps … 284.83 ns)  312.5 ps  337.5 ps  341.7 ps
includes    60.78 ns/iter  (55.94 ns … 122.27 ns)  61.53 ns 110.34 ns 119.61 ns
indexOf     59.25 ns/iter     (53.15 ns … 123 ns)  60.42 ns  66.92 ns 112.51 ns
```