### PR TITLE
feat: Add `c.stream()`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -336,6 +336,24 @@ export class Context<
     return this.newResponse(null, status)
   }
 
+  textStream = (
+    cb: (stream: StreamingApi) => Promise<void>,
+    arg?: StatusCode | ResponseInit,
+    headers?: HeaderRecord
+  ): Response => {
+    const { readable, writable } = new TransformStream()
+    const stream = new StreamingApi(writable)
+    cb(stream).finally(() => stream.close())
+
+    this._pH ??= {}
+    this._pH['content-type'] = 'text/plain'
+    this._pH['transfer-encoding'] = 'chunked'
+
+    return typeof arg === 'number'
+      ? this.newResponse(readable, arg, headers)
+      : this.newResponse(readable, arg)
+  }
+
   stream = (
     cb: (stream: StreamingApi) => Promise<void>,
     arg?: StatusCode | ResponseInit,
@@ -346,7 +364,6 @@ export class Context<
     cb(stream).finally(() => stream.close())
 
     this._pH ??= {}
-    this._pH['content-type'] = 'text/plain; charset=UTF-8'
     this._pH['transfer-encoding'] = 'chunked'
 
     return typeof arg === 'number'

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -336,22 +336,16 @@ export class Context<
     return this.newResponse(null, status)
   }
 
-  textStream = (
+  streamText = (
     cb: (stream: StreamingApi) => Promise<void>,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
-    const { readable, writable } = new TransformStream()
-    const stream = new StreamingApi(writable)
-    cb(stream).finally(() => stream.close())
+    headers ??= {}
+    headers['content-type'] = 'text/plain; charset=UTF-8'
+    headers['x-content-type-options'] = 'nosniff'
 
-    this._pH ??= {}
-    this._pH['content-type'] = 'text/plain'
-    this._pH['transfer-encoding'] = 'chunked'
-
-    return typeof arg === 'number'
-      ? this.newResponse(readable, arg, headers)
-      : this.newResponse(readable, arg)
+    return this.stream(cb, arg, headers)
   }
 
   stream = (

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -344,6 +344,7 @@ export class Context<
     headers ??= {}
     headers['content-type'] = 'text/plain; charset=UTF-8'
     headers['x-content-type-options'] = 'nosniff'
+    headers['transfer-encoding'] = 'chunked'
 
     return this.stream(cb, arg, headers)
   }
@@ -358,7 +359,6 @@ export class Context<
     cb(stream).finally(() => stream.close())
 
     this._pH ??= {}
-    this._pH['transfer-encoding'] = 'chunked'
 
     return typeof arg === 'number'
       ? this.newResponse(readable, arg, headers)

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -358,8 +358,6 @@ export class Context<
     const stream = new StreamingApi(writable)
     cb(stream).finally(() => stream.close())
 
-    this._pH ??= {}
-
     return typeof arg === 'number'
       ? this.newResponse(readable, arg, headers)
       : this.newResponse(readable, arg)

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -1,0 +1,35 @@
+export class StreamingApi {
+  private writer: WritableStreamDefaultWriter<Uint8Array>
+  private encoder: TextEncoder
+  buffer: string[] = []
+
+  constructor(writable: WritableStream<Uint8Array>) {
+    this.writer = writable.getWriter()
+    this.encoder = new TextEncoder()
+  }
+
+  write(str: string): StreamingApi {
+    this.buffer.push(str)
+    return this
+  }
+
+  writeln(str: string): StreamingApi {
+    return this.write(str + '\n')
+  }
+
+  clear(): void {
+    this.buffer = []
+  }
+
+  async flush(): Promise<void> {
+    const text = this.buffer.join('')
+    const encoded = this.encoder.encode(text)
+    await this.writer.write(encoded)
+    this.clear()
+  }
+
+  async close(): Promise<void> {
+    await this.writer.close()
+    this.clear()
+  }
+}

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -9,7 +9,7 @@ export class StreamingApi {
     this.encoder = new TextEncoder()
   }
 
-  async write(input?: Uint8Array | string) {
+  async write(input: Uint8Array | string) {
     if (typeof input === 'string') {
       input = this.encoder.encode(input)
     }
@@ -17,8 +17,8 @@ export class StreamingApi {
     return this
   }
 
-  async writeln(input?: string) {
-    await this.write((input || '') + '\n')
+  async writeln(input: string) {
+    await this.write(input + '\n')
     return this
   }
 

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -27,6 +27,10 @@ export class StreamingApi {
     return this
   }
 
+  wait(ms: number) {
+    return new Promise((res) => setTimeout(res, ms))
+  }
+
   async close() {
     await this.writer.close()
   }

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -1,35 +1,39 @@
 export class StreamingApi {
   private writer: WritableStreamDefaultWriter<Uint8Array>
   private encoder: TextEncoder
-  buffer: string[] = []
+  private writable: WritableStream
 
-  constructor(writable: WritableStream<Uint8Array>) {
+  constructor(writable: WritableStream) {
+    this.writable = writable
     this.writer = writable.getWriter()
     this.encoder = new TextEncoder()
   }
 
-  write(str: string): StreamingApi {
-    this.buffer.push(str)
+  async write(input?: Uint8Array | string) {
+    if (typeof input === 'string') {
+      input = this.encoder.encode(input)
+    }
+    await this.writer.write(input)
     return this
   }
 
-  writeln(str: string): StreamingApi {
-    return this.write(str + '\n')
+  async writeln(input?: string) {
+    await this.write((input || '') + '\n')
+    return this
   }
 
-  clear(): void {
-    this.buffer = []
+  async log(arg: any) {
+    await this.writeln(JSON.stringify(arg))
+    return this
   }
 
-  async flush(): Promise<void> {
-    const text = this.buffer.join('')
-    const encoded = this.encoder.encode(text)
-    await this.writer.write(encoded)
-    this.clear()
-  }
-
-  async close(): Promise<void> {
+  async close() {
     await this.writer.close()
-    this.clear()
+  }
+
+  async pipe(body: ReadableStream) {
+    this.writer.releaseLock()
+    await body.pipeTo(this.writable, { preventClose: true })
+    this.writer = this.writable.getWriter()
   }
 }

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -22,12 +22,7 @@ export class StreamingApi {
     return this
   }
 
-  async log(arg: any) {
-    await this.writeln(JSON.stringify(arg))
-    return this
-  }
-
-  wait(ms: number) {
+  sleep(ms: number) {
     return new Promise((res) => setTimeout(res, ms))
   }
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -260,8 +260,8 @@ describe('Pass a ResponseInit to respond methods', () => {
     expect(await res.text()).toBe('<h1>foo</h1>')
   })
 
-  it('c.textStream()', async () => {
-    const res = c.textStream(async (stream) => {
+  it('c.streamText()', async () => {
+    const res = c.streamText(async (stream) => {
       for (let i = 0; i < 3; i++) {
         await stream.write(`${i}`)
         await new Promise((res) => setTimeout(res, 1000))

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -264,7 +264,7 @@ describe('Pass a ResponseInit to respond methods', () => {
     const res = c.streamText(async (stream) => {
       for (let i = 0; i < 3; i++) {
         await stream.write(`${i}`)
-        await stream.sleep(1000)
+        await stream.sleep(1)
       }
     })
     if (!res.body) {
@@ -282,7 +282,7 @@ describe('Pass a ResponseInit to respond methods', () => {
     const res = c.stream(async (stream) => {
       for (let i = 0; i < 3; i++) {
         await stream.write(new Uint8Array([i]))
-        await stream.sleep(1000)
+        await stream.sleep(1)
       }
     })
     if (!res.body) {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -264,7 +264,7 @@ describe('Pass a ResponseInit to respond methods', () => {
     const res = c.streamText(async (stream) => {
       for (let i = 0; i < 3; i++) {
         await stream.write(`${i}`)
-        await new Promise((res) => setTimeout(res, 1000))
+        await stream.sleep(1000)
       }
     })
     if (!res.body) {
@@ -282,7 +282,7 @@ describe('Pass a ResponseInit to respond methods', () => {
     const res = c.stream(async (stream) => {
       for (let i = 0; i < 3; i++) {
         await stream.write(new Uint8Array([i]))
-        await new Promise((res) => setTimeout(res, 1000))
+        await stream.sleep(1000)
       }
     })
     if (!res.body) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -336,6 +336,24 @@ export class Context<
     return this.newResponse(null, status)
   }
 
+  textStream = (
+    cb: (stream: StreamingApi) => Promise<void>,
+    arg?: StatusCode | ResponseInit,
+    headers?: HeaderRecord
+  ): Response => {
+    const { readable, writable } = new TransformStream()
+    const stream = new StreamingApi(writable)
+    cb(stream).finally(() => stream.close())
+
+    this._pH ??= {}
+    this._pH['content-type'] = 'text/plain'
+    this._pH['transfer-encoding'] = 'chunked'
+
+    return typeof arg === 'number'
+      ? this.newResponse(readable, arg, headers)
+      : this.newResponse(readable, arg)
+  }
+
   stream = (
     cb: (stream: StreamingApi) => Promise<void>,
     arg?: StatusCode | ResponseInit,
@@ -346,7 +364,6 @@ export class Context<
     cb(stream).finally(() => stream.close())
 
     this._pH ??= {}
-    this._pH['content-type'] = 'text/plain; charset=UTF-8'
     this._pH['transfer-encoding'] = 'chunked'
 
     return typeof arg === 'number'

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import type { Env, NotFoundHandler, Input, TypedResponse } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
+import { StreamingApi } from './utils/stream'
 import type { JSONValue, InterfaceToType } from './utils/types'
 
 type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'lagon' | 'other'
@@ -333,6 +334,24 @@ export class Context<
     this._h ??= new Headers()
     this._h.set('Location', location)
     return this.newResponse(null, status)
+  }
+
+  stream = (
+    cb: (stream: StreamingApi) => Promise<void>,
+    arg?: StatusCode | ResponseInit,
+    headers?: HeaderRecord
+  ): Response => {
+    const { readable, writable } = new TransformStream()
+    const stream = new StreamingApi(writable)
+    cb(stream).finally(() => stream.close())
+
+    this._pH ??= {}
+    this._pH['content-type'] = 'text/plain; charset=UTF-8'
+    this._pH['transfer-encoding'] = 'chunked'
+
+    return typeof arg === 'number'
+      ? this.newResponse(readable, arg, headers)
+      : this.newResponse(readable, arg)
   }
 
   /** @deprecated

--- a/src/context.ts
+++ b/src/context.ts
@@ -336,7 +336,7 @@ export class Context<
     return this.newResponse(null, status)
   }
 
-  textStream = (
+  streamText = (
     cb: (stream: StreamingApi) => Promise<void>,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord

--- a/src/context.ts
+++ b/src/context.ts
@@ -341,17 +341,11 @@ export class Context<
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response => {
-    const { readable, writable } = new TransformStream()
-    const stream = new StreamingApi(writable)
-    cb(stream).finally(() => stream.close())
+    headers ??= {}
+    headers['content-type'] = 'text/plain; charset=UTF-8'
+    headers['x-content-type-options'] = 'nosniff'
 
-    this._pH ??= {}
-    this._pH['content-type'] = 'text/plain; charset=UTF-8'
-    this._pH['transfer-encoding'] = 'chunked'
-
-    return typeof arg === 'number'
-      ? this.newResponse(readable, arg, headers)
-      : this.newResponse(readable, arg)
+    return this.stream(cb, arg, headers)
   }
 
   stream = (

--- a/src/context.ts
+++ b/src/context.ts
@@ -346,7 +346,7 @@ export class Context<
     cb(stream).finally(() => stream.close())
 
     this._pH ??= {}
-    this._pH['content-type'] = 'text/plain'
+    this._pH['content-type'] = 'text/plain; charset=UTF-8'
     this._pH['transfer-encoding'] = 'chunked'
 
     return typeof arg === 'number'

--- a/src/context.ts
+++ b/src/context.ts
@@ -344,6 +344,7 @@ export class Context<
     headers ??= {}
     headers['content-type'] = 'text/plain; charset=UTF-8'
     headers['x-content-type-options'] = 'nosniff'
+    headers['transfer-encoding'] = 'chunked'
 
     return this.stream(cb, arg, headers)
   }
@@ -358,7 +359,6 @@ export class Context<
     cb(stream).finally(() => stream.close())
 
     this._pH ??= {}
-    this._pH['transfer-encoding'] = 'chunked'
 
     return typeof arg === 'number'
       ? this.newResponse(readable, arg, headers)

--- a/src/context.ts
+++ b/src/context.ts
@@ -358,8 +358,6 @@ export class Context<
     const stream = new StreamingApi(writable)
     cb(stream).finally(() => stream.close())
 
-    this._pH ??= {}
-
     return typeof arg === 'number'
       ? this.newResponse(readable, arg, headers)
       : this.newResponse(readable, arg)

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -1,0 +1,56 @@
+import { StreamingApi } from './stream'
+
+describe('StreamingApi', () => {
+  it('write()', async () => {
+    const writable = new WritableStream()
+    const api = new StreamingApi(writable)
+    api.write('foo')
+    expect(api.buffer).toEqual(['foo'])
+    api.write('bar')
+    expect(api.buffer).toEqual(['foo', 'bar'])
+  })
+
+  it('writeln()', async () => {
+    const writable = new WritableStream()
+    const api = new StreamingApi(writable)
+    api.writeln('foo')
+    expect(api.buffer).toEqual(['foo\n'])
+    api.writeln('bar')
+    expect(api.buffer).toEqual(['foo\n', 'bar\n'])
+  })
+
+  it('clear()', async () => {
+    const writable = new WritableStream()
+    const api = new StreamingApi(writable)
+    api.write('foo')
+    api.clear()
+    expect(api.buffer).toEqual([])
+  })
+
+  it('flush()', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable)
+    const encoder = new TextEncoder()
+    const reader = readable.getReader()
+    ;(async () => {
+      await api.write('foo').flush()
+      await api.writeln('bar').flush()
+    })()
+    const { value } = await reader.read()
+    expect(value).toEqual(encoder.encode('foo'))
+    const { value: value2 } = await reader.read()
+    expect(value2).toEqual(encoder.encode('bar\n'))
+  })
+
+  it('close()', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable)
+    const reader = readable.getReader()
+    api.write('foo')
+    api.close()
+    await expect(api.flush()).rejects.toThrow()
+    await expect(api.close()).rejects.toThrow()
+    const { value } = await reader.read()
+    expect(value).toEqual(undefined)
+  })
+})

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -31,32 +31,6 @@ describe('StreamingApi', () => {
     expect((await reader.read()).value).toEqual(new TextEncoder().encode('bar\n'))
   })
 
-  it('log(string)', async () => {
-    const { readable, writable } = new TransformStream()
-    const api = new StreamingApi(writable)
-    const reader = readable.getReader()
-    api.log('foo')
-    expect((await reader.read()).value).toEqual(new TextEncoder().encode('"foo"\n'))
-  })
-
-  it('log(object)', async () => {
-    const { readable, writable } = new TransformStream()
-    const api = new StreamingApi(writable)
-    const reader = readable.getReader()
-    api.log({ foo: 'bar' })
-    expect((await reader.read()).value).toEqual(new TextEncoder().encode('{"foo":"bar"}\n'))
-  })
-
-  it('log(arg)', async () => {
-    const { readable, writable } = new TransformStream()
-    const api = new StreamingApi(writable)
-    const reader = readable.getReader()
-    api.log('foo')
-    expect((await reader.read()).value).toEqual(new TextEncoder().encode('"foo"\n'))
-    api.log({ foo: 'bar' })
-    expect((await reader.read()).value).toEqual(new TextEncoder().encode('{"foo":"bar"}\n'))
-  })
-
   it('pipe()', async () => {
     const { readable: senderReadable, writable: senderWritable } = new TransformStream()
 

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -27,7 +27,7 @@ export class StreamingApi {
     return this
   }
 
-  wait(ms: number) {
+  sleep(ms: number) {
     return new Promise((res) => setTimeout(res, ms))
   }
 

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,0 +1,35 @@
+export class StreamingApi {
+  private writer: WritableStreamDefaultWriter<Uint8Array>
+  private encoder: TextEncoder
+  buffer: string[] = []
+
+  constructor(writable: WritableStream<Uint8Array>) {
+    this.writer = writable.getWriter()
+    this.encoder = new TextEncoder()
+  }
+
+  write(str: string): StreamingApi {
+    this.buffer.push(str)
+    return this
+  }
+
+  writeln(str: string): StreamingApi {
+    return this.write(str + '\n')
+  }
+
+  clear(): void {
+    this.buffer = []
+  }
+
+  async flush(): Promise<void> {
+    const text = this.buffer.join('')
+    const encoded = this.encoder.encode(text)
+    await this.writer.write(encoded)
+    this.clear()
+  }
+
+  async close(): Promise<void> {
+    await this.writer.close()
+    this.clear()
+  }
+}

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -22,11 +22,6 @@ export class StreamingApi {
     return this
   }
 
-  async log(arg: any) {
-    await this.writeln(JSON.stringify(arg))
-    return this
-  }
-
   sleep(ms: number) {
     return new Promise((res) => setTimeout(res, ms))
   }

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -9,16 +9,16 @@ export class StreamingApi {
     this.encoder = new TextEncoder()
   }
 
-  async write(bytes?: Uint8Array | string) {
-    if (typeof bytes === 'string') {
-      bytes = this.encoder.encode(bytes)
+  async write(input?: Uint8Array | string) {
+    if (typeof input === 'string') {
+      input = this.encoder.encode(input)
     }
-    await this.writer.write(bytes)
+    await this.writer.write(input)
     return this
   }
 
-  async writeln(bytes?: string) {
-    await this.write((bytes || '') + '\n')
+  async writeln(input?: string) {
+    await this.write((input || '') + '\n')
     return this
   }
 

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -9,7 +9,7 @@ export class StreamingApi {
     this.encoder = new TextEncoder()
   }
 
-  async write(input?: Uint8Array | string) {
+  async write(input: Uint8Array | string) {
     if (typeof input === 'string') {
       input = this.encoder.encode(input)
     }
@@ -17,8 +17,8 @@ export class StreamingApi {
     return this
   }
 
-  async writeln(input?: string) {
-    await this.write((input || '') + '\n')
+  async writeln(input: string) {
+    await this.write(input + '\n')
     return this
   }
 

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -27,6 +27,10 @@ export class StreamingApi {
     return this
   }
 
+  wait(ms: number) {
+    return new Promise((res) => setTimeout(res, ms))
+  }
+
   async close() {
     await this.writer.close()
   }


### PR DESCRIPTION
Hi, @yusukebe, @ geelen

I implemented `c.stream()` according to #914. I'd like to see @geelen added as a co-author as well, since I'm pretty much quoting the code from the issue.

This is the first time I've use a StreamAPI, so feel free to point out any mistakes.

@yusukebe asked me to give some examples of using `c.stream()`.
Below are some examples.

## Usecase

### 1: ChatGPT Proxy
Enable rate limiting to protect or hide external APIs

<details>
<summary>Code</summary>

```ts
import OpenAI from 'openai'
import { Hono } from 'hono'

const app = new Hono<{
  Bindings: {
    OPENAI_API_KEY: string
  }
}>()

const PROMPT = (message: string) => [
  {
    role: 'system' as const,
    content:
      'You are an Web developer. If you receive a question about Web-related technologies, you can answer it.',
  },
  {
    role: 'user' as const,
    content: message,
  },
]

app.post('/', async (c) => {
  const body = await c.req.json()
  const openai = new OpenAI({ apiKey: c.env.OPENAI_API_KEY })

  return c.stream(async (stream) => {
    const chatStream = await openai.chat.completions.create({
      messages: PROMPT(body.message),
      model: 'gpt-3.5-turbo',
      stream: true,
    })

    for await (const message of chatStream) {
      stream.write(message.choices[0]?.delta.content || '').flush()
    }
  })
})

export default app
```

</details>

### 2: Read some large files using stream

In this example, I'm reading a large file from the disk and sending it to the client using stream.
eg: [Read Geojson using stream and gradually draw](
    https://gunmagisgeek.com/blog/javascript/6054
)

<details>
<summary>Code</summary>

```ts
import * as fs from 'fs'
import { serve } from '@hono/node-server'
import { Hono } from 'hono'

const app = new Hono()
app.get('/assets/:key', async (c) => {
  const key = c.req.param('key')
  const path = `./assets/${key}`
  const stream = fs.createReadStream(path)
  return c.stream(async (s) => {
    for await (const chunk of stream) {
      s.write(chunk).flush()
    }
  })
})

serve(app)
```

</detail>

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

