### PR TITLE
Fix: combine fluent interface with route grouping

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/index.js",
       "require": "./dist/cjs/index.js"
     },
+    "./types": {
+      "types": "./dist/types/types.d.ts",
+      "import": "./dist/types.js",
+      "require": "./dist/cjs/types.js"
+    },
     "./hono-base": {
       "types": "./dist/types/hono-base.d.ts",
       "import": "./dist/hono-base.js",


### PR DESCRIPTION
**How to reproduce**

```ts
import { Hono } from 'hono';

const group = new Hono().get('/', (c) => c.text('ok'));
const app = new Hono().use().route('/group', group);

export default app;
```

The issue only appears if `app` is exported (or `group` is imported).

**Error observed**

```
The inferred type of 'app' cannot be named without a reference to '../../../node_modules/hono/dist/types/hono-base'. This is likely not portable. A type annotation is necessary.ts(2742)
```

<img width="632" alt="image" src="https://github.com/colinhacks/zod/assets/6740947/459f7cf9-bac9-4ba9-b925-35e2a4bdf0c9">

**Solution**

Upgrading to `v3.8.2` partially addressed the issue (https://github.com/honojs/hono/pull/1604/files), but I found it necessary to make `hono/types` publicly accessible also.