### PR TITLE
feat(app): `basePath` option for the constructor, deprecate `app.basePath()`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -21,7 +21,6 @@ import type {
   FetchEventLike,
   Schema,
 } from './types.ts'
-import type { RemoveBlankRecord } from './utils/types.ts'
 import { getPath, getPathNoStrict, getQueryStrings, mergePath } from './utils/url.ts'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -68,12 +67,14 @@ class Hono<
   */
   router!: Router<H>
   readonly getPath: (request: Request, options?: { env?: E['Bindings'] }) => string
-  private _basePath: string = '/'
+  #basePath: string
   private path: string = '/'
 
   routes: RouterRoute[] = []
 
-  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean; basePath: BasePath }> = {}
+  ) {
     super()
 
     // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
@@ -123,6 +124,7 @@ class Hono<
     const strict = init.strict ?? true
     delete init.strict
     Object.assign(this, init)
+    this.#basePath = init.basePath ?? '/'
     this.getPath = strict ? init.getPath ?? getPath : getPathNoStrict
   }
 
@@ -145,24 +147,10 @@ class Hono<
     SubBasePath extends string
   >(
     path: SubPath,
-    app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath>
-  /** @description
-   * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
-   * The use of `route` with **one** argument has been removed in v4.
-   * However, you can still use `route` with **two** arguments, like `app.route('/api', subApp)`."
-   */
-  route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
-  route<
-    SubPath extends string,
-    SubEnv extends Env,
-    SubSchema extends Schema,
-    SubBasePath extends string
-  >(
-    path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
   ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
-    const subApp = this.basePath(path)
+    const subApp = this.clone()
+    subApp.#basePath = mergePath(this.#basePath, path)
 
     if (!app) {
       return subApp
@@ -179,9 +167,14 @@ class Hono<
     return this
   }
 
+  /**
+   * @deprecated
+   * `app.basePath()` will be removed in the v4.
+   * Use `new Hono({ basePath: '/api' })` instead of `new Hono().basePath('/api')`.
+   */
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp._basePath = mergePath(this._basePath, path)
+    subApp.#basePath = mergePath(this.#basePath, path)
     return subApp
   }
 
@@ -215,7 +208,7 @@ class Hono<
     applicationHandler: (request: Request, ...args: any) => Response | Promise<Response>,
     optionHandler?: (c: Context) => unknown
   ): Hono<E, S, BasePath> {
-    const mergedPath = mergePath(this._basePath, path)
+    const mergedPath = mergePath(this.#basePath, path)
     const pathPrefixLength = mergedPath === '/' ? 0 : mergedPath.length
 
     const handler: MiddlewareHandler = async (c, next) => {
@@ -249,7 +242,7 @@ class Hono<
   }
 
   /**
-   * @deprecate
+   * @deprecated
    * `app.head()` is no longer used.
    * `app.get()` implicitly handles the HEAD method.
    */
@@ -260,9 +253,7 @@ class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    if (this._basePath) {
-      path = mergePath(this._basePath, path)
-    }
+    path = mergePath(this.#basePath, path)
     this.router.add(method, path, handler)
     const r: RouterRoute = { path: path, method: method, handler: handler }
     this.routes.push(r)
@@ -358,7 +349,7 @@ class Hono<
 
   /**
    * @deprecated
-   * `app.handleEvent()` will be removed in v4.
+   * `app.handleEvent()` will be removed in the v4.
    * Use `app.fetch()` instead of `app.handleEvent()`.
    */
   handleEvent = (event: FetchEventLike) => {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -1,4 +1,5 @@
 import { HonoBase } from './hono-base.ts'
+import type { HonoOptions } from './hono-base.ts'
 import { RegExpRouter } from './router/reg-exp-router/index.ts'
 import { SmartRouter } from './router/smart-router/index.ts'
 import { TrieRouter } from './router/trie-router/index.ts'
@@ -9,14 +10,10 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(
-    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
-      basePath?: BasePath
-    } = {}
-  ) {
-    super(init)
+  constructor(options: HonoOptions<E, BasePath> = {}) {
+    super(options)
     this.router =
-      init.router ??
+      options.router ??
       new SmartRouter({
         routers: [new RegExpRouter(), new TrieRouter()],
       })

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -9,7 +9,11 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
+      basePath?: BasePath
+    } = {}
+  ) {
     super(init)
     this.router =
       init.router ??

--- a/deno_dist/preset/quick.ts
+++ b/deno_dist/preset/quick.ts
@@ -9,7 +9,11 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
+      basePath?: BasePath
+    } = {}
+  ) {
     super(init)
     this.router = new SmartRouter({
       routers: [new LinearRouter(), new TrieRouter()],

--- a/deno_dist/preset/quick.ts
+++ b/deno_dist/preset/quick.ts
@@ -1,4 +1,5 @@
 import { HonoBase } from '../hono-base.ts'
+import type { HonoOptions } from '../hono-base.ts'
 import { LinearRouter } from '../router/linear-router/index.ts'
 import { SmartRouter } from '../router/smart-router/index.ts'
 import { TrieRouter } from '../router/trie-router/index.ts'
@@ -9,12 +10,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(
-    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
-      basePath?: BasePath
-    } = {}
-  ) {
-    super(init)
+  constructor(options: HonoOptions<E, BasePath> = {}) {
+    super(options)
     this.router = new SmartRouter({
       routers: [new LinearRouter(), new TrieRouter()],
     })

--- a/deno_dist/preset/tiny.ts
+++ b/deno_dist/preset/tiny.ts
@@ -1,4 +1,5 @@
 import { HonoBase } from '../hono-base.ts'
+import type { HonoOptions } from '../hono-base.ts'
 import { PatternRouter } from '../router/pattern-router/index.ts'
 import type { Env, Schema } from '../types.ts'
 
@@ -7,12 +8,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(
-    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
-      basePath?: BasePath
-    } = {}
-  ) {
-    super(init)
+  constructor(options: HonoOptions<E, BasePath> = {}) {
+    super(options)
     this.router = new PatternRouter()
   }
 }

--- a/deno_dist/preset/tiny.ts
+++ b/deno_dist/preset/tiny.ts
@@ -7,7 +7,11 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
+      basePath?: BasePath
+    } = {}
+  ) {
     super(init)
     this.router = new PatternRouter()
   }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -21,7 +21,6 @@ import type {
   FetchEventLike,
   Schema,
 } from './types'
-import type { RemoveBlankRecord } from './utils/types'
 import { getPath, getPathNoStrict, getQueryStrings, mergePath } from './utils/url'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -68,12 +67,14 @@ class Hono<
   */
   router!: Router<H>
   readonly getPath: (request: Request, options?: { env?: E['Bindings'] }) => string
-  private _basePath: string = '/'
+  #basePath: string
   private path: string = '/'
 
   routes: RouterRoute[] = []
 
-  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean; basePath: BasePath }> = {}
+  ) {
     super()
 
     // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
@@ -123,6 +124,7 @@ class Hono<
     const strict = init.strict ?? true
     delete init.strict
     Object.assign(this, init)
+    this.#basePath = init.basePath ?? '/'
     this.getPath = strict ? init.getPath ?? getPath : getPathNoStrict
   }
 
@@ -145,24 +147,10 @@ class Hono<
     SubBasePath extends string
   >(
     path: SubPath,
-    app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath>
-  /** @description
-   * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
-   * The use of `route` with **one** argument has been removed in v4.
-   * However, you can still use `route` with **two** arguments, like `app.route('/api', subApp)`."
-   */
-  route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
-  route<
-    SubPath extends string,
-    SubEnv extends Env,
-    SubSchema extends Schema,
-    SubBasePath extends string
-  >(
-    path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
   ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
-    const subApp = this.basePath(path)
+    const subApp = this.clone()
+    subApp.#basePath = mergePath(this.#basePath, path)
 
     if (!app) {
       return subApp
@@ -179,9 +167,14 @@ class Hono<
     return this
   }
 
+  /**
+   * @deprecated
+   * `app.basePath()` will be removed in the v4.
+   * Use `new Hono({ basePath: '/api' })` instead of `new Hono().basePath('/api')`.
+   */
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp._basePath = mergePath(this._basePath, path)
+    subApp.#basePath = mergePath(this.#basePath, path)
     return subApp
   }
 
@@ -215,7 +208,7 @@ class Hono<
     applicationHandler: (request: Request, ...args: any) => Response | Promise<Response>,
     optionHandler?: (c: Context) => unknown
   ): Hono<E, S, BasePath> {
-    const mergedPath = mergePath(this._basePath, path)
+    const mergedPath = mergePath(this.#basePath, path)
     const pathPrefixLength = mergedPath === '/' ? 0 : mergedPath.length
 
     const handler: MiddlewareHandler = async (c, next) => {
@@ -249,7 +242,7 @@ class Hono<
   }
 
   /**
-   * @deprecate
+   * @deprecated
    * `app.head()` is no longer used.
    * `app.get()` implicitly handles the HEAD method.
    */
@@ -260,9 +253,7 @@ class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    if (this._basePath) {
-      path = mergePath(this._basePath, path)
-    }
+    path = mergePath(this.#basePath, path)
     this.router.add(method, path, handler)
     const r: RouterRoute = { path: path, method: method, handler: handler }
     this.routes.push(r)
@@ -358,7 +349,7 @@ class Hono<
 
   /**
    * @deprecated
-   * `app.handleEvent()` will be removed in v4.
+   * `app.handleEvent()` will be removed in the v4.
    * Use `app.fetch()` instead of `app.handleEvent()`.
    */
   handleEvent = (event: FetchEventLike) => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -111,7 +111,26 @@ describe('Register handlers without a path', () => {
     })
   })
 
-  describe('With specifying basePath', () => {
+  describe('With specifying a basePath option', () => {
+    const app = new Hono({ basePath: '/about' })
+
+    app.get((c) => {
+      return c.text('About')
+    })
+
+    it('GET http://localhost/about is ok', async () => {
+      const res = await app.request('/about')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('About')
+    })
+
+    it('GET http://localhost/ is not found', async () => {
+      const res = await app.request('/')
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('With specifying app.basePath() - deprecated', () => {
     const app = new Hono().basePath('/about')
 
     app.get((c) => {
@@ -271,21 +290,24 @@ describe('Routing', () => {
   })
 
   it('Nested route', async () => {
-    const app = new Hono()
-
-    const book = app.basePath('/book')
+    const book = new Hono({ basePath: '/book' })
     book.get('/', (c) => c.text('get /book'))
     book.get('/:id', (c) => {
       return c.text('get /book/' + c.req.param('id'))
     })
     book.post('/', (c) => c.text('post /book'))
 
-    const user = app.basePath('/user')
+    const user = new Hono({ basePath: '/user' })
     user.get('/login', (c) => c.text('get /user/login'))
     user.post('/register', (c) => c.text('post /user/register'))
 
-    const appForEachUser = user.basePath(':id')
+    const appForEachUser = new Hono({ basePath: ':id' })
     appForEachUser.get('/profile', (c) => c.text('get /user/' + c.req.param('id') + '/profile'))
+    user.route('/', appForEachUser)
+
+    const app = new Hono()
+    app.route('/', book)
+    app.route('/', user)
 
     app.get('/add-path-after-route-call', (c) => c.text('get /add-path-after-route-call'))
 
@@ -1329,7 +1351,24 @@ describe('Hono with `app.route`', () => {
       })
     })
 
-    describe('With app.get(...handler) and app.basePath()', () => {
+    describe('With app.get(...handler) and a basePath option', () => {
+      const about = new Hono({ basePath: '/about' })
+      about.get((c) => c.text('me'))
+      app.route('/', about)
+
+      it('Should return 200 response - /about', async () => {
+        const res = await app.request('/about')
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe('me')
+      })
+
+      test('Should return 404 response /about/foo', async () => {
+        const res = await app.request('/about/foo')
+        expect(res.status).toBe(404)
+      })
+    })
+
+    describe('With app.get(...handler) and app.basePath() - deprecated', () => {
       const app = new Hono()
       const about = new Hono().basePath('/about')
       about.get((c) => c.text('me'))
@@ -2186,7 +2225,7 @@ describe('app.mount()', () => {
     })
     app.mount('/another-app2/sub-slash/', anotherApp)
 
-    const api = new Hono().basePath('/api')
+    const api = new Hono({ basePath: '/api' })
     api.mount('/another-app', anotherApp)
 
     it('Should return responses from Hono app', async () => {
@@ -2239,7 +2278,7 @@ describe('app.mount()', () => {
       expect(await res.text()).toBe('AnotherApp')
     })
 
-    it('Should return responses from AnotherApp - with `basePath()`', async () => {
+    it('Should return responses from AnotherApp - with a `basePath` option', async () => {
       const res = await api.request('/api/another-app')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('AnotherApp')

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,4 +1,5 @@
 import { HonoBase } from './hono-base'
+import type { HonoOptions } from './hono-base'
 import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { TrieRouter } from './router/trie-router'
@@ -9,14 +10,10 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(
-    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
-      basePath?: BasePath
-    } = {}
-  ) {
-    super(init)
+  constructor(options: HonoOptions<E, BasePath> = {}) {
+    super(options)
     this.router =
-      init.router ??
+      options.router ??
       new SmartRouter({
         routers: [new RegExpRouter(), new TrieRouter()],
       })

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -9,7 +9,11 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
+      basePath?: BasePath
+    } = {}
+  ) {
     super(init)
     this.router =
       init.router ??

--- a/src/preset/quick.ts
+++ b/src/preset/quick.ts
@@ -1,4 +1,5 @@
 import { HonoBase } from '../hono-base'
+import type { HonoOptions } from '../hono-base'
 import { LinearRouter } from '../router/linear-router'
 import { SmartRouter } from '../router/smart-router'
 import { TrieRouter } from '../router/trie-router'
@@ -9,12 +10,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(
-    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
-      basePath?: BasePath
-    } = {}
-  ) {
-    super(init)
+  constructor(options: HonoOptions<E, BasePath> = {}) {
+    super(options)
     this.router = new SmartRouter({
       routers: [new LinearRouter(), new TrieRouter()],
     })

--- a/src/preset/quick.ts
+++ b/src/preset/quick.ts
@@ -9,7 +9,11 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
+      basePath?: BasePath
+    } = {}
+  ) {
     super(init)
     this.router = new SmartRouter({
       routers: [new LinearRouter(), new TrieRouter()],

--- a/src/preset/tiny.ts
+++ b/src/preset/tiny.ts
@@ -7,7 +7,11 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+  constructor(
+    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
+      basePath?: BasePath
+    } = {}
+  ) {
     super(init)
     this.router = new PatternRouter()
   }

--- a/src/preset/tiny.ts
+++ b/src/preset/tiny.ts
@@ -1,4 +1,5 @@
 import { HonoBase } from '../hono-base'
+import type { HonoOptions } from '../hono-base'
 import { PatternRouter } from '../router/pattern-router'
 import type { Env, Schema } from '../types'
 
@@ -7,12 +8,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(
-    init: Exclude<ConstructorParameters<typeof HonoBase>[0], 'basePath'> & {
-      basePath?: BasePath
-    } = {}
-  ) {
-    super(init)
+  constructor(options: HonoOptions<E, BasePath> = {}) {
+    super(options)
     this.router = new PatternRouter()
   }
 }


### PR DESCRIPTION
* Create `basePath` option for the constructor of `Hono`.
* Deprecate `app.basePath()`.

You can specify the base-path like the following:

```ts
const app = new Hono({ basePath: '/api' })
```


Resolves #1531

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
