### PR TITLE
fix(types): remove type-errors for routes

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -1,24 +1,13 @@
 import type { Hono } from '../hono.ts'
-import type { ValidationTargets } from '../types.ts'
+import type { Schema } from '../types.ts'
 import type { RemoveBlankRecord } from '../utils/types.ts'
-
-type MethodName = `$${string}`
-
-type Endpoint = Record<MethodName, Data>
-
-type Data = {
-  input: Partial<ValidationTargets> & {
-    param?: Record<string, string>
-  }
-  output: {}
-}
 
 export type ClientRequestOptions = {
   headers?: Record<string, string>
   fetch?: typeof fetch
 }
 
-type ClientRequest<S extends Data> = {
+type ClientRequest<S extends Schema> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
     ? RemoveBlankRecord<R> extends never
       ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
@@ -65,7 +54,7 @@ export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientRes
 
 type PathToChain<
   Path extends string,
-  E extends Endpoint,
+  E extends Schema,
   Original extends string = ''
 > = Path extends `/${infer P}`
   ? PathToChain<P, E, Path>
@@ -79,7 +68,7 @@ type PathToChain<
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Client<T> = T extends Hono<any, infer S, any>
-  ? S extends Record<infer K, Endpoint>
+  ? S extends Record<infer K, Schema>
     ? K extends string
       ? PathToChain<K, S>
       : never

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -19,6 +19,7 @@ import type {
   MergePath,
   MergeSchemaPath,
   FetchEventLike,
+  Schema,
 } from './types.ts'
 import type { RemoveBlankRecord } from './utils/types.ts'
 import { getPath, getPathNoStrict, getQueryStrings, mergePath } from './utils/url.ts'
@@ -32,7 +33,7 @@ interface RouterRoute {
 }
 
 function defineDynamicClass(): {
-  new <E extends Env = Env, S = {}, BasePath extends string = '/'>(): {
+  new <E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'>(): {
     [M in Methods]: HandlerInterface<E, M, S, BasePath>
   } & {
     on: OnHandlerInterface<E, S, BasePath>
@@ -56,11 +57,11 @@ const errorHandler = (err: Error, c: Context) => {
   return c.text(message, 500)
 }
 
-class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends defineDynamicClass()<
-  E,
-  S,
-  BasePath
-> {
+class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends defineDynamicClass()<E, S, BasePath> {
   /*
     This class is like an abstract class and does not have a router.
     To use it, inherit the class and implement router in the constructor.
@@ -138,20 +139,30 @@ class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends d
   private notFoundHandler: NotFoundHandler = notFoundHandler
   private errorHandler: ErrorHandler = errorHandler
 
-  route<SubPath extends string, SubEnv extends Env, SubSchema, SubBasePath extends string>(
+  route<
+    SubPath extends string,
+    SubEnv extends Env,
+    SubSchema extends Schema,
+    SubBasePath extends string
+  >(
     path: SubPath,
     app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath>
+  ): Hono<E, MergeSchemaPath<SubSchema, SubPath> & S, BasePath>
   /** @description
    * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
    * The use of `route` with **one** argument has been removed in v4.
    * However, you can still use `route` with **two** arguments, like `app.route('/api', subApp)`."
    */
   route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
-  route<SubPath extends string, SubEnv extends Env, SubSchema, SubBasePath extends string>(
+  route<
+    SubPath extends string,
+    SubEnv extends Env,
+    SubSchema extends Schema,
+    SubBasePath extends string
+  >(
     path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, RemoveBlankRecord<MergeSchemaPath<SubSchema, SubPath> | S>, BasePath> {
+  ): Hono<E, MergeSchemaPath<SubSchema, SubPath> & S, BasePath> {
     const subApp = this.basePath(path)
 
     if (!app) {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -2,13 +2,13 @@ import { HonoBase } from './hono-base.ts'
 import { RegExpRouter } from './router/reg-exp-router/index.ts'
 import { SmartRouter } from './router/smart-router/index.ts'
 import { TrieRouter } from './router/trie-router/index.ts'
-import type { Env } from './types.ts'
+import type { Env, Schema } from './types.ts'
 
-export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
-  E,
-  S,
-  BasePath
-> {
+export class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends HonoBase<E, S, BasePath> {
   constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
     super(init)
     this.router =

--- a/deno_dist/preset/quick.ts
+++ b/deno_dist/preset/quick.ts
@@ -2,13 +2,13 @@ import { HonoBase } from '../hono-base.ts'
 import { LinearRouter } from '../router/linear-router/index.ts'
 import { SmartRouter } from '../router/smart-router/index.ts'
 import { TrieRouter } from '../router/trie-router/index.ts'
-import type { Env } from '../types.ts'
+import type { Env, Schema } from '../types.ts'
 
-export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
-  E,
-  S,
-  BasePath
-> {
+export class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends HonoBase<E, S, BasePath> {
   constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
     super(init)
     this.router = new SmartRouter({

--- a/deno_dist/preset/tiny.ts
+++ b/deno_dist/preset/tiny.ts
@@ -1,12 +1,12 @@
 import { HonoBase } from '../hono-base.ts'
 import { PatternRouter } from '../router/pattern-router/index.ts'
-import type { Env } from '../types.ts'
+import type { Env, Schema } from '../types.ts'
 
-export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
-  E,
-  S,
-  BasePath
-> {
+export class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends HonoBase<E, S, BasePath> {
   constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
     super(init)
     this.router = new PatternRouter()

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -321,7 +321,7 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 
 export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = {
   [K in P]: {
-    [K2 in M as PrefixWithDollar<string & K2>]: {
+    [K2 in M as AddDollar<string & K2>]: {
       input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
       output: unknown extends O ? {} : O
     }
@@ -347,7 +347,7 @@ export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
   : I & { param: UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>> }
 
-export type PrefixWithDollar<T extends string> = `$${Lowercase<T>}`
+type AddDollar<T extends string> = `$${Lowercase<T>}`
 
 export type MergePath<A extends string, B extends string> = A extends ''
   ? B

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -66,7 +66,7 @@ export type ErrorHandler<E extends Env = any> = (
 export interface HandlerInterface<
   E extends Env = Env,
   M extends string = any,
-  S = {},
+  S extends Schema = {},
   BasePath extends string = '/'
 > {
   //// app.get(...handlers[])
@@ -78,7 +78,7 @@ export interface HandlerInterface<
     O = {}
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I['in'], O>, BasePath>
 
   // app.get(handler x 3)
   <
@@ -89,7 +89,7 @@ export interface HandlerInterface<
     I3 extends Input = I & I2
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I3['in'], O>, BasePath>
 
   // app.get(handler x 4)
   <
@@ -101,7 +101,7 @@ export interface HandlerInterface<
     I4 extends Input = I & I2 & I3
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I4['in'], O>, BasePath>
 
   // app.get(handler x 5)
   <
@@ -114,7 +114,7 @@ export interface HandlerInterface<
     I5 extends Input = I & I2 & I3 & I4
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I5['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I5['in'], O>, BasePath>
 
   // app.get(...handlers[])
   <
@@ -123,7 +123,7 @@ export interface HandlerInterface<
     O = {}
   >(
     ...handlers: Handler<E, P, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I['in'], O>, BasePath>
 
   ////  app.get(path, ...handlers[])
 
@@ -131,13 +131,13 @@ export interface HandlerInterface<
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     handler: H<E, MergePath<BasePath, P>, I, O>
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.get(path, handler, handler)
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
@@ -147,7 +147,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], O>, BasePath>
 
   // app.get(path, handler x4)
   <
@@ -165,7 +165,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], O>, BasePath>
 
   // app.get(path, handler x5)
   <
@@ -185,13 +185,13 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = {}, O = {}>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -202,7 +202,7 @@ export interface HandlerInterface<
 
 export interface MiddlewareHandlerInterface<
   E extends Env = Env,
-  S = {},
+  S extends Schema = {},
   BasePath extends string = '/'
 > {
   //// app.get(...handlers[])
@@ -221,13 +221,17 @@ export interface MiddlewareHandlerInterface<
 //////                            //////
 ////////////////////////////////////////
 
-export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extends string = '/'> {
+export interface OnHandlerInterface<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> {
   // app.on(method, path, handler, handler)
   <M extends string, P extends string, O = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.get(method, path, handler x3)
   <
@@ -245,7 +249,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], O>, BasePath>
 
   // app.get(method, path, handler x4)
   <
@@ -265,7 +269,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], O>, BasePath>
 
   // app.get(method, path, handler x5)
   <
@@ -287,20 +291,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
 
   <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I extends Input = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I['in'], O>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -311,34 +315,37 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 
 ////////////////////////////////////////
 //////                            //////
-//////           Schema           //////
+//////           ToSchema           //////
 //////                            //////
 ////////////////////////////////////////
 
-export type Schema<M extends string, P extends string, I extends Input['in'], O> = {
-  [K in P]: AddDollar<{
-    [K2 in M]: {
+export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = {
+  [K in P]: {
+    [K2 in M as PrefixWithDollar<string & K2>]: {
       input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
       output: unknown extends O ? {} : O
     }
-  }>
+  }
+}
+
+export type Schema = {
+  [Path: string]: {
+    [Method: `$${Lowercase<string>}`]: {
+      input: any
+      output: any
+    }
+  }
+}
+
+export type MergeSchemaPath<OrigSchema, SubPath extends string> = {
+  [K in keyof OrigSchema as `${SubPath}${K & string}`]: OrigSchema[K]
 }
 
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
   : I & { param: UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>> }
 
-export type AddDollar<T> = T extends Record<infer K, infer R>
-  ? K extends string
-    ? { [MethodName in `$${Lowercase<K>}`]: R }
-    : never
-  : never
-
-export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, infer T>
-  ? Key extends string
-    ? Record<MergePath<P, Key>, T>
-    : never
-  : never
+export type PrefixWithDollar<T extends string> = `$${Lowercase<T>}`
 
 export type MergePath<A extends string, B extends string> = A extends ''
   ? B

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -331,8 +331,10 @@ export type ToSchema<M extends string, P extends string, I extends Input['in'], 
 export type Schema = {
   [Path: string]: {
     [Method: `$${Lowercase<string>}`]: {
-      input: any
-      output: any
+      input: Partial<ValidationTargets> & {
+        param?: Record<string, string>
+      }
+      output: {}
     }
   }
 }

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,7 +1,7 @@
 // @denoify-ignore
 import crypto from 'crypto'
 import type { Hono } from '../../hono'
-import type { Env } from '../../types'
+import type { Env, Schema } from '../../types'
 
 import { encodeBase64 } from '../../utils/encode'
 import type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from './custom-context'
@@ -58,7 +58,7 @@ const getRequestContext = (
 /**
  * Accepts events from API Gateway/ELB(`APIGatewayProxyEvent`) and directly through Function Url(`APIGatewayProxyEventV2`)
  */
-export const handle = <E extends Env = Env, S = {}, BasePath extends string = '/'>(
+export const handle = <E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'>(
   app: Hono<E, S, BasePath>
 ) => {
   return async (

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,24 +1,13 @@
 import type { Hono } from '../hono'
-import type { ValidationTargets } from '../types'
+import type { Schema } from '../types'
 import type { RemoveBlankRecord } from '../utils/types'
-
-type MethodName = `$${string}`
-
-type Endpoint = Record<MethodName, Data>
-
-type Data = {
-  input: Partial<ValidationTargets> & {
-    param?: Record<string, string>
-  }
-  output: {}
-}
 
 export type ClientRequestOptions = {
   headers?: Record<string, string>
   fetch?: typeof fetch
 }
 
-type ClientRequest<S extends Data> = {
+type ClientRequest<S extends Schema> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
     ? RemoveBlankRecord<R> extends never
       ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
@@ -65,7 +54,7 @@ export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientRes
 
 type PathToChain<
   Path extends string,
-  E extends Endpoint,
+  E extends Schema,
   Original extends string = ''
 > = Path extends `/${infer P}`
   ? PathToChain<P, E, Path>
@@ -79,7 +68,7 @@ type PathToChain<
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Client<T> = T extends Hono<any, infer S, any>
-  ? S extends Record<infer K, Endpoint>
+  ? S extends Record<infer K, Schema>
     ? K extends string
       ? PathToChain<K, S>
       : never

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -2,13 +2,13 @@ import { HonoBase } from './hono-base'
 import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { TrieRouter } from './router/trie-router'
-import type { Env } from './types'
+import type { Env, Schema } from './types'
 
-export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
-  E,
-  S,
-  BasePath
-> {
+export class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends HonoBase<E, S, BasePath> {
   constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
     super(init)
     this.router =

--- a/src/preset/quick.ts
+++ b/src/preset/quick.ts
@@ -2,13 +2,13 @@ import { HonoBase } from '../hono-base'
 import { LinearRouter } from '../router/linear-router'
 import { SmartRouter } from '../router/smart-router'
 import { TrieRouter } from '../router/trie-router'
-import type { Env } from '../types'
+import type { Env, Schema } from '../types'
 
-export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
-  E,
-  S,
-  BasePath
-> {
+export class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends HonoBase<E, S, BasePath> {
   constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
     super(init)
     this.router = new SmartRouter({

--- a/src/preset/tiny.ts
+++ b/src/preset/tiny.ts
@@ -1,12 +1,12 @@
 import { HonoBase } from '../hono-base'
 import { PatternRouter } from '../router/pattern-router'
-import type { Env } from '../types'
+import type { Env, Schema } from '../types'
 
-export class Hono<E extends Env = Env, S = {}, BasePath extends string = '/'> extends HonoBase<
-  E,
-  S,
-  BasePath
-> {
+export class Hono<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> extends HonoBase<E, S, BasePath> {
   constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
     super(init)
     this.router = new PatternRouter()

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -14,7 +14,7 @@ import type {
   ParamKeys,
   ParamKeyToRecord,
   RemoveQuestion,
-  Schema,
+  ToSchema,
   UndefinedIfHavingQuestion,
 } from './types'
 import type { Expect, Equal } from './utils/types'
@@ -264,7 +264,7 @@ describe('Schema', () => {
   test('Schema', () => {
     type AppType = Hono<
       Env,
-      Schema<
+      ToSchema<
         'post',
         '/api/posts/:id',
         {
@@ -467,7 +467,7 @@ describe('merge path', () => {
   })
 
   test('MergeSchemaPath', () => {
-    type Sub = Schema<
+    type Sub = ToSchema<
       'post',
       '/posts',
       {
@@ -480,7 +480,7 @@ describe('merge path', () => {
         message: string
       }
     > &
-      Schema<
+      ToSchema<
         'get',
         '/posts',
         {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,7 +321,7 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 
 export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = {
   [K in P]: {
-    [K2 in M as PrefixWithDollar<string & K2>]: {
+    [K2 in M as AddDollar<string & K2>]: {
       input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
       output: unknown extends O ? {} : O
     }
@@ -347,7 +347,7 @@ export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
   : I & { param: UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>> }
 
-export type PrefixWithDollar<T extends string> = `$${Lowercase<T>}`
+type AddDollar<T extends string> = `$${Lowercase<T>}`
 
 export type MergePath<A extends string, B extends string> = A extends ''
   ? B

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export type ErrorHandler<E extends Env = any> = (
 export interface HandlerInterface<
   E extends Env = Env,
   M extends string = any,
-  S = {},
+  S extends Schema = {},
   BasePath extends string = '/'
 > {
   //// app.get(...handlers[])
@@ -78,7 +78,7 @@ export interface HandlerInterface<
     O = {}
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I['in'], O>, BasePath>
 
   // app.get(handler x 3)
   <
@@ -89,7 +89,7 @@ export interface HandlerInterface<
     I3 extends Input = I & I2
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I3['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I3['in'], O>, BasePath>
 
   // app.get(handler x 4)
   <
@@ -101,7 +101,7 @@ export interface HandlerInterface<
     I4 extends Input = I & I2 & I3
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I4['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I4['in'], O>, BasePath>
 
   // app.get(handler x 5)
   <
@@ -114,7 +114,7 @@ export interface HandlerInterface<
     I5 extends Input = I & I2 & I3 & I4
   >(
     ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I5['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I5['in'], O>, BasePath>
 
   // app.get(...handlers[])
   <
@@ -123,7 +123,7 @@ export interface HandlerInterface<
     O = {}
   >(
     ...handlers: Handler<E, P, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, P, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I['in'], O>, BasePath>
 
   ////  app.get(path, ...handlers[])
 
@@ -131,13 +131,13 @@ export interface HandlerInterface<
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     handler: H<E, MergePath<BasePath, P>, I, O>
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.get(path, handler, handler)
   <P extends string, O = {}, I extends Input = {}>(
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.get(path, handler x3)
   <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
@@ -147,7 +147,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], O>, BasePath>
 
   // app.get(path, handler x4)
   <
@@ -165,7 +165,7 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], O>, BasePath>
 
   // app.get(path, handler x5)
   <
@@ -185,13 +185,13 @@ export interface HandlerInterface<
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I5['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = {}, O = {}>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -202,7 +202,7 @@ export interface HandlerInterface<
 
 export interface MiddlewareHandlerInterface<
   E extends Env = Env,
-  S = {},
+  S extends Schema = {},
   BasePath extends string = '/'
 > {
   //// app.get(...handlers[])
@@ -221,13 +221,17 @@ export interface MiddlewareHandlerInterface<
 //////                            //////
 ////////////////////////////////////////
 
-export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extends string = '/'> {
+export interface OnHandlerInterface<
+  E extends Env = Env,
+  S extends Schema = {},
+  BasePath extends string = '/'
+> {
   // app.on(method, path, handler, handler)
   <M extends string, P extends string, O = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.get(method, path, handler x3)
   <
@@ -245,7 +249,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I2, O>,
       H<E, MergePath<BasePath, P>, I3, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I3['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], O>, BasePath>
 
   // app.get(method, path, handler x4)
   <
@@ -265,7 +269,7 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I3, O>,
       H<E, MergePath<BasePath, P>, I4, O>
     ]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I4['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], O>, BasePath>
 
   // app.get(method, path, handler x5)
   <
@@ -287,20 +291,20 @@ export interface OnHandlerInterface<E extends Env = Env, S = {}, BasePath extend
       H<E, MergePath<BasePath, P>, I4, O>,
       H<E, MergePath<BasePath, P>, I5, O>
     ]
-  ): Hono<E, S | Schema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
 
   <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<M, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, O extends {} = {}, I extends Input = {}>(
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, RemoveBlankRecord<S | Schema<string, MergePath<BasePath, P>, I['in'], O>>, BasePath>
+  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I['in'], O>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -311,34 +315,37 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 
 ////////////////////////////////////////
 //////                            //////
-//////           Schema           //////
+//////           ToSchema           //////
 //////                            //////
 ////////////////////////////////////////
 
-export type Schema<M extends string, P extends string, I extends Input['in'], O> = {
-  [K in P]: AddDollar<{
-    [K2 in M]: {
+export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = {
+  [K in P]: {
+    [K2 in M as PrefixWithDollar<string & K2>]: {
       input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
       output: unknown extends O ? {} : O
     }
-  }>
+  }
+}
+
+export type Schema = {
+  [Path: string]: {
+    [Method: `$${Lowercase<string>}`]: {
+      input: any
+      output: any
+    }
+  }
+}
+
+export type MergeSchemaPath<OrigSchema, SubPath extends string> = {
+  [K in keyof OrigSchema as `${SubPath}${K & string}`]: OrigSchema[K]
 }
 
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
   : I & { param: UnionToIntersection<ParamKeyToRecord<ParamKeys<P>>> }
 
-export type AddDollar<T> = T extends Record<infer K, infer R>
-  ? K extends string
-    ? { [MethodName in `$${Lowercase<K>}`]: R }
-    : never
-  : never
-
-export type MergeSchemaPath<S, P extends string> = S extends Record<infer Key, infer T>
-  ? Key extends string
-    ? Record<MergePath<P, Key>, T>
-    : never
-  : never
+export type PrefixWithDollar<T extends string> = `$${Lowercase<T>}`
 
 export type MergePath<A extends string, B extends string> = A extends ''
   ? B

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,8 +331,10 @@ export type ToSchema<M extends string, P extends string, I extends Input['in'], 
 export type Schema = {
   [Path: string]: {
     [Method: `$${Lowercase<string>}`]: {
-      input: any
-      output: any
+      input: Partial<ValidationTargets> & {
+        param?: Record<string, string>
+      }
+      output: {}
     }
   }
 }


### PR DESCRIPTION
This PR prevents infinite loops in type inference for routes. With this update, you can use many routes in RPC mode.

Current:
<img width="694" alt="Screenshot 2023-08-24 at 14 55 47" src="https://github.com/honojs/hono/assets/10682/17726680-27ef-4fdb-a745-ad58bf43cfe4">

With this PR:
<img width="784" alt="Screenshot 2023-08-24 at 14 54 46" src="https://github.com/honojs/hono/assets/10682/bf9d73a9-13bd-4e9e-b58d-b8b72b58bc64">

May fix #1360

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
