### PR TITLE
fix(tests): Lagon env test

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:deno": "env NAME=Deno deno test --allow-read --allow-env runtime_tests/deno",
     "test:bun": "env NAME=Bun bun test --jsx-import-source ../../src/middleware/jsx runtime_tests/bun/index.test.tsx",
     "test:fastly": "jest --config ./runtime_tests/fastly/jest.config.js",
-    "test:lagon": "start-server-and-test \"lagon dev runtime_tests/lagon/index.ts\" http://127.0.0.1:1234 \"yarn jest runtime_tests/lagon/index.test.ts --testMatch '**/*.test.ts'\"",
+    "test:lagon": "start-server-and-test \"lagon dev runtime_tests/lagon/index.ts -e runtime_tests/lagon/.env.lagon\" http://127.0.0.1:1234 \"yarn jest runtime_tests/lagon/index.test.ts --testMatch '**/*.test.ts'\"",
     "test:node": "env NAME=Node jest --config ./runtime_tests/node/jest.config.js",
     "test:wrangler": "jest --config ./runtime_tests/wrangler/jest.config.js",
     "test:lambda": "env NAME=Node jest --config ./runtime_tests/lambda/jest.config.js",

--- a/runtime_tests/lagon/index.test.ts
+++ b/runtime_tests/lagon/index.test.ts
@@ -25,14 +25,11 @@ describe('Example', () => {
     expect(await res.text()).toBe('lagon')
   })
 
-  /*
-  TODO: It can't resolve the file path `.env` on CI
   test('GET /env', async () => {
     const res = await fetch('http://127.0.0.1:1234/env')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('Lagon')
   })
-  */
 
   test('GET /entry/:id', async () => {
     const res = await fetch('http://127.0.0.1:1234/entry/42')


### PR DESCRIPTION
This PR fixes the env test of Lagon by using the `-e` (or `--env`) flag of `lagon dev` to load the `.env.lagon` file.