### PR TITLE
Fix replaceUrlParam to ignore regexp in path

### DIFF
--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k)
+    const reg = new RegExp('/:' + k + '({[^}]*})?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -20,6 +20,16 @@ describe('replaceUrlParams', () => {
     const replacedUrl = replaceUrlParam(url, params)
     expect(replacedUrl).toBe('http://localhost/posts/123/comments/456')
   })
+
+  it('Should replace correctly when there is regex pattern', () => {
+    const url = 'http://localhost/posts/:postId{[abc]+}/comments/:commentId{[0-9]+}'
+    const params = {
+      postId: 'abc',
+      commentId: '456',
+    }
+    const replacedUrl = replaceUrlParam(url, params)
+    expect(replacedUrl).toBe('http://localhost/posts/abc/comments/456')
+  })
 })
 
 describe('removeIndexString', () => {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k)
+    const reg = new RegExp('/:' + k + '({[^}]*})?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString


### PR DESCRIPTION
This PR fixes #1213. 

Fix Regex pattern in replaceUrlParam to replace regex path correctly.