### PR TITLE
feat: expose the Jwt fucntions under the 'hono/jwt' path

### DIFF
--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -77,3 +77,7 @@ export const jwt = (options: {
     await next()
   }
 }
+
+export const verify = Jwt.verify
+export const decode = Jwt.decode
+export const sign = Jwt.sign

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -77,3 +77,7 @@ export const jwt = (options: {
     await next()
   }
 }
+
+export const verify = Jwt.verify
+export const decode = Jwt.decode
+export const sign = Jwt.sign


### PR DESCRIPTION
Expose the `sign`, `verify` and `decode` functions under `hono/jwt`

Usage: 

```js
import { decode, sign, verify } from 'hono/jwt'
```

Closes #1443