### PR TITLE
fix(hono/quick): use SmartRouter

### DIFF
--- a/deno_dist/preset/quick.ts
+++ b/deno_dist/preset/quick.ts
@@ -1,5 +1,7 @@
 import { HonoBase } from '../hono-base.ts'
 import { LinearRouter } from '../router/linear-router/index.ts'
+import { SmartRouter } from '../router/smart-router/index.ts'
+import { TrieRouter } from '../router/trie-router/index.ts'
 import type { Env } from '../types.ts'
 
 export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
@@ -9,6 +11,8 @@ export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> ex
 > {
   constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
     super(init)
-    this.router = new LinearRouter()
+    this.router = new SmartRouter({
+      routers: [new LinearRouter(), new TrieRouter()],
+    })
   }
 }

--- a/src/preset/quick.ts
+++ b/src/preset/quick.ts
@@ -1,5 +1,7 @@
 import { HonoBase } from '../hono-base'
 import { LinearRouter } from '../router/linear-router'
+import { SmartRouter } from '../router/smart-router'
+import { TrieRouter } from '../router/trie-router'
 import type { Env } from '../types'
 
 export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
@@ -9,6 +11,8 @@ export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> ex
 > {
   constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
     super(init)
-    this.router = new LinearRouter()
+    this.router = new SmartRouter({
+      routers: [new LinearRouter(), new TrieRouter()],
+    })
   }
 }


### PR DESCRIPTION
As discussed in #1243, the LinearRouter can't handle all route patterns. Therefore, the `hono/quick` preset must use SmartRouter with LinearRouter and TrieRouter.

```ts
this.router = new SmartRouter({
  routers: [new LinearRouter(), new TrieRouter()],
})
```

As a result of this PR, the bundle size will increase slightly:

```
// `hono/quick` before this PR
Total Upload: 13.14 KiB / gzip: 4.89 KiB

// `hono/quick` with this PR
Total Upload: 16.85 KiB / gzip: 6.36 KiB
```
