### PR TITLE
feat(context): introduce `c.var`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -195,6 +195,10 @@ export class Context<
     return this._map ? this._map[key] : undefined
   }
 
+  get var(): E['Variables'] {
+    return this._map
+  }
+
   newResponse: NewResponse = (
     data: Data | null,
     arg?: StatusCode | ResponseInit,

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -87,12 +87,12 @@ export class Context<
 > {
   req: HonoRequest<P, I['out']>
   env: E['Bindings'] = {}
+  var: E['Variables'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
 
   private _status: StatusCode = 200
   private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
-  private _map: Record<string, unknown> | undefined
   private _h: Headers | undefined = undefined //  _headers
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
@@ -187,16 +187,12 @@ export class Context<
   }
 
   set: Set<E> = (key: string, value: unknown) => {
-    this._map ||= {}
-    this._map[key as string] = value
+    this.var ??= {}
+    this.var[key as string] = value
   }
 
   get: Get<E> = (key: string) => {
-    return this._map ? this._map[key] : undefined
-  }
-
-  get var(): E['Variables'] {
-    return this._map
+    return this.var ? this.var[key] : undefined
   }
 
   newResponse: NewResponse = (

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -94,7 +94,7 @@ export class Context<
 > {
   req: HonoRequest<P, I['out']>
   env: E['Bindings'] = {}
-  var: E['Variables'] = {}
+  private _var: E['Variables'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
 
@@ -214,12 +214,17 @@ export class Context<
   }
 
   set: Set<E> = (key: string, value: unknown) => {
-    this.var ??= {}
-    this.var[key as string] = value
+    this._var ??= {}
+    this._var[key as string] = value
   }
 
   get: Get<E> = (key: string) => {
-    return this.var ? this.var[key] : undefined
+    return this._var ? this._var[key] : undefined
+  }
+
+  // c.var.propName is a read-only
+  get var(): Readonly<E['Variables']> {
+    return { ...this._var }
   }
 
   newResponse: NewResponse = (

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -75,14 +75,26 @@ export interface HandlerInterface<
 > {
   //// app.get(...handlers[])
 
+  // app.get(handler)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    I extends Input = {},
+    R extends HandlerResponse<any> = any,
+    Temp extends Env = E
+  >(
+    handler: H<E, P, I, Temp, R>
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+
   // app.get(handler, handler)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
     R extends HandlerResponse<any> = any,
-    E2 extends Env = E
+    E2 extends Env = E,
+    E3 extends Env = E,
+    Temp extends Env = E & E2
   >(
-    ...handlers: [H<E2, P, I, E2, R>, H<E, P, I, E & E2, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I, Temp, R>]
   ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
@@ -94,9 +106,10 @@ export interface HandlerInterface<
     I3 extends Input = I & I2,
     E2 extends Env = E,
     E3 extends Env = E,
-    E4 extends Env = E
+    E4 extends Env = E,
+    Temp extends Env = E & E2 & E3
   >(
-    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I2, E3, R>, H<E4, P, I3, E & E2 & E3, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I2, E3, R>, H<E4, P, I3, Temp, R>]
   ): Hono<E, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
@@ -110,13 +123,14 @@ export interface HandlerInterface<
     E2 extends Env = E,
     E3 extends Env = E,
     E4 extends Env = E,
-    E5 extends Env = E
+    E5 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4
   >(
     ...handlers: [
       H<E2, P, I, E2, R>,
       H<E3, P, I2, E3, R>,
       H<E4, P, I3, E4, R>,
-      H<E5, P, I3, E & E2 & E3 & E4, R>
+      H<E5, P, I3, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -133,14 +147,15 @@ export interface HandlerInterface<
     E3 extends Env = E,
     E4 extends Env = E,
     E5 extends Env = E,
-    E6 extends Env = E
+    E6 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4 & E5
   >(
     ...handlers: [
       H<E2, P, I, E2, R>,
       H<E3, P, I2, E3, R>,
       H<E4, P, I3, E4, R>,
       H<E5, P, I3, E5, R>,
-      H<E5, P, I3, E & E2 & E3 & E4 & E5, R>
+      H<E6, P, I3, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -165,9 +180,14 @@ export interface HandlerInterface<
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler)
-  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
+  <
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    Temp extends Env = E
+  >(
     path: P,
-    handler: H<E, MergePath<BasePath, P>, I, E, R>
+    handler: H<E, MergePath<BasePath, P>, I, Temp, R>
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler, handler)
@@ -175,13 +195,14 @@ export interface HandlerInterface<
     P extends string,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
-    E2 extends Env = {},
-    E3 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    Temp extends Env = E & E2
   >(
     path: P,
     ...handlers: [
       H<E2, MergePath<BasePath, P>, I, E2, R>,
-      H<E3, MergePath<BasePath, P>, I, E & E2, R>
+      H<E3, MergePath<BasePath, P>, I, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -192,15 +213,16 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    E2 extends Env = {},
-    E3 extends Env = {},
-    E4 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    Temp extends Env = E & E2 & E3
   >(
     path: P,
     ...handlers: [
       H<E2, MergePath<BasePath, P>, I, E2, R>,
       H<E3, MergePath<BasePath, P>, I2, E3, R>,
-      H<E4, MergePath<BasePath, P>, I3, E & E2 & E3, R>
+      H<E4, MergePath<BasePath, P>, I3, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -212,17 +234,18 @@ export interface HandlerInterface<
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I & I2 & I3,
-    E2 extends Env = {},
-    E3 extends Env = {},
-    E4 extends Env = {},
-    E5 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4
   >(
     path: P,
     ...handlers: [
       H<E2, MergePath<BasePath, P>, I, E2, R>,
       H<E3, MergePath<BasePath, P>, I2, E3, R>,
       H<E4, MergePath<BasePath, P>, I3, E4, R>,
-      H<E5, MergePath<BasePath, P>, I4, E & E2 & E3 & E4, R>
+      H<E5, MergePath<BasePath, P>, I4, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -235,11 +258,12 @@ export interface HandlerInterface<
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
-    E2 extends Env = {},
-    E3 extends Env = {},
-    E4 extends Env = {},
-    E5 extends Env = {},
-    E6 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4 & E5
   >(
     path: P,
     ...handlers: [
@@ -247,7 +271,7 @@ export interface HandlerInterface<
       H<E3, MergePath<BasePath, P>, I2, E3, R>,
       H<E4, MergePath<BasePath, P>, I3, E4, R>,
       H<E5, MergePath<BasePath, P>, I4, E5, R>,
-      H<E6, MergePath<BasePath, P>, I5, E & E2 & E3 & E4 & E5, R>
+      H<E6, MergePath<BasePath, P>, I5, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -50,8 +50,9 @@ export type H<
   E extends Env = any,
   P extends string = any,
   I extends Input = {},
+  E2 extends Env = E,
   R extends HandlerResponse<any> = any
-> = Handler<E, P, I, R> | MiddlewareHandler<E, P, I>
+> = Handler<E2, P, I, R> | MiddlewareHandler<E2, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 export type ErrorHandler<E extends Env = any> = (
@@ -77,9 +78,10 @@ export interface HandlerInterface<
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
-    R extends HandlerResponse<any> = any
+    R extends HandlerResponse<any> = any,
+    E2 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E, P, I, E & E2, R>]
   ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
@@ -88,9 +90,12 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
-    I3 extends Input = I & I2
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I2, E3, R>, H<E4, P, I3, E & E2 & E3, R>]
   ): Hono<E, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
@@ -100,9 +105,18 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+    ...handlers: [
+      H<E2, P, I, E2, R>,
+      H<E3, P, I2, E3, R>,
+      H<E4, P, I3, E4, R>,
+      H<E5, P, I3, E & E2 & E3 & E4, R>
+    ]
   ): Hono<E, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 5)
@@ -113,9 +127,20 @@ export interface HandlerInterface<
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
+    ...handlers: [
+      H<E2, P, I, E2, R>,
+      H<E3, P, I2, E3, R>,
+      H<E4, P, I3, E4, R>,
+      H<E5, P, I3, E5, R>,
+      H<E5, P, I3, E & E2 & E3 & E4 & E5, R>
+    ]
   ): Hono<E, S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(...handlers[])
@@ -124,21 +149,39 @@ export interface HandlerInterface<
     I extends Input = {},
     R extends HandlerResponse<any> = any
   >(
-    ...handlers: Handler<E, P, I, R>[]
+    ...handlers: H<E, P, I, E, R>[]
   ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  ////  app.get(path)
+
+  // app.get(path)
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
+    E,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     path: P,
-    handler: H<E, MergePath<BasePath, P>, I, R>
+    handler: H<E, MergePath<BasePath, P>, I, E, R>
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler, handler)
-  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
+  <
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    E2 extends Env = {},
+    E3 extends Env = {}
+  >(
     path: P,
-    ...handlers: [H<E, MergePath<BasePath, P>, I, R>, H<E, MergePath<BasePath, P>, I, R>]
+    ...handlers: [
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I, E & E2, R>
+    ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x3)
@@ -147,13 +190,16 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
-    I3 extends Input = I & I2
+    I3 extends Input = I & I2,
+    E2 extends Env = {},
+    E3 extends Env = {},
+    E4 extends Env = {}
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E & E2 & E3, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -164,14 +210,18 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = {},
+    E3 extends Env = {},
+    E4 extends Env = {},
+    E5 extends Env = {}
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E & E2 & E3 & E4, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -183,22 +233,27 @@ export interface HandlerInterface<
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = {},
+    E3 extends Env = {},
+    E4 extends Env = {},
+    E5 extends Env = {},
+    E6 extends Env = {}
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>,
-      H<E, MergePath<BasePath, P>, I5, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E5, R>,
+      H<E6, MergePath<BasePath, P>, I5, E & E2 & E3 & E4 & E5, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = {}, R extends HandlerResponse<any> = any>(
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+    ...handlers: H<E, MergePath<BasePath, P>, I, E, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 }
 
@@ -235,10 +290,20 @@ export interface OnHandlerInterface<
   BasePath extends string = '/'
 > {
   // app.on(method, path, handler, handler)
-  <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
+  <
+    M extends string,
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    E2 extends Env = E,
+    E3 extends Env = E
+  >(
     method: M,
     path: P,
-    ...handlers: [H<E, MergePath<BasePath, P>, I, R>, H<E, MergePath<BasePath, P>, I, R>]
+    ...handlers: [
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I, E & E2, R>
+    ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method, path, handler x3)
@@ -248,17 +313,19 @@ export interface OnHandlerInterface<
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
-    I3 extends Input = I & I2
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E & E2 & E3, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
-
   // app.get(method, path, handler x4)
   <
     M extends string,
@@ -267,15 +334,19 @@ export interface OnHandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E & E2 & E3 & E4, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -287,31 +358,36 @@ export interface OnHandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
-    I5 extends Input = I3 & I4
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>,
-      H<E, MergePath<BasePath, P>, I5, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E5, R>,
+      H<E6, MergePath<BasePath, P>, I5, E & E2 & E3 & E4 & E5, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     method: M,
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+    ...handlers: H<E, MergePath<BasePath, P>, I, E, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     methods: string[],
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+    ...handlers: H<E, MergePath<BasePath, P>, I, E, R>[]
   ): Hono<
     E,
     S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,

--- a/src/context.ts
+++ b/src/context.ts
@@ -195,6 +195,10 @@ export class Context<
     return this._map ? this._map[key] : undefined
   }
 
+  get var(): E['Variables'] {
+    return this._map
+  }
+
   newResponse: NewResponse = (
     data: Data | null,
     arg?: StatusCode | ResponseInit,

--- a/src/context.ts
+++ b/src/context.ts
@@ -87,12 +87,12 @@ export class Context<
 > {
   req: HonoRequest<P, I['out']>
   env: E['Bindings'] = {}
+  var: E['Variables'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
 
   private _status: StatusCode = 200
   private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
-  private _map: Record<string, unknown> | undefined
   private _h: Headers | undefined = undefined //  _headers
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
@@ -187,16 +187,12 @@ export class Context<
   }
 
   set: Set<E> = (key: string, value: unknown) => {
-    this._map ||= {}
-    this._map[key as string] = value
+    this.var ??= {}
+    this.var[key as string] = value
   }
 
   get: Get<E> = (key: string) => {
-    return this._map ? this._map[key] : undefined
-  }
-
-  get var(): E['Variables'] {
-    return this._map
+    return this.var ? this.var[key] : undefined
   }
 
   newResponse: NewResponse = (

--- a/src/context.ts
+++ b/src/context.ts
@@ -94,7 +94,7 @@ export class Context<
 > {
   req: HonoRequest<P, I['out']>
   env: E['Bindings'] = {}
-  var: E['Variables'] = {}
+  private _var: E['Variables'] = {}
   finalized: boolean = false
   error: Error | undefined = undefined
 
@@ -214,12 +214,17 @@ export class Context<
   }
 
   set: Set<E> = (key: string, value: unknown) => {
-    this.var ??= {}
-    this.var[key as string] = value
+    this._var ??= {}
+    this._var[key as string] = value
   }
 
   get: Get<E> = (key: string) => {
-    return this.var ? this.var[key] : undefined
+    return this._var ? this._var[key] : undefined
+  }
+
+  // c.var.propName is a read-only
+  get var(): Readonly<E['Variables']> {
+    return { ...this._var }
   }
 
   newResponse: NewResponse = (

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2620,6 +2620,26 @@ describe('c.var - with testing types', () => {
     expect(await res.text()).toBe('hellohello2hello3hello4hello5')
   })
 
+  it('Should not throw type errors', () => {
+    const app = new Hono<{
+      Variables: {
+        hello: () => string
+      }
+    }>()
+
+    app.get(mw())
+    app.get(mw(), mw2())
+    app.get(mw(), mw2(), mw3())
+    app.get(mw(), mw2(), mw3(), mw4())
+    app.get(mw(), mw2(), mw3(), mw4(), mw5())
+
+    app.get('/', mw())
+    app.get('/', mw(), mw2())
+    app.get('/', mw(), mw2(), mw3())
+    app.get('/', mw(), mw2(), mw3(), mw4())
+    app.get('/', mw(), mw2(), mw3(), mw4(), mw5())
+  })
+
   it('Should be a read-only', () => {
     expect(() => {
       app.get('/path/1', mw(), (c) => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2619,4 +2619,14 @@ describe('c.var - with testing types', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('hellohello2hello3hello4hello5')
   })
+
+  it('Should be a read-only', () => {
+    expect(() => {
+      app.get('/path/1', mw(), (c) => {
+        // @ts-expect-error
+        c.var.echo = 'hello'
+        return c.text(c.var.echo('hello'))
+      })
+    }).toThrow()
+  })
 })

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Context } from './context'
 import { Hono } from './hono'
 import { HTTPException } from './http-exception'
@@ -7,7 +8,7 @@ import { poweredBy } from './middleware/powered-by'
 import { SmartRouter } from './mod'
 import { RegExpRouter } from './router/reg-exp-router'
 import { TrieRouter } from './router/trie-router'
-import type { Handler, Next } from './types'
+import type { Handler, MiddlewareHandler, Next } from './types'
 import type { Expect, Equal } from './utils/types'
 import { getPath } from './utils/url'
 
@@ -2353,5 +2354,231 @@ describe('HEAD method', () => {
     expect(res.headers.get('X-Message')).toBe('Foo')
     expect(res.headers.get('X-Method')).toBe('HEAD')
     expect(res.body).toBe(null)
+  })
+})
+
+describe('c.var - with testing types', () => {
+  const app = new Hono<{
+    Bindings: {
+      Token: string
+    }
+  }>()
+
+  const mw =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo', (str) => str)
+      await next()
+    }
+
+  const mw2 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo2: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo2', (str) => str)
+      await next()
+    }
+
+  const mw3 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo3: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo3', (str) => str)
+      await next()
+    }
+
+  const mw4 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo4: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo4', (str) => str)
+      await next()
+    }
+
+  const mw5 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo5: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo5', (str) => str)
+      await next()
+    }
+
+  app.use('/no-path/1').get(mw(), (c) => {
+    return c.text(c.var.echo('hello'))
+  })
+
+  app.use('/no-path/2').get(mw(), mw2(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2'))
+  })
+
+  app.use('/no-path/3').get(mw(), mw2(), mw3(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3'))
+  })
+
+  app.use('/no-path/4').get(mw(), mw2(), mw3(), mw4(), (c) => {
+    return c.text(
+      c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3') + c.var.echo4('hello4')
+    )
+  })
+
+  app.use('/no-path/5').get(mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
+    return c.text(
+      // @ts-ignore
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5')
+    )
+  })
+
+  app.get('/path/1', mw(), (c) => {
+    return c.text(c.var.echo('hello'))
+  })
+
+  app.get('/path/2', mw(), mw2(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2'))
+  })
+
+  app.get('/path/3', mw(), mw2(), mw3(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3'))
+  })
+
+  app.get('/path/4', mw(), mw2(), mw3(), mw4(), (c) => {
+    return c.text(
+      c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3') + c.var.echo4('hello4')
+    )
+  })
+
+  // @ts-expect-error
+  app.get('/path/5', mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
+    return c.text(
+      // @ts-expect-error
+      c.var.echo('hello') +
+        // @ts-expect-error
+        c.var.echo2('hello2') +
+        // @ts-expect-error
+        c.var.echo3('hello3') +
+        // @ts-expect-error
+        c.var.echo4('hello4') +
+        // @ts-expect-error
+        c.var.echo5('hello5')
+    )
+  })
+
+  app.on('GET', '/on/1', mw(), (c) => {
+    return c.text(c.var.echo('hello'))
+  })
+
+  app.on('GET', '/on/2', mw(), mw2(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2'))
+  })
+
+  app.on('GET', '/on/3', mw(), mw2(), mw3(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3'))
+  })
+
+  app.on('GET', '/on/4', mw(), mw2(), mw3(), mw4(), (c) => {
+    return c.text(
+      c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3') + c.var.echo4('hello4')
+    )
+  })
+
+  // @ts-expect-error
+  app.on('GET', '/on/5', mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
+    return c.text(
+      // @ts-expect-error
+      c.var.echo('hello') +
+        // @ts-expect-error
+        c.var.echo2('hello2') +
+        // @ts-expect-error
+        c.var.echo3('hello3') +
+        // @ts-expect-error
+        c.var.echo4('hello4') +
+        // @ts-expect-error
+        c.var.echo5('hello5')
+    )
+  })
+
+  it('Should return the correct response - no-path', async () => {
+    let res = await app.request('/no-path/1')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+
+    res = await app.request('/no-path/2')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2')
+
+    res = await app.request('/no-path/3')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3')
+
+    res = await app.request('/no-path/4')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3hello4')
+
+    res = await app.request('/no-path/5')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3hello4hello5')
+  })
+
+  it('Should return the correct response - path', async () => {
+    let res = await app.request('/path/1')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+
+    res = await app.request('/path/2')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2')
+
+    res = await app.request('/path/3')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3')
+
+    res = await app.request('/path/4')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3hello4')
+
+    res = await app.request('/path/5')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3hello4hello5')
+  })
+
+  it('Should return the correct response - on', async () => {
+    let res = await app.request('/on/1')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+
+    res = await app.request('/on/2')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2')
+
+    res = await app.request('/on/3')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3')
+
+    res = await app.request('/on/4')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3hello4')
+
+    res = await app.request('/on/5')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hellohello2hello3hello4hello5')
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,14 +75,26 @@ export interface HandlerInterface<
 > {
   //// app.get(...handlers[])
 
+  // app.get(handler)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    I extends Input = {},
+    R extends HandlerResponse<any> = any,
+    Temp extends Env = E
+  >(
+    handler: H<E, P, I, Temp, R>
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+
   // app.get(handler, handler)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
     R extends HandlerResponse<any> = any,
-    E2 extends Env = E
+    E2 extends Env = E,
+    E3 extends Env = E,
+    Temp extends Env = E & E2
   >(
-    ...handlers: [H<E2, P, I, E2, R>, H<E, P, I, E & E2, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I, Temp, R>]
   ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
@@ -94,9 +106,10 @@ export interface HandlerInterface<
     I3 extends Input = I & I2,
     E2 extends Env = E,
     E3 extends Env = E,
-    E4 extends Env = E
+    E4 extends Env = E,
+    Temp extends Env = E & E2 & E3
   >(
-    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I2, E3, R>, H<E4, P, I3, E & E2 & E3, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I2, E3, R>, H<E4, P, I3, Temp, R>]
   ): Hono<E, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
@@ -110,13 +123,14 @@ export interface HandlerInterface<
     E2 extends Env = E,
     E3 extends Env = E,
     E4 extends Env = E,
-    E5 extends Env = E
+    E5 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4
   >(
     ...handlers: [
       H<E2, P, I, E2, R>,
       H<E3, P, I2, E3, R>,
       H<E4, P, I3, E4, R>,
-      H<E5, P, I3, E & E2 & E3 & E4, R>
+      H<E5, P, I3, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -133,14 +147,15 @@ export interface HandlerInterface<
     E3 extends Env = E,
     E4 extends Env = E,
     E5 extends Env = E,
-    E6 extends Env = E
+    E6 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4 & E5
   >(
     ...handlers: [
       H<E2, P, I, E2, R>,
       H<E3, P, I2, E3, R>,
       H<E4, P, I3, E4, R>,
       H<E5, P, I3, E5, R>,
-      H<E5, P, I3, E & E2 & E3 & E4 & E5, R>
+      H<E6, P, I3, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -165,9 +180,14 @@ export interface HandlerInterface<
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler)
-  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
+  <
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    Temp extends Env = E
+  >(
     path: P,
-    handler: H<E, MergePath<BasePath, P>, I, E, R>
+    handler: H<E, MergePath<BasePath, P>, I, Temp, R>
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler, handler)
@@ -175,13 +195,14 @@ export interface HandlerInterface<
     P extends string,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
-    E2 extends Env = {},
-    E3 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    Temp extends Env = E & E2
   >(
     path: P,
     ...handlers: [
       H<E2, MergePath<BasePath, P>, I, E2, R>,
-      H<E3, MergePath<BasePath, P>, I, E & E2, R>
+      H<E3, MergePath<BasePath, P>, I, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -192,15 +213,16 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    E2 extends Env = {},
-    E3 extends Env = {},
-    E4 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    Temp extends Env = E & E2 & E3
   >(
     path: P,
     ...handlers: [
       H<E2, MergePath<BasePath, P>, I, E2, R>,
       H<E3, MergePath<BasePath, P>, I2, E3, R>,
-      H<E4, MergePath<BasePath, P>, I3, E & E2 & E3, R>
+      H<E4, MergePath<BasePath, P>, I3, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -212,17 +234,18 @@ export interface HandlerInterface<
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I & I2 & I3,
-    E2 extends Env = {},
-    E3 extends Env = {},
-    E4 extends Env = {},
-    E5 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4
   >(
     path: P,
     ...handlers: [
       H<E2, MergePath<BasePath, P>, I, E2, R>,
       H<E3, MergePath<BasePath, P>, I2, E3, R>,
       H<E4, MergePath<BasePath, P>, I3, E4, R>,
-      H<E5, MergePath<BasePath, P>, I4, E & E2 & E3 & E4, R>
+      H<E5, MergePath<BasePath, P>, I4, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -235,11 +258,12 @@ export interface HandlerInterface<
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
-    E2 extends Env = {},
-    E3 extends Env = {},
-    E4 extends Env = {},
-    E5 extends Env = {},
-    E6 extends Env = {}
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    Temp extends Env = E & E2 & E3 & E4 & E5
   >(
     path: P,
     ...handlers: [
@@ -247,7 +271,7 @@ export interface HandlerInterface<
       H<E3, MergePath<BasePath, P>, I2, E3, R>,
       H<E4, MergePath<BasePath, P>, I3, E4, R>,
       H<E5, MergePath<BasePath, P>, I4, E5, R>,
-      H<E6, MergePath<BasePath, P>, I5, E & E2 & E3 & E4 & E5, R>
+      H<E6, MergePath<BasePath, P>, I5, Temp, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,8 +50,9 @@ export type H<
   E extends Env = any,
   P extends string = any,
   I extends Input = {},
+  E2 extends Env = E,
   R extends HandlerResponse<any> = any
-> = Handler<E, P, I, R> | MiddlewareHandler<E, P, I>
+> = Handler<E2, P, I, R> | MiddlewareHandler<E2, P, I>
 
 export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
 export type ErrorHandler<E extends Env = any> = (
@@ -77,9 +78,10 @@ export interface HandlerInterface<
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
-    R extends HandlerResponse<any> = any
+    R extends HandlerResponse<any> = any,
+    E2 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E, P, I, E & E2, R>]
   ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
@@ -88,9 +90,12 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
-    I3 extends Input = I & I2
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
+    ...handlers: [H<E2, P, I, E2, R>, H<E3, P, I2, E3, R>, H<E4, P, I3, E & E2 & E3, R>]
   ): Hono<E, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
@@ -100,9 +105,18 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+    ...handlers: [
+      H<E2, P, I, E2, R>,
+      H<E3, P, I2, E3, R>,
+      H<E4, P, I3, E4, R>,
+      H<E5, P, I3, E & E2 & E3 & E4, R>
+    ]
   ): Hono<E, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 5)
@@ -113,9 +127,20 @@ export interface HandlerInterface<
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E
   >(
-    ...handlers: [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
+    ...handlers: [
+      H<E2, P, I, E2, R>,
+      H<E3, P, I2, E3, R>,
+      H<E4, P, I3, E4, R>,
+      H<E5, P, I3, E5, R>,
+      H<E5, P, I3, E & E2 & E3 & E4 & E5, R>
+    ]
   ): Hono<E, S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(...handlers[])
@@ -124,21 +149,39 @@ export interface HandlerInterface<
     I extends Input = {},
     R extends HandlerResponse<any> = any
   >(
-    ...handlers: Handler<E, P, I, R>[]
+    ...handlers: H<E, P, I, E, R>[]
   ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  ////  app.get(path)
+
+  // app.get(path)
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
+    E,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 
   ////  app.get(path, ...handlers[])
 
   // app.get(path, handler)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     path: P,
-    handler: H<E, MergePath<BasePath, P>, I, R>
+    handler: H<E, MergePath<BasePath, P>, I, E, R>
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler, handler)
-  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
+  <
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    E2 extends Env = {},
+    E3 extends Env = {}
+  >(
     path: P,
-    ...handlers: [H<E, MergePath<BasePath, P>, I, R>, H<E, MergePath<BasePath, P>, I, R>]
+    ...handlers: [
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I, E & E2, R>
+    ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x3)
@@ -147,13 +190,16 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
-    I3 extends Input = I & I2
+    I3 extends Input = I & I2,
+    E2 extends Env = {},
+    E3 extends Env = {},
+    E4 extends Env = {}
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E & E2 & E3, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -164,14 +210,18 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = {},
+    E3 extends Env = {},
+    E4 extends Env = {},
+    E5 extends Env = {}
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E & E2 & E3 & E4, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -183,22 +233,27 @@ export interface HandlerInterface<
     I2 extends Input = I,
     I3 extends Input = I & I2,
     I4 extends Input = I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = {},
+    E3 extends Env = {},
+    E4 extends Env = {},
+    E5 extends Env = {},
+    E6 extends Env = {}
   >(
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>,
-      H<E, MergePath<BasePath, P>, I5, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E5, R>,
+      H<E6, MergePath<BasePath, P>, I5, E & E2 & E3 & E4 & E5, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = {}, R extends HandlerResponse<any> = any>(
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+    ...handlers: H<E, MergePath<BasePath, P>, I, E, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 }
 
@@ -235,10 +290,20 @@ export interface OnHandlerInterface<
   BasePath extends string = '/'
 > {
   // app.on(method, path, handler, handler)
-  <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
+  <
+    M extends string,
+    P extends string,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    E2 extends Env = E,
+    E3 extends Env = E
+  >(
     method: M,
     path: P,
-    ...handlers: [H<E, MergePath<BasePath, P>, I, R>, H<E, MergePath<BasePath, P>, I, R>]
+    ...handlers: [
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I, E & E2, R>
+    ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method, path, handler x3)
@@ -248,17 +313,19 @@ export interface OnHandlerInterface<
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
-    I3 extends Input = I & I2
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E & E2 & E3, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
-
   // app.get(method, path, handler x4)
   <
     M extends string,
@@ -267,15 +334,19 @@ export interface OnHandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E & E2 & E3 & E4, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
@@ -287,31 +358,36 @@ export interface OnHandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
-    I5 extends Input = I3 & I4
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E, MergePath<BasePath, P>, I, R>,
-      H<E, MergePath<BasePath, P>, I2, R>,
-      H<E, MergePath<BasePath, P>, I3, R>,
-      H<E, MergePath<BasePath, P>, I4, R>,
-      H<E, MergePath<BasePath, P>, I5, R>
+      H<E2, MergePath<BasePath, P>, I, E2, R>,
+      H<E3, MergePath<BasePath, P>, I2, E3, R>,
+      H<E4, MergePath<BasePath, P>, I3, E4, R>,
+      H<E5, MergePath<BasePath, P>, I4, E5, R>,
+      H<E6, MergePath<BasePath, P>, I5, E & E2 & E3 & E4 & E5, R>
     ]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
 
   <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     method: M,
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+    ...handlers: H<E, MergePath<BasePath, P>, I, E, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.on(method[], path, ...handler)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     methods: string[],
     path: P,
-    ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
+    ...handlers: H<E, MergePath<BasePath, P>, I, E, R>[]
   ): Hono<
     E,
     S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,


### PR DESCRIPTION
This PR introduces two new features: the ability to set variables using `Middleware` generics and accessing them via `c.var`.

Currently, you can globally define variable types using generics for `Hono`.

```ts
type Client = 'foo client'

const app = new Hono<{
  Variables: {
    client: Client
  }
}>()
```

Alternatively, you can specify them for a specific middleware using `ContextVariableMap`:

```ts
// JWT middleare
declare module '../../context' { // Or you can write `declare module 'hono'`
  interface ContextVariableMap {
    jwtPayload: any
  }
}
```

The challenge here is that using `ContextVariableMap` makes it globally available. For instance, after importing the JWT middleware, you can access `jwtPayload` in any handler.

With this PR, you can confine middleware-defined variables to specific handlers where the middleware is applied.

```ts
const oneApiMiddleware: MiddlewareHandler<{
  Variables: {
    client: Client
  }
}> = async (c, next) => {
  c.set('client', new Client())
  await next()
}

app.get('/foo', oneApiMiddleware, (c) => {
  const client = c.get('client') // `client` is accessible only in this handler
  // ...
  return c.json({})
})
```

This offers a scoped approach to variable type availability.

The second feature is `c.var`. While the conventional method to access the actual value of a variable is `c.get()`:

```ts
const client = c.get('client')
```

With `c.var`, you can use a more intuitive syntax:

```ts
const result = c.var.client.oneMethod()
```

The combination of these two features will provide a powerful tool for developers:

```ts
const app = new Hono()

const echoMiddleware: MiddlewareHandler<{
  Variables: {
    echo: (str: string) => string
  }
}> = async (c, next) => {
  c.set('echo', (str) => str)
  await next()
}

app.get('/echo', echoMiddleware, (c) => {
  return c.text(c.var.echo('Hello!'))
})
```

<img width="479" alt="Screenshot 2023-09-04 at 22 54 18" src="https://github.com/honojs/hono/assets/10682/b7b18848-cb69-4080-8a9c-3ee9bdfc1f92">

This was discussed in issue #414 and is now being realized.
