### PR TITLE
feat(reg-exp-router): Improve capture group support.

### DIFF
--- a/deno_dist/router/reg-exp-router/node.ts
+++ b/deno_dist/router/reg-exp-router/node.ts
@@ -77,7 +77,14 @@ export class Node {
     let node
     if (pattern) {
       const name = pattern[1]
-      const regexpStr = pattern[2] || LABEL_REG_EXP_STR
+      let regexpStr = pattern[2] || LABEL_REG_EXP_STR
+      if (name && pattern[2]) {
+        regexpStr = regexpStr.replace(/^\((?!\?:)(?=[^)]+\)$)/, '(?:') // (a|b) => (?:a|b)
+        if (/\((?!\?:)/.test(regexpStr)) {
+          // prefix(?:a|b) is allowed, but prefix(a|b) is not
+          throw PATH_ERROR
+        }
+      }
 
       node = this.children[regexpStr]
       if (!node) {

--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -77,7 +77,14 @@ export class Node {
     let node
     if (pattern) {
       const name = pattern[1]
-      const regexpStr = pattern[2] || LABEL_REG_EXP_STR
+      let regexpStr = pattern[2] || LABEL_REG_EXP_STR
+      if (name && pattern[2]) {
+        regexpStr = regexpStr.replace(/^\((?!\?:)(?=[^)]+\)$)/, '(?:') // (a|b) => (?:a|b)
+        if (/\((?!\?:)/.test(regexpStr)) {
+          // prefix(?:a|b) is allowed, but prefix(a|b) is not
+          throw PATH_ERROR
+        }
+      }
 
       node = this.children[regexpStr]
       if (!node) {

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -503,3 +503,84 @@ describe('Routing with a hostname', () => {
     expect(res).toBeNull()
   })
 })
+
+describe('Capture Group', () => {
+  describe('Simple capturing group', () => {
+    const router = new RegExpRouter<string>()
+    router.add('get', '/foo/:capture{(bar|baz)}', 'ok')
+    it('GET /foo/bar', () => {
+      const res = router.match('get', '/foo/bar')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['ok'])
+      expect(res?.params).toEqual({ capture: 'bar' })
+    })
+
+    it('GET /foo/baz', () => {
+      const res = router.match('get', '/foo/baz')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['ok'])
+      expect(res?.params).toEqual({ capture: 'baz' })
+    })
+
+    it('GET /foo/qux', () => {
+      const res = router.match('get', '/foo/qux')
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('Non-capturing group', () => {
+    const router = new RegExpRouter<string>()
+    router.add('get', '/foo/:capture{(?:bar|baz)}', 'ok')
+    it('GET /foo/bar', () => {
+      const res = router.match('get', '/foo/bar')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['ok'])
+      expect(res?.params).toEqual({ capture: 'bar' })
+    })
+
+    it('GET /foo/baz', () => {
+      const res = router.match('get', '/foo/baz')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['ok'])
+      expect(res?.params).toEqual({ capture: 'baz' })
+    })
+
+    it('GET /foo/qux', () => {
+      const res = router.match('get', '/foo/qux')
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('Non-capturing group with prefix', () => {
+    const router = new RegExpRouter<string>()
+    router.add('get', '/foo/:capture{ba(?:r|z)}', 'ok')
+    it('GET /foo/bar', () => {
+      const res = router.match('get', '/foo/bar')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['ok'])
+      expect(res?.params).toEqual({ capture: 'bar' })
+    })
+
+    it('GET /foo/baz', () => {
+      const res = router.match('get', '/foo/baz')
+      expect(res).not.toBeNull()
+      expect(res?.handlers).toEqual(['ok'])
+      expect(res?.params).toEqual({ capture: 'baz' })
+    })
+
+    it('GET /foo/qux', () => {
+      const res = router.match('get', '/foo/qux')
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('Complex capturing group', () => {
+    const router = new RegExpRouter<string>()
+    router.add('get', '/foo/:capture{ba(r|z)}', 'ok')
+    it('GET request', () => {
+      expect(() => {
+        router.match('GET', '/foo/bar')
+      }).toThrowError(UnsupportedPathError)
+    })
+  })
+})


### PR DESCRIPTION
### What will this PR improve?

* `(a|b)` => Automatically converted to non-capturing group and no longer an error in RegExpRouter. 🆕 
* `(?:a|b)` => If you already explicitly use non-capturing groups, it works without error. (Backward compatible)
* `prefix(a|b)` => Throw `UnsupportedPathError`. 🆕 

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
