### PR TITLE
feat: extend app.request paramters

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -374,17 +374,22 @@ class Hono<
     return this.dispatch(request, executionCtx, Env, request.method)
   }
 
-  request = (input: Request | string | URL, requestInit?: RequestInit) => {
+  request = (
+    input: Request | string | URL,
+    requestInit?: RequestInit,
+    Env?: E['Bindings'] | {},
+    executionCtx?: ExecutionContext
+  ) => {
     if (input instanceof Request) {
       if (requestInit !== undefined) {
         input = new Request(input, requestInit)
       }
-      return this.fetch(input)
+      return this.fetch(input, Env, executionCtx)
     }
     input = input.toString()
     const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
     const req = new Request(path, requestInit)
-    return this.fetch(req)
+    return this.fetch(req, Env, executionCtx)
   }
 
   fire = () => {

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -374,17 +374,22 @@ class Hono<
     return this.dispatch(request, executionCtx, Env, request.method)
   }
 
-  request = (input: Request | string | URL, requestInit?: RequestInit) => {
+  request = (
+    input: Request | string | URL,
+    requestInit?: RequestInit,
+    Env?: E['Bindings'] | {},
+    executionCtx?: ExecutionContext
+  ) => {
     if (input instanceof Request) {
       if (requestInit !== undefined) {
         input = new Request(input, requestInit)
       }
-      return this.fetch(input)
+      return this.fetch(input, Env, executionCtx)
     }
     input = input.toString()
     const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
     const req = new Request(path, requestInit)
-    return this.fetch(req)
+    return this.fetch(req, Env, executionCtx)
   }
 
   fire = () => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -34,6 +34,10 @@ describe('GET Request', () => {
     return c.html('<h1>Hono!!!</h1>')
   })
 
+  app.get('/hello-env', (c) => {
+    return c.json(c.env)
+  })
+
   it('GET http://localhost/hello is ok', async () => {
     const res = await app.request('http://localhost/hello')
     expect(res).not.toBeNull()
@@ -76,6 +80,12 @@ describe('GET Request', () => {
     const res = await app.request('http://localhost/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(404)
+  })
+
+  it('GET /hello-env is ok', async () => {
+    const res = await app.request('/hello-env', undefined, { HELLO: 'world' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ HELLO: 'world' })
   })
 })
 


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### What this PR do?
Added optional Env?: E['Bindings'] | {} and executionCtx?: ExecutionContext parameters to the app.request method signature.
Modified app.request to pass these new parameters to the app.fetch method.

