### PR TITLE
fix: return status 500 when using validator 'form'

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -51,7 +51,7 @@ export const validator = <
       case 'json':
         try {
           const contentType = c.req.header('Content-Type')
-          if (!contentType || !/application\/json/.test(contentType)) {
+          if (!contentType || !contentType.startsWith('application/json')) {
             throw new Error(`Invalid HTTP header: Content-Type=${contentType}`)
           }
           /**

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -70,17 +70,29 @@ export const validator = <
         }
         break
       case 'form': {
-        const contentType = c.req.header('Content-Type')
-        if (contentType) {
-          const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
-          const formData = await bufferToFormData(arrayBuffer, contentType)
-          const form: BodyData = {}
-          formData.forEach((value, key) => {
-            form[key] = value
-          })
-          value = form
-          c.req.bodyCache.formData = formData
-          c.req.bodyCache.arrayBuffer = arrayBuffer
+        try {
+          const contentType = c.req.header('Content-Type')
+          if (contentType) {
+            const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
+            const formData = await bufferToFormData(arrayBuffer, contentType)
+            const form: BodyData = {}
+            formData.forEach((value, key) => {
+              form[key] = value
+            })
+            value = form
+            c.req.bodyCache.formData = formData
+            c.req.bodyCache.arrayBuffer = arrayBuffer
+          }
+        } catch (e) {
+          let message = 'Malformed FormData request.'
+          message += e instanceof Error ? ` ${e.message}` : ` ${String(e)}`
+          return c.json(
+            {
+              success: false,
+              message,
+            },
+            400
+          )
         }
         break
       }

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -50,6 +50,10 @@ export const validator = <
     switch (target) {
       case 'json':
         try {
+          const contentType = c.req.header('Content-Type')
+          if (!contentType || !/application\/json/.test(contentType)) {
+            throw new Error(`Invalid HTTP header: Content-Type=${contentType}`)
+          }
           /**
            * Get the arrayBuffer first, create JSON object via Response,
            * and cache the arrayBuffer in the c.req.bodyCache.

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -94,6 +94,45 @@ describe('Malformed JSON', () => {
   })
 })
 
+describe('Malformed FormData request', () => {
+  const app = new Hono()
+  app.post(
+    '/post',
+    validator('form', (value, c) => ({})),
+    (c) => {
+      return c.text('Valid!')
+    }
+  )
+
+  it('Should return 400 response, for unsupported content type header', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      body: 'hi',
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({
+      success: false,
+      message:
+        'Malformed FormData request. Response.formData: Could not parse content as FormData.',
+    })
+  })
+
+  it('Should return 400 response, for malformed content type header', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      body: 'hi',
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({
+      success: false,
+      message: 'Malformed FormData request. Error: Multipart: Boundary not found',
+    })
+  })
+})
+
 describe('Validator middleware with a custom validation function', () => {
   const app = new Hono()
 

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -92,6 +92,19 @@ describe('Malformed JSON', () => {
     })
     expect(res.status).toBe(400)
   })
+
+  it('Should return 400 response, for request with wrong Content-Type header', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain;charset=utf-8',
+      },
+      body: JSON.stringify({
+        any: 'thing',
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('Malformed FormData request', () => {
@@ -176,6 +189,9 @@ describe('Validator middleware with a custom validation function', () => {
   it('Should validate JSON with transformation and return 200 response', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         id: '123',
       }),
@@ -235,6 +251,9 @@ describe('Validator middleware with Zod validates JSON', () => {
   it('Should validate JSON and return 200 response', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         id: 123,
         title: 'Hello',
@@ -252,6 +271,9 @@ describe('Validator middleware with Zod validates JSON', () => {
   it('Should validate JSON and return 400 response', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         id: '123',
         title: 'Hello',
@@ -714,6 +736,9 @@ describe('Clone Request object', () => {
     it('Should not throw the error with c.req.json()', async () => {
       const req = new Request('http://localhost', {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ foo: 'bar' }),
       })
       const res = await app.request(req)

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -105,6 +105,19 @@ describe('Malformed JSON', () => {
     })
     expect(res.status).toBe(400)
   })
+
+  it('Should return 400 response, if Content-Type header does not start with application/json', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'Xapplication/json',
+      },
+      body: JSON.stringify({
+        any: 'thing',
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('Malformed FormData request', () => {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -51,7 +51,7 @@ export const validator = <
       case 'json':
         try {
           const contentType = c.req.header('Content-Type')
-          if (!contentType || !/application\/json/.test(contentType)) {
+          if (!contentType || !contentType.startsWith('application/json')) {
             throw new Error(`Invalid HTTP header: Content-Type=${contentType}`)
           }
           /**

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -70,17 +70,29 @@ export const validator = <
         }
         break
       case 'form': {
-        const contentType = c.req.header('Content-Type')
-        if (contentType) {
-          const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
-          const formData = await bufferToFormData(arrayBuffer, contentType)
-          const form: BodyData = {}
-          formData.forEach((value, key) => {
-            form[key] = value
-          })
-          value = form
-          c.req.bodyCache.formData = formData
-          c.req.bodyCache.arrayBuffer = arrayBuffer
+        try {
+          const contentType = c.req.header('Content-Type')
+          if (contentType) {
+            const arrayBuffer = c.req.bodyCache.arrayBuffer ?? (await c.req.raw.arrayBuffer())
+            const formData = await bufferToFormData(arrayBuffer, contentType)
+            const form: BodyData = {}
+            formData.forEach((value, key) => {
+              form[key] = value
+            })
+            value = form
+            c.req.bodyCache.formData = formData
+            c.req.bodyCache.arrayBuffer = arrayBuffer
+          }
+        } catch (e) {
+          let message = 'Malformed FormData request.'
+          message += e instanceof Error ? ` ${e.message}` : ` ${String(e)}`
+          return c.json(
+            {
+              success: false,
+              message,
+            },
+            400
+          )
         }
         break
       }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -50,6 +50,10 @@ export const validator = <
     switch (target) {
       case 'json':
         try {
+          const contentType = c.req.header('Content-Type')
+          if (!contentType || !/application\/json/.test(contentType)) {
+            throw new Error(`Invalid HTTP header: Content-Type=${contentType}`)
+          }
           /**
            * Get the arrayBuffer first, create JSON object via Response,
            * and cache the arrayBuffer in the c.req.bodyCache.


### PR DESCRIPTION
When using `validator('form', ...)` hono is returning a 500 status when receiving a POST request with a JSON in request body, instead of a bad request 400, .

This is happenning due to a unhandled error in an
underlying library (@miniflare).
https://github.com/cloudflare/miniflare/pull/711

The code changes in this PR are responsible to prepare the code to handle possible TypeError that can be thrown in the future, by the lib doing the FormData parsing, as per, https://fetch.spec.whatwg.org/#dom-body-formdata.

This PR should wait for bugfix on @miniflare.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests (don't have deno to perform `yarn test:all`
- [x] `yarn denoify` to generate files for Deno
