### PR TITLE
fix(`jsonT`): remove overloads from `JSONTRespond`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -45,28 +45,10 @@ interface JSONRespond {
 
 interface JSONTRespond {
   <T>(
-    object: T extends JSONValue ? T : JSONValue,
-    status?: StatusCode,
-    headers?: HeaderRecord
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
-  <T>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
     status?: StatusCode,
     headers?: HeaderRecord
   ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
-  <T>(object: T extends JSONValue ? T : JSONValue, init?: ResponseInit): TypedResponse<
     InterfaceToType<T> extends JSONValue
       ? JSONValue extends InterfaceToType<T>
         ? never

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -287,7 +287,7 @@ describe('Infer the response/request type', () => {
       const req = client.index.$get
 
       type Actual = InferResponseType<typeof req>
-      type Expected = { ok: true }
+      type Expected = { ok: boolean }
       type verify = Expect<Equal<Expected, Actual>>
     })
 
@@ -344,7 +344,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
     const data = await res.json()
-    type verify = Expect<Equal<true, typeof data.ok>>
+    type verify = Expect<Equal<boolean, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 
@@ -355,7 +355,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
     const data = await res.json()
-    type verify = Expect<Equal<true, typeof data.ok>>
+    type verify = Expect<Equal<boolean, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -45,28 +45,10 @@ interface JSONRespond {
 
 interface JSONTRespond {
   <T>(
-    object: T extends JSONValue ? T : JSONValue,
-    status?: StatusCode,
-    headers?: HeaderRecord
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
-  <T>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
     status?: StatusCode,
     headers?: HeaderRecord
   ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
-  <T>(object: T extends JSONValue ? T : JSONValue, init?: ResponseInit): TypedResponse<
     InterfaceToType<T> extends JSONValue
       ? JSONValue extends InterfaceToType<T>
         ? never

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -174,7 +174,7 @@ describe('OnHandlerInterface', () => {
             }
           }
           output: {
-            success: true
+            success: boolean
           }
         }
       }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -521,7 +521,7 @@ describe('`on`', () => {
           }
         }
         output: {
-          success: true
+          success: boolean
         }
       }
     }


### PR DESCRIPTION
The code below should not throw an error, but currently, it throws a "Type" error:

```ts
const route = app.get('/message', (c) => {
  const ok = Math.random() > 0.5
  if (ok) {
    return c.jsonT({
      success: true,
      message: 'Error!',
    })
  }
  return c.jsonT({
    success: false,
    message: 'Success!',
  })
})
```

<img width="521" alt="SS" src="https://github.com/honojs/hono/assets/10682/e1bdb544-d9d2-49bd-9220-1a9f587a9c05">

This is because 'success' is "`true`", not "`boolean`".

<img width="556" alt="SS" src="https://github.com/honojs/hono/assets/10682/35d3983f-7513-4bb5-b625-91ab9eb03d36">

PR #1162 fixed this bug or something similar, but to maintain backward compatibility, the old pattern remains via overloading.

However, I think it's unnecessary to keep the old code and it's better to change the test code just for that. This is because, it's a bug if 'success' is not considered as "`boolean`", rather than maintaining the test code unchanged.

With this PR, the code works as expected.

<img width="783" alt="SS" src="https://github.com/honojs/hono/assets/10682/9563858b-6031-451f-9ed6-27676d7c2a54">