### PR TITLE
perf(Request) optimize Request.prototype.header

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -69,14 +69,13 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   header(name: string): string | undefined
   header(): Record<string, string>
   header(name?: string) {
+    if (name) return this.raw.headers.get(name.toLowerCase()) ?? undefined
+
     const headerData: Record<string, string | undefined> = {}
     this.raw.headers.forEach((value, key) => {
       headerData[key] = value
     })
-    if (!name) {
-      return headerData
-    }
-    return headerData[name.toLowerCase()]
+    return headerData
   }
 
   /** @deprecated

--- a/src/request.ts
+++ b/src/request.ts
@@ -69,14 +69,13 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   header(name: string): string | undefined
   header(): Record<string, string>
   header(name?: string) {
+    if (name) return this.raw.headers.get(name.toLowerCase()) ?? undefined
+
     const headerData: Record<string, string | undefined> = {}
     this.raw.headers.forEach((value, key) => {
       headerData[key] = value
     })
-    if (!name) {
-      return headerData
-    }
-    return headerData[name.toLowerCase()]
+    return headerData
   }
 
   /** @deprecated


### PR DESCRIPTION
`Request.prototype.header` has two overloads:

 1. with a string name, it returns that header value if present
 2. with no argument, it returns all the headers as an object

Previously, the implementation built the whole object for (2) even when returning a single header. This was wasteful. This commit changes it to return the header by name if specified and only iterate over all the headers when the caller asks for the whole object.