### PR TITLE
fix(types): add a missing handler type

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -126,11 +126,16 @@ export interface HandlerInterface<
 
   ////  app.get(path, ...handlers[])
 
-  // app.get(path, handler, handler)
-
+  // app.get(path, handler)
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
+    handler: H<E, MergePath<BasePath, P>, I, O>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+
+  // app.get(path, handler, handler)
+  <P extends string, O = {}, I extends Input = {}>(
+    path: P,
+    ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(path, handler x3)

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,16 +127,15 @@ export interface HandlerInterface<
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler)
-  <P extends string, O = {}, I extends Input = {}>(path: P, handler: H<E, P, I, O>): Hono<
-    E,
-    RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>,
-    BasePath
-  >
+  <P extends string, O = {}, I extends Input = {}>(
+    path: P,
+    handler: H<E, MergePath<BasePath, P>, I, O>
+  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(path, handler, handler)
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
-    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
+    ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
   ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
 
   // app.get(path, handler x3)

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,8 +126,14 @@ export interface HandlerInterface<
 
   ////  app.get(path, ...handlers[])
 
-  // app.get(path, handler, handler)
+  // app.get(path, handler)
+  <P extends string, O = {}, I extends Input = {}>(path: P, handler: H<E, P, I, O>): Hono<
+    E,
+    RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>,
+    BasePath
+  >
 
+  // app.get(path, handler, handler)
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]


### PR DESCRIPTION
Added a missing handler type: `app.get(path, handler)`.

<img width="285" alt="Screenshot 2023-08-03 at 22 58 02" src="https://github.com/honojs/hono/assets/10682/9fa6494b-41bc-4941-8e1b-27545f37f6ec">

Will be:

<img width="355" alt="Screenshot 2023-08-03 at 22 58 07" src="https://github.com/honojs/hono/assets/10682/ff9c980f-7643-4bc7-a655-611618e3071f">
