### PR TITLE
feat(`package.json`): export `hono/context`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/index.js",
       "require": "./dist/cjs/index.js"
     },
+    "./context": {
+      "types": "./dist/types/context.d.ts",
+      "import": "./dist/context.js",
+      "require": "./dist/cjs/context.js"
+    },
     "./tiny": {
       "types": "./dist/types/preset/tiny.d.ts",
       "import": "./dist/preset/tiny.js",
@@ -224,6 +229,9 @@
   },
   "typesVersions": {
     "*": {
+      "context": [
+        "./dist/types/context"
+      ],
       "tiny": [
         "./dist/types/preset/tiny"
       ],


### PR DESCRIPTION
This PR enables to export `hono/context`. With this feature, you can set the variables types for `c.get()`/`c.set()` using `ContextVariableMap`.

```ts
declare module 'hono/context' {
  interface ContextVariableMap {
    message: string
  }
}
```

<img width="496" alt="Screenshot 2023-08-15 at 12 22 57" src="https://github.com/honojs/hono/assets/10682/2aabd96e-4695-4dfa-8e2e-23ae03a0b429">

Fix #1319