### PR TITLE
test: ignore `sandbox` dir

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,11 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['**/src/**/(*.)+(spec|test).+(ts|tsx|js)'],
+    exclude: [...configDefaults.exclude, '**/sandbox/**'],
     environment: 'miniflare',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
I always create a directory called `sandbox` for my experiments.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
