### PR TITLE
feat: include multivalue form data as an array

### DIFF
--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -17,7 +17,7 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       for (const key of formData.keys()) {
-        const values = formData.getAll(key);
+        const values = formData.getAll(key)
         form[key] = values.length === 1 ? values[0] : values
       }
       body = form

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,6 +1,6 @@
 import type { HonoRequest } from '../request.ts'
 
-export type BodyData = Record<string, string | File>
+export type BodyData = Record<string, string | File | (string | File)[]>
 
 export const parseBody = async <T extends BodyData = BodyData>(
   request: HonoRequest | Request
@@ -16,9 +16,10 @@ export const parseBody = async <T extends BodyData = BodyData>(
     const formData = await request.formData()
     if (formData) {
       const form: BodyData = {}
-      formData.forEach((value, key) => {
-        form[key] = value
-      })
+      for (const key of formData.keys()) {
+        const values = formData.getAll(key);
+        form[key] = values.length === 1 ? values[0] : values
+      }
       body = form
     }
   }

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -39,18 +39,20 @@ describe('Parse Body Util', () => {
     const data = new FormData()
     data.append('foo', 'value1')
     data.append('foo', 'value2')
+    data.append('bar', 'value3')
     const req = new Request('https://localhost/form', {
       method: 'POST',
       body: data,
       // `Content-Type` header must not be set.
     })
-    expect(await parseBody(req)).toEqual({ foo: ['value1', 'value2'] })
+    expect(await parseBody(req)).toEqual({ foo: ['value1', 'value2'], bar: 'value3' })
   })
 
   it('should parse `x-www-form-urlencoded` and return an array for key with multiple values', async () => {
     const searchParams = new URLSearchParams()
     searchParams.append('foo', 'value1')
     searchParams.append('foo', 'value2')
+    searchParams.append('bar', 'value3')
     const req = new Request('https://localhost/search', {
       method: 'POST',
       body: searchParams,
@@ -58,6 +60,6 @@ describe('Parse Body Util', () => {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
     })
-    expect(await parseBody(req)).toEqual({ foo: ['value1', 'value2'] })
+    expect(await parseBody(req)).toEqual({ foo: ['value1', 'value2'], bar: 'value3' })
   })
 })

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -34,4 +34,30 @@ describe('Parse Body Util', () => {
     })
     expect(await parseBody(req)).toEqual({})
   })
+
+  it('should parse `multipart/form-data` and return an array for key with multiple values', async () => {
+    const data = new FormData()
+    data.append('foo', 'value1')
+    data.append('foo', 'value2')
+    const req = new Request('https://localhost/form', {
+      method: 'POST',
+      body: data,
+      // `Content-Type` header must not be set.
+    })
+    expect(await parseBody(req)).toEqual({ foo: ['value1', 'value2'] })
+  })
+
+  it('should parse `x-www-form-urlencoded` and return an array for key with multiple values', async () => {
+    const searchParams = new URLSearchParams()
+    searchParams.append('foo', 'value1')
+    searchParams.append('foo', 'value2')
+    const req = new Request('https://localhost/search', {
+      method: 'POST',
+      body: searchParams,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    })
+    expect(await parseBody(req)).toEqual({ foo: ['value1', 'value2'] })
+  })
 })

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -17,7 +17,7 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       for (const key of formData.keys()) {
-        const values = formData.getAll(key);
+        const values = formData.getAll(key)
         form[key] = values.length === 1 ? values[0] : values
       }
       body = form

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,6 +1,6 @@
 import type { HonoRequest } from '../request'
 
-export type BodyData = Record<string, string | File>
+export type BodyData = Record<string, string | File | (string | File)[]>
 
 export const parseBody = async <T extends BodyData = BodyData>(
   request: HonoRequest | Request
@@ -16,9 +16,10 @@ export const parseBody = async <T extends BodyData = BodyData>(
     const formData = await request.formData()
     if (formData) {
       const form: BodyData = {}
-      formData.forEach((value, key) => {
-        form[key] = value
-      })
+      for (const key of formData.keys()) {
+        const values = formData.getAll(key);
+        form[key] = values.length === 1 ? values[0] : values
+      }
       body = form
     }
   }


### PR DESCRIPTION
In a `multipart/form-data` or a `application/x-www-form-urlencoded` POST request, if there are multiple values for a given field name (key), `c.req.parseBody()` will not only include one of them.

This makes it so that when using `c.req.parseBody()`, if there are multiple values for a given key, they'll be included in an array.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
