### PR TITLE
improvements to secure headers middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ out
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IDE-specific settings
+.idea

--- a/deno_dist/middleware/secure-headers/index.ts
+++ b/deno_dist/middleware/secure-headers/index.ts
@@ -3,30 +3,61 @@ import type { MiddlewareHandler } from '../../types.ts'
 interface ContentSecurityPolicyOptions {
   defaultSrc?: string[]
   baseUri?: string[]
+  childSrc?: string[]
+  connectSrc?: string[]
   fontSrc?: string[]
+  formAction?: string[]
   frameAncestors?: string[]
+  frameSrc?: string[]
   imgSrc?: string[]
+  manifestSrc?: string[]
+  mediaSrc?: string[]
   objectSrc?: string[]
+  reportTo?: string
+  sandbox?: string[]
   scriptSrc?: string[]
   scriptSrcAttr?: string[]
+  scriptSrcElem?: string[]
   styleSrc?: string[]
+  styleSrcAttr?: string[]
+  styleSrcElem?: string[]
   upgradeInsecureRequests?: string[]
+  workerSrc?: string[]
 }
+
+interface ReportToOptions {
+  group: string
+  max_age: number
+  endpoints: ReportToEndpoint[]
+}
+
+interface ReportToEndpoint {
+  url: string
+}
+
+interface ReportingEndpointOptions {
+  name: string
+  url: string
+}
+
+type overridableHeader = boolean | string
 
 interface SecureHeadersOptions {
   contentSecurityPolicy?: ContentSecurityPolicyOptions
-  crossOriginEmbedderPolicy?: boolean
-  crossOriginResourcePolicy?: boolean
-  crossOriginOpenerPolicy?: boolean
-  originAgentCluster: boolean
-  referrerPolicy?: boolean
-  strictTransportSecurity?: boolean
-  xContentTypeOptions?: boolean
-  xDnsPrefetchControl?: boolean
-  xDownloadOptions?: boolean
-  xFrameOptions?: boolean
-  xPermittedCrossDomainPolicies?: boolean
-  xXssProtection?: boolean
+  crossOriginEmbedderPolicy?: overridableHeader
+  crossOriginResourcePolicy?: overridableHeader
+  crossOriginOpenerPolicy?: overridableHeader
+  originAgentCluster: overridableHeader
+  referrerPolicy?: overridableHeader
+  reportingEndpoints?: ReportingEndpointOptions[]
+  reportTo?: ReportToOptions[]
+  strictTransportSecurity?: overridableHeader
+  xContentTypeOptions?: overridableHeader
+  xDnsPrefetchControl?: overridableHeader
+  xDownloadOptions?: overridableHeader
+  xFrameOptions?: overridableHeader
+  xPermittedCrossDomainPolicies?: overridableHeader
+  xXssProtection?: overridableHeader
 }
 
 type HeadersMap = {
@@ -48,7 +79,7 @@ const HEADERS_MAP: HeadersMap = {
   xXssProtection: ['X-XSS-Protection', '0'],
 }
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_OPTIONS: SecureHeadersOptions = {
   crossOriginEmbedderPolicy: false,
   crossOriginResourcePolicy: true,
   crossOriginOpenerPolicy: true,
@@ -67,22 +98,43 @@ export const secureHeaders = (customOptions?: Partial<SecureHeadersOptions>): Mi
   const options = { ...DEFAULT_OPTIONS, ...customOptions }
   const headersToSet = Object.entries(HEADERS_MAP)
     .filter(([key]) => options[key as keyof SecureHeadersOptions])
-    .map(([, value]) => value)
+    .map(([key, defaultValue]) => {
+      const overrideValue = options[key as keyof SecureHeadersOptions]
+      if (typeof overrideValue === 'string') return [defaultValue[0], overrideValue]
+      return defaultValue
+    })
+
+  if (options.contentSecurityPolicy) {
+    const cspDirectives = Object.entries(options.contentSecurityPolicy)
+      .map(([directive, value]) => {
+        // convert camelCase to kebab-case directives (e.g. `defaultSrc` -> `default-src`)
+        directive = directive.replace(
+          /[A-Z]+(?![a-z])|[A-Z]/g,
+          (match, offset) => (offset ? '-' : '') + match.toLowerCase()
+        )
+        return `${directive} ${Array.isArray(value) ? value.join(' ') : value}`
+      })
+      .join('; ')
+    headersToSet.push(['Content-Security-Policy', cspDirectives])
+  }
+
+  if (options.reportingEndpoints) {
+    const reportingEndpoints = options.reportingEndpoints
+      .map((endpoint) => `${endpoint.name}="${endpoint.url}"`)
+      .join(', ')
+    headersToSet.push(['Reporting-Endpoints', reportingEndpoints])
+  }
+
+  if (options.reportTo) {
+    const reportToOptions = options.reportTo.map((option) => JSON.stringify(option)).join(', ')
+    headersToSet.push(['Report-To', reportToOptions])
+  }
 
   return async (ctx, next) => {
     await next()
     headersToSet.forEach(([header, value]) => {
       ctx.res.headers.set(header, value)
     })
-
-    if (options.contentSecurityPolicy) {
-      const cspDirectives = Object.entries(options.contentSecurityPolicy)
-        .map(([directive, sources]) => {
-          return `${directive} ${sources.join(' ')}`
-        })
-        .join('; ')
-      ctx.res.headers.set('Content-Security-Policy', cspDirectives)
-    }
 
     ctx.res.headers.delete('X-Powered-By')
   }


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### Improvements
- fix CSP directive names (e.g. `defaultSrc ` should be `default-src`)
- add more CSP directives (e.g. `child-src`, `connect-src`, `form-action`, etc...)
- add new `Report-To` and `Reporting-Endpoints` headers in support of the `report-to` CSP directive
- pre-calculate CSP header once at setup instead of per request
- allow overriding header values (e.g. `xFrameOptions: true` or `xFrameOptions: 'DENY'`)

I'd be happy to update the [docs](https://hono.dev/middleware/builtin/secure-headers) as well once this PR is accepted.
