### PR TITLE
fix: application/x-www-form-urlencoded decoding

### DIFF
--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -6,7 +6,7 @@ export async function parseBody(r: Request | Response) {
   if (
     contentType &&
     (contentType.startsWith('multipart/form-data') ||
-      contentType === 'application/x-www-form-urlencoded')
+      contentType.startsWith('application/x-www-form-urlencoded'))
   ) {
     const form: BodyData = {}
     ;(await r.formData()).forEach((value, key) => {

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -6,7 +6,7 @@ export async function parseBody(r: Request | Response) {
   if (
     contentType &&
     (contentType.startsWith('multipart/form-data') ||
-      contentType === 'application/x-www-form-urlencoded')
+      contentType.startsWith('application/x-www-form-urlencoded'))
   ) {
     const form: BodyData = {}
     ;(await r.formData()).forEach((value, key) => {


### PR DESCRIPTION
The current logic for decoding application/x-www-form-urlencoded is overly restrictive and misses `Content-Type` headers with a character encoding set, i.e., `application/x-www-form-urlencoded; charset=UTF-8`.

This fix harmonizes the logic for handling `multipart/form-data` and `application/x-www-form-urlencoded` in the `parseBody` method of request objects.