### PR TITLE
test: fix the sleep time for SSE

### DIFF
--- a/src/helper/streaming/index.test.ts
+++ b/src/helper/streaming/index.test.ts
@@ -12,7 +12,7 @@ describe('SSE Streaming headers', () => {
         while (id < maxIterations) {
           const message = `It is ${id}`
           await stream.writeSSE({ data: message, event: 'time-update', id: String(id++) })
-          await stream.sleep(1000)
+          await stream.sleep(100)
         }
       })
     })


### PR DESCRIPTION
We don't need the much time.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
