### PR TITLE
fix(jsx): render a child or odd children with `Fragment` correctly

### DIFF
--- a/deno_dist/jsx/index.test.tsx
+++ b/deno_dist/jsx/index.test.tsx
@@ -403,6 +403,24 @@ describe('Fragment', () => {
     expect(template.toString()).toBe('<p>1</p><p>2</p>')
   })
 
+  it('Should render a child', () => {
+    const template = (
+      <>
+        <p>1</p>
+      </>
+    )
+    expect(template.toString()).toBe('<p>1</p>')
+  })
+
+  it('Should render a child - with `Fragment`', () => {
+    const template = (
+      <Fragment>
+        <p>1</p>
+      </Fragment>
+    )
+    expect(template.toString()).toBe('<p>1</p>')
+  })
+
   it('Should render nothing for empty Fragment', () => {
     const template = <></>
     expect(template.toString()).toBe('')

--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -235,6 +235,9 @@ export const memo = <T>(
   }) as FC<T>
 }
 
-export const Fragment = (props: { key?: string; children?: Child[] }): HtmlEscapedString => {
-  return new JSXFragmentNode('', {}, props.children || []) as never
+export const Fragment = (props: {
+  key?: string
+  children?: Child | HtmlEscapedString
+}): HtmlEscapedString => {
+  return new JSXFragmentNode('', {}, props.children ? [props.children] : []) as never
 }

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -403,6 +403,24 @@ describe('Fragment', () => {
     expect(template.toString()).toBe('<p>1</p><p>2</p>')
   })
 
+  it('Should render a child', () => {
+    const template = (
+      <>
+        <p>1</p>
+      </>
+    )
+    expect(template.toString()).toBe('<p>1</p>')
+  })
+
+  it('Should render a child - with `Fragment`', () => {
+    const template = (
+      <Fragment>
+        <p>1</p>
+      </Fragment>
+    )
+    expect(template.toString()).toBe('<p>1</p>')
+  })
+
   it('Should render nothing for empty Fragment', () => {
     const template = <></>
     expect(template.toString()).toBe('')

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -235,6 +235,9 @@ export const memo = <T>(
   }) as FC<T>
 }
 
-export const Fragment = (props: { key?: string; children?: Child[] }): HtmlEscapedString => {
-  return new JSXFragmentNode('', {}, props.children || []) as never
+export const Fragment = (props: {
+  key?: string
+  children?: Child | HtmlEscapedString
+}): HtmlEscapedString => {
+  return new JSXFragmentNode('', {}, props.children ? [props.children] : []) as never
 }


### PR DESCRIPTION
Fixes #1539

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
