### PR TITLE
fix(types): corrected argument types for `Context` methods

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -207,7 +207,7 @@ export class Context<
       })
     }
 
-    // Return Response immediately if arg is RequestInit.
+    // Return Response immediately if arg is ResponseInit.
     if (arg && typeof arg !== 'number') {
       const res = new Response(data, arg)
       const contentType = this._pH?.['content-type']
@@ -254,7 +254,7 @@ export class Context<
 
   body: BodyRespond = (
     data: Data | null,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
     return typeof arg === 'number'
@@ -264,7 +264,7 @@ export class Context<
 
   text: TextRespond = (
     text: string,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
     // If the header is empty, return Response immediately.
@@ -287,7 +287,7 @@ export class Context<
 
   json: JSONRespond = <T = {}>(
     object: T,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ) => {
     const body = JSON.stringify(object)
@@ -300,7 +300,7 @@ export class Context<
 
   jsonT: JSONTRespond = <T>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): TypedResponse<
     InterfaceToType<T> extends JSONValue
@@ -319,7 +319,7 @@ export class Context<
 
   html: HTMLRespond = (
     html: string,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
     this._pH ??= {}

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -430,7 +430,9 @@ export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | un
 //////                            //////
 ////////////////////////////////////////
 
-export type ExtractSchema<T> = UnionToIntersection<T extends Hono<infer _, infer S, any> ? S : never>
+export type ExtractSchema<T> = UnionToIntersection<
+  T extends Hono<infer _, infer S, any> ? S : never
+>
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/context.ts
+++ b/src/context.ts
@@ -207,7 +207,7 @@ export class Context<
       })
     }
 
-    // Return Response immediately if arg is RequestInit.
+    // Return Response immediately if arg is ResponseInit.
     if (arg && typeof arg !== 'number') {
       const res = new Response(data, arg)
       const contentType = this._pH?.['content-type']
@@ -254,7 +254,7 @@ export class Context<
 
   body: BodyRespond = (
     data: Data | null,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
     return typeof arg === 'number'
@@ -264,7 +264,7 @@ export class Context<
 
   text: TextRespond = (
     text: string,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
     // If the header is empty, return Response immediately.
@@ -287,7 +287,7 @@ export class Context<
 
   json: JSONRespond = <T = {}>(
     object: T,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ) => {
     const body = JSON.stringify(object)
@@ -300,7 +300,7 @@ export class Context<
 
   jsonT: JSONTRespond = <T>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): TypedResponse<
     InterfaceToType<T> extends JSONValue
@@ -319,7 +319,7 @@ export class Context<
 
   html: HTMLRespond = (
     html: string,
-    arg?: StatusCode | RequestInit,
+    arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
     this._pH ??= {}


### PR DESCRIPTION
Each method is typed by Interface and doesn't affect the type of function arguments as seen by the caller, but wouldn't it be healthier to modify it?

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
