### PR TITLE
feat: `parseBody()` for multi values' field

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -10,7 +10,7 @@ import type {
   ValidationTargets,
 } from './types.ts'
 import { parseBody } from './utils/body.ts'
-import type { BodyData } from './utils/body.ts'
+import type { BodyData, ParseBodyOptions } from './utils/body.ts'
 import type { Cookie } from './utils/cookie.ts'
 import { parse } from './utils/cookie.ts'
 import type { UnionToIntersection } from './utils/types.ts'
@@ -126,9 +126,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     }
   }
 
-  async parseBody<T extends BodyData = BodyData>(): Promise<T> {
+  async parseBody<T extends BodyData = BodyData>(options?: ParseBodyOptions): Promise<T> {
     if (this.bodyCache.parsedBody) return this.bodyCache.parsedBody as T
-    const parsedBody = await parseBody<T>(this)
+    const parsedBody = await parseBody<T>(this, options)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
   }

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -39,16 +39,16 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       formData.forEach((value, key) => {
-        const isParseAll = options.all || key.slice(-2) === '[]'
+        const shouldParseAllValues = options.all || key.slice(-2) === '[]'
 
-        if (!isParseAll) {
-          form[key] = value
+        if (!shouldParseAllValues) {
+          form[key] = value // override if same key
           return
         }
 
         form[key] ??= []
         if (Array.isArray(form[key])) {
-          ;(form[key] as (string | File)[]).push(value)
+          ;(form[key] as (string | File)[]).push(value) // append if same key
           return
         }
       })

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,9 +1,31 @@
 import type { HonoRequest } from '../request.ts'
 
-export type BodyData = Record<string, string | string[] | File>
+export type BodyData = Record<string, string | File | (string | File)[]>
+export type ParseBodyOptions = {
+  /**
+   * Parse all fields with multiple values should be parsed as an array.
+   * @default false
+   * @example
+   * ```ts
+   * const data = new FormData()
+   * data.append('file', 'aaa')
+   * data.append('file', 'bbb')
+   * ```
+   *
+   * If `all` is `false`:
+   * parseBody should return `{ file: 'bbb' }`
+   *
+   * If `all` is `true`:
+   * parseBody should return `{ file: ['aaa', 'bbb'] }`
+   */
+  all?: boolean
+}
 
 export const parseBody = async <T extends BodyData = BodyData>(
-  request: HonoRequest | Request
+  request: HonoRequest | Request,
+  options: ParseBodyOptions = {
+    all: false,
+  }
 ): Promise<T> => {
   let body: BodyData = {}
   const contentType = request.headers.get('Content-Type')
@@ -17,16 +39,17 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       formData.forEach((value, key) => {
-        if (key.slice(-2) === '[]') {
-          if (!form[key]) {
-            form[key] = [value.toString()]
-          } else {
-            if (Array.isArray(form[key])) {
-              ;(form[key] as string[]).push(value.toString())
-            }
-          }
-        } else {
+        const isParseAll = options.all || key.slice(-2) === '[]'
+
+        if (!isParseAll) {
           form[key] = value
+          return
+        }
+
+        form[key] ??= []
+        if (Array.isArray(form[key])) {
+          ;(form[key] as (string | File)[]).push(value)
+          return
         }
       })
       body = form

--- a/src/request.ts
+++ b/src/request.ts
@@ -10,7 +10,7 @@ import type {
   ValidationTargets,
 } from './types'
 import { parseBody } from './utils/body'
-import type { BodyData } from './utils/body'
+import type { BodyData, ParseBodyOptions } from './utils/body'
 import type { Cookie } from './utils/cookie'
 import { parse } from './utils/cookie'
 import type { UnionToIntersection } from './utils/types'
@@ -126,9 +126,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     }
   }
 
-  async parseBody<T extends BodyData = BodyData>(): Promise<T> {
+  async parseBody<T extends BodyData = BodyData>(options?: ParseBodyOptions): Promise<T> {
     if (this.bodyCache.parsedBody) return this.bodyCache.parsedBody as T
-    const parsedBody = await parseBody<T>(this)
+    const parsedBody = await parseBody<T>(this, options)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
   }

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -14,6 +14,34 @@ describe('Parse Body Util', () => {
     expect(await parseBody(req)).toEqual({ message: 'hello', 'multi[]': ['foo', 'bar'] })
   })
 
+  it('should not parse multiple values in default', async () => {
+    const data = new FormData()
+    data.append('file', 'aaa')
+    data.append('file', 'bbb')
+    const req = new Request('https://localhost/form', {
+      method: 'POST',
+      body: data,
+      // `Content-Type` header must not be set.
+    })
+    expect(await parseBody(req)).toEqual({
+      file: 'bbb',
+    })
+  })
+
+  it('should parse multiple values if `all` option is true', async () => {
+    const data = new FormData()
+    data.append('file', 'aaa')
+    data.append('file', 'bbb')
+    const req = new Request('https://localhost/form', {
+      method: 'POST',
+      body: data,
+      // `Content-Type` header must not be set.
+    })
+    expect(await parseBody(req, { all: true })).toEqual({
+      file: ['aaa', 'bbb'],
+    })
+  })
+
   it('should parse `x-www-form-urlencoded`', async () => {
     const searchParams = new URLSearchParams()
     searchParams.append('message', 'hello')

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -29,12 +29,14 @@ describe('Parse Body Util', () => {
     const data = new FormData()
     data.append('file', 'aaa')
     data.append('file', 'bbb')
+    data.append('message', 'hello')
     const req = new Request('https://localhost/form', {
       method: 'POST',
       body: data,
     })
     expect(await parseBody(req)).toEqual({
       file: 'bbb',
+      message: 'hello',
     })
   })
 
@@ -42,12 +44,14 @@ describe('Parse Body Util', () => {
     const data = new FormData()
     data.append('file', 'aaa')
     data.append('file', 'bbb')
+    data.append('message', 'hello')
     const req = new Request('https://localhost/form', {
       method: 'POST',
       body: data,
     })
     expect(await parseBody(req, { all: true })).toEqual({
       file: ['aaa', 'bbb'],
+      message: 'hello',
     })
   })
 
@@ -55,12 +59,14 @@ describe('Parse Body Util', () => {
     const data = new FormData()
     data.append('file[]', 'aaa')
     data.append('file[]', 'bbb')
+    data.append('message', 'hello')
     const req = new Request('https://localhost/form', {
       method: 'POST',
       body: data,
     })
     expect(await parseBody(req, { all: true })).toEqual({
       'file[]': ['aaa', 'bbb'],
+      message: 'hello',
     })
   })
 

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -4,42 +4,12 @@ describe('Parse Body Util', () => {
   it('should parse `multipart/form-data`', async () => {
     const data = new FormData()
     data.append('message', 'hello')
-    data.append('multi[]', 'foo')
-    data.append('multi[]', 'bar')
     const req = new Request('https://localhost/form', {
       method: 'POST',
       body: data,
       // `Content-Type` header must not be set.
     })
-    expect(await parseBody(req)).toEqual({ message: 'hello', 'multi[]': ['foo', 'bar'] })
-  })
-
-  it('should not parse multiple values in default', async () => {
-    const data = new FormData()
-    data.append('file', 'aaa')
-    data.append('file', 'bbb')
-    const req = new Request('https://localhost/form', {
-      method: 'POST',
-      body: data,
-      // `Content-Type` header must not be set.
-    })
-    expect(await parseBody(req)).toEqual({
-      file: 'bbb',
-    })
-  })
-
-  it('should parse multiple values if `all` option is true', async () => {
-    const data = new FormData()
-    data.append('file', 'aaa')
-    data.append('file', 'bbb')
-    const req = new Request('https://localhost/form', {
-      method: 'POST',
-      body: data,
-      // `Content-Type` header must not be set.
-    })
-    expect(await parseBody(req, { all: true })).toEqual({
-      file: ['aaa', 'bbb'],
-    })
+    expect(await parseBody(req)).toEqual({ message: 'hello' })
   })
 
   it('should parse `x-www-form-urlencoded`', async () => {
@@ -53,6 +23,45 @@ describe('Parse Body Util', () => {
       },
     })
     expect(await parseBody(req)).toEqual({ message: 'hello' })
+  })
+
+  it('should not parse multiple values in default', async () => {
+    const data = new FormData()
+    data.append('file', 'aaa')
+    data.append('file', 'bbb')
+    const req = new Request('https://localhost/form', {
+      method: 'POST',
+      body: data,
+    })
+    expect(await parseBody(req)).toEqual({
+      file: 'bbb',
+    })
+  })
+
+  it('should parse multiple values if `all` option is true', async () => {
+    const data = new FormData()
+    data.append('file', 'aaa')
+    data.append('file', 'bbb')
+    const req = new Request('https://localhost/form', {
+      method: 'POST',
+      body: data,
+    })
+    expect(await parseBody(req, { all: true })).toEqual({
+      file: ['aaa', 'bbb'],
+    })
+  })
+
+  it('should parse multiple values if key ends with `[]`', async () => {
+    const data = new FormData()
+    data.append('file[]', 'aaa')
+    data.append('file[]', 'bbb')
+    const req = new Request('https://localhost/form', {
+      method: 'POST',
+      body: data,
+    })
+    expect(await parseBody(req, { all: true })).toEqual({
+      'file[]': ['aaa', 'bbb'],
+    })
   })
 
   it('should return blank object if body is JSON', async () => {

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,9 +1,31 @@
 import type { HonoRequest } from '../request'
 
-export type BodyData = Record<string, string | string[] | File>
+export type BodyData = Record<string, string | File | (string | File)[]>
+export type ParseBodyOptions = {
+  /**
+   * Parse all fields with multiple values should be parsed as an array.
+   * @default false
+   * @example
+   * ```ts
+   * const data = new FormData()
+   * data.append('file', 'aaa')
+   * data.append('file', 'bbb')
+   * ```
+   *
+   * If `all` is `false`:
+   * parseBody should return `{ file: 'bbb' }`
+   *
+   * If `all` is `true`:
+   * parseBody should return `{ file: ['aaa', 'bbb'] }`
+   */
+  all?: boolean
+}
 
 export const parseBody = async <T extends BodyData = BodyData>(
-  request: HonoRequest | Request
+  request: HonoRequest | Request,
+  options: ParseBodyOptions = {
+    all: false,
+  }
 ): Promise<T> => {
   let body: BodyData = {}
   const contentType = request.headers.get('Content-Type')
@@ -17,16 +39,17 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       formData.forEach((value, key) => {
-        if (key.slice(-2) === '[]') {
-          if (!form[key]) {
-            form[key] = [value.toString()]
-          } else {
-            if (Array.isArray(form[key])) {
-              ;(form[key] as string[]).push(value.toString())
-            }
-          }
-        } else {
+        const isParseAll = options.all || key.slice(-2) === '[]'
+
+        if (!isParseAll) {
           form[key] = value
+          return
+        }
+
+        form[key] ??= []
+        if (Array.isArray(form[key])) {
+          ;(form[key] as (string | File)[]).push(value)
+          return
         }
       })
       body = form

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -39,16 +39,16 @@ export const parseBody = async <T extends BodyData = BodyData>(
     if (formData) {
       const form: BodyData = {}
       formData.forEach((value, key) => {
-        const isParseAll = options.all || key.slice(-2) === '[]'
+        const shouldParseAllValues = options.all || key.slice(-2) === '[]'
 
-        if (!isParseAll) {
-          form[key] = value
+        if (!shouldParseAllValues) {
+          form[key] = value // override if same key
           return
         }
 
         form[key] ??= []
         if (Array.isArray(form[key])) {
-          ;(form[key] as (string | File)[]).push(value)
+          ;(form[key] as (string | File)[]).push(value) // append if same key
           return
         }
       })


### PR DESCRIPTION
### Author should do the followings, if applicable

Hi @yusukebe 
This is an implemention of the suggesion in #1018
As you mention, this changes have backward compatible.

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
