### PR TITLE
fix(jwt): incorrect error message

### DIFF
--- a/deno_dist/utils/jwt/types.ts
+++ b/deno_dist/utils/jwt/types.ts
@@ -1,6 +1,6 @@
 export class JwtAlgorithmNotImplemented extends Error {
-  constructor(token: string) {
-    super(`invalid JWT token: ${token}`)
+  constructor(alg: string) {
+    super(`${alg} is not an implemented algorithm`)
     this.name = 'JwtAlgorithmNotImplemented'
   }
 }

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -1,6 +1,6 @@
 export class JwtAlgorithmNotImplemented extends Error {
-  constructor(token: string) {
-    super(`invalid JWT token: ${token}`)
+  constructor(alg: string) {
+    super(`${alg} is not an implemented algorithm`)
     this.name = 'JwtAlgorithmNotImplemented'
   }
 }


### PR DESCRIPTION
### Description

The error message is a duplicate of line 14 `JwtTokenInvalid` and is no descriptive to the actual cause of the issue.

### Updated 

Updated the error message to align with the name of the error

### Author should do the followings, if applicable
- N/A: Add test
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
