### PR TITLE
Improvement of Parse Body

### DIFF
--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -4,12 +4,14 @@ describe('Parse Body Util', () => {
   it('should parse `multipart/form-data`', async () => {
     const data = new FormData()
     data.append('message', 'hello')
+    data.append('multi[]', 'foo')
+    data.append('multi[]', 'bar')
     const req = new Request('https://localhost/form', {
       method: 'POST',
       body: data,
       // `Content-Type` header must not be set.
     })
-    expect(await parseBody(req)).toEqual({ message: 'hello' })
+    expect(await parseBody(req)).toEqual({ message: 'hello', 'multi[]': ['foo', 'bar'] })
   })
 
   it('should parse `x-www-form-urlencoded`', async () => {

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,6 +1,6 @@
 import type { HonoRequest } from '../request'
 
-export type BodyData = Record<string, string | File>
+export type BodyData = Record<string,  string | string[] | File>
 
 export const parseBody = async <T extends BodyData = BodyData>(
   request: HonoRequest | Request
@@ -17,7 +17,17 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       formData.forEach((value, key) => {
-        form[key] = value
+		if(key.slice(-2) === '[]') {
+			if(!form[key]) {
+				form[key] = [value.toString()]
+			}  else {
+				if(Array.isArray(form[key])) {
+					(form[key] as string[]).push(value.toString())
+				}
+			}
+		} else {
+			form[key] = value
+		}
       })
       body = form
     }


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno

### What this PR does
- Enhanced the parsing functionality in the Hono framework to properly handle multiple checkboxes.
- Resulting selections in the request body are now formatted as `selections[] = string[]`, which aligns with common conventions for handling multiple selections.

This improvement enhances the usability and clarity of the Hono framework when dealing with multiple checkboxes in user requests. Your feedback and review on this pull request are highly appreciated. Thank you!
