### PR TITLE
fix(types): allow not to set `skipLibCheck`

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -41,8 +41,7 @@ export interface ClientResponse<T> {
   arrayBuffer(): Promise<ArrayBuffer>
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface Response extends ClientResponse<any> {}
+export interface Response extends ClientResponse<unknown> {}
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -26,9 +26,23 @@ type ClientRequest<S extends Data> = {
     : never
 }
 
-export interface ClientResponse<T> extends Response {
+export interface ClientResponse<T> {
+  ok: boolean
+  status: number
+  statusText: string
+  headers: Headers
+  url: string
+  redirect(url: string, status: number): Response
+  clone(): Response
   json(): Promise<T>
+  text(): Promise<string>
+  blob(): Promise<Blob>
+  formData(): Promise<FormData>
+  arrayBuffer(): Promise<ArrayBuffer>
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Response extends ClientResponse<any> {}
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,6 +1,6 @@
 import { HonoRequest } from './request.ts'
-import type { TypedResponse } from './types.ts'
-import type { Env, NotFoundHandler, Input } from './types.ts'
+import { FetchEventLike } from './types.ts'
+import type { Env, NotFoundHandler, Input, TypedResponse } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
@@ -92,7 +92,7 @@ interface HTMLRespond {
 
 type ContextOptions<E extends Env> = {
   env: E['Bindings']
-  executionCtx?: FetchEvent | ExecutionContext | undefined
+  executionCtx?: FetchEventLike | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
   path?: string
   params?: Record<string, string>
@@ -112,7 +112,7 @@ export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _req?: HonoRequest<any, any>
   private _status: StatusCode = 200
-  private _exCtx: FetchEvent | ExecutionContext | undefined // _executionCtx
+  private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
   private _pre: boolean = false // _pretty
   private _preS: number = 2 // _prettySpace
   private _map: Record<string, unknown> | undefined
@@ -149,8 +149,8 @@ export class Context<
     }
   }
 
-  get event(): FetchEvent {
-    if (this._exCtx instanceof FetchEvent) {
+  get event(): FetchEventLike {
+    if (this._exCtx instanceof FetchEventLike) {
       return this._exCtx
     } else {
       throw Error('This context has no FetchEvent')

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -17,6 +17,7 @@ import type {
   TypedResponse,
   MergePath,
   MergeSchemaPath,
+  FetchEventLike,
 } from './types.ts'
 import type { RemoveBlankRecord } from './utils/types.ts'
 import { getPath, getPathNoStrict, mergePath } from './utils/url.ts'
@@ -266,7 +267,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
   private dispatch(
     request: Request,
-    executionCtx: ExecutionContext | FetchEvent | undefined,
+    executionCtx: ExecutionContext | FetchEventLike | undefined,
     env: E['Bindings'],
     method: string
   ): Response | Promise<Response> {
@@ -344,7 +345,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     })()
   }
 
-  handleEvent = (event: FetchEvent) => {
+  handleEvent = (event: FetchEventLike) => {
     return this.dispatch(event.request, event, undefined, event.request.method)
   }
 

--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -1,19 +1,6 @@
 import { Hono } from './hono.ts'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  class ExtendableEvent extends Event {
-    constructor(type: string, init?: EventInit)
-    waitUntil(promise: Promise<void>): void
-  }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  abstract class FetchEvent extends ExtendableEvent {
-    readonly request: Request
-    respondWith(promise: Response | Promise<Response>): void
-    passThroughOnException(): void
-  }
   interface ExecutionContext {
     waitUntil(promise: Promise<void>): void
     passThroughOnException(): void

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -165,20 +165,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get headers() {
     return this.raw.headers
   }
-  get redirect() {
-    return this.raw.redirect
-  }
   get body() {
     return this.raw.body
   }
   get bodyUsed() {
     return this.raw.bodyUsed
-  }
-  get cache() {
-    return this.raw.cache
-  }
-  get credentials() {
-    return this.raw.credentials
   }
   get integrity() {
     return this.raw.integrity
@@ -186,14 +177,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get keepalive() {
     return this.raw.keepalive
   }
-  get mode() {
-    return this.raw.mode
-  }
   get referrer() {
     return this.raw.referrer
-  }
-  get refererPolicy() {
-    return this.raw.referrerPolicy
   }
   get signal() {
     return this.raw.signal

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -423,3 +423,16 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 ////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
+
+////////////////////////////////////////
+//////                            //////
+//////         FetchEvent         //////
+//////                            //////
+////////////////////////////////////////
+
+export abstract class FetchEventLike {
+  abstract readonly request: Request
+  abstract respondWith(promise: Response | Promise<Response>): void
+  abstract passThroughOnException(): void
+  abstract waitUntil(promise: Promise<void>): void
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -41,8 +41,7 @@ export interface ClientResponse<T> {
   arrayBuffer(): Promise<ArrayBuffer>
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface Response extends ClientResponse<any> {}
+export interface Response extends ClientResponse<unknown> {}
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -26,9 +26,23 @@ type ClientRequest<S extends Data> = {
     : never
 }
 
-export interface ClientResponse<T> extends Response {
+export interface ClientResponse<T> {
+  ok: boolean
+  status: number
+  statusText: string
+  headers: Headers
+  url: string
+  redirect(url: string, status: number): Response
+  clone(): Response
   json(): Promise<T>
+  text(): Promise<string>
+  blob(): Promise<Blob>
+  formData(): Promise<FormData>
+  arrayBuffer(): Promise<ArrayBuffer>
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Response extends ClientResponse<any> {}
 
 export type Fetch<T> = (
   args?: InferRequestType<T>,

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import { HonoRequest } from './request'
-import type { TypedResponse } from './types'
-import type { Env, NotFoundHandler, Input } from './types'
+import { FetchEventLike } from './types'
+import type { Env, NotFoundHandler, Input, TypedResponse } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
@@ -92,7 +92,7 @@ interface HTMLRespond {
 
 type ContextOptions<E extends Env> = {
   env: E['Bindings']
-  executionCtx?: FetchEvent | ExecutionContext | undefined
+  executionCtx?: FetchEventLike | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
   path?: string
   params?: Record<string, string>
@@ -112,7 +112,7 @@ export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _req?: HonoRequest<any, any>
   private _status: StatusCode = 200
-  private _exCtx: FetchEvent | ExecutionContext | undefined // _executionCtx
+  private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
   private _pre: boolean = false // _pretty
   private _preS: number = 2 // _prettySpace
   private _map: Record<string, unknown> | undefined
@@ -149,8 +149,8 @@ export class Context<
     }
   }
 
-  get event(): FetchEvent {
-    if (this._exCtx instanceof FetchEvent) {
+  get event(): FetchEventLike {
+    if (this._exCtx instanceof FetchEventLike) {
       return this._exCtx
     } else {
       throw Error('This context has no FetchEvent')

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -17,6 +17,7 @@ import type {
   TypedResponse,
   MergePath,
   MergeSchemaPath,
+  FetchEventLike,
 } from './types'
 import type { RemoveBlankRecord } from './utils/types'
 import { getPath, getPathNoStrict, mergePath } from './utils/url'
@@ -266,7 +267,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
 
   private dispatch(
     request: Request,
-    executionCtx: ExecutionContext | FetchEvent | undefined,
+    executionCtx: ExecutionContext | FetchEventLike | undefined,
     env: E['Bindings'],
     method: string
   ): Response | Promise<Response> {
@@ -344,7 +345,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     })()
   }
 
-  handleEvent = (event: FetchEvent) => {
+  handleEvent = (event: FetchEventLike) => {
     return this.dispatch(event.request, event, undefined, event.request.method)
   }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,19 +1,6 @@
 import { Hono } from './hono'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  class ExtendableEvent extends Event {
-    constructor(type: string, init?: EventInit)
-    waitUntil(promise: Promise<void>): void
-  }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  abstract class FetchEvent extends ExtendableEvent {
-    readonly request: Request
-    respondWith(promise: Response | Promise<Response>): void
-    passThroughOnException(): void
-  }
   interface ExecutionContext {
     waitUntil(promise: Promise<void>): void
     passThroughOnException(): void

--- a/src/request.ts
+++ b/src/request.ts
@@ -165,20 +165,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get headers() {
     return this.raw.headers
   }
-  get redirect() {
-    return this.raw.redirect
-  }
   get body() {
     return this.raw.body
   }
   get bodyUsed() {
     return this.raw.bodyUsed
-  }
-  get cache() {
-    return this.raw.cache
-  }
-  get credentials() {
-    return this.raw.credentials
   }
   get integrity() {
     return this.raw.integrity
@@ -186,14 +177,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get keepalive() {
     return this.raw.keepalive
   }
-  get mode() {
-    return this.raw.mode
-  }
   get referrer() {
     return this.raw.referrer
-  }
-  get refererPolicy() {
-    return this.raw.referrerPolicy
   }
   get signal() {
     return this.raw.signal

--- a/src/types.ts
+++ b/src/types.ts
@@ -423,3 +423,16 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 ////////////////////////////////////////
 
 export type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
+
+////////////////////////////////////////
+//////                            //////
+//////         FetchEvent         //////
+//////                            //////
+////////////////////////////////////////
+
+export abstract class FetchEventLike {
+  abstract readonly request: Request
+  abstract respondWith(promise: Response | Promise<Response>): void
+  abstract passThroughOnException(): void
+  abstract waitUntil(promise: Promise<void>): void
+}


### PR DESCRIPTION
Currently, if a user doesn't set `skipLibCheck` to `true` in `tsconfig.json`, it throws the error as shown below:

<img width="1108" alt="SS" src="https://github.com/honojs/hono/assets/10682/19bead2f-6b58-4232-baba-1ecbe744a2ce">

To fix it, in this PR, I've done the following:

1. Removed unnecessary properties that are not in `@cloudflare/workers-types` and `DOM` from `Request`.
2. Created `FetchEventLike` to ensure compatibility between environments where there is `FetchEvent` and where there isn't.
3. Added the properties in `Response` to `ClientResponse`.

This change allows it to pass `tsc` and simplifies `tsconfig.json`:

<img width="428" alt="SS" src="https://github.com/honojs/hono/assets/10682/f8cc2900-9492-4aa0-9826-d4e65d76c2ff">

```ts
{
  "compilerOptions": {
    "target": "ESNext",
    "module": "ESNext",
    "moduleResolution": "node",
    "strict": true,
    "lib": [
      "esnext"
    ],
    "types": [
      "@cloudflare/workers-types",
    ],
  },
}
```

And if you don't want to use `@cloudflare/workers-types`:

```ts
{
  "compilerOptions": {
    "target": "ESNext",
    "module": "ESNext",
    "moduleResolution": "node",
    "strict": true,
    "lib": [
      "esnext",
      "DOM"
    ],
    "types": [
      "node"
    ],
  },
}
```

Fixes #1200