### PR TITLE
feat: add Hono test client (RPC)

### DIFF
--- a/deno_dist/helper/testing/index.ts
+++ b/deno_dist/helper/testing/index.ts
@@ -1,0 +1,18 @@
+import { hc as HonoClient } from '../../client/index.ts'
+import type { Hono } from '../../hono.ts'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExtractEnv<T> = T extends Hono<infer E, any, any> ? E : never
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const hc = <T extends Hono<any, any, any>>(
+  app: T,
+  Env?: ExtractEnv<T>['Bindings'] | {},
+  executionCtx?: ExecutionContext
+) => {
+  const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    return app.request(input, init, Env, executionCtx)
+  }
+
+  return HonoClient<typeof app>('', { fetch: customFetch })
+}

--- a/deno_dist/helper/testing/index.ts
+++ b/deno_dist/helper/testing/index.ts
@@ -1,11 +1,11 @@
-import { hc as HonoClient } from '../../client/index.ts'
+import { hc } from '../../client/index.ts'
 import type { Hono } from '../../hono.ts'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExtractEnv<T> = T extends Hono<infer E, any, any> ? E : never
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(
+export const testClient = <T extends Hono<any, any, any>>(
   app: T,
   Env?: ExtractEnv<T>['Bindings'] | {},
   executionCtx?: ExecutionContext
@@ -14,5 +14,5 @@ export const hc = <T extends Hono<any, any, any>>(
     return app.request(input, init, Env, executionCtx)
   }
 
-  return HonoClient<typeof app>('', { fetch: customFetch })
+  return hc<typeof app>('', { fetch: customFetch })
 }

--- a/package.json
+++ b/package.json
@@ -233,6 +233,11 @@
       "types": "./dist/types/adapter/lambda-edge/index.d.ts",
       "import": "./dist/adapter/lambda-edge/index.js",
       "require": "./dist/cjs/adapter/lambda-edge/index.js"
+    },
+    "./testing": {
+      "types": "./dist/types/helper/testing/index.d.ts",
+      "import": "./dist/helper/testing/index.js",
+      "require": "./dist/cjs/helper/testing/index.js"
     }
   },
   "typesVersions": {
@@ -353,6 +358,9 @@
       ],
       "lambda-edge": [
         "./dist/types/adapter/lambda-edge"
+      ],
+      "testing": [
+        "./dist/types/helper/testing"
       ]
     }
   },

--- a/src/helper/testing/index.test.ts
+++ b/src/helper/testing/index.test.ts
@@ -1,0 +1,19 @@
+import { Hono } from '../../hono'
+import { hc } from '.'
+
+describe('hono testClinet', () => {
+  it('should return the correct search result', async () => {
+    const app = new Hono().get('/search', (c) => c.jsonT({ hello: 'world' }))
+    const res = await hc(app).search.$get()
+    expect(await res.json()).toEqual({ hello: 'world' })
+  })
+
+  it('should return the correct environment variables value', async () => {
+    type Bindings = { hello: string }
+    const app = new Hono<{ Bindings: Bindings }>().get('/search', (c) => {
+      return c.jsonT({ hello: c.env.hello })
+    })
+    const res = await hc(app, { hello: 'world' }).search.$get()
+    expect(await res.json()).toEqual({ hello: 'world' })
+  })
+})

--- a/src/helper/testing/index.test.ts
+++ b/src/helper/testing/index.test.ts
@@ -1,10 +1,10 @@
 import { Hono } from '../../hono'
-import { hc } from '.'
+import { testClient } from '.'
 
 describe('hono testClinet', () => {
   it('should return the correct search result', async () => {
     const app = new Hono().get('/search', (c) => c.jsonT({ hello: 'world' }))
-    const res = await hc(app).search.$get()
+    const res = await testClient(app).search.$get()
     expect(await res.json()).toEqual({ hello: 'world' })
   })
 
@@ -13,7 +13,7 @@ describe('hono testClinet', () => {
     const app = new Hono<{ Bindings: Bindings }>().get('/search', (c) => {
       return c.jsonT({ hello: c.env.hello })
     })
-    const res = await hc(app, { hello: 'world' }).search.$get()
+    const res = await testClient(app, { hello: 'world' }).search.$get()
     expect(await res.json()).toEqual({ hello: 'world' })
   })
 })

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -1,0 +1,18 @@
+import { hc as HonoClient } from '../../client'
+import type { Hono } from '../../hono'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExtractEnv<T> = T extends Hono<infer E, any, any> ? E : never
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const hc = <T extends Hono<any, any, any>>(
+  app: T,
+  Env?: ExtractEnv<T>['Bindings'] | {},
+  executionCtx?: ExecutionContext
+) => {
+  const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    return app.request(input, init, Env, executionCtx)
+  }
+
+  return HonoClient<typeof app>('', { fetch: customFetch })
+}

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -1,11 +1,11 @@
-import { hc as HonoClient } from '../../client'
+import { hc } from '../../client'
 import type { Hono } from '../../hono'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExtractEnv<T> = T extends Hono<infer E, any, any> ? E : never
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(
+export const testClient = <T extends Hono<any, any, any>>(
   app: T,
   Env?: ExtractEnv<T>['Bindings'] | {},
   executionCtx?: ExecutionContext
@@ -14,5 +14,5 @@ export const hc = <T extends Hono<any, any, any>>(
     return app.request(input, init, Env, executionCtx)
   }
 
-  return HonoClient<typeof app>('', { fetch: customFetch })
+  return hc<typeof app>('', { fetch: customFetch })
 }


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### What this PR do?
By using the hc test client, we can easily write tests. This utility enables efficient integration and unit testing by allowing manipulation of the Hono application object rather than making actual HTTP requests.

### Usage Example
```ts
it('test', async() => {
  const app = new Hono().get('/search', (c) => c.jsonT({ hello: 'world' }))
  const res = await hc(app).search.$get()

  expect(await res.json()).toEqual({ hello: 'world' })
})
```
