### PR TITLE
feat(adapter): add Netlify adapter

### DIFF
--- a/deno_dist/adapter/netlify/handler.ts
+++ b/deno_dist/adapter/netlify/handler.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import type { Context } from 'https://edge.netlify.com/'
+import type { Hono } from '../../index.ts/index.ts'
+
+export type Env = {
+  Bindings: {
+    context: Context
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handle = (app: Hono<any, any>) => {
+  return (req: Request, context: Context) => {
+    return app.fetch(req, { context })
+  }
+}

--- a/deno_dist/adapter/netlify/mod.ts
+++ b/deno_dist/adapter/netlify/mod.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export { handle } from './handler.ts/index.ts'
+export type { Env } from './handler.ts/index.ts'

--- a/src/adapter/netlify/handler.ts
+++ b/src/adapter/netlify/handler.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import type { Context } from 'https://edge.netlify.com/'
+import type { Hono } from '../../index.ts'
+
+export type Env = {
+  Bindings: {
+    context: Context
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handle = (app: Hono<any, any>) => {
+  return (req: Request, context: Context) => {
+    return app.fetch(req, { context })
+  }
+}

--- a/src/adapter/netlify/mod.ts
+++ b/src/adapter/netlify/mod.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export { handle } from './handler.ts'
+export type { Env } from './handler.ts'


### PR DESCRIPTION
This PR introduces Netfliy adapter. Hono runs on Netlify Edge Functions. Fix #1281

[Netlify Edge Functions](https://www.netlify.com/products/#netlify-edge-functions) is a Deno-based platform. So, you can use the Hono's Deno module on `deno.land/x`.

Usage:

```ts
// netlify/edge-functions/index.ts
import { Hono } from 'https://deno.land/x/hono/mod.ts'
import { prettyJSON } from 'https://deno.land/x/hono/middleware.ts'

import { handle } from 'https://deno.land/x/hono/adapter/netlify/mod.ts'
import type { Env } from 'https://deno.land/x/hono/adapter/netlify/mod.ts'

const app = new Hono<Env>()

app.get('/country', prettyJSON(), (c) =>
  c.json({
    'You are in': c.env.context.geo.country?.name
  })
)

export default handle(app)
```
```toml
# netlify.toml
[[edge_functions]]
  function = "index"
  path = "/*"
```

You can develop and deploy your application with [Netlify CLI](https://www.netlify.com/products/cli/).

Dev:

```
netlify dev
```

Deploy:

```
netlify deploy --prod
```