### PR TITLE
feat(parseBody): allow passing generics to `parseBody()`

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -112,7 +112,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     }
   }
 
-  async parseBody(): Promise<BodyData> {
+  async parseBody<T extends BodyData = BodyData>(): Promise<T> {
     return await parseBody(this.raw)
   }
 

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,6 +1,8 @@
 export type BodyData = Record<string, string | File>
 
-export async function parseBody(r: Request | Response) {
+export const parseBody = async <T extends BodyData = BodyData>(
+  r: Request | Response
+): Promise<T> => {
   let body: BodyData = {}
   const contentType = r.headers.get('Content-Type')
   if (
@@ -14,5 +16,5 @@ export async function parseBody(r: Request | Response) {
     })
     body = form
   }
-  return body
+  return body as T
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -112,7 +112,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     }
   }
 
-  async parseBody(): Promise<BodyData> {
+  async parseBody<T extends BodyData = BodyData>(): Promise<T> {
     return await parseBody(this.raw)
   }
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,6 +1,8 @@
 export type BodyData = Record<string, string | File>
 
-export async function parseBody(r: Request | Response) {
+export const parseBody = async <T extends BodyData = BodyData>(
+  r: Request | Response
+): Promise<T> => {
   let body: BodyData = {}
   const contentType = r.headers.get('Content-Type')
   if (
@@ -14,5 +16,5 @@ export async function parseBody(r: Request | Response) {
     })
     body = form
   }
-  return body
+  return body as T
 }


### PR DESCRIPTION
This allows to write like the following:

```ts
app.post('/', async (c) => {
  const { foo } = await c.req.parseBody<{ foo: string }>()
  // foo is string
})
```