### PR TITLE
fix(context): fix `c.stream()` and `c.streamText()` matters

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -86,6 +86,8 @@ type ContextOptions<E extends Env> = {
   notFoundHandler?: NotFoundHandler<E>
 }
 
+const TEXT_PLAIN = 'text/plain; charset=UTF-8'
+
 export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
@@ -311,7 +313,7 @@ export class Context<
     // If Content-Type is not set, we don't have to set `text/plain`.
     // Fewer the header values, it will be faster.
     if (this._pH['content-type']) {
-      this._pH['content-type'] = 'text/plain; charset=UTF-8'
+      this._pH['content-type'] = TEXT_PLAIN
     }
     return typeof arg === 'number'
       ? this.newResponse(text, arg, headers)
@@ -378,10 +380,9 @@ export class Context<
     headers?: HeaderRecord
   ): Response => {
     headers ??= {}
-    headers['content-type'] = 'text/plain; charset=UTF-8'
-    headers['x-content-type-options'] = 'nosniff'
-    headers['transfer-encoding'] = 'chunked'
-
+    this.header('content-type', TEXT_PLAIN)
+    this.header('x-content-type-options', 'nosniff')
+    this.header('transfer-encoding', 'chunked')
     return this.stream(cb, arg, headers)
   }
 

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -10,10 +10,14 @@ export class StreamingApi {
   }
 
   async write(input: Uint8Array | string) {
-    if (typeof input === 'string') {
-      input = this.encoder.encode(input)
+    try {
+      if (typeof input === 'string') {
+        input = this.encoder.encode(input)
+      }
+      await this.writer.write(input)
+    } catch (e) {
+      // Do nothing. If you want to handle errors, create a stream by yourself.
     }
-    await this.writer.write(input)
     return this
   }
 
@@ -27,7 +31,11 @@ export class StreamingApi {
   }
 
   async close() {
-    await this.writer.close()
+    try {
+      await this.writer.close()
+    } catch (e) {
+      // Do nothing. If you want to handle errors, create a stream by yourself.
+    }
   }
 
   async pipe(body: ReadableStream) {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -269,6 +269,12 @@ describe('Pass a ResponseInit to respond methods', () => {
         await stream.sleep(1)
       }
     })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toMatch(/^text\/plain/)
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(res.headers.get('transfer-encoding')).toBe('chunked')
+
     if (!res.body) {
       throw new Error('Body is null')
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -86,6 +86,8 @@ type ContextOptions<E extends Env> = {
   notFoundHandler?: NotFoundHandler<E>
 }
 
+const TEXT_PLAIN = 'text/plain; charset=UTF-8'
+
 export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
@@ -311,7 +313,7 @@ export class Context<
     // If Content-Type is not set, we don't have to set `text/plain`.
     // Fewer the header values, it will be faster.
     if (this._pH['content-type']) {
-      this._pH['content-type'] = 'text/plain; charset=UTF-8'
+      this._pH['content-type'] = TEXT_PLAIN
     }
     return typeof arg === 'number'
       ? this.newResponse(text, arg, headers)
@@ -378,10 +380,9 @@ export class Context<
     headers?: HeaderRecord
   ): Response => {
     headers ??= {}
-    headers['content-type'] = 'text/plain; charset=UTF-8'
-    headers['x-content-type-options'] = 'nosniff'
-    headers['transfer-encoding'] = 'chunked'
-
+    this.header('content-type', TEXT_PLAIN)
+    this.header('x-content-type-options', 'nosniff')
+    this.header('transfer-encoding', 'chunked')
     return this.stream(cb, arg, headers)
   }
 

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { StreamingApi } from './stream'
 
 describe('StreamingApi', () => {

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest'
 import { StreamingApi } from './stream'
 
 describe('StreamingApi', () => {
@@ -63,6 +64,23 @@ describe('StreamingApi', () => {
     const reader = readable.getReader()
     await api.close()
     expect((await reader.read()).done).toBe(true)
-    await expect(api.write('foo')).rejects.toThrow()
+  })
+
+  it('should not throw an error in write()', async () => {
+    const { writable } = new TransformStream()
+    const api = new StreamingApi(writable)
+    await api.close()
+    const write = () => api.write('foo')
+    expect(write).not.toThrow()
+  })
+
+  it('should not throw an error in close()', async () => {
+    const { writable } = new TransformStream()
+    const api = new StreamingApi(writable)
+    const close = async () => {
+      await api.close()
+      await api.close()
+    }
+    expect(close).not.toThrow()
   })
 })

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -10,10 +10,14 @@ export class StreamingApi {
   }
 
   async write(input: Uint8Array | string) {
-    if (typeof input === 'string') {
-      input = this.encoder.encode(input)
+    try {
+      if (typeof input === 'string') {
+        input = this.encoder.encode(input)
+      }
+      await this.writer.write(input)
+    } catch (e) {
+      // Do nothing. If you want to handle errors, create a stream by yourself.
     }
-    await this.writer.write(input)
     return this
   }
 
@@ -27,7 +31,11 @@ export class StreamingApi {
   }
 
   async close() {
-    await this.writer.close()
+    try {
+      await this.writer.close()
+    } catch (e) {
+      // Do nothing. If you want to handle errors, create a stream by yourself.
+    }
   }
 
   async pipe(body: ReadableStream) {


### PR DESCRIPTION
This PR includes these fixes:

* Make the response headers of `c.streamText()` correct.
* Make `text/plain; charset=UTF-8` as the variable to reduce bundle size.
* Handling errors and ignoring them. If there is an error throw, the process may stop. And also, tracing an error may get in the way. So, I decided to do nothing in the catch.

Errors are as follows. Occurs when accessing while it is streaming.

<img width="708" alt="Screenshot 2023-09-19 at 18 28 02" src="https://github.com/honojs/hono/assets/10682/fe321cef-712d-4351-bbc0-44f38847cb5d">

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
