### PR TITLE
feat(context): introduce `c.render()`

### DIFF
--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -20,7 +20,7 @@ export type {
   ToSchema,
   TypedResponse,
 } from './types.ts'
-export type { Context, ContextVariableMap } from './context.ts'
+export type { Context, ContextVariableMap, ContextRenderer } from './context.ts'
 export type { HonoRequest } from './request.ts'
 export { Hono }
 export { HTTPException } from './http-exception.ts'

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -260,3 +260,34 @@ describe('Pass a ResponseInit to respond methods', () => {
     expect(await res.text()).toBe('<h1>foo</h1>')
   })
 })
+
+declare module './context' {
+  interface ContextRenderer {
+    (content: string, head: { title: string }): Response
+  }
+}
+
+describe('c.render', () => {
+  const req = new HonoRequest(new Request('http://localhost/'))
+  let c: Context
+  beforeEach(() => {
+    c = new Context(req)
+  })
+
+  it('Should return a Response from the default renderer', async () => {
+    c.header('foo', 'bar')
+    const res = c.render('<h1>content</h1>', { title: 'dummy ' })
+    expect(res.headers.get('foo')).toBe('bar')
+    expect(await res.text()).toBe('<h1>content</h1>')
+  })
+
+  it('Should return a Response from the custom renderer', async () => {
+    c.setRenderer((content, head) => {
+      return c.html(`<html><head>${head.title}</head><body>${content}</body></html>`)
+    })
+    c.header('foo', 'bar')
+    const res = c.render('<h1>content</h1>', { title: 'title' })
+    expect(res.headers.get('foo')).toBe('bar')
+    expect(await res.text()).toBe('<html><head>title</head><body><h1>content</h1></body></html>')
+  })
+})

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2355,3 +2355,41 @@ describe('HEAD method', () => {
     expect(res.body).toBe(null)
   })
 })
+
+declare module './context' {
+  interface ContextRenderer {
+    (content: string, head: { title: string }): Response
+  }
+}
+
+describe('Context render and setRenderer', () => {
+  const app = new Hono()
+  app.get('/default', (c) => {
+    return c.render('<h1>content</h1>', { title: 'dummy ' })
+  })
+  app.use('/page', async (c, next) => {
+    c.setRenderer((content, head) => {
+      return new Response(
+        `<html><head><title>${head.title}</title></head><body><h1>${content}</h1></body></html>`
+      )
+    })
+    await next()
+  })
+  app.get('/page', (c) => {
+    return c.render('page content', {
+      title: 'page title',
+    })
+  })
+
+  it('Should return a Response from the default renderer', async () => {
+    const res = await app.request('/default')
+    expect(await res.text()).toBe('<h1>content</h1>')
+  })
+
+  it('Should return a Response from the custom renderer', async () => {
+    const res = await app.request('/page')
+    expect(await res.text()).toBe(
+      '<html><head><title>page title</title></head><body><h1>page content</h1></body></html>'
+    )
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type {
   ToSchema,
   TypedResponse,
 } from './types'
-export type { Context, ContextVariableMap } from './context'
+export type { Context, ContextVariableMap, ContextRenderer } from './context'
 export type { HonoRequest } from './request'
 export type { InferRequestType, InferResponseType, ClientRequestOptions } from './client'
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,7 +20,7 @@ export type {
   ToSchema,
   TypedResponse,
 } from './types'
-export type { Context, ContextVariableMap } from './context'
+export type { Context, ContextVariableMap, ContextRenderer } from './context'
 export type { HonoRequest } from './request'
 export { Hono }
 export { HTTPException } from './http-exception'


### PR DESCRIPTION
This PR introduces `c.render()` and `c.setRenderer()` functions. These functions enhance Hono's response handling, allowing for more flexible and modular response structures, especially useful for defining common parts of responses, like HTML layouts.

You can set a layout using `c.setRenderer()` within a custom middleware, as shown below:

```tsx
app.use('*', async (c, next) => {
  c.setRenderer((content) => {
    return c.html(
      <html>
        <body>
          <p>{content}</p>
        </body>
      </html>
    )
  })
  await next()
})
```

Subsequently, you can utilize `c.render()` to create responses within this layout:

```tsx
app.get('/', (c) => {
  return c.render('Hello!')
})
```

The output of which will be:

```html
<html><body><p>Hello!</p></body></html>
```

Additionally, this feature offers the flexibility to customize arguments. To ensure type safety, types can be defined as:

```ts
declare module 'hono' {
  interface ContextRenderer {
    (content: string, head: { title: string }): Response
  }
}
```

Here's an example of how you can use this:

```tsx
app.use('/pages/*', async (c, next) => {
  c.setRenderer((content, head) => {
    return c.html(
      <html>
        <head>
          <title>{head.title}</title>
        </head>
        <body>
          <header>{head.title}</header>
          <p>{content}</p>
        </body>
      </html>
    )
  })
  await next()
})

app.get('/pages/my-favorite', (c) => {
  return c.render(<p>Ramen and Sushi</p>, {
    title: 'My favorite',
  })
})

app.get('/pages/my-hobbies', (c) => {
  return c.render(<p>Watching baseball</p>, {
    title: 'My hobbies',
  })
})
```

Although this feature is set to debut as experimental, its transition to general availability will be swift, contingent upon no significant issues arising.