### PR TITLE
cookie parsing improvements

### DIFF
--- a/deno_dist/helper/cookie/index.ts
+++ b/deno_dist/helper/cookie/index.ts
@@ -8,7 +8,7 @@ interface GetCookie {
 }
 
 interface GetSignedCookie {
-  (c: Context, secret: string, key: string): Promise<string | undefined | false>
+  (c: Context, secret: string | BufferSource, key: string): Promise<string | undefined | false>
   (c: Context, secret: string): Promise<SignedCookie>
 }
 
@@ -47,7 +47,7 @@ export const setSignedCookie = async (
   c: Context,
   name: string,
   value: string,
-  secret: string,
+  secret: string | BufferSource,
   opt?: CookieOptions
 ): Promise<void> => {
   const cookie = await serializeSigned(name, value, secret, opt)

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -8,7 +8,7 @@ interface GetCookie {
 }
 
 interface GetSignedCookie {
-  (c: Context, secret: string, key: string): Promise<string | undefined | false>
+  (c: Context, secret: string | BufferSource, key: string): Promise<string | undefined | false>
   (c: Context, secret: string): Promise<SignedCookie>
 }
 
@@ -47,7 +47,7 @@ export const setSignedCookie = async (
   c: Context,
   name: string,
   value: string,
-  secret: string,
+  secret: string | BufferSource,
   opt?: CookieOptions
 ): Promise<void> => {
   const cookie = await serializeSigned(name, value, secret, opt)


### PR DESCRIPTION
### Author should do the followings, if applicable
- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### Improvements
- validate cookie names and values during parsing per rfc6265 to mitigate various security threats
- protect signed cookies against timing attacks (i.e. utilize `crypto.subtle.verify` instead of comparing strings)
- fix bug where unsigned cookie values that match the shape of signed values are not returned
- remove constraints on signed cookie values (e.g. signed values can contain period now)
- allow use of binary secret for signed cookies
- improved efficiency (e.g. remove duplicated logic / cache secret key when verifying multiple signed values)
