### PR TITLE
refactor(helper):  Use getRuntimeKey() in env function

### DIFF
--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -20,6 +20,7 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
       return Deno.env.toObject() as T
     },
     workerd: () => c.env,
+    // On Fastly Compute@Edge, you can use the ConfigStore to manage user-defined data.
     fastly: () => ({} as T),
     other: () => ({} as T),
   }

--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -17,7 +17,7 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
     deno: () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      return Deno.env.toObject()
+      return Deno.env.toObject() as T
     },
     workerd: () => c.env,
     fastly: () => ({} as T),

--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -5,61 +5,39 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
 ): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
+  const globalEnv = global?.process?.env as T
 
-  if (
-    c.runtime === 'bun' ||
-    c.runtime === 'node' ||
-    c.runtime === 'edge-light' ||
-    c.runtime === 'lagon'
-  ) {
-    return global?.process?.env as T
+  const runtime = getRuntimeKey()
+
+  const runtimeEnvHandlers: Record<string, () => T> = {
+    bun: () => globalEnv,
+    node: () => globalEnv,
+    'edge-light': () => globalEnv,
+    lagon: () => globalEnv,
+    deno: () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return Deno.env.toObject()
+    },
+    workerd: () => c.env,
+    fastly: () => ({} as T),
+    other: () => ({} as T),
   }
-  if (c.runtime === 'deno') {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return Deno.env.toObject()
-  }
-  if (c.runtime === 'workerd') {
-    return c.env
-  }
-  if (c.runtime === 'fastly') {
-    // On Fastly Compute@Edge, you can use the ConfigStore to manage user-defined data.
-    return {} as T
-  }
-  return {} as T
+
+  return runtimeEnvHandlers[runtime]()
 }
 
 export const getRuntimeKey = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 
-  if (global?.Deno !== undefined) {
-    return 'deno'
-  }
-
-  if (global?.Bun !== undefined) {
-    return 'bun'
-  }
-
-  if (typeof global?.WebSocketPair === 'function') {
-    return 'workerd'
-  }
-
-  if (typeof global?.EdgeRuntime === 'string') {
-    return 'edge-light'
-  }
-
-  if (global?.fastly !== undefined) {
-    return 'fastly'
-  }
-
-  if (global?.__lagon__ !== undefined) {
-    return 'lagon'
-  }
-
-  if (global?.process?.release?.name === 'node') {
-    return 'node'
-  }
+  if (global?.Deno !== undefined) return 'deno'
+  if (global?.Bun !== undefined) return 'bun'
+  if (typeof global?.WebSocketPair === 'function') return 'workerd'
+  if (typeof global?.EdgeRuntime === 'string') return 'edge-light'
+  if (global?.fastly !== undefined) return 'fastly'
+  if (global?.__lagon__ !== undefined) return 'lagon'
+  if (global?.process?.release?.name === 'node') return 'node'
 
   return 'other'
 }

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -174,6 +174,7 @@ describe('Context', () => {
     expect(res.headers.get('foo')).toBe('bar')
   })
 
+  // The `c.runtime()` will be removed in v4.
   it('returns current runtime (workerd)', async () => {
     c = new Context(req)
     expect(c.runtime).toBe('workerd')

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -20,6 +20,7 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
       return Deno.env.toObject() as T
     },
     workerd: () => c.env,
+    // On Fastly Compute@Edge, you can use the ConfigStore to manage user-defined data.
     fastly: () => ({} as T),
     other: () => ({} as T),
   }

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -17,7 +17,7 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
     deno: () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      return Deno.env.toObject()
+      return Deno.env.toObject() as T
     },
     workerd: () => c.env,
     fastly: () => ({} as T),

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -5,61 +5,39 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
 ): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
+  const globalEnv = global?.process?.env as T;
 
-  if (
-    c.runtime === 'bun' ||
-    c.runtime === 'node' ||
-    c.runtime === 'edge-light' ||
-    c.runtime === 'lagon'
-  ) {
-    return global?.process?.env as T
+  const runtime = getRuntimeKey()
+
+  const runtimeEnvHandlers: Record<string, () => T> = {
+    'bun': () => globalEnv,
+    'node': () => globalEnv,
+    'edge-light': () => globalEnv,
+    'lagon': () => globalEnv,
+    'deno': () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return Deno.env.toObject()
+    },
+    'workerd': () => c.env,
+    'fastly': () => ({} as T),
+    'other': () => ({} as T),
   }
-  if (c.runtime === 'deno') {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return Deno.env.toObject()
-  }
-  if (c.runtime === 'workerd') {
-    return c.env
-  }
-  if (c.runtime === 'fastly') {
-    // On Fastly Compute@Edge, you can use the ConfigStore to manage user-defined data.
-    return {} as T
-  }
-  return {} as T
+
+  return runtimeEnvHandlers[runtime]()
 }
 
 export const getRuntimeKey = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 
-  if (global?.Deno !== undefined) {
-    return 'deno'
-  }
-
-  if (global?.Bun !== undefined) {
-    return 'bun'
-  }
-
-  if (typeof global?.WebSocketPair === 'function') {
-    return 'workerd'
-  }
-
-  if (typeof global?.EdgeRuntime === 'string') {
-    return 'edge-light'
-  }
-
-  if (global?.fastly !== undefined) {
-    return 'fastly'
-  }
-
-  if (global?.__lagon__ !== undefined) {
-    return 'lagon'
-  }
-
-  if (global?.process?.release?.name === 'node') {
-    return 'node'
-  }
-
+  if (global?.Deno !== undefined) return 'deno'
+  if (global?.Bun !== undefined) return 'bun'
+  if (typeof global?.WebSocketPair === 'function') return 'workerd'
+  if (typeof global?.EdgeRuntime === 'string') return 'edge-light'
+  if (global?.fastly !== undefined) return 'fastly'
+  if (global?.__lagon__ !== undefined) return 'lagon'
+  if (global?.process?.release?.name === 'node') return 'node'
+  
   return 'other'
 }

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -5,23 +5,23 @@ export const env = <T extends Record<string, string>, C extends Context = Contex
 ): T & C['env'] => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
-  const globalEnv = global?.process?.env as T;
+  const globalEnv = global?.process?.env as T
 
   const runtime = getRuntimeKey()
 
   const runtimeEnvHandlers: Record<string, () => T> = {
-    'bun': () => globalEnv,
-    'node': () => globalEnv,
+    bun: () => globalEnv,
+    node: () => globalEnv,
     'edge-light': () => globalEnv,
-    'lagon': () => globalEnv,
-    'deno': () => {
+    lagon: () => globalEnv,
+    deno: () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       return Deno.env.toObject()
     },
-    'workerd': () => c.env,
-    'fastly': () => ({} as T),
-    'other': () => ({} as T),
+    workerd: () => c.env,
+    fastly: () => ({} as T),
+    other: () => ({} as T),
   }
 
   return runtimeEnvHandlers[runtime]()
@@ -38,6 +38,6 @@ export const getRuntimeKey = () => {
   if (global?.fastly !== undefined) return 'fastly'
   if (global?.__lagon__ !== undefined) return 'lagon'
   if (global?.process?.release?.name === 'node') return 'node'
-  
+
   return 'other'
 }


### PR DESCRIPTION
I've removed the logic that depends on c.runtime. I've also refactored the code to map behavior for each runtime to an object. If this is overkill, I can revert it back to the original code.

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

fixed: https://github.com/honojs/hono/issues/1452