### PR TITLE
Add $url method to hono client to extract an endpoint's url

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -128,6 +128,10 @@ export const hc = <T extends Hono<any, any, any>>(
 
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
+    if (method === 'url') {
+      return new URL(url)
+    }
+
     const req = new ClientRequestImpl(url, method)
     if (method) {
       options ??= {}

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -17,6 +17,8 @@ type ClientRequest<S extends Schema> = {
           options?: ClientRequestOptions
         ) => Promise<ClientResponse<O>>
     : never
+} & {
+  $url: () => Promise<URL>
 }
 
 export interface ClientResponse<T> {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -6,8 +6,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import _fetch, { Request as NodeFetchRequest } from 'node-fetch'
 import { Hono } from '../hono'
-import type { Expect } from '../utils/types'
-import type { Equal } from '../utils/types'
+import type { Equal, Expect } from '../utils/types'
 import { validator } from '../validator'
 import { hc } from './client'
 import type { InferRequestType, InferResponseType } from './types'
@@ -418,6 +417,10 @@ describe('Merge path with `app.route()`', () => {
       const res = await client.api.bar.$post()
       const data = await res.json()
       type verify = Expect<Equal<number, typeof data.bar>>
+    })
+    it('Should work with $url', async () => {
+      const url = await client.api.bar.$url()
+      expect(url.href).toBe('http://localhost/api/bar')
     })
   })
 })

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -128,6 +128,10 @@ export const hc = <T extends Hono<any, any, any>>(
 
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
+    if (method === 'url') {
+      return new URL(url)
+    }
+
     const req = new ClientRequestImpl(url, method)
     if (method) {
       options ??= {}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -17,6 +17,8 @@ type ClientRequest<S extends Schema> = {
           options?: ClientRequestOptions
         ) => Promise<ClientResponse<O>>
     : never
+} & {
+  $url: () => Promise<URL>
 }
 
 export interface ClientResponse<T> {


### PR DESCRIPTION
Hello,

This change is a proof of concept of a simple feature request. In our project, we are using Hono RPC and need to extract the URL of a Hono router endpoint for mocking in tests.
```
let fetchMock = getMiniflareFetchMock()

const { pathname, hostname } = hono.client.api.bar.$url()

fetchMock
        .get(hostname)
        .intercept({
          method: "POST",
          path: pathname,
        })
        .reply(200, {}, { headers: { "content-type": "application/json" } }),
```

This will mock the request to `http://localhost:8777/api/bar` by using the proposed `$url` method of the Hono client.

The `$url` method returns a URL representing the full url of the configured client request.

Do you think this is good to add to the client? If so, can you guide me in improving the type definitions to include `$url`?

<img width="456" alt="Screenshot 2023-08-28 at 10 48 12 PM" src="https://github.com/honojs/hono/assets/117486829/92805fff-565d-43e0-b3ff-3df24aac7cd1">

And also to let me know if I should write more tests and if they are in the right file. Thank you for your amazing library!

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
