### PR TITLE
chore(ci): update node v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,16 @@ on:
 
 jobs:
   main:
-    name: 'Main'
+    name: 'Main with Node.js v${{ matrix.node }}'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['18.18.2', '20.x']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.18.2
+          node-version: ${{ matrix.node }}
       - run: yarn install --frozen-lockfile
       - run: npm run format
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,13 @@ on:
 
 jobs:
   main:
-    name: 'Main with Node.js v${{ matrix.node }}'
+    name: 'Main'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['18.18.2', '20.x']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20.x
       - run: yarn install --frozen-lockfile
       - run: npm run format
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,11 @@ jobs:
       - run: npm run test:lagon
 
   node:
-    name: 'Node.js'
+    name: 'Node.js v${{ matrix.node }}'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['18.18.2', '20.x']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Starting from October 24, NodeJS V20 will become the LTS version. I believe we should also support this in our CI. For now, I've only added Node, but if there is a need to include other runtimes, I am more than happy to accommodate that as well.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
