### PR TITLE
fix(context): change `FetchEvent` detection way

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,6 +1,5 @@
 import type { HonoRequest } from './request.ts'
-import type { Env, NotFoundHandler, Input, TypedResponse } from './types.ts'
-import { FetchEvent } from './types.ts'
+import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types.ts'
 import type { CookieOptions } from './utils/cookie.ts'
 import { serialize } from './utils/cookie.ts'
 import type { StatusCode } from './utils/http-status.ts'
@@ -82,7 +81,7 @@ interface HTMLRespond {
 
 type ContextOptions<E extends Env> = {
   env: E['Bindings']
-  executionCtx?: FetchEvent | ExecutionContext | undefined
+  executionCtx?: FetchEventLike | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
 }
 
@@ -102,7 +101,7 @@ export class Context<
   error: Error | undefined = undefined
 
   private _status: StatusCode = 200
-  private _exCtx: FetchEvent | ExecutionContext | undefined // _executionCtx
+  private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
   private _h: Headers | undefined = undefined //  _headers
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
@@ -121,8 +120,8 @@ export class Context<
     }
   }
 
-  get event(): FetchEvent {
-    if (this._exCtx instanceof FetchEvent) {
+  get event(): FetchEventLike {
+    if (this._exCtx && 'respondWith' in this._exCtx) {
       return this._exCtx
     } else {
       throw Error('This context has no FetchEvent')

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -592,5 +592,3 @@ export abstract class FetchEventLike {
   abstract passThroughOnException(): void
   abstract waitUntil(promise: Promise<void>): void
 }
-
-export abstract class FetchEvent extends FetchEventLike {}

--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -1,8 +1,9 @@
 // @denoify-ignore
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Hono } from '../../hono'
-import type { FetchEvent } from '../../types'
+import type { FetchEventLike } from '../../types'
 
-export const handle = (app: Hono<any, any, any>) => (req: Request, requestContext: FetchEvent) => {
-  return app.fetch(req, {}, requestContext as any)
-}
+export const handle =
+  (app: Hono<any, any, any>) => (req: Request, requestContext: FetchEventLike) => {
+    return app.fetch(req, {}, requestContext as any)
+  }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,5 @@
 import type { HonoRequest } from './request'
-import type { Env, NotFoundHandler, Input, TypedResponse } from './types'
-import { FetchEvent } from './types'
+import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types'
 import type { CookieOptions } from './utils/cookie'
 import { serialize } from './utils/cookie'
 import type { StatusCode } from './utils/http-status'
@@ -82,7 +81,7 @@ interface HTMLRespond {
 
 type ContextOptions<E extends Env> = {
   env: E['Bindings']
-  executionCtx?: FetchEvent | ExecutionContext | undefined
+  executionCtx?: FetchEventLike | ExecutionContext | undefined
   notFoundHandler?: NotFoundHandler<E>
 }
 
@@ -102,7 +101,7 @@ export class Context<
   error: Error | undefined = undefined
 
   private _status: StatusCode = 200
-  private _exCtx: FetchEvent | ExecutionContext | undefined // _executionCtx
+  private _exCtx: FetchEventLike | ExecutionContext | undefined // _executionCtx
   private _h: Headers | undefined = undefined //  _headers
   private _pH: Record<string, string> | undefined = undefined // _preparedHeaders
   private _res: Response | undefined
@@ -121,8 +120,8 @@ export class Context<
     }
   }
 
-  get event(): FetchEvent {
-    if (this._exCtx instanceof FetchEvent) {
+  get event(): FetchEventLike {
+    if (this._exCtx && 'respondWith' in this._exCtx) {
       return this._exCtx
     } else {
       throw Error('This context has no FetchEvent')

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,5 +592,3 @@ export abstract class FetchEventLike {
   abstract passThroughOnException(): void
   abstract waitUntil(promise: Promise<void>): void
 }
-
-export abstract class FetchEvent extends FetchEventLike {}


### PR DESCRIPTION
To detect whether it is a `FetchEvent` or not, I've used this method in this PR instead of `instanceof`:

```ts
this._exCtx && 'respondWith' in this._exCtx
```

Fixes #1423

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
