### PR TITLE
fix(utils/cookie): allow 0 to maxAge

### DIFF
--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -26,7 +26,7 @@ export const serialize = (name: string, value: string, opt: CookieOptions = {}):
   value = encodeURIComponent(value)
   let cookie = `${name}=${value}`
 
-  if (opt.maxAge && opt.maxAge >= 0) {
+  if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
     cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
   }
 

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -28,7 +28,15 @@ describe('Set cookie', () => {
     )
   })
 
-  it('Should serialize cookie', () => {
+  it('Should serialize cookie with maxAge is 0', () => {
+    expect(
+      serialize('great_cookie', 'banana', {
+        maxAge: 0,
+      })
+    ).toBe('great_cookie=banana; Max-Age=0')
+  })
+
+  it('Should serialize cookie with maxAge is -1', () => {
     expect(
       serialize('great_cookie', 'banana', {
         maxAge: -1,

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -26,7 +26,7 @@ export const serialize = (name: string, value: string, opt: CookieOptions = {}):
   value = encodeURIComponent(value)
   let cookie = `${name}=${value}`
 
-  if (opt.maxAge && opt.maxAge >= 0) {
+  if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
     cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
   }
 


### PR DESCRIPTION
With #1194 fix, it doe's not allow `0` for the maxAge option. `0` can be set.