### PR TITLE
fix(etag): support multi-value If-None-Match

### DIFF
--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -16,7 +16,7 @@ const RETAINED_304_HEADERS = [
   'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
 ]
 
-function etagMatches(etag: string, ifNoneMatch: string | undefined) {
+function etagMatches(etag: string, ifNoneMatch: string | null) {
   return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
 }
 
@@ -25,7 +25,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const weak = options?.weak ?? false
 
   return async (c, next) => {
-    const ifNoneMatch = c.req.header('If-None-Match') || c.req.header('if-none-match')
+    const ifNoneMatch = c.req.headers.get('If-None-Match')
 
     await next()
 

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -16,6 +16,10 @@ const RETAINED_304_HEADERS = [
   'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
 ]
 
+function etagMatches(etag: string, ifNoneMatch: string | undefined) {
+  return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
+}
+
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false
@@ -35,7 +39,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
       etag = weak ? `W/"${hash}"` : `"${hash}"`
     }
 
-    if (ifNoneMatch && ifNoneMatch === etag) {
+    if (etagMatches(etag, ifNoneMatch)) {
       await undisturbedRes.blob() // Force using body
       c.res = new Response(null, {
         status: 304,

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -115,6 +115,14 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('expires')).toBe('Mon, Feb 27 2023 12:10:36 GMT')
     expect(res.headers.get('server')).toBeFalsy()
     expect(res.headers.get('vary')).toBe('Accept-Language')
+
+    // conditional GET with matching ETag among list:
+    res = await app.request('http://localhost/etag/ghi', {
+      headers: {
+        'If-None-Match': `"mismatch 1", ${etag}, "mismatch 2"`,
+      },
+    })
+    expect(res.status).toBe(304)
   })
 
   it('Should not return duplicate etag header values', async () => {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -102,4 +102,11 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('ETag')).not.toBeFalsy()
     expect(res.headers.get('ETag')).toBe('"4e32298b1cb4edc595237405e5b696e105c2399a"')
   })
+
+  it('Should not override ETag headers from upstream', async () => {
+    app.get('/etag/predefined', (c) => c.text('This response has an ETag', 200, { ETag: '"f-0194-d"'}))
+
+    const res = await app.request('http://localhost/etag/predefined')
+    expect(res.headers.get('ETag')).toBe('"f-0194-d"')
+  })
 })

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -16,7 +16,7 @@ const RETAINED_304_HEADERS = [
   'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
 ]
 
-function etagMatches(etag: string, ifNoneMatch: string | undefined) {
+function etagMatches(etag: string, ifNoneMatch: string | null) {
   return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
 }
 
@@ -25,7 +25,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const weak = options?.weak ?? false
 
   return async (c, next) => {
-    const ifNoneMatch = c.req.header('If-None-Match') || c.req.header('if-none-match')
+    const ifNoneMatch = c.req.headers.get('If-None-Match')
 
     await next()
 

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -16,6 +16,10 @@ const RETAINED_304_HEADERS = [
   'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
 ]
 
+function etagMatches(etag: string, ifNoneMatch: string | undefined) {
+  return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
+}
+
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false
@@ -35,7 +39,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
       etag = weak ? `W/"${hash}"` : `"${hash}"`
     }
 
-    if (ifNoneMatch && ifNoneMatch === etag) {
+    if (etagMatches(etag, ifNoneMatch)) {
       await undisturbedRes.blob() // Force using body
       c.res = new Response(null, {
         status: 304,

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -2,10 +2,24 @@ import type { MiddlewareHandler } from '../../types'
 import { sha1 } from '../../utils/crypto'
 
 type ETagOptions = {
-  weak: boolean
+  retainedHeaders?: string[],
+  weak?: boolean
 }
 
-export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler => {
+/**
+ * Default headers to pass through on 304 responses. From the spec:
+ * > The response must not contain a body and must include the headers that
+ * > would have been sent in an equivalent 200 OK response: Cache-Control,
+ * > Content-Location, Date, ETag, Expires, and Vary.
+ */
+const RETAINED_304_HEADERS = [
+  'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
+]
+
+export const etag = (options?: ETagOptions): MiddlewareHandler => {
+  const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
+  const weak = options?.weak ?? false
+
   return async (c, next) => {
     const ifNoneMatch = c.req.header('If-None-Match') || c.req.header('if-none-match')
 
@@ -18,7 +32,7 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
     if (!etag) {
       undisturbedRes = res.clone()
       const hash = await sha1(res.body || '')
-      etag = options.weak ? `W/"${hash}"` : `"${hash}"`
+      etag = weak ? `W/"${hash}"` : `"${hash}"`
     }
 
     if (ifNoneMatch && ifNoneMatch === etag) {
@@ -30,7 +44,11 @@ export const etag = (options: ETagOptions = { weak: false }): MiddlewareHandler 
           ETag: etag,
         },
       })
-      c.res.headers.delete('Content-Length')
+      c.res.headers.forEach((_, key) => {
+        if (retainedHeaders.indexOf(key.toLowerCase()) === -1) {
+          c.res.headers.delete(key)
+        }
+      })
     } else {
       c.res = new Response(undisturbedRes.body, undisturbedRes)
       c.res.headers.set('ETag', etag)


### PR DESCRIPTION
* chore(etag): reduce global state in tests
* perf(etag): don't override ETags from upstream
* perf(etag): 304s include only necessary headers
* fix(etag): Support multi-value If-None-Match
* perf(etag): prefer Header.prototype.get

I recommend reviewing commit-by-commit as each commit has detailed rationale, including references to the relevant specs.