### PR TITLE
test: `tsc` before `vitest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "test:deno": "env NAME=Deno deno test --allow-read --allow-env runtime_tests/deno",
     "test:bun": "env NAME=Bun bun test --jsx-import-source ../../src/jsx runtime_tests/bun/index.test.tsx",
     "test:fastly": "jest --config ./runtime_tests/fastly/jest.config.js",


### PR DESCRIPTION
After replacing Jest with Vitest, I noticed that types are not being checked. So, adding `tsc` before running `vitest`.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
