### PR TITLE
fix: avoid range-error

### DIFF
--- a/deno_dist/utils/encode.ts
+++ b/deno_dist/utils/encode.ts
@@ -8,7 +8,11 @@ export const encodeBase64Url = (buf: ArrayBufferLike): string =>
 // This approach is written in MDN.
 // btoa does not support utf-8 characters. So we need a little bit hack.
 export const encodeBase64 = (buf: ArrayBufferLike): string => {
-  const binary = String.fromCharCode(...new Uint8Array(buf))
+  let binary = ''
+  const bytes = new Uint8Array(buf)
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
   return btoa(binary)
 }
 

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -8,7 +8,11 @@ export const encodeBase64Url = (buf: ArrayBufferLike): string =>
 // This approach is written in MDN.
 // btoa does not support utf-8 characters. So we need a little bit hack.
 export const encodeBase64 = (buf: ArrayBufferLike): string => {
-  const binary = String.fromCharCode(...new Uint8Array(buf))
+  let binary = ''
+  const bytes = new Uint8Array(buf)
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
   return btoa(binary)
 }
 

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -10,7 +10,7 @@ export const encodeBase64Url = (buf: ArrayBufferLike): string =>
 export const encodeBase64 = (buf: ArrayBufferLike): string => {
   let binary = ''
   const bytes = new Uint8Array(buf)
-  for (let i = 0; i < bytes.byteLength; i++) {
+  for (let i = 0; i < bytes.length; i++) {
     binary += String.fromCharCode(bytes[i])
   }
   return btoa(binary)


### PR DESCRIPTION
In Node.js, spread operator for large-sized array occurs Range Error:

https://stackoverflow.com/questions/51249561/aws-lambda-rangeerror-maximum-call-stack-size-exceeded
https://github.com/nodejs/node/issues/16870

When I use somewhat large image this problem happens. To avoid this I re-wrote some codes. This doesn't make no change on behaiviors.