### PR TITLE
refactor(compress-middleware): resolve type assertion using const assertion

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -107,7 +107,10 @@ class ClientRequestImpl {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(baseUrl: string, options?: ClientRequestOptions) =>
+export const hc = <T extends Hono<any, any, any>>(
+  baseUrl: string,
+  options?: ClientRequestOptions
+) =>
   createProxy(async (opts) => {
     const parts = [...opts.path]
 

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -2,7 +2,7 @@ import type { MiddlewareHandler } from '../../types.ts'
 import { sha1 } from '../../utils/crypto.ts'
 
 type ETagOptions = {
-  retainedHeaders?: string[],
+  retainedHeaders?: string[]
   weak?: boolean
 }
 
@@ -13,7 +13,12 @@ type ETagOptions = {
  * > Content-Location, Date, ETag, Expires, and Vary.
  */
 const RETAINED_304_HEADERS = [
-  'cache-control', 'content-location', 'date', 'etag', 'expires', 'vary'
+  'cache-control',
+  'content-location',
+  'date',
+  'etag',
+  'expires',
+  'vary',
 ]
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -1,24 +1,23 @@
 import type { MiddlewareHandler } from '../../types'
 
-type EncodingType = 'gzip' | 'deflate'
+const ENCODING_TYPES = ['gzip', 'deflate'] as const
 
 interface CompressionOptions {
-  encoding?: EncodingType
+  encoding?: typeof ENCODING_TYPES[number]
 }
 
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   return async (ctx, next) => {
     await next()
     const accepted = ctx.req.headers.get('Accept-Encoding')
-    const pattern = options?.encoding ?? /gzip|deflate/
-    const match = accepted?.match(pattern)
-    if (!accepted || !match || !ctx.res.body) {
+    const encoding =
+      options?.encoding ?? ENCODING_TYPES.find((encoding) => accepted?.includes(encoding))
+    if (!encoding || !ctx.res.body) {
       return
     }
-    const encoding = match[0]
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const stream = new CompressionStream(encoding as EncodingType)
+    const stream = new CompressionStream(encoding)
     ctx.res = new Response(ctx.res.body.pipeThrough(stream), ctx.res)
     ctx.res.headers.set('Content-Encoding', encoding)
   }


### PR DESCRIPTION
Hello. Please merge it if you like!
I could not remove ts-ignore because Nodejs globalThis does not have a CompressionStream type...

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
