### PR TITLE
perf: make parsing a query fast

### DIFF
--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -1,5 +1,6 @@
 import { compose } from './compose'
 import { Context } from './context'
+import { HonoRequest } from './request'
 
 type C = {
   req: Record<string, string>
@@ -8,6 +9,12 @@ type C = {
 }
 
 class ExpectedError extends Error {}
+
+const req = new HonoRequest(new Request('http://localhost/'), {
+  path: '/',
+  paramData: {},
+  firstQuery: undefined,
+})
 
 describe('compose', () => {
   const middleware: Function[] = []
@@ -79,8 +86,6 @@ describe('compose with returning a promise, non-async function', () => {
 
 describe('Handler and middlewares', () => {
   const middleware: Function[] = []
-
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
 
   const mHandlerFoo = async (c: Context, next: Function) => {
@@ -116,7 +121,6 @@ describe('Handler and middlewares', () => {
 describe('compose with Context - 200 success', () => {
   const middleware: Function[] = []
 
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const handler = (c: Context) => {
     return c.text('Hello')
@@ -140,7 +144,6 @@ describe('compose with Context - 200 success', () => {
 describe('compose with Context - 404 not found', () => {
   const middleware: Function[] = []
 
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const onNotFound = (c: Context) => {
     return c.text('onNotFound', 404)
@@ -164,7 +167,6 @@ describe('compose with Context - 404 not found', () => {
 describe('compose with Context - 401 not authorized', () => {
   const middleware: Function[] = []
 
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const handler = (c: Context) => {
     return c.text('Hello')
@@ -190,7 +192,6 @@ describe('compose with Context - 401 not authorized', () => {
 describe('compose with Context - next() below', () => {
   const middleware: Function[] = []
 
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const handler = (c: Context) => {
     const message = c.req.header('x-custom') || 'blank'
@@ -217,7 +218,6 @@ describe('compose with Context - next() below', () => {
 describe('compose with Context - 500 error', () => {
   const middleware: Function[] = []
 
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
 
   it('Error on handler', async () => {
@@ -266,7 +266,6 @@ describe('compose with Context - 500 error', () => {
   })
 })
 describe('compose with Context - not finalized', () => {
-  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const onNotFound = (c: Context) => {
     return c.text('onNotFound', 404)

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,8 +1,13 @@
 import { Context } from './context'
+import { HonoRequest } from './request'
+
+const req = new HonoRequest(new Request('http://localhost/'), {
+  path: '/',
+  paramData: {},
+  firstQuery: undefined,
+})
 
 describe('Context', () => {
-  const req = new Request('http://localhost/')
-
   let c: Context
   beforeEach(() => {
     c = new Context(req)
@@ -145,7 +150,6 @@ describe('Context', () => {
   })
 
   it('Should be able read env', async () => {
-    const req = new Request('http://localhost/')
     const key = 'a-secret-key'
     const ctx = new Context(req, {
       env: {
@@ -180,7 +184,6 @@ describe('Context', () => {
 })
 
 describe('Context header', () => {
-  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)
@@ -198,7 +201,6 @@ describe('Context header', () => {
 })
 
 describe('Pass a ResponseInit to respond methods', () => {
-  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -1,9 +1,15 @@
 import { HonoRequest } from './request'
 
+const defaultOption = {
+  path: '/',
+  paramData: {},
+  firstQuery: undefined,
+}
+
 describe('Query', () => {
   test('req.query() and req.queries()', () => {
     const rawRequest = new Request('http://localhost?page=2&tag=A&tag=B')
-    const req = new HonoRequest(rawRequest)
+    const req = new HonoRequest(rawRequest, defaultOption)
 
     const page = req.query('page')
     expect(page).not.toBeUndefined()
@@ -22,7 +28,7 @@ describe('Query', () => {
 
   test('decode special chars', () => {
     const rawRequest = new Request('http://localhost?mail=framework%40hono.dev&tag=%401&tag=%402')
-    const req = new HonoRequest(rawRequest)
+    const req = new HonoRequest(rawRequest, defaultOption)
 
     const mail = req.query('mail')
     expect(mail).toBe('framework@hono.dev')
@@ -44,14 +50,14 @@ describe('req.addValidatedData() and req.data()', () => {
   }
 
   test('add data - json', () => {
-    const req = new HonoRequest(rawRequest)
+    const req = new HonoRequest(rawRequest, defaultOption)
     req.addValidatedData('json', payload)
     const data = req.valid('json')
     expect(data).toEqual(payload)
   })
 
   test('replace data - json', () => {
-    const req = new HonoRequest(rawRequest)
+    const req = new HonoRequest(rawRequest, defaultOption)
     req.addValidatedData('json', payload)
     req.addValidatedData('json', {
       tag: ['sport', 'music'],
@@ -71,7 +77,10 @@ describe('req.addValidatedData() and req.data()', () => {
 
 describe('headers', () => {
   test('empty string is a valid header value', () => {
-    const req = new HonoRequest(new Request('http://localhost', { headers: { foo: '' } }))
+    const req = new HonoRequest(
+      new Request('http://localhost', { headers: { foo: '' } }),
+      defaultOption
+    )
     const foo = req.header('foo')
     expect(foo).toEqual('')
   })

--- a/src/request.ts
+++ b/src/request.ts
@@ -21,14 +21,20 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private vData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
   path: string
 
+  private firstQuery: Record<string, string> | undefined
+
   constructor(
     request: Request,
-    path: string = '/',
-    paramData?: Record<string, string> | undefined
+    options: {
+      path: string
+      paramData: Record<string, string> | undefined
+      firstQuery: Record<string, string> | undefined
+    }
   ) {
     this.raw = request
-    this.path = path
-    this.paramData = paramData
+    this.path = options.path
+    this.paramData = options.paramData
+    this.firstQuery = options.firstQuery
     this.vData = {}
   }
 
@@ -57,6 +63,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   query(key: string): string | undefined
   query(): Record<string, string>
   query(key?: string) {
+    if (key && this.firstQuery) {
+      return this.firstQuery[key]
+    }
     return getQueryParam(this.url, key)
   }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -74,6 +74,22 @@ export const getPath = (request: Request): string => {
   return match ? match[1] : ''
 }
 
+export const getPathWithFirstQuery = (
+  request: Request
+): [string, Record<string, string> | undefined] => {
+  const url = request.url
+  if (!/\?/.test(url)) {
+    return [getPath(request), undefined]
+  }
+  const match = url.match(/^https?:\/\/[^/]+(\/[^?]+)\?([^=]+)=([^&%]+)$/)
+  if (match) {
+    const firstQuery = {} as Record<string, string>
+    firstQuery[match[2]] = match[3]
+    return [match[1], firstQuery]
+  }
+  return [getPath(request), undefined]
+}
+
 export const getQueryStrings = (url: string): string => {
   const queryIndex = url.indexOf('?', 8)
   return queryIndex === -1 ? '' : '?' + url.slice(queryIndex + 1)


### PR DESCRIPTION
For Hono, being "fast" is paramount.

Below is a link to one of the benchmark projects for Bun's web frameworks:

[https://github.com/SaltyAom/bun-http-framework-benchmark](https://github.com/SaltyAom/bun-http-framework-benchmark)

A benchmark is just a benchmark, but it's important as many users refer to it as a guideline to determine which framework is better.

In this benchmark, the fastest frameworks are overly optimized for benchmarking, making them nonsensical to compare with Hono. However, "Elysia" is a good framework for practical use cases. Elysia is also optimized for Bun, making its benchmark scores fast. Moreover, it now supports the "`fetch`" interface, as seen in applications like Cloudflare Workers:

```ts
const app = new Elysia({
  aot: false,
}).get('/', () => 'Hi')

export default {
  fetch: app.fetch,
}
```

With this syntax, the conditions between Hono and Elysia are the same, so I want Hono to outperform Elysia using this approach.

To that end, I've revised the parsing of query parameters since Hono's score for "Params, query & header" was low. Then the result was:

![Screenshot 2023-08-11 at 0 17 39](https://github.com/honojs/hono/assets/10682/32729c5c-6793-431a-8852-d9928ff27765)

The score for "Get (/)" may be slower, but it will be faster in "Params, query & header," even though it's still slower than Elysia's.

The strategy behind this change is to retrieve the first query parameter `{ name: "bun" }` at the same time as `getPathWithFirstQuery()`. I'm not sure if this is the best or even a better solution, but the score should be improved.

For performance measurement, I'm using this script: 

```ts
import { Elysia } from 'elysia'
import { Hono as CurrentHono } from 'hono'
import { RegExpRouter } from 'hono/router/reg-exp-router'
import { run, bench, group } from 'mitata'
import { Hono } from '../../../dist'

const appHono = new Hono({ router: new RegExpRouter() })
  .get('/', (c) => c.text('Hi'))
  .get('/id/:id', (c) => {
    const id = c.req.param('id')
    const name = c.req.query('name')
    return c.text(`${id} ${name}`, {
      headers: {
        'x-powered-by': 'benchmark',
      },
    })
  })
  .post('/json', (c) => c.req.json().then(c.json))

const currentHono = new CurrentHono({ router: new RegExpRouter() })
  .get('/', (c) => c.text('Hi'))
  .get('/id/:id', (c) => {
    const id = c.req.param('id')
    const name = c.req.query('name')
    return c.text(`${id} ${name}`, {
      headers: {
        'x-powered-by': 'benchmark',
      },
    })
  })
  .post('/json', (c) => c.req.json().then(c.json))

const appElysia = new Elysia({
  aot: false,
})
  .get('/', () => 'Hi')
  .get('/id/:id', (c) => {
    c.set.headers['x-powered-by'] = 'benchmark'
    return `${c.params.id} ${c.query.name}`
  })
  .post('/json', (c) => c.body)

bench('noop', () => {})

group({ name: 'Get (/)' }, () => {
  const request = new Request('http://localhost/')

  bench('Hono - next', async () => {
    await appHono.fetch(request)
  })

  bench('Hono - current', async () => {
    await currentHono.fetch(request)
  })

  bench('Elysia', async () => {
    await appElysia.fetch(request)
  })
})

group({ name: 'Params, query & header' }, () => {
  const request = new Request('http://localhost/id/1?name=bun')

  bench('Hono - next', async () => {
    await appHono.fetch(request)
  })

  bench('Hono - current', async () => {
    await currentHono.fetch(request)
  })

  bench('Elysia', async () => {
    await appElysia.fetch(request)
  })
})

const createRequest = () => {
  return new Request('http://localhost/json', {
    method: 'POST',
    body: `{
      "hello": "world"
    }`,
    headers: {
      'Content-Type': 'application/json',
    },
  })
}

group({ name: 'Post JSON' }, () => {
  bench('Hono - next', async () => {
    const request = createRequest()
    await appHono.fetch(request)
  })

  bench('Hono - current', async () => {
    const request = createRequest()
    await currentHono.fetch(request)
  })

  bench('Elysia', async () => {
    const request = createRequest()
    await appElysia.fetch(request)
  })
})

await run()
```