### PR TITLE
fix(trie-router): don't allow dot segments

### DIFF
--- a/deno_dist/router/trie-router/node.ts
+++ b/deno_dist/router/trie-router/node.ts
@@ -130,6 +130,10 @@ export class Node<T> {
 
     for (let i = 0, len = parts.length; i < len; i++) {
       const part: string = parts[i]
+
+      // Should not match when GET `/static/../foo.txt`
+      if (/\.\./.test(part)) return null
+
       const isLast = i === len - 1
       const tempNodes: Node<T>[] = []
       let matched = false

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -130,6 +130,10 @@ export class Node<T> {
 
     for (let i = 0, len = parts.length; i < len; i++) {
       const part: string = parts[i]
+
+      // Should not match when GET `/static/../foo.txt`
+      if (/\.\./.test(part)) return null
+
       const isLast = i === len - 1
       const tempNodes: Node<T>[] = []
       let matched = false

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -204,3 +204,23 @@ describe('Routing with a hostname', () => {
     expect(res).toBeNull()
   })
 })
+
+describe('Path includes `..`', () => {
+  const router = new TrieRouter<string>()
+  router.add('get', '/../hello', '/../hello')
+  router.add('get', '/hello/..', '/hello/..')
+  router.add('get', '/hello/../hello', '/hello/../hello')
+
+  it('Should not match with GET /../hello', () => {
+    const res = router.match('get', '/../hello')
+    expect(res).toBeNull()
+  })
+  it('Should not match with GET /hello/..', () => {
+    const res = router.match('get', '/hello/..')
+    expect(res).toBeNull()
+  })
+  it('Should not match with GET /hello/../hello', () => {
+    const res = router.match('get', '/hello/../hello')
+    expect(res).toBeNull()
+  })
+})


### PR DESCRIPTION
It should not allow don segments in URL path: `/../hello` to avoid a directory traversal attack.