### PR TITLE
feat(req): cache body content

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -76,3 +76,66 @@ describe('headers', () => {
     expect(foo).toEqual('')
   })
 })
+
+describe('Body methods', () => {
+  test('req.text()', async () => {
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: 'foo',
+      })
+    )
+    expect(await req.text()).toBe('foo')
+    expect(await req.text()).toBe('foo') // Should be cached
+  })
+
+  test('req.json()', async () => {
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: '{"foo":"bar"}',
+      })
+    )
+    expect(await req.json()).toEqual({ foo: 'bar' })
+    expect(await req.json()).toEqual({ foo: 'bar' }) // Should be cached
+  })
+
+  test('req.arrayBuffer()', async () => {
+    const buffer = new ArrayBuffer(8)
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: buffer,
+      })
+    )
+    expect(await req.arrayBuffer()).toEqual(buffer)
+    expect(await req.arrayBuffer()).toEqual(buffer) // Should be cached
+  })
+
+  test('req.blob()', async () => {
+    const blob = new Blob(['foo'], {
+      type: 'text/plain',
+    })
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: blob,
+      })
+    )
+    expect(await req.blob()).toEqual(blob)
+    expect(await req.blob()).toEqual(blob) // Should be cached
+  })
+
+  test('req.formData()', async () => {
+    const data = new FormData()
+    data.append('foo', 'bar')
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: data,
+      })
+    )
+    expect((await req.formData()).get('foo')).toBe('bar')
+    expect((await req.formData()).get('foo')).toBe('bar') // Should be cached
+  })
+})

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type {
   Input,
   InputToDataByTarget,
@@ -14,12 +16,16 @@ import { parse } from './utils/cookie'
 import type { UnionToIntersection } from './utils/types'
 import { getQueryParam, getQueryParams, decodeURIComponent_ } from './utils/url'
 
+type BodyType = 'json' | 'text' | 'arrayBuffer' | 'blob' | 'formData'
+type BodyCache = Partial<Record<BodyType, any>>
+
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   raw: Request
 
   private paramData: Record<string, string> | undefined
   private vData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
   path: string
+  private bodyCache: BodyCache = {}
 
   constructor(
     request: Request,
@@ -115,28 +121,34 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   async parseBody<T extends BodyData = BodyData>(): Promise<T> {
-    return await parseBody(this.raw)
+    return await parseBody(this)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private cachedBody = (key: keyof BodyCache) => {
+    const cachedBody = this.bodyCache[key]
+    if (cachedBody) return cachedBody
+    this.bodyCache[key] = this.raw[key]()
+    return this.bodyCache[key]
+  }
+
   json<T = any>(): Promise<T> {
-    return this.raw.json()
+    return this.cachedBody('json')
   }
 
-  text() {
-    return this.raw.text()
+  text(): Promise<string> {
+    return this.cachedBody('text')
   }
 
-  arrayBuffer() {
-    return this.raw.arrayBuffer()
+  arrayBuffer(): Promise<ArrayBuffer> {
+    return this.cachedBody('arrayBuffer')
   }
 
-  blob() {
-    return this.raw.blob()
+  blob(): Promise<Blob> {
+    return this.cachedBody('blob')
   }
 
-  formData() {
-    return this.raw.formData()
+  formData(): Promise<FormData> {
+    return this.cachedBody('formData')
   }
 
   addValidatedData(target: keyof ValidationTargets, data: {}) {

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,7 +1,9 @@
+import type { HonoRequest } from '../request'
+
 export type BodyData = Record<string, string | File>
 
 export const parseBody = async <T extends BodyData = BodyData>(
-  r: Request | Response
+  r: HonoRequest | Request
 ): Promise<T> => {
   let body: BodyData = {}
   const contentType = r.headers.get('Content-Type')

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,6 +1,5 @@
 import type { Context } from '../context'
 import type { Env, ValidationTargets, MiddlewareHandler } from '../types'
-import { parseBody } from '../utils/body'
 
 type ValidationTargetKeysWithBody = 'form' | 'json'
 type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD request must not have a body content.
@@ -48,7 +47,7 @@ export const validator = <
     switch (target) {
       case 'json':
         try {
-          value = await c.req.raw.clone().json()
+          value = await c.req.json()
         } catch {
           console.error('Error: Malformed JSON in request body')
           return c.json(
@@ -61,7 +60,7 @@ export const validator = <
         }
         break
       case 'form':
-        value = await parseBody(c.req.raw.clone())
+        value = await c.req.parseBody()
         break
       case 'query':
         value = Object.fromEntries(


### PR DESCRIPTION
This PR allows `HonoRequest` to cache its body content retrieved from methods like `req.raw.json()`. The following methods will have their results cached:

* `json()`
* `text()`
* `arrayBuffer()`
* `blob()`
* `formData()`

Before this feature, if we needed to call `req.json()` more than once, we would have to use `clone()`. In validators, `clone()` was used to preserve the request for subsequent uses:

```ts
value = await c.req.raw.clone().json()
```

However, this approach triggered warnings in Cloudflare/Wrangler:

```
Your worker created multiple branches of a single stream (for instance, by calling `response.clone()` or `request.clone()`) but did not consume the body of both branches. This behavior is inefficient since it requires the entire stream of data to be buffered in memory rather than being streamed. As a result, your worker might be unexpectedly terminated for exceeding the memory limit. If your intention was only to copy the request or response headers and metadata (e.g., to modify them), consider using the appropriate constructors (e.g., `new Response(response.body, response)`, `new Request(request)`, etc.).
```

With this PR, the content is cached within the `HonoRequest` object, preventing such warnings.

This change does not degrade performance and involves minimal code adjustments. I believe it's a valuable enhancement.

--- 

Fix #1317 #1179 #567 https://github.com/honojs/middleware/issues/62

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
