### PR TITLE
fix: `c.req.params()` in nested app with custom error handler.

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -165,7 +165,7 @@ class Hono<
         app.errorHandler === errorHandler
           ? r.handler
           : async (c: Context, next: Next) =>
-              (await compose<Context>([[r.handler, {}]], app.errorHandler)(c, next)).res
+              (await compose<Context>([], app.errorHandler)(c, () => r.handler(c, next))).res
       subApp.addRoute(r.method, r.path, handler)
     })
     return this

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -165,7 +165,7 @@ class Hono<
         app.errorHandler === errorHandler
           ? r.handler
           : async (c: Context, next: Next) =>
-              (await compose<Context>([[r.handler, {}]], app.errorHandler)(c, next)).res
+              (await compose<Context>([], app.errorHandler)(c, () => r.handler(c, next))).res
       subApp.addRoute(r.method, r.path, handler)
     })
     return this

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1426,8 +1426,13 @@ describe('Hono with `app.route`', () => {
       return c.text('onError by app', 500)
     })
 
-    sub.get('/ok', (c) => {
-      return c.text('ok')
+    sub.get('/posts/:id', async (c, next) => {
+      c.header('handler-chain', '1')
+      await next()
+    })
+
+    sub.get('/posts/:id', (c) => {
+      return c.text(`post: ${c.req.param('id')}`)
     })
 
     sub.get('/error', () => {
@@ -1439,6 +1444,13 @@ describe('Hono with `app.route`', () => {
     })
 
     app.route('/sub', sub)
+
+    it('GET /posts/123 for sub', async () => {
+      const res = await app.request('https://example.com/sub/posts/123')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('handler-chain')).toBe('1')
+      expect(await res.text()).toBe('post: 123')
+    })
 
     it('should be handled by app', async () => {
       const res = await app.request('https://example.com/sub/ok?app-error=1')


### PR DESCRIPTION
Fixes #1590

It may look like a dirty hack at first glance, but if you look closely, you will see it is not a problem.

I have also considered the following approaches.

* https://github.com/usualoma/hono/tree/fix-nested-onerror-params-by-getParams
* https://github.com/usualoma/hono/tree/fix-nested-onerror-params-by-undefined

However, they all increase the code and complexity of types, so this PR approach is better.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
