### PR TITLE
refactor(json-pretty): don't use `c.pretty()`

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -277,3 +277,25 @@ describe('Pass a ResponseInit to respond methods', () => {
     expect(await res.text()).toBe('<h1>foo</h1>')
   })
 })
+
+describe('Hooks', () => {
+  const req = new Request('http://localhost/')
+  let c: Context
+  beforeEach(() => {
+    c = new Context(req)
+  })
+  it('Should handle `hookBeforeRespond`', async () => {
+    c.hookBeforeRespond((r) => {
+      r.headers.set('message', 'hook!')
+      if (typeof r.body === 'string') {
+        r.body = r.body + 'bar'
+        console.log(r.body)
+      }
+      r.status = 201
+    })
+    const res = c.text('foo')
+    expect(res.headers.get('message')).toBe('hook!')
+    expect(res.status).toBe(201)
+    expect(await res.text()).toBe('foobar')
+  })
+})

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -25,24 +25,6 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
-  it('c.json() with c.pretty(true)', async () => {
-    c.pretty(true)
-    const res = c.json({ message: 'Hello' })
-    const text = await res.text()
-    expect(text).toBe(`{
-  "message": "Hello"
-}`)
-  })
-
-  it('c.json() with c.pretty(true, 4)', async () => {
-    c.pretty(true, 4)
-    const res = c.json({ message: 'Hello' })
-    const text = await res.text()
-    expect(text).toBe(`{
-    "message": "Hello"
-}`)
-  })
-
   it('c.html()', async () => {
     const res = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -259,25 +259,3 @@ describe('Pass a ResponseInit to respond methods', () => {
     expect(await res.text()).toBe('<h1>foo</h1>')
   })
 })
-
-describe('Hooks', () => {
-  const req = new Request('http://localhost/')
-  let c: Context
-  beforeEach(() => {
-    c = new Context(req)
-  })
-  it('Should handle `hookBeforeRespond`', async () => {
-    c.hookBeforeRespond((r) => {
-      r.headers.set('message', 'hook!')
-      if (typeof r.body === 'string') {
-        r.body = r.body + 'bar'
-        console.log(r.body)
-      }
-      r.status = 201
-    })
-    const res = c.text('foo')
-    expect(res.headers.get('message')).toBe('hook!')
-    expect(res.status).toBe(201)
-    expect(await res.text()).toBe('foobar')
-  })
-})

--- a/src/context.ts
+++ b/src/context.ts
@@ -105,8 +105,6 @@ export class Context<
   private _req?: HonoRequest<any, any>
   private _status: StatusCode = 200
   private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
-  private _pre: boolean = false // _pretty
-  private _preS: number = 2 // _prettySpace
   private _map: Record<string, unknown> | undefined
   private _h: Headers | undefined = undefined //  _headers
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
@@ -233,11 +231,6 @@ export class Context<
     return this._map ? this._map[key] : undefined
   }
 
-  pretty = (prettyJSON: boolean, space: number = 2): void => {
-    this._pre = prettyJSON
-    this._preS = space
-  }
-
   newResponse: NewResponse = (
     data: Data | null,
     arg?: StatusCode | ResponseInit,
@@ -343,7 +336,7 @@ export class Context<
     arg?: StatusCode | RequestInit,
     headers?: HeaderRecord
   ) => {
-    const body = this._pre ? JSON.stringify(object, null, this._preS) : JSON.stringify(object)
+    const body = JSON.stringify(object)
     this._pH ??= {}
     this._pH['content-type'] = 'application/json; charset=UTF-8'
     return typeof arg === 'number'

--- a/src/context.ts
+++ b/src/context.ts
@@ -72,16 +72,6 @@ interface HTMLRespond {
   (html: string, init?: ResponseInit): Response
 }
 
-type RespondContent = {
-  body: Data | null
-  status: StatusCode
-  headers: Headers
-}
-
-interface BeforeRespondHook {
-  (respondContent: RespondContent): void
-}
-
 type ContextOptions<E extends Env> = {
   env: E['Bindings']
   executionCtx?: FetchEventLike | ExecutionContext | undefined
@@ -112,7 +102,6 @@ export class Context<
   private _path: string = '/'
   private _params?: Record<string, string> | null
   private _init = true
-  private _beforeRespondHooks: BeforeRespondHook[] = []
   private rawRequest?: Request | null
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
@@ -172,11 +161,6 @@ export class Context<
     }
     this._res = _res
     this.finalized = true
-  }
-
-  hookBeforeRespond = (respondHook: BeforeRespondHook) => {
-    this._init = false
-    this._beforeRespondHooks.push(respondHook)
   }
 
   header = (name: string, value: string | undefined, options?: { append?: boolean }): void => {
@@ -282,19 +266,9 @@ export class Context<
       }
     }
 
-    const r = {
-      body: data,
+    return new Response(data, {
       status,
-      headers: this._h ?? new Headers(),
-    }
-
-    this._beforeRespondHooks.map((hook) => {
-      hook(r)
-    })
-
-    return new Response(r['body'], {
-      status: r['status'],
-      headers: r['headers'],
+      headers: this._h,
     })
   }
 

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -7,7 +7,10 @@ type prettyOptions = {
 export const prettyJSON = (options: prettyOptions = { space: 2 }): MiddlewareHandler => {
   return async (c, next) => {
     const pretty = c.req.query('pretty') || c.req.query('pretty') === '' ? true : false
-    c.pretty(pretty, options.space)
     await next()
+    if (pretty && c.res.headers.get('Content-Type')?.startsWith('application/json')) {
+      const obj = await c.res.json()
+      c.res = new Response(JSON.stringify(obj, null, options.space), c.res)
+    }
   }
 }


### PR DESCRIPTION
This PR refactors the Pretty JSON Middleware. It previously used the `c.pretty()` function, but this PR no longer relies on it. The middleware retrieves the JSON object with `c.res.json()` from the `Response`, stringifies it, and creates a new Response object.

Though this may seem to increase performance overhead, I've measured the benchmark, and the results are the same.

Additionally, this PR removes the `c.pretty()` method from the Context. This might seem like a breaking change, but since `c.pretty()` is not officially documented, and the users are very few, we can remove it right now.