### PR TITLE
fix(utils/filepath): don't allow dot segments

### DIFF
--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -31,6 +31,8 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
+    if (!path) return await next()
+
     path = `./${path}`
 
     let file

--- a/deno_dist/utils/filepath.ts
+++ b/deno_dist/utils/filepath.ts
@@ -4,8 +4,10 @@ type FilePathOptions = {
   defaultDocument?: string
 }
 
-export const getFilePath = (options: FilePathOptions): string => {
+export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
+  if (/\.\./.test(filename)) return
+
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'
 

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -32,6 +32,9 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
       root: options.root,
       defaultDocument: DEFAULT_DOCUMENT,
     })
+
+    if (!path) return await next()
+
     path = `./${path}`
 
     if (existsSync(path)) {

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -32,6 +32,8 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
+    if (!path) return await next()
+
     const content = await getContentFromKVAsset(path, {
       manifest: options.manifest,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -31,6 +31,8 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
+    if (!path) return await next()
+
     path = `./${path}`
 
     let file

--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -15,5 +15,8 @@ describe('getFilePath', () => {
 
     expect(getFilePath({ filename: './foo' })).toBe('foo/index.html')
     expect(getFilePath({ filename: 'foo', root: './bar' })).toBe('bar/foo/index.html')
+
+    expect(getFilePath({ filename: '../foo' })).toBeUndefined()
+    expect(getFilePath({ filename: '../foo', root: './bar' })).toBeUndefined()
   })
 })

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -4,8 +4,10 @@ type FilePathOptions = {
   defaultDocument?: string
 }
 
-export const getFilePath = (options: FilePathOptions): string => {
+export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
+  if (/\.\./.test(filename)) return
+
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'
 


### PR DESCRIPTION
Security fix for ServeStatic of Bun. Bun's Request object doesn't remove dot segments `..` in URL path. So, we have to remove it in our framework.