### PR TITLE
perf(hono-base): use `constructor.name` instead of `instanceof`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -308,13 +308,13 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
         return this.handleError(err, c)
       }
 
-      if (res instanceof Response) return res
+      if (res.constructor.name === 'Response') return res as Response
 
       if ('response' in res) {
         res = res.response
       }
 
-      if (res instanceof Response) return res
+      if (res.constructor.name === 'Response') return res as Response
 
       return (async () => {
         let awaited: Response | TypedResponse | void
@@ -338,7 +338,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     return (async () => {
       try {
         const tmp = composed(c)
-        const context = tmp instanceof Promise ? await tmp : tmp
+        const context = tmp.constructor.name === 'Promise' ? await tmp : (tmp as Context)
         if (!context.finalized) {
           throw new Error(
             'Context is not finalized. You may forget returning Response object or `await next()`'

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -308,13 +308,13 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
         return this.handleError(err, c)
       }
 
-      if (res instanceof Response) return res
+      if (res.constructor.name === 'Response') return res as Response
 
       if ('response' in res) {
         res = res.response
       }
 
-      if (res instanceof Response) return res
+      if (res.constructor.name === 'Response') return res as Response
 
       return (async () => {
         let awaited: Response | TypedResponse | void
@@ -338,7 +338,7 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
     return (async () => {
       try {
         const tmp = composed(c)
-        const context = tmp instanceof Promise ? await tmp : tmp
+        const context = tmp.constructor.name === 'Promise' ? await tmp : (tmp as Context)
         if (!context.finalized) {
           throw new Error(
             'Context is not finalized. You may forget returning Response object or `await next()`'


### PR DESCRIPTION
To detect the class name of the instance, `res.contructor.name === 'Response'` is faster than `res instanceof Response` on Bun.

<img width="709" alt="Screenshot 2023-08-09 at 13 38 42" src="https://github.com/honojs/hono/assets/10682/975e386e-a463-42cd-8147-462294372712">
