### PR TITLE
feat(context): add `status` to `TypedResponse`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -309,11 +309,15 @@ export class Context<
         : T
       : never
   > => {
+    const response =
+      typeof arg === 'number' ? this.json(object, arg, headers) : this.json(object, arg)
+
     return {
-      response: typeof arg === 'number' ? this.json(object, arg, headers) : this.json(object, arg),
+      response,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       data: object as any,
       format: 'json',
+      status: response.status,
     }
   }
 

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context.ts'
 import type { Hono } from './hono.ts'
+import type { StatusCode } from './utils/http-status.ts'
 import type { UnionToIntersection } from './utils/types.ts'
 
 ////////////////////////////////////////
@@ -385,6 +386,7 @@ export type TypedResponse<T = unknown> = {
   response: Response | Promise<Response>
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
+  status: StatusCode
 }
 
 type ExtractResponseData<T> = T extends Promise<infer T2>

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -251,6 +251,7 @@ describe('Pass a ResponseInit to respond methods', () => {
     const res = tRes['response'] as Response
     expect(res.headers.get('content-type')).toMatch(/^application\/json/)
     expect(await res.json()).toEqual({ foo: 'bar' })
+    expect(tRes.status).toEqual(200)
   })
 
   it('c.html()', async () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -309,11 +309,15 @@ export class Context<
         : T
       : never
   > => {
+    const response =
+      typeof arg === 'number' ? this.json(object, arg, headers) : this.json(object, arg)
+
     return {
-      response: typeof arg === 'number' ? this.json(object, arg, headers) : this.json(object, arg),
+      response,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       data: object as any,
       format: 'json',
+      status: response.status,
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context'
 import type { Hono } from './hono'
+import type { StatusCode } from './utils/http-status'
 import type { UnionToIntersection } from './utils/types'
 
 ////////////////////////////////////////
@@ -385,6 +386,7 @@ export type TypedResponse<T = unknown> = {
   response: Response | Promise<Response>
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
+  status: StatusCode
 }
 
 type ExtractResponseData<T> = T extends Promise<infer T2>


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

## About the PR
Very simple, just adds a `status` prop to `TypedResponse` like mentioned in the issue.

Closes #1323.