### PR TITLE
docs: support change of escapeTextForBrowser path in react

### DIFF
--- a/deno_dist/utils/html.ts
+++ b/deno_dist/utils/html.ts
@@ -3,7 +3,7 @@ export type HtmlEscapedString = string & HtmlEscaped
 export type StringBuffer = [string]
 
 // The `escapeToBuffer` implementation is based on code from the MIT licensed `react-dom` package.
-// https://github.com/facebook/react/blob/main/packages/react-dom/src/server/escapeTextForBrowser.js
+// https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/server/escapeTextForBrowser.js
 
 const escapeRe = /[&<>'"]/
 

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -3,7 +3,7 @@ export type HtmlEscapedString = string & HtmlEscaped
 export type StringBuffer = [string]
 
 // The `escapeToBuffer` implementation is based on code from the MIT licensed `react-dom` package.
-// https://github.com/facebook/react/blob/main/packages/react-dom/src/server/escapeTextForBrowser.js
+// https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/server/escapeTextForBrowser.js
 
 const escapeRe = /[&<>'"]/
 


### PR DESCRIPTION
Hello!

Sorry for the very minor changes.

On Sep 29, 2022, 
https://github.com/facebook/react/commit/97d75c9c8bcddb0daed1ed062101c7f5e9b825f4
It appears that the implementation detail portion of  React-DOM implementation details has been moved from `. /packages/react-dom` to `. /packages/react-dom-bindings`.
The link was thereby broken and has been corrected to the correct link.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
