### PR TITLE
Update server-static-module.ts

### DIFF
--- a/src/adapter/cloudflare-workers/server-static-module.ts
+++ b/src/adapter/cloudflare-workers/server-static-module.ts
@@ -2,7 +2,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 // For ES module mode
-import manifest from '__STATIC_CONTENT_MANIFEST'
 import type { ServeStaticOptions } from './serve-static'
 import { serveStatic } from './serve-static'
 
@@ -10,7 +9,7 @@ const module = (options: ServeStaticOptions = { root: '' }) => {
   return serveStatic({
     root: options.root,
     path: options.path,
-    manifest: options.manifest ? options.manifest : manifest,
+    manifest: options.manifest ? options.manifest : __STATIC_CONTENT_MANIFEST,
     rewriteRequestPath: options.rewriteRequestPath,
   })
 }


### PR DESCRIPTION
`__STATIC_CONTENT_MANIFEST` can not be resolved when compiling outside of CloudFlares worker, however it is available at run time.

Compiling from ESbuild:
```
✘ [ERROR] Could not resolve "__STATIC_CONTENT_MANIFEST"

    node_modules/hono/dist/adapter/cloudflare-workers/server-static-module.js:2:21:
      2 │ import manifest from "__STATIC_CONTENT_MANIFEST";
        ╵                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "__STATIC_CONTENT_MANIFEST" as external to exclude it from the bundle, which
  will remove this error.
```