### PR TITLE
refactor: Tweaks variable names to reduce code.

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -64,7 +64,7 @@ type ContextOptions<E extends Env> = {
   executionCtx?: FetchEvent | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
   path?: string
-  paramData?: Record<string, string>
+  params?: Record<string, string>
 }
 
 export class Context<
@@ -89,7 +89,7 @@ export class Context<
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
   private _path: string = '/'
-  private _pData?: Record<string, string> | null // __paramData
+  private _params?: Record<string, string> | null
   private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
@@ -98,7 +98,7 @@ export class Context<
     if (options) {
       this._exCtx = options.executionCtx
       this._path = options.path ?? '/'
-      this._pData = options.paramData
+      this._params = options.params
       this.env = options.env
       if (options.notFoundHandler) {
         this.notFoundHandler = options.notFoundHandler
@@ -111,9 +111,9 @@ export class Context<
       return this._req
     } else {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this._req = new HonoRequest(this.rawRequest!, this._path, this._pData!)
+      this._req = new HonoRequest(this.rawRequest!, this._path, this._params!)
       this.rawRequest = undefined
-      this._pData = undefined
+      this._params = undefined
       return this._req
     }
   }

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -117,7 +117,7 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error('Can not add a route since the matcher is already built.')
     }
 
-    if (!methodNames.includes(method)) methodNames.push(method)
+    if (methodNames.indexOf(method) === -1) methodNames.push(method)
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
         handlerMap[method] = {}

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -132,10 +132,10 @@ const _decodeURI = (value: string) => {
   if (!/[%+]/.test(value)) {
     return value
   }
-  if (value.includes('+')) {
+  if (value.indexOf('+') !== -1) {
     value = value.replace(/\+/g, ' ')
   }
-  return value.includes('%') ? decodeURIComponent_(value) : value
+  return value.indexOf('%') === -1 ? value : decodeURIComponent_(value)
 }
 
 const _getQueryParam = (

--- a/src/context.ts
+++ b/src/context.ts
@@ -64,7 +64,7 @@ type ContextOptions<E extends Env> = {
   executionCtx?: FetchEvent | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
   path?: string
-  paramData?: Record<string, string>
+  params?: Record<string, string>
 }
 
 export class Context<
@@ -89,7 +89,7 @@ export class Context<
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
   private _path: string = '/'
-  private _pData?: Record<string, string> | null // __paramData
+  private _params?: Record<string, string> | null // __params
   private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
@@ -98,7 +98,7 @@ export class Context<
     if (options) {
       this._exCtx = options.executionCtx
       this._path = options.path ?? '/'
-      this._pData = options.paramData
+      this._params = options.params
       this.env = options.env
       if (options.notFoundHandler) {
         this.notFoundHandler = options.notFoundHandler
@@ -111,9 +111,9 @@ export class Context<
       return this._req
     } else {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this._req = new HonoRequest(this.rawRequest!, this._path, this._pData!)
+      this._req = new HonoRequest(this.rawRequest!, this._path, this._params!)
       this.rawRequest = undefined
-      this._pData = undefined
+      this._params = undefined
       return this._req
     }
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -89,7 +89,7 @@ export class Context<
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
   private _path: string = '/'
-  private _params?: Record<string, string> | null // __params
+  private _params?: Record<string, string> | null
   private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -244,7 +244,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   }
 
   private matchRoute(method: string, path: string) {
-    return this.router.match(method, path)
+    return this.router.match(method, path) || { handlers: [], params: {} }
   }
 
   private handleError(err: unknown, c: Context<E>) {
@@ -256,30 +256,28 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
   private dispatch(
     request: Request,
-    eventOrExecutionCtx?: ExecutionContext | FetchEvent,
+    executionCtx?: ExecutionContext | FetchEvent,
     env?: E['Bindings']
   ): Response | Promise<Response> {
     const path = this.getPath(request)
     const method = request.method
 
-    const result = this.matchRoute(method, path)
-    const paramData = result?.params
+    const { handlers, params } = this.matchRoute(method, path)
 
     const c = new Context(request, {
       env,
-      executionCtx: eventOrExecutionCtx,
+      executionCtx,
       notFoundHandler: this.notFoundHandler,
       path,
-      paramData,
+      params,
     })
 
     // Do not `compose` if it has only one handler
-    if (result?.handlers.length === 1) {
-      const handler = result.handlers[0]
+    if (handlers.length === 1) {
       let res: ReturnType<H>
 
       try {
-        res = handler(c, async () => {})
+        res = handlers[0](c, async () => {})
         if (!res) {
           return this.notFoundHandler(c)
         }
@@ -312,7 +310,6 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
       })()
     }
 
-    const handlers = result ? result.handlers : [this.notFoundHandler]
     const composed = compose<Context>(handlers, this.errorHandler, this.notFoundHandler)
 
     return (async () => {


### PR DESCRIPTION
It would reduce the number of conditional branches in `result?.handlers` and `result?.params` and shorten the code by a few lines.

Since this is not a particularly big improvement, it is safe to decide not to merge.