### PR TITLE
Revert "feat(app): `basePath` option for the constructor, deprecate `app.basePath()` (#1560)"

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -21,6 +21,7 @@ import type {
   FetchEventLike,
   Schema,
 } from './types.ts'
+import type { RemoveBlankRecord } from './utils/types.ts'
 import { getPath, getPathNoStrict, getQueryStrings, mergePath } from './utils/url.ts'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -56,15 +57,6 @@ const errorHandler = (err: Error, c: Context) => {
   return c.text(message, 500)
 }
 
-type GetPath<E extends Env> = (request: Request, options?: { env?: E['Bindings'] }) => string
-
-export type HonoOptions<E extends Env, BasePath extends string> = {
-  strict?: boolean
-  basePath?: BasePath
-  router?: Router<H>
-  getPath?: GetPath<E>
-}
-
 class Hono<
   E extends Env = Env,
   S extends Schema = {},
@@ -75,13 +67,13 @@ class Hono<
     To use it, inherit the class and implement router in the constructor.
   */
   router!: Router<H>
-  readonly getPath: GetPath<E>
-  #basePath: string
+  readonly getPath: (request: Request, options?: { env?: E['Bindings'] }) => string
+  private _basePath: string = '/'
   private path: string = '/'
 
   routes: RouterRoute[] = []
 
-  constructor(options: HonoOptions<E, BasePath> = {}) {
+  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
     super()
 
     // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
@@ -128,11 +120,10 @@ class Hono<
       return this
     }
 
-    const strict = options.strict ?? true
-    delete options.strict
-    Object.assign(this, options)
-    this.#basePath = options.basePath ?? '/'
-    this.getPath = strict ? options.getPath ?? getPath : getPathNoStrict
+    const strict = init.strict ?? true
+    delete init.strict
+    Object.assign(this, init)
+    this.getPath = strict ? init.getPath ?? getPath : getPathNoStrict
   }
 
   private clone(): Hono<E, S, BasePath> {
@@ -154,10 +145,24 @@ class Hono<
     SubBasePath extends string
   >(
     path: SubPath,
+    app: Hono<SubEnv, SubSchema, SubBasePath>
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath>
+  /** @description
+   * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
+   * The use of `route` with **one** argument has been removed in v4.
+   * However, you can still use `route` with **two** arguments, like `app.route('/api', subApp)`."
+   */
+  route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
+  route<
+    SubPath extends string,
+    SubEnv extends Env,
+    SubSchema extends Schema,
+    SubBasePath extends string
+  >(
+    path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
   ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
-    const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    const subApp = this.basePath(path)
 
     if (!app) {
       return subApp
@@ -174,14 +179,9 @@ class Hono<
     return this
   }
 
-  /**
-   * @deprecated
-   * `app.basePath()` will be removed in the v4.
-   * Use `new Hono({ basePath: '/api' })` instead of `new Hono().basePath('/api')`.
-   */
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    subApp._basePath = mergePath(this._basePath, path)
     return subApp
   }
 
@@ -215,7 +215,7 @@ class Hono<
     applicationHandler: (request: Request, ...args: any) => Response | Promise<Response>,
     optionHandler?: (c: Context) => unknown
   ): Hono<E, S, BasePath> {
-    const mergedPath = mergePath(this.#basePath, path)
+    const mergedPath = mergePath(this._basePath, path)
     const pathPrefixLength = mergedPath === '/' ? 0 : mergedPath.length
 
     const handler: MiddlewareHandler = async (c, next) => {
@@ -249,7 +249,7 @@ class Hono<
   }
 
   /**
-   * @deprecated
+   * @deprecate
    * `app.head()` is no longer used.
    * `app.get()` implicitly handles the HEAD method.
    */
@@ -260,7 +260,9 @@ class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    path = mergePath(this.#basePath, path)
+    if (this._basePath) {
+      path = mergePath(this._basePath, path)
+    }
     this.router.add(method, path, handler)
     const r: RouterRoute = { path: path, method: method, handler: handler }
     this.routes.push(r)
@@ -357,7 +359,7 @@ class Hono<
 
   /**
    * @deprecated
-   * `app.handleEvent()` will be removed in the v4.
+   * `app.handleEvent()` will be removed in v4.
    * Use `app.fetch()` instead of `app.handleEvent()`.
    */
   handleEvent = (event: FetchEventLike) => {

--- a/deno_dist/hono.ts
+++ b/deno_dist/hono.ts
@@ -1,5 +1,4 @@
 import { HonoBase } from './hono-base.ts'
-import type { HonoOptions } from './hono-base.ts'
 import { RegExpRouter } from './router/reg-exp-router/index.ts'
 import { SmartRouter } from './router/smart-router/index.ts'
 import { TrieRouter } from './router/trie-router/index.ts'
@@ -10,10 +9,10 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(options: HonoOptions<E, BasePath> = {}) {
-    super(options)
+  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
+    super(init)
     this.router =
-      options.router ??
+      init.router ??
       new SmartRouter({
         routers: [new RegExpRouter(), new TrieRouter()],
       })

--- a/deno_dist/preset/quick.ts
+++ b/deno_dist/preset/quick.ts
@@ -1,5 +1,4 @@
 import { HonoBase } from '../hono-base.ts'
-import type { HonoOptions } from '../hono-base.ts'
 import { LinearRouter } from '../router/linear-router/index.ts'
 import { SmartRouter } from '../router/smart-router/index.ts'
 import { TrieRouter } from '../router/trie-router/index.ts'
@@ -10,8 +9,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(options: HonoOptions<E, BasePath> = {}) {
-    super(options)
+  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+    super(init)
     this.router = new SmartRouter({
       routers: [new LinearRouter(), new TrieRouter()],
     })

--- a/deno_dist/preset/tiny.ts
+++ b/deno_dist/preset/tiny.ts
@@ -1,5 +1,4 @@
 import { HonoBase } from '../hono-base.ts'
-import type { HonoOptions } from '../hono-base.ts'
 import { PatternRouter } from '../router/pattern-router/index.ts'
 import type { Env, Schema } from '../types.ts'
 
@@ -8,8 +7,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(options: HonoOptions<E, BasePath> = {}) {
-    super(options)
+  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+    super(init)
     this.router = new PatternRouter()
   }
 }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -21,6 +21,7 @@ import type {
   FetchEventLike,
   Schema,
 } from './types'
+import type { RemoveBlankRecord } from './utils/types'
 import { getPath, getPathNoStrict, getQueryStrings, mergePath } from './utils/url'
 
 type Methods = typeof METHODS[number] | typeof METHOD_NAME_ALL_LOWERCASE
@@ -56,15 +57,6 @@ const errorHandler = (err: Error, c: Context) => {
   return c.text(message, 500)
 }
 
-type GetPath<E extends Env> = (request: Request, options?: { env?: E['Bindings'] }) => string
-
-export type HonoOptions<E extends Env, BasePath extends string> = {
-  strict?: boolean
-  basePath?: BasePath
-  router?: Router<H>
-  getPath?: GetPath<E>
-}
-
 class Hono<
   E extends Env = Env,
   S extends Schema = {},
@@ -75,13 +67,13 @@ class Hono<
     To use it, inherit the class and implement router in the constructor.
   */
   router!: Router<H>
-  readonly getPath: GetPath<E>
-  #basePath: string
+  readonly getPath: (request: Request, options?: { env?: E['Bindings'] }) => string
+  private _basePath: string = '/'
   private path: string = '/'
 
   routes: RouterRoute[] = []
 
-  constructor(options: HonoOptions<E, BasePath> = {}) {
+  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
     super()
 
     // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
@@ -128,11 +120,10 @@ class Hono<
       return this
     }
 
-    const strict = options.strict ?? true
-    delete options.strict
-    Object.assign(this, options)
-    this.#basePath = options.basePath ?? '/'
-    this.getPath = strict ? options.getPath ?? getPath : getPathNoStrict
+    const strict = init.strict ?? true
+    delete init.strict
+    Object.assign(this, init)
+    this.getPath = strict ? init.getPath ?? getPath : getPathNoStrict
   }
 
   private clone(): Hono<E, S, BasePath> {
@@ -154,10 +145,24 @@ class Hono<
     SubBasePath extends string
   >(
     path: SubPath,
+    app: Hono<SubEnv, SubSchema, SubBasePath>
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath>
+  /** @description
+   * Use `basePath` instead of `route` when passing **one** argument, such as `app.route('/api')`.
+   * The use of `route` with **one** argument has been removed in v4.
+   * However, you can still use `route` with **two** arguments, like `app.route('/api', subApp)`."
+   */
+  route<SubPath extends string>(path: SubPath): Hono<E, RemoveBlankRecord<S>, BasePath>
+  route<
+    SubPath extends string,
+    SubEnv extends Env,
+    SubSchema extends Schema,
+    SubBasePath extends string
+  >(
+    path: SubPath,
     app?: Hono<SubEnv, SubSchema, SubBasePath>
   ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
-    const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    const subApp = this.basePath(path)
 
     if (!app) {
       return subApp
@@ -174,14 +179,9 @@ class Hono<
     return this
   }
 
-  /**
-   * @deprecated
-   * `app.basePath()` will be removed in the v4.
-   * Use `new Hono({ basePath: '/api' })` instead of `new Hono().basePath('/api')`.
-   */
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    subApp._basePath = mergePath(this._basePath, path)
     return subApp
   }
 
@@ -215,7 +215,7 @@ class Hono<
     applicationHandler: (request: Request, ...args: any) => Response | Promise<Response>,
     optionHandler?: (c: Context) => unknown
   ): Hono<E, S, BasePath> {
-    const mergedPath = mergePath(this.#basePath, path)
+    const mergedPath = mergePath(this._basePath, path)
     const pathPrefixLength = mergedPath === '/' ? 0 : mergedPath.length
 
     const handler: MiddlewareHandler = async (c, next) => {
@@ -249,7 +249,7 @@ class Hono<
   }
 
   /**
-   * @deprecated
+   * @deprecate
    * `app.head()` is no longer used.
    * `app.get()` implicitly handles the HEAD method.
    */
@@ -260,7 +260,9 @@ class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    path = mergePath(this.#basePath, path)
+    if (this._basePath) {
+      path = mergePath(this._basePath, path)
+    }
     this.router.add(method, path, handler)
     const r: RouterRoute = { path: path, method: method, handler: handler }
     this.routes.push(r)
@@ -357,7 +359,7 @@ class Hono<
 
   /**
    * @deprecated
-   * `app.handleEvent()` will be removed in the v4.
+   * `app.handleEvent()` will be removed in v4.
    * Use `app.fetch()` instead of `app.handleEvent()`.
    */
   handleEvent = (event: FetchEventLike) => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -111,26 +111,7 @@ describe('Register handlers without a path', () => {
     })
   })
 
-  describe('With specifying a basePath option', () => {
-    const app = new Hono({ basePath: '/about' })
-
-    app.get((c) => {
-      return c.text('About')
-    })
-
-    it('GET http://localhost/about is ok', async () => {
-      const res = await app.request('/about')
-      expect(res.status).toBe(200)
-      expect(await res.text()).toBe('About')
-    })
-
-    it('GET http://localhost/ is not found', async () => {
-      const res = await app.request('/')
-      expect(res.status).toBe(404)
-    })
-  })
-
-  describe('With specifying app.basePath() - deprecated', () => {
+  describe('With specifying basePath', () => {
     const app = new Hono().basePath('/about')
 
     app.get((c) => {
@@ -290,24 +271,21 @@ describe('Routing', () => {
   })
 
   it('Nested route', async () => {
-    const book = new Hono({ basePath: '/book' })
+    const app = new Hono()
+
+    const book = app.basePath('/book')
     book.get('/', (c) => c.text('get /book'))
     book.get('/:id', (c) => {
       return c.text('get /book/' + c.req.param('id'))
     })
     book.post('/', (c) => c.text('post /book'))
 
-    const user = new Hono({ basePath: '/user' })
+    const user = app.basePath('/user')
     user.get('/login', (c) => c.text('get /user/login'))
     user.post('/register', (c) => c.text('post /user/register'))
 
-    const appForEachUser = new Hono({ basePath: ':id' })
+    const appForEachUser = user.basePath(':id')
     appForEachUser.get('/profile', (c) => c.text('get /user/' + c.req.param('id') + '/profile'))
-    user.route('/', appForEachUser)
-
-    const app = new Hono()
-    app.route('/', book)
-    app.route('/', user)
 
     app.get('/add-path-after-route-call', (c) => c.text('get /add-path-after-route-call'))
 
@@ -1351,24 +1329,7 @@ describe('Hono with `app.route`', () => {
       })
     })
 
-    describe('With app.get(...handler) and a basePath option', () => {
-      const about = new Hono({ basePath: '/about' })
-      about.get((c) => c.text('me'))
-      app.route('/', about)
-
-      it('Should return 200 response - /about', async () => {
-        const res = await app.request('/about')
-        expect(res.status).toBe(200)
-        expect(await res.text()).toBe('me')
-      })
-
-      test('Should return 404 response /about/foo', async () => {
-        const res = await app.request('/about/foo')
-        expect(res.status).toBe(404)
-      })
-    })
-
-    describe('With app.get(...handler) and app.basePath() - deprecated', () => {
+    describe('With app.get(...handler) and app.basePath()', () => {
       const app = new Hono()
       const about = new Hono().basePath('/about')
       about.get((c) => c.text('me'))
@@ -2241,7 +2202,7 @@ describe('app.mount()', () => {
     })
     app.mount('/another-app2/sub-slash/', anotherApp)
 
-    const api = new Hono({ basePath: '/api' })
+    const api = new Hono().basePath('/api')
     api.mount('/another-app', anotherApp)
 
     it('Should return responses from Hono app', async () => {
@@ -2294,7 +2255,7 @@ describe('app.mount()', () => {
       expect(await res.text()).toBe('AnotherApp')
     })
 
-    it('Should return responses from AnotherApp - with a `basePath` option', async () => {
+    it('Should return responses from AnotherApp - with `basePath()`', async () => {
       const res = await api.request('/api/another-app')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('AnotherApp')

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,5 +1,4 @@
 import { HonoBase } from './hono-base'
-import type { HonoOptions } from './hono-base'
 import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { TrieRouter } from './router/trie-router'
@@ -10,10 +9,10 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(options: HonoOptions<E, BasePath> = {}) {
-    super(options)
+  constructor(init: Partial<Pick<Hono, 'router' | 'getPath'> & { strict: boolean }> = {}) {
+    super(init)
     this.router =
-      options.router ??
+      init.router ??
       new SmartRouter({
         routers: [new RegExpRouter(), new TrieRouter()],
       })

--- a/src/preset/quick.ts
+++ b/src/preset/quick.ts
@@ -1,5 +1,4 @@
 import { HonoBase } from '../hono-base'
-import type { HonoOptions } from '../hono-base'
 import { LinearRouter } from '../router/linear-router'
 import { SmartRouter } from '../router/smart-router'
 import { TrieRouter } from '../router/trie-router'
@@ -10,8 +9,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(options: HonoOptions<E, BasePath> = {}) {
-    super(options)
+  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+    super(init)
     this.router = new SmartRouter({
       routers: [new LinearRouter(), new TrieRouter()],
     })

--- a/src/preset/tiny.ts
+++ b/src/preset/tiny.ts
@@ -1,5 +1,4 @@
 import { HonoBase } from '../hono-base'
-import type { HonoOptions } from '../hono-base'
 import { PatternRouter } from '../router/pattern-router'
 import type { Env, Schema } from '../types'
 
@@ -8,8 +7,8 @@ export class Hono<
   S extends Schema = {},
   BasePath extends string = '/'
 > extends HonoBase<E, S, BasePath> {
-  constructor(options: HonoOptions<E, BasePath> = {}) {
-    super(options)
+  constructor(init: Partial<Pick<Hono, 'getPath'> & { strict: boolean }> = {}) {
+    super(init)
     this.router = new PatternRouter()
   }
 }


### PR DESCRIPTION
Fixes #1584 

This reverts commit 8b6bd46e6699d6ad80eced222b8cd52c9a878692.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
