### PR TITLE
feat(middleware): Simple cookie signing functionality

### DIFF
--- a/deno_dist/middleware/cookie/index.ts
+++ b/deno_dist/middleware/cookie/index.ts
@@ -1,10 +1,15 @@
 import type { Context } from '../../context.ts'
-import { parse, serialize } from '../../utils/cookie.ts'
-import type { CookieOptions, Cookie } from '../../utils/cookie.ts'
+import { parse, parseSigned, serialize, serializeSigned } from '../../utils/cookie.ts'
+import type { CookieOptions, Cookie, SignedCookie } from '../../utils/cookie.ts'
 
 interface GetCookie {
   (c: Context, key: string): string | undefined
   (c: Context): Cookie
+}
+
+interface GetSignedCookie {
+  (c: Context, sercet: string, key: string): Promise<string | undefined | false>
+  (c: Context, secret: string): Promise<SignedCookie>
 }
 
 export const getCookie: GetCookie = (c, key?) => {
@@ -20,8 +25,32 @@ export const getCookie: GetCookie = (c, key?) => {
   return obj as any
 }
 
+export const getSignedCookie: GetSignedCookie = async (c, secret, key?) => {
+  const cookie = c.req.raw.headers.get('Cookie')
+  if (typeof key === 'string') {
+    if (!cookie) return undefined
+    const obj = await parseSigned(cookie, secret, key)
+    return obj[key]
+  }
+  if (!cookie) return {}
+  const obj = await parseSigned(cookie, secret)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return obj as any
+}
+
 export const setCookie = (c: Context, name: string, value: string, opt?: CookieOptions): void => {
   const cookie = serialize(name, value, opt)
+  c.header('set-cookie', cookie, { append: true })
+}
+
+export const setSignedCookie = async (
+  c: Context,
+  name: string,
+  value: string,
+  secret: string,
+  opt?: CookieOptions
+): Promise<void> => {
+  const cookie = await serializeSigned(name, value, secret, opt)
   c.header('set-cookie', cookie, { append: true })
 }
 

--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -1,6 +1,7 @@
 import { decodeURIComponent_ } from './url.ts'
 
 export type Cookie = Record<string, string>
+export type SignedCookie = Record<string, string | false>
 export type CookieOptions = {
   domain?: string
   expires?: Date
@@ -8,22 +9,68 @@ export type CookieOptions = {
   maxAge?: number
   path?: string
   secure?: boolean
-  signed?: boolean
+  signingSecret?: string
   sameSite?: 'Strict' | 'Lax' | 'None'
 }
 
-export const parse = (cookie: string): Cookie => {
+const makeSignature = async (value: string, secret: string): Promise<string> => {
+  const algorithm = { name: 'HMAC', hash: 'SHA-256' }
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey('raw', encoder.encode(secret), algorithm, false, [
+    'sign',
+    'verify',
+  ])
+  const signature = await crypto.subtle.sign(algorithm.name, key, encoder.encode(value))
+  return btoa(String.fromCharCode(...new Uint8Array(signature)))
+}
+
+const _parseCookiePairs = (cookie: string, name?: string): string[][] => {
   const pairs = cookie.split(/;\s*/g)
+  const cookiePairs = pairs.map((pairStr: string) => pairStr.split(/\s*=\s*([^\s]+)/))
+  if (!name) return cookiePairs
+  return cookiePairs.filter((pair) => pair[0] === name)
+}
+
+export const parse = (cookie: string, name?: string): Cookie => {
   const parsedCookie: Cookie = {}
-  for (let i = 0, len = pairs.length; i < len; i++) {
-    const pair = pairs[i].split(/\s*=\s*([^\s]+)/)
-    parsedCookie[pair[0]] = decodeURIComponent_(pair[1])
+  const unsingedCookies = _parseCookiePairs(cookie, name).filter((pair) => {
+    // ignore signed cookies, assuming they always have that commonly accepted format
+    if (pair[1].split('.').length === 2) return false
+    return true
+  })
+  for (let [key, value] of unsingedCookies) {
+    value = decodeURIComponent_(value)
+    parsedCookie[key] = value
   }
   return parsedCookie
 }
 
-export const serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
-  value = encodeURIComponent(value)
+export const parseSigned = async (
+  cookie: string,
+  secret: string,
+  name?: string
+): Promise<SignedCookie> => {
+  const parsedCookie: SignedCookie = {}
+  const signedCookies = _parseCookiePairs(cookie, name).filter((pair) => {
+    // ignore signed cookies, assuming they always have that commonly accepted format
+    if (pair[1].split('.').length !== 2) return false
+    return true
+  })
+  for (let [key, value] of signedCookies) {
+    value = decodeURIComponent_(value)
+    const signedPair = value.split('.')
+    const signatureToCompare = await makeSignature(signedPair[0], secret)
+    if (signedPair[1] !== signatureToCompare) {
+      // cookie will be undefined when using getCookie
+      parsedCookie[key] = false
+      continue
+    }
+    parsedCookie[key] = signedPair[0]
+  }
+  return parsedCookie
+}
+
+const _serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
   let cookie = `${name}=${value}`
 
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
@@ -55,4 +102,21 @@ export const serialize = (name: string, value: string, opt: CookieOptions = {}):
   }
 
   return cookie
+}
+
+export const serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
+  value = encodeURIComponent(value)
+  return _serialize(name, value, opt)
+}
+
+export const serializeSigned = async (
+  name: string,
+  value: string,
+  secret: string,
+  opt: CookieOptions = {}
+): Promise<string> => {
+  const signature = await makeSignature(value, secret)
+  value = `${value}.${signature}`
+  value = encodeURIComponent(value)
+  return _serialize(name, value, opt)
 }

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -1,46 +1,131 @@
-import type { Cookie } from './cookie'
-import { parse, serialize } from './cookie'
+import type { Cookie, SignedCookie } from './cookie'
+import { parse, parseSigned, serialize, serializeSigned } from './cookie'
 
 describe('Parse cookie', () => {
-  it('Should parse cookie', () => {
+  it('Should parse cookies', () => {
     const cookieString = 'yummy_cookie=choco; tasty_cookie = strawberry '
     const cookie: Cookie = parse(cookieString)
     expect(cookie['yummy_cookie']).toBe('choco')
+    expect(cookie['tasty_cookie']).toBe('strawberry')
+  })
+
+  it('Should parse one cookie specified by name', () => {
+    const cookieString = 'yummy_cookie=choco; tasty_cookie = strawberry '
+    const cookie: Cookie = parse(cookieString, 'yummy_cookie')
+    expect(cookie['yummy_cookie']).toBe('choco')
+    expect(cookie['tasty_cookie']).toBeUndefined()
+  })
+
+  it('Should parse cookies but ignore signed cookies', () => {
+    const cookieString =
+      'yummy_cookie=choco; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['yummy_cookie']).toBe('choco')
+    expect(cookie['tasty_cookie']).toBeUndefined()
+  })
+
+  it('Should parse signed cookies', async () => {
+    const secret = 'secret ingredient'
+    const cookieString =
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret)
+    expect(cookie['yummy_cookie']).toBe('choco')
+    expect(cookie['tasty_cookie']).toBe('strawberry')
+  })
+
+  it('Should parse signed cookies and return "false" for wrong signature', async () => {
+    const secret = 'secret ingredient'
+    const cookieString =
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.invalidsignatur%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret)
+    expect(cookie['yummy_cookie']).toBe('choco')
+    expect(cookie['tasty_cookie']).toBe(false)
+  })
+
+  it('Should parse one signed cookie specified by name', async () => {
+    const secret = 'secret ingredient'
+    const cookieString =
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret, 'tasty_cookie')
+    expect(cookie['yummy_cookie']).toBeUndefined()
+    expect(cookie['tasty_cookie']).toBe('strawberry')
+  })
+
+  it('Should parse one signed cookie specified by name and return "false" for wrong signature', async () => {
+    const secret = 'secret ingredient'
+    const cookieString =
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.invalidsignatur%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret, 'tasty_cookie')
+    expect(cookie['yummy_cookie']).toBeUndefined()
+    expect(cookie['tasty_cookie']).toBe(false)
+  })
+
+  it('Should parse signed cookies and ignore regular cookies', async () => {
+    const secret = 'secret ingredient'
+    const cookieString =
+      'yummy_cookie=choco; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret)
+    expect(cookie['yummy_cookie']).toBeUndefined()
     expect(cookie['tasty_cookie']).toBe('strawberry')
   })
 })
 
 describe('Set cookie', () => {
   it('Should serialize cookie', () => {
-    expect(serialize('delicious_cookie', 'macha')).toBe('delicious_cookie=macha')
-    expect(
-      serialize('great_cookie', 'banana', {
-        path: '/',
-        secure: true,
-        domain: 'example.com',
-        httpOnly: true,
-        maxAge: 1000,
-        expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
-        sameSite: 'Strict',
-      })
-    ).toBe(
+    const serialized = serialize('delicious_cookie', 'macha')
+    expect(serialized).toBe('delicious_cookie=macha')
+  })
+
+  it('Should serialize cookie with all options', () => {
+    const serialized = serialize('great_cookie', 'banana', {
+      path: '/',
+      secure: true,
+      domain: 'example.com',
+      httpOnly: true,
+      maxAge: 1000,
+      expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
+      sameSite: 'Strict',
+    })
+    expect(serialized).toBe(
       'great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict'
     )
   })
 
+  it('Should serialize a signed cookie', async () => {
+    const secret = 'secret chocolate chips'
+    const serialized = await serializeSigned('delicious_cookie', 'macha', secret)
+    expect(serialized).toBe(
+      'delicious_cookie=macha.diubJPY8O7hI1pLa42QSfkPiyDWQ0I4DnlACH%2FN2HaA%3D'
+    )
+  })
+
+  it('Should serialize singed cookie with all options', async () => {
+    const secret = 'secret chocolate chips'
+    const serialized = await serializeSigned('great_cookie', 'banana', secret, {
+      path: '/',
+      secure: true,
+      domain: 'example.com',
+      httpOnly: true,
+      maxAge: 1000,
+      expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
+      sameSite: 'Strict',
+    })
+    expect(serialized).toBe(
+      'great_cookie=banana.hSo6gB7YT2db0WBiEAakEmh7dtwEL0DSp76G23WvHuQ%3D; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict'
+    )
+  })
+
   it('Should serialize cookie with maxAge is 0', () => {
-    expect(
-      serialize('great_cookie', 'banana', {
-        maxAge: 0,
-      })
-    ).toBe('great_cookie=banana; Max-Age=0')
+    const serialized = serialize('great_cookie', 'banana', {
+      maxAge: 0,
+    })
+    expect(serialized).toBe('great_cookie=banana; Max-Age=0')
   })
 
   it('Should serialize cookie with maxAge is -1', () => {
-    expect(
-      serialize('great_cookie', 'banana', {
-        maxAge: -1,
-      })
-    ).toBe('great_cookie=banana')
+    const serialized = serialize('great_cookie', 'banana', {
+      maxAge: -1,
+    })
+    expect(serialized).toBe('great_cookie=banana')
   })
 })

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,6 +1,7 @@
 import { decodeURIComponent_ } from './url'
 
 export type Cookie = Record<string, string>
+export type SignedCookie = Record<string, string | false>
 export type CookieOptions = {
   domain?: string
   expires?: Date
@@ -8,22 +9,68 @@ export type CookieOptions = {
   maxAge?: number
   path?: string
   secure?: boolean
-  signed?: boolean
+  signingSecret?: string
   sameSite?: 'Strict' | 'Lax' | 'None'
 }
 
-export const parse = (cookie: string): Cookie => {
+const makeSignature = async (value: string, secret: string): Promise<string> => {
+  const algorithm = { name: 'HMAC', hash: 'SHA-256' }
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey('raw', encoder.encode(secret), algorithm, false, [
+    'sign',
+    'verify',
+  ])
+  const signature = await crypto.subtle.sign(algorithm.name, key, encoder.encode(value))
+  return btoa(String.fromCharCode(...new Uint8Array(signature)))
+}
+
+const _parseCookiePairs = (cookie: string, name?: string): string[][] => {
   const pairs = cookie.split(/;\s*/g)
+  const cookiePairs = pairs.map((pairStr: string) => pairStr.split(/\s*=\s*([^\s]+)/))
+  if (!name) return cookiePairs
+  return cookiePairs.filter((pair) => pair[0] === name)
+}
+
+export const parse = (cookie: string, name?: string): Cookie => {
   const parsedCookie: Cookie = {}
-  for (let i = 0, len = pairs.length; i < len; i++) {
-    const pair = pairs[i].split(/\s*=\s*([^\s]+)/)
-    parsedCookie[pair[0]] = decodeURIComponent_(pair[1])
+  const unsingedCookies = _parseCookiePairs(cookie, name).filter((pair) => {
+    // ignore signed cookies, assuming they always have that commonly accepted format
+    if (pair[1].split('.').length === 2) return false
+    return true
+  })
+  for (let [key, value] of unsingedCookies) {
+    value = decodeURIComponent_(value)
+    parsedCookie[key] = value
   }
   return parsedCookie
 }
 
-export const serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
-  value = encodeURIComponent(value)
+export const parseSigned = async (
+  cookie: string,
+  secret: string,
+  name?: string
+): Promise<SignedCookie> => {
+  const parsedCookie: SignedCookie = {}
+  const signedCookies = _parseCookiePairs(cookie, name).filter((pair) => {
+    // ignore signed cookies, assuming they always have that commonly accepted format
+    if (pair[1].split('.').length !== 2) return false
+    return true
+  })
+  for (let [key, value] of signedCookies) {
+    value = decodeURIComponent_(value)
+    const signedPair = value.split('.')
+    const signatureToCompare = await makeSignature(signedPair[0], secret)
+    if (signedPair[1] !== signatureToCompare) {
+      // cookie will be undefined when using getCookie
+      parsedCookie[key] = false
+      continue
+    }
+    parsedCookie[key] = signedPair[0]
+  }
+  return parsedCookie
+}
+
+const _serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
   let cookie = `${name}=${value}`
 
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
@@ -55,4 +102,21 @@ export const serialize = (name: string, value: string, opt: CookieOptions = {}):
   }
 
   return cookie
+}
+
+export const serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
+  value = encodeURIComponent(value)
+  return _serialize(name, value, opt)
+}
+
+export const serializeSigned = async (
+  name: string,
+  value: string,
+  secret: string,
+  opt: CookieOptions = {}
+): Promise<string> => {
+  const signature = await makeSignature(value, secret)
+  value = `${value}.${signature}`
+  value = encodeURIComponent(value)
+  return _serialize(name, value, opt)
 }


### PR DESCRIPTION
Relates issue: https://github.com/honojs/hono/issues/1164

Related PR for website/docs: https://github.com/honojs/website/pull/77

Tried to be backwards compatible with the current `setCookie`/`getCookie` API, so decided to introduce new functions for this instead (similar to how express cookie-parser would do that).

Some things I wasn't sure about:
* If a cookie signature is not valid, what should happen with the cookie. At the moment it would return `undefined` in the `getSignedCookie` method. This might be misleading and hiding errors though, but throwing an error here instead might be too invasive. How would you handle this and at notify that the cookie was tampered with?
* Thinking about this a bit more, `getSignedCookie` should probably just work exactly like `getCookie` for multiple cookies (`key` not specified) and return all cookies, but only compare the signature for cookies where a signature is provided (and otherwise ignore).
* Somehow related to previous concern, `getCookie` without a `key` specified does return the signed cookie as well (without checking and removing the signature, so the value of the cookie would be the actual value + signature. Would that be intended behaviour or should signed cookies be removed from a `getCookie` result?

Please let me know if changes are needed.