### PR TITLE
feat(req): deprecate `c.req.headers` (not `c.req.header`) and others

### DIFF
--- a/deno_dist/middleware/bearer-auth/index.ts
+++ b/deno_dist/middleware/bearer-auth/index.ts
@@ -24,7 +24,7 @@ export const bearerAuth = (options: {
   const realm = options.realm?.replace(/"/g, '\\"')
 
   return async (c, next) => {
-    const headerToken = c.req.headers.get('Authorization')
+    const headerToken = c.req.header('Authorization')
 
     if (!headerToken) {
       // No Authorization header

--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -36,7 +36,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       c.res.headers.set(key, value)
     }
 
-    const allowOrigin = findAllowOrigin(c.req.headers.get('origin') || '')
+    const allowOrigin = findAllowOrigin(c.req.header('origin') || '')
     if (allowOrigin) {
       set('Access-Control-Allow-Origin', allowOrigin)
     }
@@ -70,7 +70,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
       let headers = opts.allowHeaders
       if (!headers?.length) {
-        const requestHeaders = c.req.headers.get('Access-Control-Request-Headers')
+        const requestHeaders = c.req.header('Access-Control-Request-Headers')
         if (requestHeaders) {
           headers = requestHeaders.split(/\s*,\s*/)
         }

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -30,7 +30,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const weak = options?.weak ?? false
 
   return async (c, next) => {
-    const ifNoneMatch = c.req.headers.get('If-None-Match')
+    const ifNoneMatch = c.req.header('If-None-Match') ?? null
 
     await next()
 

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -181,27 +181,63 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get url() {
     return this.raw.url
   }
+
   get method() {
     return this.raw.method
   }
+
+  /** @deprecated
+   * Use `c.req.raw.headers` instead of `c.req.headers`. The `c.req.headers` will be removed in v4.
+   * Or you can get the header values with using `c.req.header`.
+   * @example
+   *
+   * app.get('/', (c) => {
+   *   const userAgent = c.req.header('User-Agent')
+   *   //...
+   * })
+   */
   get headers() {
     return this.raw.headers
   }
+
+  /** @deprecated
+   * Use `c.req.raw.body` instead of `c.req.body`. The `c.req.body` will be removed in v4.
+   */
   get body() {
     return this.raw.body
   }
+
+  /** @deprecated
+   * Use `c.req.raw.bodyUsed` instead of `c.req.bodyUsed`. The `c.req.bodyUsed` will be removed in v4.
+   */
   get bodyUsed() {
     return this.raw.bodyUsed
   }
+
+  /** @deprecated
+   * Use `c.req.raw.integrity` instead of `c.req.integrity`. The `c.req.integrity` will be removed in v4.
+   */
   get integrity() {
     return this.raw.integrity
   }
+
+  /** @deprecated
+   * Use `c.req.raw.keepalive` instead of `c.req.keepalive`. The `c.req.keepalive` will be removed in v4.
+   */
   get keepalive() {
     return this.raw.keepalive
   }
+
+  /** @deprecated
+   * Use `c.req.raw.referrer` instead of `c.req.referrer`. The `c.req.referrer` will be removed in v4.
+   */
   get referrer() {
     return this.raw.referrer
   }
+
+  /** @deprecated
+   * Use `c.req.raw.signal` instead of `c.req.signal`. The `c.req.signal` will be removed in v4.
+   */
   get signal() {
     return this.raw.signal
   }

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -85,7 +85,7 @@ describe('Handler and middlewares', () => {
   const c: Context = new Context(req)
 
   const mHandlerFoo = async (c: Context, next: Function) => {
-    c.req.headers.append('x-header-foo', 'foo')
+    c.req.raw.headers.append('x-header-foo', 'foo')
     await next()
   }
 
@@ -198,7 +198,7 @@ describe('compose with Context - next() below', () => {
     return c.text(message)
   }
   const mHandler = async (c: Context, next: Function) => {
-    c.req.headers.append('x-custom', 'foo')
+    c.req.raw.headers.append('x-custom', 'foo')
     await next()
   }
 

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -821,7 +821,7 @@ describe('Middleware', () => {
     const app = new Hono()
     app
       .use('/chained/*', async (c, next) => {
-        c.req.headers.append('x-before', 'abc')
+        c.req.raw.headers.append('x-before', 'abc')
         await next()
       })
       .use(async (c, next) => {
@@ -848,7 +848,7 @@ describe('Middleware', () => {
       .use(
         '/multiple/*',
         async (c, next) => {
-          c.req.headers.append('x-before', 'abc')
+          c.req.raw.headers.append('x-before', 'abc')
           await next()
         },
         async (c, next) => {
@@ -933,7 +933,7 @@ describe('Middleware with app.HTTP_METHOD', () => {
     })
 
     const customHeader = async (c: Context, next: Next) => {
-      c.req.headers.append('x-custom-foo', 'bar')
+      c.req.raw.headers.append('x-custom-foo', 'bar')
       await next()
     }
 

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -24,7 +24,7 @@ export const bearerAuth = (options: {
   const realm = options.realm?.replace(/"/g, '\\"')
 
   return async (c, next) => {
-    const headerToken = c.req.headers.get('Authorization')
+    const headerToken = c.req.header('Authorization')
 
     if (!headerToken) {
       // No Authorization header

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -36,7 +36,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       c.res.headers.set(key, value)
     }
 
-    const allowOrigin = findAllowOrigin(c.req.headers.get('origin') || '')
+    const allowOrigin = findAllowOrigin(c.req.header('origin') || '')
     if (allowOrigin) {
       set('Access-Control-Allow-Origin', allowOrigin)
     }
@@ -70,7 +70,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
       let headers = opts.allowHeaders
       if (!headers?.length) {
-        const requestHeaders = c.req.headers.get('Access-Control-Request-Headers')
+        const requestHeaders = c.req.header('Access-Control-Request-Headers')
         if (requestHeaders) {
           headers = requestHeaders.split(/\s*,\s*/)
         }

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -30,7 +30,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const weak = options?.weak ?? false
 
   return async (c, next) => {
-    const ifNoneMatch = c.req.headers.get('If-None-Match')
+    const ifNoneMatch = c.req.header('If-None-Match') ?? null
 
     await next()
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -181,27 +181,63 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get url() {
     return this.raw.url
   }
+
   get method() {
     return this.raw.method
   }
+
+  /** @deprecated
+   * Use `c.req.raw.headers` instead of `c.req.headers`. The `c.req.headers` will be removed in v4.
+   * Or you can get the header values with using `c.req.header`.
+   * @example
+   *
+   * app.get('/', (c) => {
+   *   const userAgent = c.req.header('User-Agent')
+   *   //...
+   * })
+   */
   get headers() {
     return this.raw.headers
   }
+
+  /** @deprecated
+   * Use `c.req.raw.body` instead of `c.req.body`. The `c.req.body` will be removed in v4.
+   */
   get body() {
     return this.raw.body
   }
+
+  /** @deprecated
+   * Use `c.req.raw.bodyUsed` instead of `c.req.bodyUsed`. The `c.req.bodyUsed` will be removed in v4.
+   */
   get bodyUsed() {
     return this.raw.bodyUsed
   }
+
+  /** @deprecated
+   * Use `c.req.raw.integrity` instead of `c.req.integrity`. The `c.req.integrity` will be removed in v4.
+   */
   get integrity() {
     return this.raw.integrity
   }
+
+  /** @deprecated
+   * Use `c.req.raw.keepalive` instead of `c.req.keepalive`. The `c.req.keepalive` will be removed in v4.
+   */
   get keepalive() {
     return this.raw.keepalive
   }
+
+  /** @deprecated
+   * Use `c.req.raw.referrer` instead of `c.req.referrer`. The `c.req.referrer` will be removed in v4.
+   */
   get referrer() {
     return this.raw.referrer
   }
+
+  /** @deprecated
+   * Use `c.req.raw.signal` instead of `c.req.signal`. The `c.req.signal` will be removed in v4.
+   */
   get signal() {
     return this.raw.signal
   }


### PR DESCRIPTION
This PR makes these properties in `HonoRequest` deprecated:

```ts
get headers() {
  return this.raw.headers
}
get body() {
  return this.raw.body
}
get bodyUsed() {
  return this.raw.bodyUsed
}
get integrity() {
  return this.raw.integrity
}
get keepalive() {
  return this.raw.keepalive
}
get referrer() {
  return this.raw.referrer
}
get signal() {
  return this.raw.signal
}
```

These will be obsolete in v4.


Close #1399

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
