### PR TITLE
feat: Refactor ClientRequest Type for header validation

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -22,6 +22,7 @@ type ClientRequest<S extends Schema> = {
       ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
       : HasHeaderOption<R> extends never
       ? (
+          // Client does not support `cookie`
           args?: Omit<R, 'header' | 'cookie'>,
           options?: ClientRequestOptions
         ) => Promise<ClientResponse<O>>

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -4,19 +4,30 @@ import type { RemoveBlankRecord } from '../utils/types.ts'
 
 type HonoRequest = typeof Hono.prototype['request']
 
-export type ClientRequestOptions = {
-  headers?: Record<string, string>
-  fetch?: typeof fetch | HonoRequest
-}
+type HasHeaderOption<T> = T extends { header: unknown } ? T['header'] : never
+
+export type ClientRequestOptions<T = unknown> = keyof T extends never
+  ? {
+      headers?: Record<string, string>
+      fetch?: typeof fetch | HonoRequest
+    }
+  : {
+      headers: T
+      fetch?: typeof fetch | HonoRequest
+    }
 
 type ClientRequest<S extends Schema> = {
   [M in keyof S]: S[M] extends { input: infer R; output: infer O }
     ? RemoveBlankRecord<R> extends never
       ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
-      : (
-          // Client does not support `header` and `cookie`
-          args: Omit<R, 'header' | 'cookie'>,
+      : HasHeaderOption<R> extends never
+      ? (
+          args?: Omit<R, 'header' | 'cookie'>,
           options?: ClientRequestOptions
+        ) => Promise<ClientResponse<O>>
+      : (
+          args: Omit<R, 'header' | 'cookie'> | undefined,
+          options: ClientRequestOptions<HasHeaderOption<R>>
         ) => Promise<ClientResponse<O>>
     : never
 } & {
@@ -53,12 +64,26 @@ export type Fetch<T> = (
 
 export type InferResponseType<T> = T extends (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any | undefined
+  args: any | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any | undefined
 ) => Promise<ClientResponse<infer O>>
   ? O
   : never
 
-export type InferRequestType<T> = T extends (args: infer R) => Promise<ClientResponse<unknown>>
+export type InferRequestType<T> = T extends (
+  args: infer R,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any | undefined
+) => Promise<ClientResponse<unknown>>
+  ? NonNullable<R>
+  : never
+
+export type InferRequestOptionsType<T> = T extends (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any,
+  options: infer R
+) => Promise<ClientResponse<unknown>>
   ? NonNullable<R>
   : never
 

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -10,7 +10,7 @@ import { Hono } from '../hono'
 import type { Equal, Expect } from '../utils/types'
 import { validator } from '../validator'
 import { hc } from './client'
-import type { InferRequestType, InferResponseType } from './types'
+import type { InferRequestOptionsType, InferRequestType, InferResponseType } from './types'
 
 // @ts-ignore
 global.fetch = _fetch
@@ -31,10 +31,9 @@ describe('Basic - JSON', () => {
           debug: string
         }
       }),
-      // Client does not support `header`
       validator('header', () => {
         return {} as {
-          'x-request-id': string
+          'x-message': string
         }
       }),
       validator('json', () => {
@@ -260,6 +259,11 @@ describe('Infer the response/request type', () => {
         age: 'dummy',
       }
     }),
+    validator('header', () => {
+      return {
+        'x-request-id': 'dummy',
+      }
+    }),
     (c) =>
       c.jsonT({
         id: 123,
@@ -291,6 +295,18 @@ describe('Infer the response/request type', () => {
       name: string
     }
     type verify = Expect<Equal<Expected, Actual['query']>>
+  })
+
+  it('Should infer request header type the type correctly', () => {
+    const client = hc<AppType>('/')
+    const req = client.index.$get
+    type c = typeof req
+
+    type Actual = InferRequestOptionsType<c>
+    type Expected = {
+      'x-request-id': string
+    }
+    type verify = Expect<Equal<Expected, Actual['headers']>>
   })
 
   describe('Without input', () => {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -22,6 +22,7 @@ type ClientRequest<S extends Schema> = {
       ? (args?: {}, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
       : HasHeaderOption<R> extends never
       ? (
+          // Client does not support `cookie`
           args?: Omit<R, 'header' | 'cookie'>,
           options?: ClientRequestOptions
         ) => Promise<ClientResponse<O>>


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### What this PR do?

The changes are aimed at improving the type safety when dealing with client requests that include headers. 
By enforcing the validation at the type level, we can catch potential issues earlier in the development process, reducing the risk of runtime errors.

