### PR TITLE
fix(validator): cache `arrayBuffer` to use after validation

### DIFF
--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -3,20 +3,24 @@ import type { HonoRequest } from '../request.ts'
 export type BodyData = Record<string, string | File>
 
 export const parseBody = async <T extends BodyData = BodyData>(
-  r: HonoRequest | Request
+  request: HonoRequest | Request
 ): Promise<T> => {
   let body: BodyData = {}
-  const contentType = r.headers.get('Content-Type')
+  const contentType = request.headers.get('Content-Type')
+
   if (
     contentType &&
     (contentType.startsWith('multipart/form-data') ||
       contentType.startsWith('application/x-www-form-urlencoded'))
   ) {
-    const form: BodyData = {}
-    ;(await r.formData()).forEach((value, key) => {
-      form[key] = value
-    })
-    body = form
+    const formData = await request.formData()
+    if (formData) {
+      const form: BodyData = {}
+      formData.forEach((value, key) => {
+        form[key] = value
+      })
+      body = form
+    }
   }
   return body as T
 }

--- a/deno_dist/utils/buffer.ts
+++ b/deno_dist/utils/buffer.ts
@@ -47,3 +47,34 @@ export const bufferToString = (buffer: ArrayBuffer): string => {
   }
   return buffer
 }
+
+const _decodeURIComponent = decodeURIComponent
+
+export const bufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
+  const decoder = new TextDecoder('utf-8')
+  const content = decoder.decode(arrayBuffer)
+  const formData = new FormData()
+
+  const boundaryMatch = contentType.match(/boundary=(.+)/)
+  const boundary = boundaryMatch ? boundaryMatch[1] : ''
+
+  if (contentType.startsWith('multipart/form-data') && boundary) {
+    const parts = content.split('--' + boundary).slice(1, -1)
+    for (const part of parts) {
+      const [header, body] = part.split('\r\n\r\n')
+      const nameMatch = header.match(/name="([^"]+)"/)
+      if (nameMatch) {
+        const name = nameMatch[1]
+        formData.append(name, body.trim())
+      }
+    }
+  } else if (contentType.startsWith('application/x-www-form-urlencoded')) {
+    const pairs = content.split('&')
+    for (const pair of pairs) {
+      const [key, value] = pair.split('=')
+      formData.append(_decodeURIComponent(key), _decodeURIComponent(value))
+    }
+  }
+
+  return formData
+}

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -68,22 +68,21 @@ export const validator = <
           )
         }
         break
-      case 'form':
-        await (async () => {
-          const contentType = c.req.header('Content-Type')
-          if (contentType) {
-            const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
-            const formData = arrayBufferToFormData(arrayBuffer, contentType)
-            const form: BodyData = {}
-            formData.forEach((value, key) => {
-              form[key] = value
-            })
-            value = form
-            c.req.bodyCache.formData = formData
-            c.req.bodyCache.arrayBuffer = arrayBuffer
-          }
-        })()
+      case 'form': {
+        const contentType = c.req.header('Content-Type')
+        if (contentType) {
+          const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
+          const formData = arrayBufferToFormData(arrayBuffer, contentType)
+          const form: BodyData = {}
+          formData.forEach((value, key) => {
+            form[key] = value
+          })
+          value = form
+          c.req.bodyCache.formData = formData
+          c.req.bodyCache.arrayBuffer = arrayBuffer
+        }
         break
+      }
       case 'query':
         value = Object.fromEntries(
           Object.entries(c.req.queries()).map(([k, v]) => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -16,8 +16,14 @@ import { parse } from './utils/cookie'
 import type { UnionToIntersection } from './utils/types'
 import { getQueryParam, getQueryParams, decodeURIComponent_ } from './utils/url'
 
-type BodyType = 'json' | 'text' | 'arrayBuffer' | 'blob' | 'formData'
-type BodyCache = Partial<Record<BodyType, any>>
+type Body = {
+  json: any
+  text: string
+  arrayBuffer: ArrayBuffer
+  blob: Blob
+  formData: FormData
+}
+type BodyCache = Partial<Body & { parsedBody: BodyData }>
 
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   raw: Request
@@ -25,7 +31,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private paramData: Record<string, string> | undefined
   private vData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
   path: string
-  private bodyCache: BodyCache = {}
+  bodyCache: BodyCache = {}
 
   constructor(
     request: Request,
@@ -121,13 +127,30 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   async parseBody<T extends BodyData = BodyData>(): Promise<T> {
-    return await parseBody(this)
+    if (this.bodyCache.parsedBody) return this.bodyCache.parsedBody as T
+    let arrayBuffer = this.bodyCache.arrayBuffer
+    if (!arrayBuffer) {
+      arrayBuffer = await this.raw.arrayBuffer()
+      this.bodyCache.arrayBuffer = arrayBuffer
+    }
+    const parsedBody = await parseBody<T>(this, arrayBuffer)
+    this.bodyCache.parsedBody = parsedBody
+    return parsedBody
   }
 
-  private cachedBody = (key: keyof BodyCache) => {
+  private cachedBody = (key: keyof Body) => {
     const { bodyCache, raw } = this
     const cachedBody = bodyCache[key]
     if (cachedBody) return cachedBody
+    /**
+     * If an arrayBuffer cache is exist,
+     * use it for creating a text, json, and others.
+     */
+    if (bodyCache.arrayBuffer) {
+      return (async () => {
+        return await new Response(bodyCache.arrayBuffer)[key]()
+      })()
+    }
     return (bodyCache[key] = raw[key]())
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -128,12 +128,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
 
   async parseBody<T extends BodyData = BodyData>(): Promise<T> {
     if (this.bodyCache.parsedBody) return this.bodyCache.parsedBody as T
-    let arrayBuffer = this.bodyCache.arrayBuffer
-    if (!arrayBuffer) {
-      arrayBuffer = await this.raw.arrayBuffer()
-      this.bodyCache.arrayBuffer = arrayBuffer
-    }
-    const parsedBody = await parseBody<T>(this, arrayBuffer)
+    const parsedBody = await parseBody<T>(this)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
   }

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -34,37 +34,4 @@ describe('Parse Body Util', () => {
     })
     expect(await parseBody(req)).toEqual({})
   })
-
-  it('should correctly parse multipart/form-data from ArrayBuffer', async () => {
-    const dummyRequest = new Request('http://localhost', {
-      method: 'POST',
-      headers: [['Content-Type', 'multipart/form-data; boundary=sampleboundary']],
-      body: new FormData(),
-    })
-
-    const encoder = new TextEncoder()
-    const testData =
-      '--sampleboundary\r\nContent-Disposition: form-data; name="test"\r\n\r\nHello\r\n--sampleboundary--'
-    const arrayBuffer = encoder.encode(testData).buffer
-
-    const result = await parseBody(dummyRequest, arrayBuffer)
-
-    expect(result).toEqual({ test: 'Hello' })
-  })
-
-  it('should correctly parse application/x-www-form-urlencoded from ArrayBuffer', async () => {
-    const dummyRequest = new Request('http://localhost', {
-      method: 'POST',
-      headers: [['Content-Type', 'application/x-www-form-urlencoded']],
-      body: new FormData(),
-    })
-
-    const encoder = new TextEncoder()
-    const testData = 'key1=value1&key2=value2'
-    const arrayBuffer = encoder.encode(testData).buffer
-
-    const result = await parseBody(dummyRequest, arrayBuffer)
-
-    expect(result).toEqual({ key1: 'value1', key2: 'value2' })
-  })
 })

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -34,4 +34,37 @@ describe('Parse Body Util', () => {
     })
     expect(await parseBody(req)).toEqual({})
   })
+
+  it('should correctly parse multipart/form-data from ArrayBuffer', async () => {
+    const dummyRequest = new Request('http://localhost', {
+      method: 'POST',
+      headers: [['Content-Type', 'multipart/form-data; boundary=sampleboundary']],
+      body: new FormData(),
+    })
+
+    const encoder = new TextEncoder()
+    const testData =
+      '--sampleboundary\r\nContent-Disposition: form-data; name="test"\r\n\r\nHello\r\n--sampleboundary--'
+    const arrayBuffer = encoder.encode(testData).buffer
+
+    const result = await parseBody(dummyRequest, arrayBuffer)
+
+    expect(result).toEqual({ test: 'Hello' })
+  })
+
+  it('should correctly parse application/x-www-form-urlencoded from ArrayBuffer', async () => {
+    const dummyRequest = new Request('http://localhost', {
+      method: 'POST',
+      headers: [['Content-Type', 'application/x-www-form-urlencoded']],
+      body: new FormData(),
+    })
+
+    const encoder = new TextEncoder()
+    const testData = 'key1=value1&key2=value2'
+    const arrayBuffer = encoder.encode(testData).buffer
+
+    const result = await parseBody(dummyRequest, arrayBuffer)
+
+    expect(result).toEqual({ key1: 'value1', key2: 'value2' })
+  })
 })

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -2,30 +2,18 @@ import type { HonoRequest } from '../request'
 
 export type BodyData = Record<string, string | File>
 
-/**
- * To reduce the bundle size, make them as variables.
- */
-const _multipartFormData = 'multipart/form-data'
-const _formUrlEncoded = 'application/x-www-form-urlencoded'
-const _decodeURIComponent = decodeURIComponent
-
 export const parseBody = async <T extends BodyData = BodyData>(
-  request: HonoRequest | Request,
-  arrayBuffer?: ArrayBuffer
+  request: HonoRequest | Request
 ): Promise<T> => {
   let body: BodyData = {}
   const contentType = request.headers.get('Content-Type')
 
-  if (contentType) {
-    let formData: FormData | undefined
-    if (arrayBuffer) {
-      formData = arrayBufferToFormData(arrayBuffer, contentType)
-    } else if (
-      contentType.startsWith(_multipartFormData) ||
-      contentType.startsWith(_formUrlEncoded)
-    ) {
-      formData = await request.formData()
-    }
+  if (
+    contentType &&
+    (contentType.startsWith('multipart/form-data') ||
+      contentType.startsWith('application/x-www-form-urlencoded'))
+  ) {
+    const formData = await request.formData()
     if (formData) {
       const form: BodyData = {}
       formData.forEach((value, key) => {
@@ -35,33 +23,4 @@ export const parseBody = async <T extends BodyData = BodyData>(
     }
   }
   return body as T
-}
-
-const arrayBufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
-  const decoder = new TextDecoder('utf-8')
-  const content = decoder.decode(arrayBuffer)
-  const formData = new FormData()
-
-  const boundaryMatch = contentType.match(/boundary=(.+)/)
-  const boundary = boundaryMatch ? boundaryMatch[1] : ''
-
-  if (contentType.startsWith(_multipartFormData) && boundary) {
-    const parts = content.split('--' + boundary).slice(1, -1)
-    for (const part of parts) {
-      const [header, body] = part.split('\r\n\r\n')
-      const nameMatch = header.match(/name="([^"]+)"/)
-      if (nameMatch) {
-        const name = nameMatch[1]
-        formData.append(name, body.trim())
-      }
-    }
-  } else if (contentType.startsWith(_formUrlEncoded)) {
-    const pairs = content.split('&')
-    for (const pair of pairs) {
-      const [key, value] = pair.split('=')
-      formData.append(_decodeURIComponent(key), _decodeURIComponent(value))
-    }
-  }
-
-  return formData
 }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -2,21 +2,66 @@ import type { HonoRequest } from '../request'
 
 export type BodyData = Record<string, string | File>
 
+/**
+ * To reduce the bundle size, make them as variables.
+ */
+const _multipartFormData = 'multipart/form-data'
+const _formUrlEncoded = 'application/x-www-form-urlencoded'
+const _decodeURIComponent = decodeURIComponent
+
 export const parseBody = async <T extends BodyData = BodyData>(
-  r: HonoRequest | Request
+  request: HonoRequest | Request,
+  arrayBuffer?: ArrayBuffer
 ): Promise<T> => {
   let body: BodyData = {}
-  const contentType = r.headers.get('Content-Type')
-  if (
-    contentType &&
-    (contentType.startsWith('multipart/form-data') ||
-      contentType.startsWith('application/x-www-form-urlencoded'))
-  ) {
-    const form: BodyData = {}
-    ;(await r.formData()).forEach((value, key) => {
-      form[key] = value
-    })
-    body = form
+  const contentType = request.headers.get('Content-Type')
+
+  if (contentType) {
+    let formData: FormData | undefined
+    if (arrayBuffer) {
+      formData = arrayBufferToFormData(arrayBuffer, contentType)
+    } else if (
+      contentType.startsWith(_multipartFormData) ||
+      contentType.startsWith(_formUrlEncoded)
+    ) {
+      formData = await request.formData()
+    }
+    if (formData) {
+      const form: BodyData = {}
+      formData.forEach((value, key) => {
+        form[key] = value
+      })
+      body = form
+    }
   }
   return body as T
+}
+
+const arrayBufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
+  const decoder = new TextDecoder('utf-8')
+  const content = decoder.decode(arrayBuffer)
+  const formData = new FormData()
+
+  const boundaryMatch = contentType.match(/boundary=(.+)/)
+  const boundary = boundaryMatch ? boundaryMatch[1] : ''
+
+  if (contentType.startsWith(_multipartFormData) && boundary) {
+    const parts = content.split('--' + boundary).slice(1, -1)
+    for (const part of parts) {
+      const [header, body] = part.split('\r\n\r\n')
+      const nameMatch = header.match(/name="([^"]+)"/)
+      if (nameMatch) {
+        const name = nameMatch[1]
+        formData.append(name, body.trim())
+      }
+    }
+  } else if (contentType.startsWith(_formUrlEncoded)) {
+    const pairs = content.split('&')
+    for (const pair of pairs) {
+      const [key, value] = pair.split('=')
+      formData.append(_decodeURIComponent(key), _decodeURIComponent(value))
+    }
+  }
+
+  return formData
 }

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,5 +1,5 @@
 import { SHA256 as sha256CryptoJS } from 'crypto-js'
-import { timingSafeEqual, bufferToString } from './buffer'
+import { timingSafeEqual, bufferToString, bufferToFormData } from './buffer'
 
 describe('buffer', () => {
   it('positive', async () => {
@@ -51,5 +51,29 @@ describe('bufferToString', () => {
     const bytes = [227, 129, 130, 227, 129, 132, 227, 129, 134, 227, 129, 136, 227, 129, 138]
     const buffer = Uint8Array.from(bytes).buffer
     expect(bufferToString(buffer)).toBe('あいうえお')
+  })
+})
+
+describe('bufferToFormData', () => {
+  it('Should parse multipart/form-data from ArrayBuffer', () => {
+    const encoder = new TextEncoder()
+    const testData =
+      '--sampleboundary\r\nContent-Disposition: form-data; name="test"\r\n\r\nHello\r\n--sampleboundary--'
+    const arrayBuffer = encoder.encode(testData).buffer
+
+    const result = bufferToFormData(arrayBuffer, 'multipart/form-data; boundary=sampleboundary')
+
+    expect(result.get('test')).toBe('Hello')
+  })
+
+  it('Should parse application/x-www-form-urlencoded from ArrayBuffer', () => {
+    const encoder = new TextEncoder()
+    const testData = 'key1=value1&key2=value2'
+    const arrayBuffer = encoder.encode(testData).buffer
+
+    const result = bufferToFormData(arrayBuffer, 'application/x-www-form-urlencoded')
+
+    expect(result.get('key1')).toBe('value1')
+    expect(result.get('key2')).toBe('value2')
   })
 })

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -47,3 +47,34 @@ export const bufferToString = (buffer: ArrayBuffer): string => {
   }
   return buffer
 }
+
+const _decodeURIComponent = decodeURIComponent
+
+export const bufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
+  const decoder = new TextDecoder('utf-8')
+  const content = decoder.decode(arrayBuffer)
+  const formData = new FormData()
+
+  const boundaryMatch = contentType.match(/boundary=(.+)/)
+  const boundary = boundaryMatch ? boundaryMatch[1] : ''
+
+  if (contentType.startsWith('multipart/form-data') && boundary) {
+    const parts = content.split('--' + boundary).slice(1, -1)
+    for (const part of parts) {
+      const [header, body] = part.split('\r\n\r\n')
+      const nameMatch = header.match(/name="([^"]+)"/)
+      if (nameMatch) {
+        const name = nameMatch[1]
+        formData.append(name, body.trim())
+      }
+    }
+  } else if (contentType.startsWith('application/x-www-form-urlencoded')) {
+    const pairs = content.split('&')
+    for (const pair of pairs) {
+      const [key, value] = pair.split('=')
+      formData.append(_decodeURIComponent(key), _decodeURIComponent(value))
+    }
+  }
+
+  return formData
+}

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -660,8 +660,14 @@ describe('Clone Request object', () => {
         }
       }),
       async (c) => {
-        // `c.req.json` should not throw the error
+        // `c.req.json()` should not throw the error
         await c.req.json()
+        // `c.req.text()` should not throw the error
+        await c.req.text()
+        // `c.req.arrayBuffer()` should not throw the error
+        await c.req.arrayBuffer()
+        // `c.req.blob()` should not throw the error
+        await c.req.blob()
         return c.text('foo')
       }
     )
@@ -686,8 +692,14 @@ describe('Clone Request object', () => {
         }
       }),
       async (c) => {
-        // `c.req.json` should not throw the error
+        // `c.req.parseBody()` should not throw the error
         await c.req.parseBody()
+        // `c.req.text()` should not throw the error
+        await c.req.text()
+        // `c.req.arrayBuffer()` should not throw the error
+        await c.req.arrayBuffer()
+        // `c.req.blob()` should not throw the error
+        await c.req.blob()
         return c.text('foo')
       }
     )

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -2,6 +2,7 @@ import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
 import type { Env, ValidationTargets, MiddlewareHandler } from '../types'
 import type { BodyData } from '../utils/body'
+import { bufferToFormData } from '../utils/buffer'
 
 type ValidationTargetKeysWithBody = 'form' | 'json'
 type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD request must not have a body content.
@@ -72,7 +73,7 @@ export const validator = <
         const contentType = c.req.header('Content-Type')
         if (contentType) {
           const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
-          const formData = arrayBufferToFormData(arrayBuffer, contentType)
+          const formData = bufferToFormData(arrayBuffer, contentType)
           const form: BodyData = {}
           formData.forEach((value, key) => {
             form[key] = value
@@ -115,35 +116,4 @@ export const validator = <
 
     await next()
   }
-}
-
-const _decodeURIComponent = decodeURIComponent
-
-const arrayBufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
-  const decoder = new TextDecoder('utf-8')
-  const content = decoder.decode(arrayBuffer)
-  const formData = new FormData()
-
-  const boundaryMatch = contentType.match(/boundary=(.+)/)
-  const boundary = boundaryMatch ? boundaryMatch[1] : ''
-
-  if (contentType.startsWith('multipart/form-data') && boundary) {
-    const parts = content.split('--' + boundary).slice(1, -1)
-    for (const part of parts) {
-      const [header, body] = part.split('\r\n\r\n')
-      const nameMatch = header.match(/name="([^"]+)"/)
-      if (nameMatch) {
-        const name = nameMatch[1]
-        formData.append(name, body.trim())
-      }
-    }
-  } else if (contentType.startsWith('application/x-www-form-urlencoded')) {
-    const pairs = content.split('&')
-    for (const pair of pairs) {
-      const [key, value] = pair.split('=')
-      formData.append(_decodeURIComponent(key), _decodeURIComponent(value))
-    }
-  }
-
-  return formData
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -48,7 +48,13 @@ export const validator = <
     switch (target) {
       case 'json':
         try {
-          value = await c.req.json()
+          /**
+           * Get the arrayBuffer first, create JSON object via Response,
+           * and cache the arrayBuffer in the c.req.bodyCache.
+           */
+          const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
+          value = await new Response(arrayBuffer).json()
+          c.req.bodyCache.arrayBuffer = arrayBuffer
         } catch {
           console.error('Error: Malformed JSON in request body')
           return c.json(

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,6 +1,7 @@
 import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
 import type { Env, ValidationTargets, MiddlewareHandler } from '../types'
+import type { BodyData } from '../utils/body'
 
 type ValidationTargetKeysWithBody = 'form' | 'json'
 type ValidationTargetByMethod<M> = M extends 'get' | 'head' // GET and HEAD request must not have a body content.
@@ -54,6 +55,7 @@ export const validator = <
            */
           const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
           value = await new Response(arrayBuffer).json()
+          c.req.bodyCache.json = value
           c.req.bodyCache.arrayBuffer = arrayBuffer
         } catch {
           console.error('Error: Malformed JSON in request body')
@@ -67,7 +69,20 @@ export const validator = <
         }
         break
       case 'form':
-        value = await c.req.parseBody()
+        await (async () => {
+          const contentType = c.req.header('Content-Type')
+          if (contentType) {
+            const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
+            const formData = arrayBufferToFormData(arrayBuffer, contentType)
+            const form: BodyData = {}
+            formData.forEach((value, key) => {
+              form[key] = value
+            })
+            value = form
+            c.req.bodyCache.formData = formData
+            c.req.bodyCache.arrayBuffer = arrayBuffer
+          }
+        })()
         break
       case 'query':
         value = Object.fromEntries(
@@ -101,4 +116,35 @@ export const validator = <
 
     await next()
   }
+}
+
+const _decodeURIComponent = decodeURIComponent
+
+const arrayBufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
+  const decoder = new TextDecoder('utf-8')
+  const content = decoder.decode(arrayBuffer)
+  const formData = new FormData()
+
+  const boundaryMatch = contentType.match(/boundary=(.+)/)
+  const boundary = boundaryMatch ? boundaryMatch[1] : ''
+
+  if (contentType.startsWith('multipart/form-data') && boundary) {
+    const parts = content.split('--' + boundary).slice(1, -1)
+    for (const part of parts) {
+      const [header, body] = part.split('\r\n\r\n')
+      const nameMatch = header.match(/name="([^"]+)"/)
+      if (nameMatch) {
+        const name = nameMatch[1]
+        formData.append(name, body.trim())
+      }
+    }
+  } else if (contentType.startsWith('application/x-www-form-urlencoded')) {
+    const pairs = content.split('&')
+    for (const pair of pairs) {
+      const [key, value] = pair.split('=')
+      formData.append(_decodeURIComponent(key), _decodeURIComponent(value))
+    }
+  }
+
+  return formData
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -68,22 +68,21 @@ export const validator = <
           )
         }
         break
-      case 'form':
-        await (async () => {
-          const contentType = c.req.header('Content-Type')
-          if (contentType) {
-            const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
-            const formData = arrayBufferToFormData(arrayBuffer, contentType)
-            const form: BodyData = {}
-            formData.forEach((value, key) => {
-              form[key] = value
-            })
-            value = form
-            c.req.bodyCache.formData = formData
-            c.req.bodyCache.arrayBuffer = arrayBuffer
-          }
-        })()
+      case 'form': {
+        const contentType = c.req.header('Content-Type')
+        if (contentType) {
+          const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
+          const formData = arrayBufferToFormData(arrayBuffer, contentType)
+          const form: BodyData = {}
+          formData.forEach((value, key) => {
+            form[key] = value
+          })
+          value = form
+          c.req.bodyCache.formData = formData
+          c.req.bodyCache.arrayBuffer = arrayBuffer
+        }
         break
+      }
       case 'query':
         value = Object.fromEntries(
           Object.entries(c.req.queries()).map(([k, v]) => {


### PR DESCRIPTION
This PR enhances the handling of request bodies post-validation. After validating a JSON with the validator, you can now invoke `c.req.text()` to access the request body. Additionally, `c.req.text()` is now available `body` validation. We achieve this by caching the `arrayBuffer` in `c.req.bodyCache` and reusing it when calling `c.req.text()`.

Note, if you attempt to use `c.req.raw.text()` after validating the `json` or `body`, you will encounter an error. Instead, always use `c.req.text()` in this context.

Fix #1387


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
