### PR TITLE
feat(jsx): export `FC`

### DIFF
--- a/deno_dist/jsx/index.test.tsx
+++ b/deno_dist/jsx/index.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { html } from '../helper/html/index.ts'
 import { Hono } from '../hono.ts'
+import type { FC } from './index.ts'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, memo, Fragment } from './index.ts'
 
@@ -267,6 +268,32 @@ describe('render to string', () => {
       const template = <ListOfTenThings />
       expect(template.toString()).toBe(
         '<div><div key="0">This is item 0 in the list</div><div key="1">This is item 1 in the list</div><div key="2">This is item 2 in the list</div><div key="3">This is item 3 in the list</div><div key="4">This is item 4 in the list</div><div key="5">This is item 5 in the list</div><div key="6">This is item 6 in the list</div><div key="7">This is item 7 in the list</div><div key="8">This is item 8 in the list</div><div key="9">This is item 9 in the list</div></div>'
+      )
+    })
+  })
+
+  describe('FC', () => {
+    it('Should define the type correctly', () => {
+      const Layout: FC<{ title: string }> = (props) => {
+        return (
+          <html>
+            <head>
+              <title>{props.title}</title>
+            </head>
+            <body>{props.children}</body>
+          </html>
+        )
+      }
+
+      const Top = (
+        <Layout title='Home page'>
+          <h1>Hono</h1>
+          <p>Hono is great</p>
+        </Layout>
+      )
+
+      expect(Top.toString()).toBe(
+        '<html><head><title>Home page</title></head><body><h1>Hono</h1><p>Hono is great</p></body></html>'
       )
     })
   })

--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -198,7 +198,7 @@ const jsxFn = (
   }
 }
 
-type FC<T = Props> = (props: T) => HtmlEscapedString
+export type FC<T = Props> = (props: T & { children?: Child }) => HtmlEscapedString
 
 const shallowEqual = (a: Props, b: Props): boolean => {
   if (a === b) {
@@ -226,7 +226,7 @@ export const memo = <T>(
 ): FC<T> => {
   let computed = undefined
   let prevProps: T | undefined = undefined
-  return ((props: T): HtmlEscapedString => {
+  return ((props: T & { children?: Child }): HtmlEscapedString => {
     if (prevProps && !propsAreEqual(prevProps, props)) {
       computed = undefined
     }

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { html } from '../helper/html'
 import { Hono } from '../hono'
+import type { FC } from './index'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, memo, Fragment } from './index'
 
@@ -267,6 +268,32 @@ describe('render to string', () => {
       const template = <ListOfTenThings />
       expect(template.toString()).toBe(
         '<div><div key="0">This is item 0 in the list</div><div key="1">This is item 1 in the list</div><div key="2">This is item 2 in the list</div><div key="3">This is item 3 in the list</div><div key="4">This is item 4 in the list</div><div key="5">This is item 5 in the list</div><div key="6">This is item 6 in the list</div><div key="7">This is item 7 in the list</div><div key="8">This is item 8 in the list</div><div key="9">This is item 9 in the list</div></div>'
+      )
+    })
+  })
+
+  describe('FC', () => {
+    it('Should define the type correctly', () => {
+      const Layout: FC<{ title: string }> = (props) => {
+        return (
+          <html>
+            <head>
+              <title>{props.title}</title>
+            </head>
+            <body>{props.children}</body>
+          </html>
+        )
+      }
+
+      const Top = (
+        <Layout title='Home page'>
+          <h1>Hono</h1>
+          <p>Hono is great</p>
+        </Layout>
+      )
+
+      expect(Top.toString()).toBe(
+        '<html><head><title>Home page</title></head><body><h1>Hono</h1><p>Hono is great</p></body></html>'
       )
     })
   })

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -198,7 +198,7 @@ const jsxFn = (
   }
 }
 
-type FC<T = Props> = (props: T) => HtmlEscapedString
+export type FC<T = Props> = (props: T & { children?: Child }) => HtmlEscapedString
 
 const shallowEqual = (a: Props, b: Props): boolean => {
   if (a === b) {
@@ -226,7 +226,7 @@ export const memo = <T>(
 ): FC<T> => {
   let computed = undefined
   let prevProps: T | undefined = undefined
-  return ((props: T): HtmlEscapedString => {
+  return ((props: T & { children?: Child }): HtmlEscapedString => {
     if (prevProps && !propsAreEqual(prevProps, props)) {
       computed = undefined
     }


### PR DESCRIPTION
This PR makes JSX supports exporting `FC`. You can use it for specifying types to the function component.

```tsx
import { FC } from 'hono/jsx'

const Layout: FC<{ title: string }> = (props) => {
  return (
    <html>
      <head>
        <title>{props.title}</title>
      </head>
      <body>{props.children}</body>
    </html>
  )
}

const Top = (
  <Layout title='Home page'>
    <h1>Hono</h1>
    <p>Hono is great</p>
  </Layout>
)
```

Fix #1419

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
