### PR TITLE
fix(types): fix inferring path strings for an optional parameter with regexp

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -533,9 +533,10 @@ export type ValidationTargets = {
 //////                            //////
 ////////////////////////////////////////
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
-  ? Name
+type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer Rest}`
+  ? Rest extends `${infer _Pattern}?`
+    ? `${Name}?`
+    : Name
   : NameWithPattern
 
 type ParamKey<Component> = Component extends `:${infer NameWithPattern}`

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2131,6 +2131,7 @@ describe('Optional parameters', () => {
   })
 
   it('Should have a correct type with an optional parameter in a regexp path', async () => {
+    const app = new Hono()
     app.get('/url/:url{.*}?', (c) => {
       const url = c.req.param('url')
       expectTypeOf(url).toEqualTypeOf<string | undefined>()

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2129,6 +2129,14 @@ describe('Optional parameters', () => {
       type: undefined,
     })
   })
+
+  it('Should have a correct type with an optional parameter in a regexp path', async () => {
+    app.get('/url/:url{.*}?', (c) => {
+      const url = c.req.param('url')
+      expectTypeOf(url).toEqualTypeOf<string | undefined>()
+      return c.json(0)
+    })
+  })
 })
 
 describe('app.mount()', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -533,9 +533,10 @@ export type ValidationTargets = {
 //////                            //////
 ////////////////////////////////////////
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
-  ? Name
+type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer Rest}`
+  ? Rest extends `${infer _Pattern}?`
+    ? `${Name}?`
+    : Name
   : NameWithPattern
 
 type ParamKey<Component> = Component extends `:${infer NameWithPattern}`


### PR DESCRIPTION
Fix the issue in this comment: https://github.com/honojs/hono/issues/1513#issuecomment-1738890316

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
