### PR TITLE
fix(adapter): types for env function

### DIFF
--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -1,6 +1,7 @@
 import type { Context } from '../../context.ts'
+import type { Env } from '../../types.ts'
 
-export const env = <T extends Record<string, string>, C extends Context = Context<{}>>(
+export const env = <T extends Env, C extends Context = Context<{}>>(
   c: C
 ): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -1,6 +1,7 @@
 import type { Context } from '../../context'
+import type { Env } from '../../types'
 
-export const env = <T extends Record<string, string>, C extends Context = Context<{}>>(
+export const env = <T extends Env, C extends Context = Context<{}>>(
   c: C
 ): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR creates a fix for `env` function types from `hono/adapter`. This function did not respect `env` that the `hono` server could accept and it was impossible to use `Bindings` and `Variables`. This could be made even more generic, but this would require making the server even more generic. I didn't add any tests, because there are no tests for this `env` function, so I didn't want to scaffold a new suite.