### PR TITLE
feat(jwt): add optional flag for middleware

### DIFF
--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -14,7 +14,8 @@ declare module '../../context.ts' {
 export const jwt = (options: {
   secret: string
   cookie?: string
-  alg?: string
+  alg?: string,
+  optional?: boolean
 }): MiddlewareHandler => {
   if (!options) {
     throw new Error('JWT auth middleware requires options for "secret')
@@ -45,6 +46,11 @@ export const jwt = (options: {
     }
 
     if (!token) {
+      if (options.optional) {
+        await next()
+        return
+      }
+
       const res = new Response('Unauthorized', {
         status: 401,
         headers: {
@@ -62,6 +68,11 @@ export const jwt = (options: {
       msg = `${e}`
     }
     if (!payload) {
+      if (options.optional) {
+        await next()
+        return
+      }
+      
       const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -14,7 +14,8 @@ declare module '../../context' {
 export const jwt = (options: {
   secret: string
   cookie?: string
-  alg?: string
+  alg?: string,
+  optional?: boolean
 }): MiddlewareHandler => {
   if (!options) {
     throw new Error('JWT auth middleware requires options for "secret')
@@ -45,6 +46,11 @@ export const jwt = (options: {
     }
 
     if (!token) {
+      if (options.optional) {
+        await next()
+        return
+      }
+
       const res = new Response('Unauthorized', {
         status: 401,
         headers: {
@@ -62,6 +68,11 @@ export const jwt = (options: {
       msg = `${e}`
     }
     if (!payload) {
+      if (options.optional) {
+        await next()
+        return
+      }
+      
       const res = new Response('Unauthorized', {
         status: 401,
         statusText: msg,


### PR DESCRIPTION
I added the option to disable the HTTP 401 response when using the JWT middleware. That way API routes can still make use of the payload context without necessarily requiring users to be authenticated to access the route.

```js
app.use(path, jwt({
  secret: ...,
  optional: true
}));
```

Happy to submit a PR for the website docs as well, or whatever else you may need.

Thanks for all of your work on Hono, it's a joy to work with!