### PR TITLE
fix(lambda): avoid UTF-8-encoding binary data

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,5 +1,6 @@
 // @denoify-ignore
 import crypto from 'crypto'
+import { Buffer } from 'node:buffer'
 import type { Hono } from '../../hono'
 
 import { encodeBase64 } from '../../utils/encode'
@@ -116,7 +117,7 @@ const createRequest = (
   }
 
   if (event.body) {
-    requestInit.body = event.isBase64Encoded ? atob(event.body) : event.body
+    requestInit.body = event.isBase64Encoded ? new Buffer(event.body, 'base64') : event.body
   }
 
   return new Request(url, requestInit)


### PR DESCRIPTION
So far, the AWS Lambda adapter has used `atob` to convert a Base64-encoded request body to a binary. However, `atob` returns a string, and passing that to the `Request` constructor (at least on Node.js, which Lambda runs on) results in the binary string being encoded as UTF-8. This means that if the request body contains bytes which are not in the ASCII range, they are replaced with UTF-8 multi-byte encodings, which leads to `c.req.blob()`, `c.req.formData()`, etc. returning the wrong binary data!

This commit fixes the issue by replacing `atob(body)` with `Buffer.from(body, 'base64')`, which does not have that problem. The `Buffer` can be directly passed as body for `new Request()` because it implements the `Uint8Array` interface. While this makes the AWS Lambda adapter depend directly on the "node:buffer" module, this should be fine because AWS Lambda functions always run on Node.