### PR TITLE
fix: Safe modification of Buffer

### DIFF
--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -32,6 +32,11 @@ describe('Lambda@Edge Adapter for Hono', () => {
     c.env.callback(null, c.env.request)
   })
 
+  app.post('/post/binary', async (c) => {
+    const body = await c.req.blob()
+    return c.text(`${body.size} bytes`)
+  })
+
   const username = 'hono-user-a'
   const password = 'hono-password-a'
   app.use('/auth/*', basicAuth({ username, password }))
@@ -542,7 +547,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
                 inputTruncated: false,
                 action: 'read-only',
                 encoding: 'base64',
-                data: btoa(searchParam.toString()),
+                data: Buffer.from(searchParam.toString()).toString('base64'),
               },
             },
           },
@@ -554,6 +559,55 @@ describe('Lambda@Edge Adapter for Hono', () => {
 
     expect(response.status).toBe('200')
     expect(response.body).toBe('Good Morning Lambda!')
+  })
+
+  it('Should handle a POST request with binary and return a 200 response', async () => {
+    const array = new Uint8Array([0xc0, 0xff, 0xee])
+    const buffer = Buffer.from(array)
+    const event = {
+      Records: [
+        {
+          cf: {
+            config: {
+              distributionDomainName: 'example.com',
+              distributionId: 'EXAMPLE123',
+              eventType: 'viewer-request',
+              requestId: 'exampleRequestId',
+            },
+            request: {
+              clientIp: '123.123.123.123',
+              headers: {
+                host: [
+                  {
+                    key: 'Host',
+                    value: 'example.com',
+                  },
+                ],
+                'content-type': [
+                  {
+                    key: 'Content-Type',
+                    value: 'application/x-www-form-urlencoded',
+                  },
+                ],
+              },
+              method: 'POST',
+              querystring: '',
+              uri: '/post/binary',
+              body: {
+                inputTruncated: false,
+                action: 'read-only',
+                encoding: 'base64',
+                data: buffer.toString('base64'),
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    const response = await handler(event)
+    expect(response.status).toBe('200')
+    expect(response.body).toBe('3 bytes')
   })
 
   it('Should handle a request and return a 401 response with Basic auth', async () => {

--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -117,7 +117,7 @@ describe('AWS Lambda Adapter for Hono', () => {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       path: '/post',
-      body: btoa(searchParam.toString()),
+      body: Buffer.from(searchParam.toString()).toString('base64'),
       isBase64Encoded: true,
       requestContext: {
         domainName: 'example.com',
@@ -138,7 +138,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       },
       rawPath: '/post',
       rawQueryString: '',
-      body: btoa(searchParam.toString()),
+      body: Buffer.from(searchParam.toString()).toString('base64'),
       isBase64Encoded: true,
       requestContext: {
         domainName: 'example.com',

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,6 +1,5 @@
 // @denoify-ignore
 import crypto from 'crypto'
-import { Buffer } from 'node:buffer'
 import type { Hono } from '../../hono'
 
 import { encodeBase64 } from '../../utils/encode'
@@ -117,7 +116,7 @@ const createRequest = (
   }
 
   if (event.body) {
-    requestInit.body = event.isBase64Encoded ? new Buffer(event.body, 'base64') : event.body
+    requestInit.body = event.isBase64Encoded ? Buffer.from(event.body, 'base64') : event.body
   }
 
   return new Request(url, requestInit)

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -142,7 +142,7 @@ const createRequest = (event: CloudFrontEdgeEvent) => {
   const requestBody = event.Records[0].cf.request.body
   requestInit.body =
     requestBody?.encoding === 'base64' && requestBody?.data
-      ? atob(requestBody.data)
+      ? Buffer.from(requestBody.data, 'base64')
       : requestBody?.data
   return new Request(url, requestInit)
 }


### PR DESCRIPTION
This modification replaces the use of atob() and new Buffer() with Buffer.from(). As mentioned in [this article](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_class_buffer), I believe that new Buffer() should not be used.