### PR TITLE
fix(context): different types using `jsonT()`

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -19,6 +19,12 @@ type ClientRequest<S extends Schema> = {
     : never
 }
 
+type BlankRecordToNever<T> = T extends Record<infer R, unknown>
+  ? R extends never
+    ? never
+    : T
+  : never
+
 export interface ClientResponse<T> {
   ok: boolean
   status: number
@@ -27,7 +33,7 @@ export interface ClientResponse<T> {
   url: string
   redirect(url: string, status: number): Response
   clone(): Response
-  json(): Promise<T>
+  json(): Promise<BlankRecordToNever<T>>
   text(): Promise<string>
   blob(): Promise<Blob>
   formData(): Promise<FormData>

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -391,7 +391,7 @@ describe('Merge path with `app.route()`', () => {
 
   it('Should not allow the incorrect JSON type', async () => {
     const app = new Hono()
-    // @ts-ignore
+    // @ts-expect-error
     const route = app.get('/api/foo', (c) => c.jsonT({ datetime: new Date() }))
     type AppType = typeof route
     const client = hc<AppType>('http://localhost')

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -19,6 +19,12 @@ type ClientRequest<S extends Schema> = {
     : never
 }
 
+type BlankRecordToNever<T> = T extends Record<infer R, unknown>
+  ? R extends never
+    ? never
+    : T
+  : never
+
 export interface ClientResponse<T> {
   ok: boolean
   status: number
@@ -27,7 +33,7 @@ export interface ClientResponse<T> {
   url: string
   redirect(url: string, status: number): Response
   clone(): Response
-  json(): Promise<T>
+  json(): Promise<BlankRecordToNever<T>>
   text(): Promise<string>
   blob(): Promise<Blob>
   formData(): Promise<FormData>

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -517,3 +517,81 @@ describe('merge path', () => {
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
+
+describe('Different types using jsonT()', () => {
+  describe('no path pattern', () => {
+    const app = new Hono()
+    test('Three different types', () => {
+      const route = app.get((c) => {
+        const flag = false
+        if (flag) {
+          return c.jsonT({
+            ng: true,
+          })
+        }
+        if (!flag) {
+          return c.jsonT({
+            ok: true,
+          })
+        }
+        return c.jsonT({
+          default: true,
+        })
+      })
+      type Actual = ExtractSchema<typeof route>
+      type Expected = {
+        '/': {
+          $get: {
+            input: {}
+            output: {
+              ng: boolean
+            } & {
+              ok: boolean
+            } & {
+              default: boolean
+            }
+          }
+        }
+      }
+      type verify = Expect<Equal<Expected, Actual>>
+    })
+  })
+
+  describe('path pattern', () => {
+    const app = new Hono()
+    test('Three different types', () => {
+      const route = app.get('/foo', (c) => {
+        const flag = false
+        if (flag) {
+          return c.jsonT({
+            ng: true,
+          })
+        }
+        if (!flag) {
+          return c.jsonT({
+            ok: true,
+          })
+        }
+        return c.jsonT({
+          default: true,
+        })
+      })
+      type Actual = ExtractSchema<typeof route>
+      type Expected = {
+        '/foo': {
+          $get: {
+            input: {}
+            output: {
+              ng: boolean
+            } & {
+              ok: boolean
+            } & {
+              default: boolean
+            }
+          }
+        }
+      }
+      type verify = Expect<Equal<Expected, Actual>>
+    })
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context'
 import type { Hono } from './hono'
-import type { UnionToIntersection, RemoveBlankRecord } from './utils/types'
+import type { UnionToIntersection } from './utils/types'
 
 ////////////////////////////////////////
 //////                            //////
@@ -32,24 +32,26 @@ export type Input = {
 //////                            //////
 ////////////////////////////////////////
 
+type HandlerResponse<O> = Response | TypedResponse<O> | Promise<Response | TypedResponse<O>>
+
 export type Handler<
   E extends Env = any,
   P extends string = any,
   I extends Input = Input,
-  O = {}
-> = (
-  c: Context<E, P, I>,
-  next: Next
-) => Response | Promise<Response | TypedResponse<O>> | TypedResponse<O>
+  R extends HandlerResponse<any> = any
+> = (c: Context<E, P, I>, next: Next) => R
 
 export type MiddlewareHandler<E extends Env = any, P extends string = any, I extends Input = {}> = (
   c: Context<E, P, I>,
   next: Next
 ) => Promise<Response | void>
 
-export type H<E extends Env = any, P extends string = any, I extends Input = {}, O = {}> =
-  | Handler<E, P, I, O>
-  | MiddlewareHandler<E, P, I>
+export type H<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = {},
+  R extends HandlerResponse<any> = any
+> = Handler<E, P, I, R> | MiddlewareHandler<E, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 export type ErrorHandler<E extends Env = any> = (
@@ -75,84 +77,90 @@ export interface HandlerInterface<
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
-    O = {}
+    R extends HandlerResponse<any> = any
   >(
-    ...handlers: [H<E, P, I, O>, H<E, P, I, O>]
-  ): Hono<E, S & ToSchema<M, P, I['in'], O>, BasePath>
+    ...handlers: [H<E, P, I, R>, H<E, P, I, R>]
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2
   >(
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>]
-  ): Hono<E, S & ToSchema<M, P, I3['in'], O>, BasePath>
+    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
+  ): Hono<E, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I & I2 & I3
   >(
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>]
-  ): Hono<E, S & ToSchema<M, P, I4['in'], O>, BasePath>
+    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+  ): Hono<E, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 5)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
     I5 extends Input = I & I2 & I3 & I4
   >(
-    ...handlers: [H<E, P, I, O>, H<E, P, I2, O>, H<E, P, I3, O>, H<E, P, I4, O>, H<E, P, I5, O>]
-  ): Hono<E, S & ToSchema<M, P, I5['in'], O>, BasePath>
+    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
+  ): Hono<E, S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(...handlers[])
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
-    O = {}
+    R extends HandlerResponse<any> = any
   >(
-    ...handlers: Handler<E, P, I, O>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], O>, BasePath>
+    ...handlers: Handler<E, P, I, R>[]
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler)
-  <P extends string, O = {}, I extends Input = {}>(
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     path: P,
-    handler: H<E, MergePath<BasePath, P>, I, O>
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
+    handler: H<E, MergePath<BasePath, P>, I, R>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler, handler)
-  <P extends string, O = {}, I extends Input = {}>(
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     path: P,
-    ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
+    ...handlers: [H<E, MergePath<BasePath, P>, I, R>, H<E, MergePath<BasePath, P>, I, R>]
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x3)
-  <P extends string, O = {}, I extends Input = {}, I2 extends Input = I, I3 extends Input = I & I2>(
+  <
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2
+  >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, O>,
-      H<E, MergePath<BasePath, P>, I2, O>,
-      H<E, MergePath<BasePath, P>, I3, O>
+      H<E, MergePath<BasePath, P>, I, R>,
+      H<E, MergePath<BasePath, P>, I2, R>,
+      H<E, MergePath<BasePath, P>, I3, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x4)
   <
     P extends string,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
@@ -160,17 +168,17 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, O>,
-      H<E, MergePath<BasePath, P>, I2, O>,
-      H<E, MergePath<BasePath, P>, I3, O>,
-      H<E, MergePath<BasePath, P>, I4, O>
+      H<E, MergePath<BasePath, P>, I, R>,
+      H<E, MergePath<BasePath, P>, I2, R>,
+      H<E, MergePath<BasePath, P>, I3, R>,
+      H<E, MergePath<BasePath, P>, I4, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x5)
   <
     P extends string,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
@@ -179,19 +187,19 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, O>,
-      H<E, MergePath<BasePath, P>, I2, O>,
-      H<E, MergePath<BasePath, P>, I3, O>,
-      H<E, MergePath<BasePath, P>, I4, O>,
-      H<E, MergePath<BasePath, P>, I5, O>
+      H<E, MergePath<BasePath, P>, I, R>,
+      H<E, MergePath<BasePath, P>, I2, R>,
+      H<E, MergePath<BasePath, P>, I3, R>,
+      H<E, MergePath<BasePath, P>, I4, R>,
+      H<E, MergePath<BasePath, P>, I5, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
-  <P extends string, I extends Input = {}, O = {}>(
+  <P extends string, I extends Input = {}, R extends HandlerResponse<any> = any>(
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
+    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 }
 
 ////////////////////////////////////////
@@ -227,17 +235,17 @@ export interface OnHandlerInterface<
   BasePath extends string = '/'
 > {
   // app.on(method, path, handler, handler)
-  <M extends string, P extends string, O = {}, I extends Input = {}>(
+  <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     method: M,
     path: P,
-    ...handlers: [H<E, MergePath<BasePath, P>, I, O>, H<E, MergePath<BasePath, P>, I, O>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
+    ...handlers: [H<E, MergePath<BasePath, P>, I, R>, H<E, MergePath<BasePath, P>, I, R>]
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method, path, handler x3)
   <
     M extends string,
     P extends string,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2
@@ -245,17 +253,17 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, O>,
-      H<E, MergePath<BasePath, P>, I2, O>,
-      H<E, MergePath<BasePath, P>, I3, O>
+      H<E, MergePath<BasePath, P>, I, R>,
+      H<E, MergePath<BasePath, P>, I2, R>,
+      H<E, MergePath<BasePath, P>, I3, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method, path, handler x4)
   <
     M extends string,
     P extends string,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
@@ -264,18 +272,18 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, O>,
-      H<E, MergePath<BasePath, P>, I2, O>,
-      H<E, MergePath<BasePath, P>, I3, O>,
-      H<E, MergePath<BasePath, P>, I4, O>
+      H<E, MergePath<BasePath, P>, I, R>,
+      H<E, MergePath<BasePath, P>, I2, R>,
+      H<E, MergePath<BasePath, P>, I3, R>,
+      H<E, MergePath<BasePath, P>, I4, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method, path, handler x5)
   <
     M extends string,
     P extends string,
-    O = {},
+    R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
@@ -285,26 +293,30 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, O>,
-      H<E, MergePath<BasePath, P>, I2, O>,
-      H<E, MergePath<BasePath, P>, I3, O>,
-      H<E, MergePath<BasePath, P>, I4, O>,
-      H<E, MergePath<BasePath, P>, I5, O>
+      H<E, MergePath<BasePath, P>, I, R>,
+      H<E, MergePath<BasePath, P>, I2, R>,
+      H<E, MergePath<BasePath, P>, I3, R>,
+      H<E, MergePath<BasePath, P>, I4, R>,
+      H<E, MergePath<BasePath, P>, I5, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], O>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
-  <M extends string, P extends string, O extends {} = {}, I extends Input = {}>(
+  <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     method: M,
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], O>, BasePath>
+    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.on(method[], path, ...handler)
-  <P extends string, O extends {} = {}, I extends Input = {}>(
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     methods: string[],
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, O>[]
-  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I['in'], O>, BasePath>
+    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+  ): Hono<
+    E,
+    S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -374,6 +386,10 @@ export type TypedResponse<T = unknown> = {
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
 }
+
+type ExtractResponseData<T> = T extends TypedResponse<infer U> ? U : never
+
+type MergeTypedResponseData<T> = UnionToIntersection<ExtractResponseData<T>>
 
 ////////////////////////////////////////
 //////                             /////


### PR DESCRIPTION
With this PR, `c.jsonT()` can now handle two or more distinct types:

```ts
const app = new Hono()

const routes = app.get('/all', (c) => {
  const data: Data = { success: true, data: {} }

  if (!data.success) {
    return c.jsonT({
      success: false,
      message: 'Could not fetch data',
    })
  }

  return c.jsonT({
    success: true,
    data: data.data,
  })
})
```

The returned types are as follows:

```ts
{
    success: boolean;
    message: string;
} & {
    success: boolean;
    data: any;
}
```

<img width="372" alt="Screenshot 2023-08-27 at 16 19 41" src="https://github.com/honojs/hono/assets/10682/c430685f-9e7d-4a90-9452-44579861a965">

Fix #1377.