### PR TITLE
fix(adaptor): Unable to modify headers in lambda@edge

### DIFF
--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -43,21 +43,13 @@ describe('Lambda@Edge Adapter for Hono', () => {
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
   app.get('/header/add', async (c, next) => {
-    c.header("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
-    c.header("Content-Security-Policy", "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'")
-    await next()
-    c.env.callback(null, c.env.request)
-  })
-
-  app.get('/header/add2', async (c, next) => {
-    let res, newResponse
     try {
       const res = await fetch(c.req.raw);
       const newResponse = new Response(res.body, res);
       newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
+      newResponse.headers.set('X-Custom', 'Foo')
       await next()
       c.env.callback(null, newResponse)
-      // その他のコード
     } catch (error) {
       if (error instanceof Error) {
         console.error("Fetch error:", error.message);
@@ -66,11 +58,6 @@ describe('Lambda@Edge Adapter for Hono', () => {
         console.error("Unknown error:", error);
       }
     }
-    // const res = await fetch(c.req.raw.url)
-    // const newResponse = new Response(res.body, res)
-    // newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
-    // await next()
-    // c.env.callback(null, newResponse)
   })
 
   const handler = handle(app)
@@ -795,7 +782,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
               },
               method: 'GET',
               querystring: '',
-              uri: '/header/add2',
+              uri: '/header/add',
             },
             response: {
               headers: {
@@ -894,6 +881,12 @@ describe('Lambda@Edge Adapter for Hono', () => {
       {
         key: "strict-transport-security",
         value: "max-age=63072000; includeSubdomains; preload"
+      }
+    ]);
+    expect(headers["x-custom"]).toEqual([
+      {
+        key: "x-custom",
+        value: "Foo"
       }
     ]);
   })

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -43,21 +43,12 @@ describe('Lambda@Edge Adapter for Hono', () => {
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
   app.get('/header/add', async (c, next) => {
-    try {
-      const res = await fetch(c.req.raw);
-      const newResponse = new Response(res.body, res);
-      newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
-      newResponse.headers.set('X-Custom', 'Foo')
-      await next()
-      c.env.callback(null, newResponse)
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error("Fetch error:", error.message);
-        console.error("Error stack:", error.stack);
-      } else {
-        console.error("Unknown error:", error);
-      }
-    }
+    const res = await fetch(c.req.raw);
+    const newResponse = new Response(res.body, res);
+    newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
+    newResponse.headers.set('X-Custom', 'Foo')
+    await next()
+    c.env.callback(null, newResponse)
   })
 
   const handler = handle(app)

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -83,7 +83,6 @@ interface CloudFrontResult {
   bodyEncoding?: 'text' | 'base64'
 }
 
-
 const convertHeaders = (headers: Headers): CloudFrontHeaders => {
   const cfHeaders: CloudFrontHeaders = {}
   headers.forEach((value, key) => {
@@ -159,10 +158,6 @@ const createRequest = (event: CloudFrontEdgeEvent) => {
     method: event.Records[0].cf.request.method,
     body,
   })
-}
-
-const extractQueryString = (event: CloudFrontEdgeEvent) => {
-  return event.Records[0].cf.request.querystring
 }
 
 export const isContentTypeBinary = (contentType: string) => {

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -99,7 +99,6 @@ function convertToLambdaEdgeResponse(response: Response): CloudFrontResult {
     status: response.status.toString(),
     headers,
     body: response.body ? response.body.toString() : undefined,
-    // 必要に応じて他のプロパティも追加
   }
 }
 


### PR DESCRIPTION
The callback was not handling cloned responses. This has been fixed, and the operation is now possible.

https://zenn.dev/yusukebe/articles/647aa9ba8c1550#1.%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%83%98%E3%83%83%E3%83%80%E3%81%AE%E8%BF%BD%E5%8A%A0