### PR TITLE
perf(hono-base): use `instanceOf`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -313,13 +313,13 @@ class Hono<
         return this.handleError(err, c)
       }
 
-      if (res.constructor.name === 'Response') return res as Response
+      if (res instanceof Response) return res
 
       if ('response' in res) {
         res = res.response
       }
 
-      if (res.constructor.name === 'Response') return res as Response
+      if (res instanceof Response) return res
 
       return (async () => {
         let awaited: Response | TypedResponse | void

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -313,13 +313,13 @@ class Hono<
         return this.handleError(err, c)
       }
 
-      if (res.constructor.name === 'Response') return res as Response
+      if (res instanceof Response) return res
 
       if ('response' in res) {
         res = res.response
       }
 
-      if (res.constructor.name === 'Response') return res as Response
+      if (res instanceof Response) return res
 
       return (async () => {
         let awaited: Response | TypedResponse | void


### PR DESCRIPTION
Since #1311, it uses `res.constructor.name === 'Response'` instead of `res instanceof Response`. However, on Node.js, this change results in a significant performance decrease. Therefore, it should be rolled back.

<img width="587" alt="Screenshot 2023-10-12 at 17 36 16" src="https://github.com/honojs/hono/assets/10682/37399211-32a8-4433-a717-518c4b4b2bad">

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
