### PR TITLE
Web query undefined check

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -2,7 +2,7 @@ import type { Hono } from '../hono.ts'
 import type { ValidationTargets } from '../types.ts'
 import type { UnionToIntersection } from '../utils/types.ts'
 import type { Callback, Client, ClientRequestOptions } from './types.ts'
-import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils.ts'
+import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './utils.ts'
 
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
@@ -41,6 +41,10 @@ class ClientRequestImpl {
     if (args) {
       if (args.query) {
         for (const [k, v] of Object.entries(args.query)) {
+          if (v === undefined) {
+            return
+          }
+
           this.queryParams ||= new URLSearchParams()
           if (Array.isArray(v)) {
             for (const v2 of v) {
@@ -107,7 +111,10 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: ClientRequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(
+  baseUrl: string,
+  options?: ClientRequestOptions
+) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -2,7 +2,7 @@ import type { MiddlewareHandler } from '../../types.ts'
 import { sha1 } from '../../utils/crypto.ts'
 
 type ETagOptions = {
-  retainedHeaders?: string[],
+  retainedHeaders?: string[]
   weak?: boolean
 }
 
@@ -13,7 +13,12 @@ type ETagOptions = {
  * > Content-Location, Date, ETag, Expires, and Vary.
  */
 const RETAINED_304_HEADERS = [
-  'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
+  'cache-control',
+  'content-location',
+  'date',
+  'etag',
+  'expires',
+  'vary',
 ]
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import type { Hono } from '../hono'
 import type { ValidationTargets } from '../types'
 import type { UnionToIntersection } from '../utils/types'
 import type { Callback, Client, ClientRequestOptions } from './types'
-import { replaceUrlParam, mergePath, removeIndexString, deepMerge } from './utils'
+import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './utils'
 
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
@@ -41,6 +41,10 @@ class ClientRequestImpl {
     if (args) {
       if (args.query) {
         for (const [k, v] of Object.entries(args.query)) {
+          if (v === undefined) {
+            return
+          }
+
           this.queryParams ||= new URLSearchParams()
           if (Array.isArray(v)) {
             for (const v2 of v) {


### PR DESCRIPTION
### Notes
- Opened this PR after I was confused why conditional code was being ran in my API when using the RPC client. Realized that I had a query string that contained `&filter=undefined` that was then parsed into `{ filter: 'undefined'}`
- Added check for undefined value in query to prevent API receiving values of `undefined`. 
