### PR TITLE
feat(jsx): React-like `style` conversion

### DIFF
--- a/deno_dist/middleware/jsx/index.test.tsx
+++ b/deno_dist/middleware/jsx/index.test.tsx
@@ -268,6 +268,26 @@ describe('render to string', () => {
       )
     })
   })
+
+  describe('style attribute', () => {
+    it('should convert the object to strings', () => {
+      const template = (
+        <h1
+          style={{
+            color: 'red',
+            fontSize: 'small',
+          }}
+        >
+          Hello
+        </h1>
+      )
+      expect(template.toString()).toBe('<h1 style="color:red;font-size:small">Hello</h1>')
+    })
+    it('should not convert the strings', () => {
+      const template = <h1 style='color:red;font-size:small'>Hello</h1>
+      expect(template.toString()).toBe('<h1 style="color:red;font-size:small">Hello</h1>')
+    })
+  })
 })
 
 describe('memo', () => {

--- a/deno_dist/middleware/jsx/index.ts
+++ b/deno_dist/middleware/jsx/index.ts
@@ -111,20 +111,28 @@ export class JSXNode implements HtmlEscaped {
     const propsKeys = Object.keys(props || {})
 
     for (let i = 0, len = propsKeys.length; i < len; i++) {
-      const v = props[propsKeys[i]]
-      if (typeof v === 'string') {
-        buffer[0] += ` ${propsKeys[i]}="`
+      const key = propsKeys[i]
+      const v = props[key]
+      // object to style strings
+      if (key === 'style' && typeof v === 'object') {
+        const styles = Object.keys(v)
+          .map((k) => `${k}:${v[k]}`)
+          .join(';')
+          .replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+        buffer[0] += ` style="${styles}"`
+      } else if (typeof v === 'string') {
+        buffer[0] += ` ${key}="`
         escapeToBuffer(v, buffer)
         buffer[0] += '"'
       } else if (typeof v === 'number') {
-        buffer[0] += ` ${propsKeys[i]}="${v}"`
+        buffer[0] += ` ${key}="${v}"`
       } else if (v === null || v === undefined) {
         // Do nothing
-      } else if (typeof v === 'boolean' && booleanAttributes.includes(propsKeys[i])) {
+      } else if (typeof v === 'boolean' && booleanAttributes.includes(key)) {
         if (v) {
-          buffer[0] += ` ${propsKeys[i]}=""`
+          buffer[0] += ` ${key}=""`
         }
-      } else if (propsKeys[i] === 'dangerouslySetInnerHTML') {
+      } else if (key === 'dangerouslySetInnerHTML') {
         if (children.length > 0) {
           throw 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
         }
@@ -133,7 +141,7 @@ export class JSXNode implements HtmlEscaped {
         escapedString.isEscaped = true
         children = [escapedString]
       } else {
-        buffer[0] += ` ${propsKeys[i]}="`
+        buffer[0] += ` ${key}="`
         escapeToBuffer(v.toString(), buffer)
         buffer[0] += '"'
       }

--- a/src/middleware/jsx/index.test.tsx
+++ b/src/middleware/jsx/index.test.tsx
@@ -268,6 +268,26 @@ describe('render to string', () => {
       )
     })
   })
+
+  describe('style attribute', () => {
+    it('should convert the object to strings', () => {
+      const template = (
+        <h1
+          style={{
+            color: 'red',
+            fontSize: 'small',
+          }}
+        >
+          Hello
+        </h1>
+      )
+      expect(template.toString()).toBe('<h1 style="color:red;font-size:small">Hello</h1>')
+    })
+    it('should not convert the strings', () => {
+      const template = <h1 style='color:red;font-size:small'>Hello</h1>
+      expect(template.toString()).toBe('<h1 style="color:red;font-size:small">Hello</h1>')
+    })
+  })
 })
 
 describe('memo', () => {

--- a/src/middleware/jsx/index.ts
+++ b/src/middleware/jsx/index.ts
@@ -111,20 +111,28 @@ export class JSXNode implements HtmlEscaped {
     const propsKeys = Object.keys(props || {})
 
     for (let i = 0, len = propsKeys.length; i < len; i++) {
-      const v = props[propsKeys[i]]
-      if (typeof v === 'string') {
-        buffer[0] += ` ${propsKeys[i]}="`
+      const key = propsKeys[i]
+      const v = props[key]
+      // object to style strings
+      if (key === 'style' && typeof v === 'object') {
+        const styles = Object.keys(v)
+          .map((k) => `${k}:${v[k]}`)
+          .join(';')
+          .replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+        buffer[0] += ` style="${styles}"`
+      } else if (typeof v === 'string') {
+        buffer[0] += ` ${key}="`
         escapeToBuffer(v, buffer)
         buffer[0] += '"'
       } else if (typeof v === 'number') {
-        buffer[0] += ` ${propsKeys[i]}="${v}"`
+        buffer[0] += ` ${key}="${v}"`
       } else if (v === null || v === undefined) {
         // Do nothing
-      } else if (typeof v === 'boolean' && booleanAttributes.includes(propsKeys[i])) {
+      } else if (typeof v === 'boolean' && booleanAttributes.includes(key)) {
         if (v) {
-          buffer[0] += ` ${propsKeys[i]}=""`
+          buffer[0] += ` ${key}=""`
         }
-      } else if (propsKeys[i] === 'dangerouslySetInnerHTML') {
+      } else if (key === 'dangerouslySetInnerHTML') {
         if (children.length > 0) {
           throw 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
         }
@@ -133,7 +141,7 @@ export class JSXNode implements HtmlEscaped {
         escapedString.isEscaped = true
         children = [escapedString]
       } else {
-        buffer[0] += ` ${propsKeys[i]}="`
+        buffer[0] += ` ${key}="`
         escapeToBuffer(v.toString(), buffer)
         buffer[0] += '"'
       }


### PR DESCRIPTION
This PR introduces a React-like `style` attribute conversion in the JSX middleware. This could be referred to as "CSS in JS", but since the definition isn't clear, I'll call it "React-like" for now.

You can now write `style` attributes using an object:

```ts
const Tag = () => (
  <h1
    style={{
      color: 'red',
      fontSize: 'small',
    }}
  >
    Hello
  </h1>
)
```

This will be converted to:

```html
<h1 style="color:red;font-size:small">Hello</h1>
```

I believe this feature will be useful for creating styled web pages.