### PR TITLE
fix(middleware): signed cookie misinterpretation of cookie values with dot

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -107,7 +107,10 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: ClientRequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(
+  baseUrl: string,
+  options?: ClientRequestOptions
+) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -2,7 +2,7 @@ import type { MiddlewareHandler } from '../../types.ts'
 import { sha1 } from '../../utils/crypto.ts'
 
 type ETagOptions = {
-  retainedHeaders?: string[],
+  retainedHeaders?: string[]
   weak?: boolean
 }
 
@@ -13,7 +13,12 @@ type ETagOptions = {
  * > Content-Location, Date, ETag, Expires, and Vary.
  */
 const RETAINED_304_HEADERS = [
-  'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
+  'cache-control',
+  'content-location',
+  'date',
+  'etag',
+  'expires',
+  'vary',
 ]
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {

--- a/src/middleware/cookie/index.test.ts
+++ b/src/middleware/cookie/index.test.ts
@@ -88,8 +88,9 @@ describe('Cookie Middleware', () => {
 
     it('Get signed cookies invalid signature', async () => {
       const req = new Request('http://localhost/cookie-signed-get-all')
+      // fruit_cookie has invalid signature
       const cookieString =
-        'fortune_cookie=lots-of-money.UO6vMygDM6NCDU4LdvBnzdVb2Xcdj+h+ZTnmS8X7iH8%3D; fruit_cookie=mango.verytasty%3D'
+        'fortune_cookie=lots-of-money.UO6vMygDM6NCDU4LdvBnzdVb2Xcdj+h+ZTnmS8X7iH8%3D; fruit_cookie=mango.LAa7RX43t2vCrLNcKmNG65H41OkyV02sraRPuY5RuVg%3D'
       req.headers.set('Cookie', cookieString)
       const res = await app.request(req)
       expect(res.headers.get('Fortune-Cookie')).toBe('lots-of-money')
@@ -107,8 +108,9 @@ describe('Cookie Middleware', () => {
 
     it('Get signed cookie witn invalid signature', async () => {
       const req = new Request('http://localhost/cookie-signed-get-one')
+      // fortune_cookie has invalid signature
       const cookieString =
-        'fortune_cookie=lots-of-money.nolucktoday%3D; fruit_cookie=mango.lRwgtW9ooM9%2Fd9ZZA%2FInNRG64CbQsfWGXQyFLPM9520%3D'
+        'fortune_cookie=lots-of-money.LAa7RX43t2vCrLNcKmNG65H41OkyV02sraRPuY5RuVg=; fruit_cookie=mango.lRwgtW9ooM9%2Fd9ZZA%2FInNRG64CbQsfWGXQyFLPM9520%3D'
       req.headers.set('Cookie', cookieString)
       const res = await app.request(req)
       expect(res.headers.get('Fortune-Cookie')).toBe('INVALID')

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -17,11 +17,13 @@ describe('Parse cookie', () => {
   })
 
   it('Should parse cookies but ignore signed cookies', () => {
+    // also contains another cookie with a '.' in its value to test it is not misinterpreted as signed cookie
     const cookieString =
-      'yummy_cookie=choco; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+      'yummy_cookie=choco; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D; great_cookie=rating3.5'
     const cookie: Cookie = parse(cookieString)
     expect(cookie['yummy_cookie']).toBe('choco')
     expect(cookie['tasty_cookie']).toBeUndefined()
+    expect(cookie['great_cookie']).toBe('rating3.5')
   })
 
   it('Should parse signed cookies', async () => {
@@ -35,8 +37,9 @@ describe('Parse cookie', () => {
 
   it('Should parse signed cookies and return "false" for wrong signature', async () => {
     const secret = 'secret ingredient'
+    // tasty_cookie has invalid signature
     const cookieString =
-      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.invalidsignatur%3D'
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.LAa7RX43t2vCrLNcKmNG65H41OkyV02sraRPuY5RuVg%3D'
     const cookie: SignedCookie = await parseSigned(cookieString, secret)
     expect(cookie['yummy_cookie']).toBe('choco')
     expect(cookie['tasty_cookie']).toBe(false)
@@ -53,8 +56,9 @@ describe('Parse cookie', () => {
 
   it('Should parse one signed cookie specified by name and return "false" for wrong signature', async () => {
     const secret = 'secret ingredient'
+    // tasty_cookie has invalid signature
     const cookieString =
-      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.invalidsignatur%3D'
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; tasty_cookie = strawberry.LAa7RX43t2vCrLNcKmNG65H41OkyV02sraRPuY5RuVg%3D'
     const cookie: SignedCookie = await parseSigned(cookieString, secret, 'tasty_cookie')
     expect(cookie['yummy_cookie']).toBeUndefined()
     expect(cookie['tasty_cookie']).toBe(false)
@@ -62,11 +66,13 @@ describe('Parse cookie', () => {
 
   it('Should parse signed cookies and ignore regular cookies', async () => {
     const secret = 'secret ingredient'
+    // also contains another cookie with a '.' in its value to test it is not misinterpreted as signed cookie
     const cookieString =
-      'yummy_cookie=choco; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+      'yummy_cookie=choco; tasty_cookie = strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D; great_cookie=rating3.5'
     const cookie: SignedCookie = await parseSigned(cookieString, secret)
     expect(cookie['yummy_cookie']).toBeUndefined()
     expect(cookie['tasty_cookie']).toBe('strawberry')
+    expect(cookie['great_cookie']).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Related issue: https://github.com/honojs/hono/issues/1337

Done the following:
- [x] Modified tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
