### PR TITLE
feat(adaptor): Lambda@Edge supports response callbacks

### DIFF
--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -43,21 +43,13 @@ describe('Lambda@Edge Adapter for Hono', () => {
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
   app.get('/header/add', async (c, next) => {
-    c.header("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
-    c.header("Content-Security-Policy", "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'")
-    await next()
-    c.env.callback(null, c.env.request)
-  })
-
-  app.get('/header/add2', async (c, next) => {
-    let res, newResponse
     try {
       const res = await fetch(c.req.raw);
       const newResponse = new Response(res.body, res);
       newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
+      newResponse.headers.set('X-Custom', 'Foo')
       await next()
       c.env.callback(null, newResponse)
-      // その他のコード
     } catch (error) {
       if (error instanceof Error) {
         console.error("Fetch error:", error.message);
@@ -66,11 +58,6 @@ describe('Lambda@Edge Adapter for Hono', () => {
         console.error("Unknown error:", error);
       }
     }
-    // const res = await fetch(c.req.raw.url)
-    // const newResponse = new Response(res.body, res)
-    // newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
-    // await next()
-    // c.env.callback(null, newResponse)
   })
 
   const handler = handle(app)
@@ -795,7 +782,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
               },
               method: 'GET',
               querystring: '',
-              uri: '/header/add2',
+              uri: '/header/add',
             },
             response: {
               headers: {
@@ -894,6 +881,12 @@ describe('Lambda@Edge Adapter for Hono', () => {
       {
         key: "strict-transport-security",
         value: "max-age=63072000; includeSubdomains; preload"
+      }
+    ]);
+    expect(headers["x-custom"]).toEqual([
+      {
+        key: "x-custom",
+        value: "Foo"
       }
     ]);
   })

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -43,21 +43,12 @@ describe('Lambda@Edge Adapter for Hono', () => {
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
   app.get('/header/add', async (c, next) => {
-    try {
-      const res = await fetch(c.req.raw);
-      const newResponse = new Response(res.body, res);
-      newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
-      newResponse.headers.set('X-Custom', 'Foo')
-      await next()
-      c.env.callback(null, newResponse)
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error("Fetch error:", error.message);
-        console.error("Error stack:", error.stack);
-      } else {
-        console.error("Unknown error:", error);
-      }
-    }
+    const res = await fetch(c.req.raw);
+    const newResponse = new Response(res.body, res);
+    newResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
+    newResponse.headers.set('X-Custom', 'Foo')
+    await next()
+    c.env.callback(null, newResponse)
   })
 
   const handler = handle(app)

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -33,6 +33,11 @@ describe('Lambda@Edge Adapter for Hono', () => {
     c.env.callback(null, c.env.request)
   })
 
+  app.get('/callback/response', async (c, next) => {
+    await next()
+    c.env.callback(null, c.env.response)
+  })
+
   app.post('/post/binary', async (c) => {
     const body = await c.req.blob()
     return c.text(`${body.size} bytes`)
@@ -43,12 +48,6 @@ describe('Lambda@Edge Adapter for Hono', () => {
   app.use('/auth/*', basicAuth({ username, password }))
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
-
-  app.get('/callback/response', async (c, next) => {
-    await next()
-    c.env.callback(null, c.env.response)
-  })
-
   app.get('/header/add', async (c, next) => {
     c.env.response.headers['Strict-Transport-Security'.toLowerCase()] = [{
       key: 'Strict-Transport-Security'.toLocaleLowerCase(),
@@ -58,7 +57,6 @@ describe('Lambda@Edge Adapter for Hono', () => {
       key: 'X-Custom'.toLocaleLowerCase(),
       value: 'Foo'
     }];
-    c.env.response
     await next()
     c.env.callback(null, c.env.response)
   })
@@ -750,7 +748,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
     expect(requestClientIp).toBe('123.123.123.123')
   })
 
-  it('Should handle a GET request and add header (Lambda@Edge viewer response)', async () => {
+  it('Should call a callback to continue processing the response', async () => {
     const event = {
       Records: [
         {
@@ -785,7 +783,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
               },
               method: 'GET',
               querystring: '',
-              uri: '/callback/request',
+              uri: '/callback/response',
             },
             response: {
               headers: {
@@ -863,7 +861,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
         },
       ],
     }
-    
+
     interface CloudFrontHeaders {
       [name: string]: [{
         key: string
@@ -882,13 +880,13 @@ describe('Lambda@Edge Adapter for Hono', () => {
     expect(called).toBe(true)
     expect(headers["access-control-allow-credentials"]).toEqual([
       {
-        key: "access-control-allow-credentials",
+        key: "Access-Control-Allow-Credentials",
         value: "true"
       }
     ]);
     expect(headers["access-control-allow-origin"]).toEqual([
       {
-        key: "access-control-allow-origin",
+        key: "Access-Control-Allow-Origin",
         value: "*"
       }
     ]);

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -50,11 +50,11 @@ describe('Lambda@Edge Adapter for Hono', () => {
 
   app.get('/header/add', async (c, next) => {
     c.env.response.headers['Strict-Transport-Security'.toLowerCase()] = [{
-      key: 'Strict-Transport-Security'.toLocaleLowerCase(),
+      key: 'Strict-Transport-Security',
       value: 'max-age=63072000; includeSubdomains; preload'
     }];
     c.env.response.headers['X-Custom'.toLowerCase()] = [{
-      key: 'X-Custom'.toLocaleLowerCase(),
+      key: 'X-Custom',
       value: 'Foo'
     }];
     await next()
@@ -1024,13 +1024,13 @@ describe('Lambda@Edge Adapter for Hono', () => {
     expect(called).toBe(true)
     expect(headers["strict-transport-security"]).toEqual([
       {
-        key: "strict-transport-security",
+        key: "Strict-Transport-Security",
         value: "max-age=63072000; includeSubdomains; preload"
       }
     ]);
     expect(headers["x-custom"]).toEqual([
       {
-        key: "x-custom",
+        key: "X-Custom",
         value: "Foo"
       }
     ]);

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -83,7 +83,6 @@ interface CloudFrontResult {
   bodyEncoding?: 'text' | 'base64'
 }
 
-
 const convertHeaders = (headers: Headers): CloudFrontHeaders => {
   const cfHeaders: CloudFrontHeaders = {}
   headers.forEach((value, key) => {
@@ -159,10 +158,6 @@ const createRequest = (event: CloudFrontEdgeEvent) => {
     method: event.Records[0].cf.request.method,
     body,
   })
-}
-
-const extractQueryString = (event: CloudFrontEdgeEvent) => {
-  return event.Records[0].cf.request.querystring
 }
 
 export const isContentTypeBinary = (contentType: string) => {

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -73,7 +73,7 @@ export interface CloudFrontEdgeEvent {
 type CloudFrontContext = {}
 
 export interface Callback {
-  (err: Error | null, result?: CloudFrontRequest | CloudFrontResult | Response): void
+  (err: Error | null, result?: CloudFrontRequest | CloudFrontResult ): void
 }
 
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-generating-http-responses-in-requests.html#lambda-generating-http-responses-programming-model
@@ -98,18 +98,6 @@ const convertHeaders = (headers: Headers): CloudFrontHeaders => {
   return cfHeaders
 }
 
-/**
- * Accepts events from 'Lambda@Edge' event
- * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
- */
-function convertToLambdaEdgeResponse(response: Response): CloudFrontResult {
-  return {
-    status: response.status.toString(),
-    headers: convertHeaders(response.headers),
-    body: response.body?.toString(),
-  }
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handle = (app: Hono<any>) => {
   return async (
@@ -123,12 +111,8 @@ export const handle = (app: Hono<any>) => {
       context,
       request: event.Records[0].cf.request,
       response: event.Records[0].cf.response,
-      callback: (err: Error | null, result?: Response | CloudFrontResult | CloudFrontRequest) => {
-        if (result instanceof Response) {
-          callback?.(err, convertToLambdaEdgeResponse(result))
-        } else {
-          callback?.(err, result)
-        }
+      callback: (err: Error | null, result?: CloudFrontResult | CloudFrontRequest) => {
+        callback?.(err, result)
       }
     })
     return createResult(res)

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -99,7 +99,6 @@ function convertToLambdaEdgeResponse(response: Response): CloudFrontResult {
     status: response.status.toString(),
     headers,
     body: response.body ? response.body.toString() : undefined,
-    // 必要に応じて他のプロパティも追加
   }
 }
 

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -73,7 +73,7 @@ export interface CloudFrontEdgeEvent {
 type CloudFrontContext = {}
 
 export interface Callback {
-  (err: Error | null, result?: CloudFrontRequest | CloudFrontResult ): void
+  (err: Error | null, result?: CloudFrontRequest | CloudFrontResult): void
 }
 
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-generating-http-responses-in-requests.html#lambda-generating-http-responses-programming-model
@@ -90,6 +90,10 @@ interface CloudFrontResult {
   bodyEncoding?: 'text' | 'base64'
 }
 
+/**
+ * Accepts events from 'Lambda@Edge' event
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
+ */
 const convertHeaders = (headers: Headers): CloudFrontHeaders => {
   const cfHeaders: CloudFrontHeaders = {}
   headers.forEach((value, key) => {
@@ -105,15 +109,14 @@ export const handle = (app: Hono<any>) => {
     context?: CloudFrontContext,
     callback?: Callback
   ): Promise<CloudFrontResult> => {
-
     const res = await app.fetch(createRequest(event), {
       event,
       context,
-      request: event.Records[0].cf.request,
-      response: event.Records[0].cf.response,
       callback: (err: Error | null, result?: CloudFrontResult | CloudFrontRequest) => {
         callback?.(err, result)
-      }
+      },
+      request: event.Records[0].cf.request,
+      response: event.Records[0].cf.response,
     })
     return createResult(res)
   }

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -45,6 +45,12 @@ export interface CloudFrontRequest {
   }
 }
 
+export interface CloudFrontResponse {
+  headers: CloudFrontHeaders
+  status: string
+  statusDescription?: string
+}
+
 interface CloudFrontConfig {
   distributionDomainName: string
   distributionId: string
@@ -56,6 +62,7 @@ interface CloudFrontEvent {
   cf: {
     config: CloudFrontConfig
     request: CloudFrontRequest
+    response?: CloudFrontResponse
   }
 }
 
@@ -110,10 +117,12 @@ export const handle = (app: Hono<any>) => {
     context?: CloudFrontContext,
     callback?: Callback
   ): Promise<CloudFrontResult> => {
+
     const res = await app.fetch(createRequest(event), {
       event,
       context,
       request: event.Records[0].cf.request,
+      response: event.Records[0].cf.response,
       callback: (err: Error | null, result?: Response | CloudFrontResult | CloudFrontRequest) => {
         if (result instanceof Response) {
           callback?.(err, convertToLambdaEdgeResponse(result))
@@ -122,7 +131,6 @@ export const handle = (app: Hono<any>) => {
         }
       }
     })
-
     return createResult(res)
   }
 }


### PR DESCRIPTION

adding

1. Cloudflont response can now be handled.

```ts
type Bindings = {
  callback: Callback
  request: CloudFrontRequest
  response: CloudFrontResponse
}

app.get('/callback/response', async (c, next) => {
  await next()
  c.env.callback(null, c.env.response)
})

```

2. Headers can now be added in OriginResponse. (I have a feeling we can do this in a much cooler way)

```ts
  app.get('/header/add', async (c, next) => {
    c.env.response.headers['Strict-Transport-Security'.toLowerCase()] = [{
      key: 'Strict-Transport-Security',
      value: 'max-age=63072000; includeSubdomains; preload'
    }];
    c.env.response.headers['X-Custom'.toLowerCase()] = [{
      key: 'X-Custom',
      value: 'Foo'
    }];
    await next()
    c.env.callback(null, c.env.response)
  })
```

3. refactoring. I cut out a lot of the internal header manipulation process.