### PR TITLE
fix(compress): delete `content-length` header

### DIFF
--- a/deno_dist/middleware/compress/index.ts
+++ b/deno_dist/middleware/compress/index.ts
@@ -19,6 +19,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     // @ts-ignore
     const stream = new CompressionStream(encoding)
     ctx.res = new Response(ctx.res.body.pipeThrough(stream), ctx.res)
+    ctx.res.headers.delete('Content-Length')
     ctx.res.headers.set('Content-Encoding', encoding)
   }
 }

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -6,6 +6,7 @@ describe('Parse Compress Middleware', () => {
 
   app.use('*', compress())
   app.get('/hello', async (ctx) => {
+    ctx.header('Content-Length', '5')
     return ctx.text('hello')
   })
 
@@ -18,6 +19,7 @@ describe('Parse Compress Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toEqual('gzip')
+    expect(res.headers.get('Content-Length')).toBeNull()
   })
 
   it('deflate', async () => {
@@ -29,6 +31,7 @@ describe('Parse Compress Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toEqual('deflate')
+    expect(res.headers.get('Content-Length')).toBeNull()
   })
 
   it('gzip or deflate', async () => {
@@ -40,6 +43,7 @@ describe('Parse Compress Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toEqual('gzip')
+    expect(res.headers.get('Content-Length')).toBeNull()
   })
 
   it('raw', async () => {
@@ -50,5 +54,6 @@ describe('Parse Compress Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toBeNull()
+    expect(res.headers.get('Content-Length')).toBe('5')
   })
 })

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -19,6 +19,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     // @ts-ignore
     const stream = new CompressionStream(encoding)
     ctx.res = new Response(ctx.res.body.pipeThrough(stream), ctx.res)
+    ctx.res.headers.delete('Content-Length')
     ctx.res.headers.set('Content-Encoding', encoding)
   }
 }


### PR DESCRIPTION
It should be deleted. Fix https://github.com/honojs/node-server/issues/79

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
