### PR TITLE
fix(adaptor): Access to custom request context on AWS Lambda Adaptor 

### DIFF
--- a/runtime_tests/deno/.vscode/settings.json
+++ b/runtime_tests/deno/.vscode/settings.json
@@ -1,10 +1,5 @@
 {
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -1,5 +1,10 @@
 /* eslint-disable quotes */
-import type { Callback, CloudFrontConfig, CloudFrontRequest, CloudFrontResponse } from '../../src/adapter/lambda-edge/handler'
+import type {
+  Callback,
+  CloudFrontConfig,
+  CloudFrontRequest,
+  CloudFrontResponse,
+} from '../../src/adapter/lambda-edge/handler'
 import { handle } from '../../src/adapter/lambda-edge/handler'
 import { Hono } from '../../src/hono'
 import { basicAuth } from '../../src/middleware/basic-auth'
@@ -36,7 +41,7 @@ describe('Lambda@Edge Adapter for Hono', () => {
 
   app.get('/config/eventCheck', async (c, next) => {
     await next()
-    if(c.env.config.eventType in ['viewer-request', 'origin-request']) {
+    if (c.env.config.eventType in ['viewer-request', 'origin-request']) {
       c.env.callback(null, c.env.request)
     } else {
       c.env.callback(null, c.env.response)
@@ -59,14 +64,18 @@ describe('Lambda@Edge Adapter for Hono', () => {
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
   app.get('/header/add', async (c, next) => {
-    c.env.response.headers['Strict-Transport-Security'.toLowerCase()] = [{
-      key: 'Strict-Transport-Security',
-      value: 'max-age=63072000; includeSubdomains; preload'
-    }]
-    c.env.response.headers['X-Custom'.toLowerCase()] = [{
-      key: 'X-Custom',
-      value: 'Foo'
-    }]
+    c.env.response.headers['Strict-Transport-Security'.toLowerCase()] = [
+      {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=63072000; includeSubdomains; preload',
+      },
+    ]
+    c.env.response.headers['X-Custom'.toLowerCase()] = [
+      {
+        key: 'X-Custom',
+        value: 'Foo',
+      },
+    ]
     await next()
     c.env.callback(null, c.env.response)
   })
@@ -873,10 +882,12 @@ describe('Lambda@Edge Adapter for Hono', () => {
     }
 
     interface CloudFrontHeaders {
-      [name: string]: [{
-        key: string
-        value: string
-      }]
+      [name: string]: [
+        {
+          key: string
+          value: string
+        }
+      ]
     }
     let called = false
     let headers: CloudFrontHeaders = {}
@@ -888,17 +899,17 @@ describe('Lambda@Edge Adapter for Hono', () => {
     })
 
     expect(called).toBe(true)
-    expect(headers["access-control-allow-credentials"]).toEqual([
+    expect(headers['access-control-allow-credentials']).toEqual([
       {
-        key: "Access-Control-Allow-Credentials",
-        value: "true"
-      }
+        key: 'Access-Control-Allow-Credentials',
+        value: 'true',
+      },
     ])
-    expect(headers["access-control-allow-origin"]).toEqual([
+    expect(headers['access-control-allow-origin']).toEqual([
       {
-        key: "Access-Control-Allow-Origin",
-        value: "*"
-      }
+        key: 'Access-Control-Allow-Origin',
+        value: '*',
+      },
     ])
   })
 
@@ -1015,12 +1026,14 @@ describe('Lambda@Edge Adapter for Hono', () => {
         },
       ],
     }
-    
+
     interface CloudFrontHeaders {
-      [name: string]: [{
-        key: string
-        value: string
-      }]
+      [name: string]: [
+        {
+          key: string
+          value: string
+        }
+      ]
     }
     let called = false
     let headers: CloudFrontHeaders = {}
@@ -1032,17 +1045,17 @@ describe('Lambda@Edge Adapter for Hono', () => {
     })
 
     expect(called).toBe(true)
-    expect(headers["strict-transport-security"]).toEqual([
+    expect(headers['strict-transport-security']).toEqual([
       {
-        key: "Strict-Transport-Security",
-        value: "max-age=63072000; includeSubdomains; preload"
-      }
+        key: 'Strict-Transport-Security',
+        value: 'max-age=63072000; includeSubdomains; preload',
+      },
     ])
-    expect(headers["x-custom"]).toEqual([
+    expect(headers['x-custom']).toEqual([
       {
-        key: "X-Custom",
-        value: "Foo"
-      }
+        key: 'X-Custom',
+        value: 'Foo',
+      },
     ])
   })
 
@@ -1071,11 +1084,11 @@ describe('Lambda@Edge Adapter for Hono', () => {
               querystring: '',
               uri: '/config/eventCheck',
             },
-          }
+          },
         },
       ],
     }
-    
+
     let called = false
     await handler(event, {}, (_err, result) => {
       called = true
@@ -1083,6 +1096,4 @@ describe('Lambda@Edge Adapter for Hono', () => {
 
     expect(called).toBe(true)
   })
-
-
 })

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -62,11 +62,11 @@ describe('Lambda@Edge Adapter for Hono', () => {
     c.env.response.headers['Strict-Transport-Security'.toLowerCase()] = [{
       key: 'Strict-Transport-Security',
       value: 'max-age=63072000; includeSubdomains; preload'
-    }];
+    }]
     c.env.response.headers['X-Custom'.toLowerCase()] = [{
       key: 'X-Custom',
       value: 'Foo'
-    }];
+    }]
     await next()
     c.env.callback(null, c.env.response)
   })
@@ -879,10 +879,10 @@ describe('Lambda@Edge Adapter for Hono', () => {
       }]
     }
     let called = false
-    let headers: CloudFrontHeaders = {};
+    let headers: CloudFrontHeaders = {}
     await handler(event, {}, (_err, result) => {
       if (result && result.headers) {
-        headers = result.headers as CloudFrontHeaders;
+        headers = result.headers as CloudFrontHeaders
       }
       called = true
     })
@@ -893,13 +893,13 @@ describe('Lambda@Edge Adapter for Hono', () => {
         key: "Access-Control-Allow-Credentials",
         value: "true"
       }
-    ]);
+    ])
     expect(headers["access-control-allow-origin"]).toEqual([
       {
         key: "Access-Control-Allow-Origin",
         value: "*"
       }
-    ]);
+    ])
   })
 
   it('Should handle a GET request and add header (Lambda@Edge viewer response)', async () => {
@@ -1023,10 +1023,10 @@ describe('Lambda@Edge Adapter for Hono', () => {
       }]
     }
     let called = false
-    let headers: CloudFrontHeaders = {};
+    let headers: CloudFrontHeaders = {}
     await handler(event, {}, (_err, result) => {
       if (result && result.headers) {
-        headers = result.headers as CloudFrontHeaders;
+        headers = result.headers as CloudFrontHeaders
       }
       called = true
     })
@@ -1037,13 +1037,13 @@ describe('Lambda@Edge Adapter for Hono', () => {
         key: "Strict-Transport-Security",
         value: "max-age=63072000; includeSubdomains; preload"
       }
-    ]);
+    ])
     expect(headers["x-custom"]).toEqual([
       {
         key: "X-Custom",
         value: "Foo"
       }
-    ]);
+    ])
   })
 
   it('Callback Event (Lambda@Edge response)', async () => {

--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -1,10 +1,13 @@
-import type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from '../../src/adapter/aws-lambda/custom-context'
+import type {
+  ApiGatewayRequestContext,
+  LambdaFunctionUrlRequestContext,
+} from '../../src/adapter/aws-lambda/custom-context'
 import { handle } from '../../src/adapter/aws-lambda/handler'
 import { Hono } from '../../src/hono'
 import { basicAuth } from '../../src/middleware/basic-auth'
 
 type Bindings = {
-  requestContext: ApiGatewayRequestContext | LambdaFunctionUrlRequestContext 
+  requestContext: ApiGatewayRequestContext | LambdaFunctionUrlRequestContext
 }
 
 describe('AWS Lambda Adapter for Hono', () => {
@@ -47,62 +50,62 @@ describe('AWS Lambda Adapter for Hono', () => {
 
   const handler = handle(app)
 
-const testApiGatewayRequestContext = {
-  accountId: '123456789012',
-  apiId: 'id',
-  authorizer: {
-    claims: null,
-    scopes: null
-  },
-  domainName: 'example.com',
-  domainPrefix: 'id',
-  extendedRequestId: 'request-id',
-  httpMethod: 'GET',
-  identity: {
-    'sourceIp': 'IP',
-    'userAgent': 'user-agent',
-  },
-  path: '/my/path',
-  protocol: 'HTTP/1.1',
-  requestId: 'id=',
-  requestTime: '04/Mar/2020:19:15:17 +0000',
-  requestTimeEpoch: 1583349317135,
-  resourcePath: '/',
-  stage: '$default',
-  customProperty: 'customValue'
-}
-
-const testLambdaFunctionUrlRequestContext = {
-  accountId: '123456789012',
-  apiId: 'urlid',
-  authentication: null,
-  authorizer: {
-    iam: {
-      accessKey: 'AKIA...',
-      accountId: '111122223333',
-      callerId: 'AIDA...',
-      cognitoIdentity: null,
-      principalOrgId: null,
-      userArn: 'arn:aws:iam::111122223333:user/example-user',
-      userId: 'AIDA...'
-    }
-  },
-  domainName: 'example.com',
-  domainPrefix: '<url-id>',
-  http: {
-    method: 'POST',
+  const testApiGatewayRequestContext = {
+    accountId: '123456789012',
+    apiId: 'id',
+    authorizer: {
+      claims: null,
+      scopes: null,
+    },
+    domainName: 'example.com',
+    domainPrefix: 'id',
+    extendedRequestId: 'request-id',
+    httpMethod: 'GET',
+    identity: {
+      sourceIp: 'IP',
+      userAgent: 'user-agent',
+    },
     path: '/my/path',
     protocol: 'HTTP/1.1',
-    sourceIp: '123.123.123.123',
-    userAgent: 'agent'
-  },
-  requestId: 'id',
-  routeKey: '$default',
-  stage: '$default',
-  time: '12/Mar/2020:19:03:58 +0000',
-  timeEpoch: 1583348638390,
-  customProperty: 'customValue'
-}
+    requestId: 'id=',
+    requestTime: '04/Mar/2020:19:15:17 +0000',
+    requestTimeEpoch: 1583349317135,
+    resourcePath: '/',
+    stage: '$default',
+    customProperty: 'customValue',
+  }
+
+  const testLambdaFunctionUrlRequestContext = {
+    accountId: '123456789012',
+    apiId: 'urlid',
+    authentication: null,
+    authorizer: {
+      iam: {
+        accessKey: 'AKIA...',
+        accountId: '111122223333',
+        callerId: 'AIDA...',
+        cognitoIdentity: null,
+        principalOrgId: null,
+        userArn: 'arn:aws:iam::111122223333:user/example-user',
+        userId: 'AIDA...',
+      },
+    },
+    domainName: 'example.com',
+    domainPrefix: '<url-id>',
+    http: {
+      method: 'POST',
+      path: '/my/path',
+      protocol: 'HTTP/1.1',
+      sourceIp: '123.123.123.123',
+      userAgent: 'agent',
+    },
+    requestId: 'id',
+    routeKey: '$default',
+    stage: '$default',
+    time: '12/Mar/2020:19:03:58 +0000',
+    timeEpoch: 1583348638390,
+    customProperty: 'customValue',
+  }
 
   it('Should handle a GET request and return a 200 response', async () => {
     const event = {
@@ -182,7 +185,7 @@ const testLambdaFunctionUrlRequestContext = {
       path: '/post',
       body: Buffer.from(searchParam.toString()).toString('base64'),
       isBase64Encoded: true,
-      requestContext: testApiGatewayRequestContext
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
@@ -266,8 +269,6 @@ const testLambdaFunctionUrlRequestContext = {
   })
 
   it('Should handle a GET request and return custom context', async () => {
-
-  
     const event = {
       httpMethod: 'GET',
       headers: { 'content-type': 'application/json' },
@@ -276,10 +277,9 @@ const testLambdaFunctionUrlRequestContext = {
       isBase64Encoded: false,
       requestContext: testApiGatewayRequestContext,
     }
-  
+
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
     expect(JSON.parse(response.body).customProperty).toEqual('customValue')
   })
-  
 })

--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -1,9 +1,14 @@
 import { handle } from '../../src/adapter/aws-lambda/handler'
+import type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from '../../src/adapter/aws-lambda/custom-context'
 import { Hono } from '../../src/hono'
 import { basicAuth } from '../../src/middleware/basic-auth'
 
+type Bindings = {
+  requestContext: ApiGatewayRequestContext | LambdaFunctionUrlRequestContext 
+}
+
 describe('AWS Lambda Adapter for Hono', () => {
-  const app = new Hono()
+  const app = new Hono<{ Bindings: Bindings }>()
 
   app.get('/', (c) => {
     return c.text('Hello Lambda!')
@@ -30,7 +35,74 @@ describe('AWS Lambda Adapter for Hono', () => {
   app.use('/auth/*', basicAuth({ username, password }))
   app.get('/auth/abc', (c) => c.text('Good Night Lambda!'))
 
+  app.get('/custom-context/apigw', (c) => {
+    const lambdaContext = c.env.requestContext
+    return c.json(lambdaContext)
+  })
+
+  app.get('/custom-context/lambda', (c) => {
+    const lambdaContext = c.env.requestContext
+    return c.json(lambdaContext)
+  })
+
   const handler = handle(app)
+
+const testApiGatewayRequestContext = {
+  accountId: "123456789012",
+  apiId: "id",
+  authorizer: {
+    claims: null,
+    scopes: null
+  },
+  domainName: 'example.com',
+  domainPrefix: "id",
+  extendedRequestId: "request-id",
+  httpMethod: "GET",
+  identity: {
+    "sourceIp": "IP",
+    "userAgent": "user-agent",
+  },
+  path: "/my/path",
+  protocol: "HTTP/1.1",
+  requestId: "id=",
+  requestTime: "04/Mar/2020:19:15:17 +0000",
+  requestTimeEpoch: 1583349317135,
+  resourcePath: "/",
+  stage: "$default",
+  customProperty: 'customValue'
+}
+
+const testLambdaFunctionUrlRequestContext = {
+  accountId: "123456789012",
+  apiId: "urlid",
+  authentication: null,
+  authorizer: {
+    iam: {
+      accessKey: "AKIA...",
+      accountId: "111122223333",
+      callerId: "AIDA...",
+      cognitoIdentity: null,
+      principalOrgId: null,
+      userArn: "arn:aws:iam::111122223333:user/example-user",
+      userId: "AIDA..."
+    }
+  },
+  domainName: "example.com",
+  domainPrefix: "<url-id>",
+  http: {
+    method: "POST",
+    path: "/my/path",
+    protocol: "HTTP/1.1",
+    sourceIp: "123.123.123.123",
+    userAgent: "agent"
+  },
+  requestId: "id",
+  routeKey: "$default",
+  stage: "$default",
+  time: "12/Mar/2020:19:03:58 +0000",
+  timeEpoch: 1583348638390,
+  customProperty: 'customValue'
+};
 
   it('Should handle a GET request and return a 200 response', async () => {
     const event = {
@@ -39,9 +111,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/',
       body: null,
       isBase64Encoded: false,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
@@ -58,9 +128,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/binary',
       body: null,
       isBase64Encoded: false,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
@@ -77,13 +145,10 @@ describe('AWS Lambda Adapter for Hono', () => {
       rawQueryString: '',
       body: null,
       isBase64Encoded: false,
-      requestContext: {
-        domainName: 'example.com',
-        http: {
-          method: 'GET',
-        },
-      },
+      requestContext: testLambdaFunctionUrlRequestContext,
     }
+
+    testLambdaFunctionUrlRequestContext.http.method = "GET";
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
@@ -99,9 +164,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/nothing',
       body: null,
       isBase64Encoded: false,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
@@ -119,9 +182,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/post',
       body: Buffer.from(searchParam.toString()).toString('base64'),
       isBase64Encoded: true,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext
     }
 
     const response = await handler(event)
@@ -140,13 +201,10 @@ describe('AWS Lambda Adapter for Hono', () => {
       rawQueryString: '',
       body: Buffer.from(searchParam.toString()).toString('base64'),
       isBase64Encoded: true,
-      requestContext: {
-        domainName: 'example.com',
-        http: {
-          method: 'POST',
-        },
-      },
+      requestContext: testLambdaFunctionUrlRequestContext,
     }
+
+    testLambdaFunctionUrlRequestContext.http.method = "POST";
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
@@ -164,9 +222,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/post/binary',
       body: buffer.toString('base64'),
       isBase64Encoded: true,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
@@ -183,9 +239,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/auth/abc',
       body: null,
       isBase64Encoded: true,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
@@ -203,13 +257,31 @@ describe('AWS Lambda Adapter for Hono', () => {
       path: '/auth/abc',
       body: null,
       isBase64Encoded: true,
-      requestContext: {
-        domainName: 'example.com',
-      },
+      requestContext: testApiGatewayRequestContext,
     }
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
     expect(response.body).toBe('Good Night Lambda!')
   })
+
+  it('Should handle a GET request and return custom context', async () => {
+    const customContext = {
+      customProperty: 'customValue',
+    };
+  
+    const event = {
+      httpMethod: 'GET',
+      headers: { 'content-type': 'application/json' },
+      path: '/custom-context/apigw',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: testApiGatewayRequestContext,
+    }
+  
+    const response = await handler(event);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).customProperty).toEqual('customValue');
+  });
+  
 })

--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -1,5 +1,5 @@
-import { handle } from '../../src/adapter/aws-lambda/handler'
 import type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from '../../src/adapter/aws-lambda/custom-context'
+import { handle } from '../../src/adapter/aws-lambda/handler'
 import { Hono } from '../../src/hono'
 import { basicAuth } from '../../src/middleware/basic-auth'
 
@@ -48,61 +48,61 @@ describe('AWS Lambda Adapter for Hono', () => {
   const handler = handle(app)
 
 const testApiGatewayRequestContext = {
-  accountId: "123456789012",
-  apiId: "id",
+  accountId: '123456789012',
+  apiId: 'id',
   authorizer: {
     claims: null,
     scopes: null
   },
   domainName: 'example.com',
-  domainPrefix: "id",
-  extendedRequestId: "request-id",
-  httpMethod: "GET",
+  domainPrefix: 'id',
+  extendedRequestId: 'request-id',
+  httpMethod: 'GET',
   identity: {
-    "sourceIp": "IP",
-    "userAgent": "user-agent",
+    'sourceIp': 'IP',
+    'userAgent': 'user-agent',
   },
-  path: "/my/path",
-  protocol: "HTTP/1.1",
-  requestId: "id=",
-  requestTime: "04/Mar/2020:19:15:17 +0000",
+  path: '/my/path',
+  protocol: 'HTTP/1.1',
+  requestId: 'id=',
+  requestTime: '04/Mar/2020:19:15:17 +0000',
   requestTimeEpoch: 1583349317135,
-  resourcePath: "/",
-  stage: "$default",
+  resourcePath: '/',
+  stage: '$default',
   customProperty: 'customValue'
 }
 
 const testLambdaFunctionUrlRequestContext = {
-  accountId: "123456789012",
-  apiId: "urlid",
+  accountId: '123456789012',
+  apiId: 'urlid',
   authentication: null,
   authorizer: {
     iam: {
-      accessKey: "AKIA...",
-      accountId: "111122223333",
-      callerId: "AIDA...",
+      accessKey: 'AKIA...',
+      accountId: '111122223333',
+      callerId: 'AIDA...',
       cognitoIdentity: null,
       principalOrgId: null,
-      userArn: "arn:aws:iam::111122223333:user/example-user",
-      userId: "AIDA..."
+      userArn: 'arn:aws:iam::111122223333:user/example-user',
+      userId: 'AIDA...'
     }
   },
-  domainName: "example.com",
-  domainPrefix: "<url-id>",
+  domainName: 'example.com',
+  domainPrefix: '<url-id>',
   http: {
-    method: "POST",
-    path: "/my/path",
-    protocol: "HTTP/1.1",
-    sourceIp: "123.123.123.123",
-    userAgent: "agent"
+    method: 'POST',
+    path: '/my/path',
+    protocol: 'HTTP/1.1',
+    sourceIp: '123.123.123.123',
+    userAgent: 'agent'
   },
-  requestId: "id",
-  routeKey: "$default",
-  stage: "$default",
-  time: "12/Mar/2020:19:03:58 +0000",
+  requestId: 'id',
+  routeKey: '$default',
+  stage: '$default',
+  time: '12/Mar/2020:19:03:58 +0000',
   timeEpoch: 1583348638390,
   customProperty: 'customValue'
-};
+}
 
   it('Should handle a GET request and return a 200 response', async () => {
     const event = {
@@ -148,7 +148,7 @@ const testLambdaFunctionUrlRequestContext = {
       requestContext: testLambdaFunctionUrlRequestContext,
     }
 
-    testLambdaFunctionUrlRequestContext.http.method = "GET";
+    testLambdaFunctionUrlRequestContext.http.method = 'GET'
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
@@ -204,7 +204,7 @@ const testLambdaFunctionUrlRequestContext = {
       requestContext: testLambdaFunctionUrlRequestContext,
     }
 
-    testLambdaFunctionUrlRequestContext.http.method = "POST";
+    testLambdaFunctionUrlRequestContext.http.method = 'POST'
 
     const response = await handler(event)
     expect(response.statusCode).toBe(200)
@@ -266,9 +266,7 @@ const testLambdaFunctionUrlRequestContext = {
   })
 
   it('Should handle a GET request and return custom context', async () => {
-    const customContext = {
-      customProperty: 'customValue',
-    };
+
   
     const event = {
       httpMethod: 'GET',
@@ -279,9 +277,9 @@ const testLambdaFunctionUrlRequestContext = {
       requestContext: testApiGatewayRequestContext,
     }
   
-    const response = await handler(event);
-    expect(response.statusCode).toBe(200);
-    expect(JSON.parse(response.body).customProperty).toEqual('customValue');
-  });
+    const response = await handler(event)
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body).customProperty).toEqual('customValue')
+  })
   
 })

--- a/src/adapter/aws-lambda/custom-context.ts
+++ b/src/adapter/aws-lambda/custom-context.ts
@@ -1,0 +1,83 @@
+// @denoify-ignore
+
+interface ClientCert {
+  clientCertPem: string;
+  subjectDN: string;
+  issuerDN: string;
+  serialNumber: string;
+  validity: {
+    notBefore: string;
+    notAfter: string;
+  };
+}
+
+interface Identity {
+  accessKey?: string;
+  accountId?: string;
+  caller?: string;
+  cognitoAuthenticationProvider?: string;
+  cognitoAuthenticationType?: string;
+  cognitoIdentityId?: string;
+  cognitoIdentityPoolId?: string;
+  principalOrgId?: string;
+  sourceIp: string;
+  user?: string;
+  userAgent: string;
+  userArn?: string;
+  clientCert?: ClientCert;
+}
+
+export interface ApiGatewayRequestContext {
+  accountId: string;
+  apiId: string;
+  authorizer: {
+    claims?: any;
+    scopes?: any;
+  };
+  domainName: string;
+  domainPrefix: string;
+  extendedRequestId: string;
+  httpMethod: string;
+  identity: Identity;
+  path: string;
+  protocol: string;
+  requestId: string;
+  requestTime: string;
+  requestTimeEpoch: number;
+  resourceId?: string;
+  resourcePath: string;
+  stage: string;
+}
+
+interface Authorizer {
+  iam?: {
+    accessKey: string;
+    accountId: string;
+    callerId: string;
+    cognitoIdentity: null;
+    principalOrgId: null;
+    userArn: string;
+    userId: string;
+  };
+}
+
+export interface LambdaFunctionUrlRequestContext {
+  accountId: string;
+  apiId: string;
+  authentication: null;
+  authorizer: Authorizer;
+  domainName: string;
+  domainPrefix: string;
+  http: {
+    method: string;
+    path: string;
+    protocol: string;
+    sourceIp: string;
+    userAgent: string;
+  };
+  requestId: string;
+  routeKey: string;
+  stage: string;
+  time: string;
+  timeEpoch: number;
+}

--- a/src/adapter/aws-lambda/custom-context.ts
+++ b/src/adapter/aws-lambda/custom-context.ts
@@ -31,8 +31,8 @@ export interface ApiGatewayRequestContext {
   accountId: string;
   apiId: string;
   authorizer: {
-    claims?: any;
-    scopes?: any;
+    claims?: unknown;
+    scopes?: unknown;
   };
   domainName: string;
   domainPrefix: string;

--- a/src/adapter/aws-lambda/index.ts
+++ b/src/adapter/aws-lambda/index.ts
@@ -1,2 +1,4 @@
 // @denoify-ignore
 export { handle } from './handler'
+export type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from './custom-context'
+


### PR DESCRIPTION
fixed: https://github.com/honojs/hono/issues/1197

We have revised the approach by opting to retrieve it as c.env, rather than the method of the function we were discussing.

usage:

```typescript
import { handle, getLambdaContext } from 'hono/aws-lambda'
import type { ApiGatewayRequestContext } from 'hono/aws-lambda'
import { Hono } from 'hono'

type Bindings = {
  requestContext: ApiGatewayRequestContext 
}

app.get('/custom-context/apigw', (c) => {
  const lambdaContext = c.env.requestContext
  return c.json(lambdaContext)
})

```