### PR TITLE
fix(utils/filepath): allow `..` in filename

### DIFF
--- a/deno_dist/utils/filepath.ts
+++ b/deno_dist/utils/filepath.ts
@@ -6,7 +6,7 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/\.\./.test(filename)) return
+  if (/\.\.\//.test(filename)) return
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'

--- a/deno_dist/utils/filepath.ts
+++ b/deno_dist/utils/filepath.ts
@@ -6,7 +6,7 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/\.\.\//.test(filename)) return
+  if (/(?:^|\/)\.\.(?:$|\/)/.test(filename)) return
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'

--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -22,5 +22,6 @@ describe('getFilePath', () => {
     expect(getFilePath({ filename: 'foo..bar.txt' })).toBe('foo..bar.txt')
     expect(getFilePath({ filename: '/foo..bar.txt' })).toBe('foo..bar.txt')
     expect(getFilePath({ filename: './foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: './foo../bar.txt' })).toBe('foo../bar.txt')
   })
 })

--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -22,6 +22,8 @@ describe('getFilePath', () => {
     expect(getFilePath({ filename: 'foo..bar.txt' })).toBe('foo..bar.txt')
     expect(getFilePath({ filename: '/foo..bar.txt' })).toBe('foo..bar.txt')
     expect(getFilePath({ filename: './foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: './..foo/bar.txt' })).toBe('..foo/bar.txt')
     expect(getFilePath({ filename: './foo../bar.txt' })).toBe('foo../bar.txt')
+    expect(getFilePath({ filename: './..foo../bar.txt' })).toBe('..foo../bar.txt')
   })
 })

--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -17,6 +17,10 @@ describe('getFilePath', () => {
     expect(getFilePath({ filename: 'foo', root: './bar' })).toBe('bar/foo/index.html')
 
     expect(getFilePath({ filename: '../foo' })).toBeUndefined()
-    expect(getFilePath({ filename: '../foo', root: './bar' })).toBeUndefined()
+    expect(getFilePath({ filename: '/../foo' })).toBeUndefined()
+    expect(getFilePath({ filename: './../foo' })).toBeUndefined()
+    expect(getFilePath({ filename: 'foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: '/foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: './foo..bar.txt' })).toBe('foo..bar.txt')
   })
 })

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -6,7 +6,7 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/\.\./.test(filename)) return
+  if (/\.\.\//.test(filename)) return
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -6,7 +6,7 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/\.\.\//.test(filename)) return
+  if (/(?:^|\/)\.\.(?:$|\/)/.test(filename)) return
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'


### PR DESCRIPTION
It can allow `foo/bar....buzz.jpg` and `foo../bar.jpg` as filepath.