### PR TITLE
fix(types): don't use webworker types

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,9 +1,6 @@
-/// <reference lib="es2022" />
-/// <reference lib="webworker" />
-// We need these triple slashes to correctly refer to `FetchEvent` in Deno.
-
 import type { HonoRequest } from './request.ts'
 import type { Env, NotFoundHandler, Input, TypedResponse } from './types.ts'
+import { FetchEvent } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -592,3 +592,5 @@ export abstract class FetchEventLike {
   abstract passThroughOnException(): void
   abstract waitUntil(promise: Promise<void>): void
 }
+
+export abstract class FetchEvent extends FetchEventLike {}

--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -1,6 +1,7 @@
 // @denoify-ignore
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Hono } from '../../hono'
+import type { FetchEvent } from '../../types'
 
 export const handle = (app: Hono<any, any, any>) => (req: Request, requestContext: FetchEvent) => {
   return app.fetch(req, {}, requestContext as any)

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,9 +1,6 @@
-/// <reference lib="es2022" />
-/// <reference lib="webworker" />
-// We need these triple slashes to correctly refer to `FetchEvent` in Deno.
-
 import type { HonoRequest } from './request'
 import type { Env, NotFoundHandler, Input, TypedResponse } from './types'
+import { FetchEvent } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,3 +592,5 @@ export abstract class FetchEventLike {
   abstract passThroughOnException(): void
   abstract waitUntil(promise: Promise<void>): void
 }
+
+export abstract class FetchEvent extends FetchEventLike {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,6 @@
     "skipLibCheck": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "lib": [
-      "ES2022",
-      "WebWorker"
-    ],
     "types": [
       "jest",
       "node"


### PR DESCRIPTION
Fixes #1546 #1547

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
