### PR TITLE
feat: allow the type of app.request

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -2,9 +2,11 @@ import type { Hono } from '../hono.ts'
 import type { Schema } from '../types.ts'
 import type { RemoveBlankRecord } from '../utils/types.ts'
 
+type HonoRequest = typeof Hono.prototype['request']
+
 export type ClientRequestOptions = {
   headers?: Record<string, string>
-  fetch?: typeof fetch
+  fetch?: typeof fetch | HonoRequest
 }
 
 type ClientRequest<S extends Schema> = {

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -375,7 +375,7 @@ class Hono<
   }
 
   request = (
-    input: Request | string | URL,
+    input: RequestInfo | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -470,3 +470,13 @@ describe('Use custom fetch method', () => {
     expect(res).toEqual(returnValue)
   })
 })
+
+describe('Use custom fetch (app.request) method', () => {
+  it('Should return Response from qpp request method', async () => {
+    const app = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
+    type AppType = typeof app
+    const client = hc<AppType>('', { fetch: app.request })
+    const res = await client.search.$get()
+    expect(res.ok).toBe(true)
+  })
+})

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -472,7 +472,7 @@ describe('Use custom fetch method', () => {
 })
 
 describe('Use custom fetch (app.request) method', () => {
-  it('Should return Response from qpp request method', async () => {
+  it('Should return Response from app request method', async () => {
     const app = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
     type AppType = typeof app
     const client = hc<AppType>('', { fetch: app.request })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -2,9 +2,11 @@ import type { Hono } from '../hono'
 import type { Schema } from '../types'
 import type { RemoveBlankRecord } from '../utils/types'
 
+type HonoRequest = typeof Hono.prototype['request']
+
 export type ClientRequestOptions = {
   headers?: Record<string, string>
-  fetch?: typeof fetch
+  fetch?: typeof fetch | HonoRequest
 }
 
 type ClientRequest<S extends Schema> = {

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -375,7 +375,7 @@ class Hono<
   }
 
   request = (
-    input: Request | string | URL,
+    input: RequestInfo | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### Changes:
- Defined HonoRequest using type Hono.prototype['request'].
- Updated ClientRequestOptions to optionally accept either the native fetch method or the HonoRequest method.

### What this PR do?
By specifying app.request as a custom fetch, users can now write tests through app.request more efficiently while still adhering to type safety.

