### PR TITLE
fix(rpc): infer path with `route()` and `basePath()`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -147,7 +147,7 @@ class Hono<
   >(
     path: SubPath,
     app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, SubPath> & S, BasePath>
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath>
   /** @description
    * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
    * The use of `route` with **one** argument has been removed in v4.
@@ -162,7 +162,7 @@ class Hono<
   >(
     path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, SubPath> & S, BasePath> {
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
     const subApp = this.basePath(path)
 
     if (!app) {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -339,6 +339,13 @@ describe('Merge path with `app.route()`', () => {
           ok: true,
         })
       )
+    }),
+    rest.get('http://localhost/v1/book', async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          ok: true,
+        })
+      )
     })
   )
 
@@ -369,6 +376,17 @@ describe('Merge path with `app.route()`', () => {
     type AppType = typeof app
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
+    const data = await res.json()
+    type verify = Expect<Equal<boolean, typeof data.ok>>
+    expect(data.ok).toBe(true)
+  })
+
+  it('Should have correct types - basePath(), route(), get()', async () => {
+    const book = new Hono().get('/', (c) => c.jsonT({ ok: true }))
+    const app = new Hono().basePath('/v1').route('/book', book)
+    type AppType = typeof app
+    const client = hc<AppType>('http://localhost')
+    const res = await client.v1.book.index.$get()
     const data = await res.json()
     type verify = Expect<Equal<boolean, typeof data.ok>>
     expect(data.ok).toBe(true)

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -147,7 +147,7 @@ class Hono<
   >(
     path: SubPath,
     app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, SubPath> & S, BasePath>
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath>
   /** @description
    * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
    * The use of `route` with **one** argument has been removed in v4.
@@ -162,7 +162,7 @@ class Hono<
   >(
     path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, SubPath> & S, BasePath> {
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
     const subApp = this.basePath(path)
 
     if (!app) {


### PR DESCRIPTION
This PR will make the RPC-mode infers the path type correctly, with `app.basePath()` and `app.route()`:

```ts
const book = new Hono().post('/create', (c) => c.jsonT('test root'))
const api = new Hono().basePath('/v1').route('/book', book)
```

Will be handled as:

```ts
const res = await client.v1.book.create.$post()
// ...
```


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
