### PR TITLE
feat(lambda-edge): pass the `context` and `callback` as env

### DIFF
--- a/src/adapter/lambda-edge/index.ts
+++ b/src/adapter/lambda-edge/index.ts
@@ -1,2 +1,3 @@
 // @denoify-ignore
 export { handle } from './handler'
+export type { Callback, CloudFrontRequest, CloudFrontEdgeEvent } from './handler'


### PR DESCRIPTION
This PR allows the Lambda@Edge Adapter to pass the `callback` method, `context`, and `request` object to handlers as `env` variables. This means it can continue request processing if basic authentication has been verified.


```ts
import { Callback, CloudFrontRequest, handle } from 'hono/lambda-edge'

type Bindings = {
  callback: Callback
  request: CloudFrontRequest
}

const app = new Hono<{ Bindings: Bindings }>()

app.get(
  '*',
  basicAuth({
    username: 'a',
    password: 'b'
  })
)

app.get('/index.html', async (c, next) => {
  await next()
  c.env.callback(null, c.env.request)
})

export const handler = handle(app)
```

There's a limitation issue where you cannot add headers such as a specific header value to an origin response. You can only pass through.

Fix #1225