### PR TITLE
fix(types): infer a response type for async handler

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -387,7 +387,13 @@ export type TypedResponse<T = unknown> = {
   format: 'json' // Currently, support only `json` with `c.jsonT()`
 }
 
-type ExtractResponseData<T> = T extends TypedResponse<infer U> ? U : never
+type ExtractResponseData<T> = T extends Promise<infer T2>
+  ? T2 extends TypedResponse<infer U>
+    ? U
+    : never
+  : T extends TypedResponse<infer U>
+  ? U
+  : never
 
 type MergeTypedResponseData<T> = UnionToIntersection<ExtractResponseData<T>>
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -595,3 +595,26 @@ describe('Different types using jsonT()', () => {
     })
   })
 })
+
+describe('jsonT() in an async handler', () => {
+  const app = new Hono()
+  test('Three different types', () => {
+    const route = app.get(async (c) => {
+      return c.jsonT({
+        ok: true,
+      })
+    })
+    type Actual = ExtractSchema<typeof route>
+    type Expected = {
+      '/': {
+        $get: {
+          input: {}
+          output: {
+            ok: boolean
+          }
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,7 +387,13 @@ export type TypedResponse<T = unknown> = {
   format: 'json' // Currently, support only `json` with `c.jsonT()`
 }
 
-type ExtractResponseData<T> = T extends TypedResponse<infer U> ? U : never
+type ExtractResponseData<T> = T extends Promise<infer T2>
+  ? T2 extends TypedResponse<infer U>
+    ? U
+    : never
+  : T extends TypedResponse<infer U>
+  ? U
+  : never
 
 type MergeTypedResponseData<T> = UnionToIntersection<ExtractResponseData<T>>
 


### PR DESCRIPTION
Degraded by the PR #1379

Fixes #1383

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
