### PR TITLE
feat(helper): introduce `factory` helper

### DIFF
--- a/deno_dist/helper/factory/index.ts
+++ b/deno_dist/helper/factory/index.ts
@@ -1,0 +1,10 @@
+import type { Env, Input, MiddlewareHandler } from '../../types.ts'
+
+/**
+ * @experimental
+ * `middleware()` is an experimental feature.
+ * The API might be changed.
+ */
+export const middleware = <E extends Env = Env, P extends string = string, I extends Input = {}>(
+  middleware: MiddlewareHandler<E, P, I>
+) => middleware

--- a/package.json
+++ b/package.json
@@ -189,6 +189,11 @@
       "import": "./dist/helper/adapter/index.js",
       "require": "./dist/cjs/helper/adapter/index.js"
     },
+    "./factory": {
+      "types": "./dist/types/helper/factory/index.d.ts",
+      "import": "./dist/helper/factory/index.js",
+      "require": "./dist/cjs/helper/factory/index.js"
+    },
     "./cloudflare-workers": {
       "types": "./dist/types/adapter/cloudflare-workers/index.d.ts",
       "import": "./dist/adapter/cloudflare-workers/index.js",
@@ -321,6 +326,9 @@
       ],
       "adapter": [
         "./dist/types/helper/adapter/index.d.ts"
+      ],
+      "factory": [
+        "./dist/types/helper/factory/index.d.ts"
       ],
       "cloudflare-workers": [
         "./dist/types/adapter/cloudflare-workers"

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -1,0 +1,32 @@
+import { hc } from '../../client'
+import { Hono } from '../../index'
+import { middleware } from './index'
+
+describe('middleware', () => {
+  type Env = { Variables: { foo: string } }
+  const app = new Hono<Env>()
+
+  const mw = (message: string) =>
+    middleware<Env>(async (c, next) => {
+      c.set('foo', 'bar')
+      await next()
+      c.header('X-Message', message)
+    })
+
+  const route = app.get('/message', mw('Hello Middleware'), (c) => {
+    return c.text(`Hey, ${c.var.foo}`)
+  })
+
+  it('Should return the correct header and the content', async () => {
+    const res = await app.request('/message')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-message')).toBe('Hello Middleware')
+    expect(await res.text()).toBe('Hey, bar')
+  })
+
+  it('Should provide the correct types', async () => {
+    const client = hc<typeof route>('http://localhost')
+    const url = client.message.$url()
+    expect(url.pathname).toBe('/message')
+  })
+})

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -1,0 +1,10 @@
+import type { Env, Input, MiddlewareHandler } from '../../types'
+
+/**
+ * @experimental
+ * `middleware()` is an experimental feature.
+ * The API might be changed.
+ */
+export const middleware = <E extends Env = Env, P extends string = string, I extends Input = {}>(
+  middleware: MiddlewareHandler<E, P, I>
+) => middleware


### PR DESCRIPTION
This PR introduces `factory` helper. Now, this provides a `middleware` factory method to create a middleware handler.

```ts
const mw = (message: string) =>
  middleware(async (c, next) => {
    await next()
    c.header('X-Message', message)
  })
```

If define your middleware with `middleware`, the appropriate types will be added.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
