### PR TITLE
Aws lambda cookies fix

### DIFF
--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -4,6 +4,7 @@ import type {
 } from '../../src/adapter/aws-lambda/custom-context'
 import { handle } from '../../src/adapter/aws-lambda/handler'
 import type { LambdaContext } from '../../src/adapter/aws-lambda/types'
+import { getCookie, setCookie } from '../../src/helper/cookie'
 import { Hono } from '../../src/hono'
 import { basicAuth } from '../../src/middleware/basic-auth'
 
@@ -53,6 +54,21 @@ describe('AWS Lambda Adapter for Hono', () => {
   app.get('/custom-context/lambda', (c) => {
     const lambdaContext = c.env.requestContext
     return c.json(lambdaContext)
+  })
+
+  const testCookieKey = 'id'
+  const testCookieValue = crypto.randomUUID()
+  const testCookie = `${testCookieKey}=${testCookieValue}`
+
+  app.post('/cookie', (c) => {
+    setCookie(c, testCookieKey, testCookieValue)
+    return c.text('Cookies Set')
+  })
+
+  app.get('/cookie', (c) => {
+    const validCookie = getCookie(c, testCookieKey) === testCookieValue
+    if (!validCookie) return c.text('Invalid Cookies')
+    return c.text('Valid Cookies')
   })
 
   const handler = handle(app)
@@ -315,5 +331,72 @@ describe('AWS Lambda Adapter for Hono', () => {
     const response = await handler(event, context)
     expect(response.statusCode).toBe(200)
     expect(JSON.parse(response.body).callbackWaitsForEmptyEventLoop).toEqual(false)
+  })
+
+  it('Shoul handle a POST request and return a 200 response with cookies set (APIGatewayProxyEvent V1 and V2)', async () => {
+    const apiGatewayEvent = {
+      httpMethod: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      path: '/cookie',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: testApiGatewayRequestContext,
+    }
+
+    const apiGatewayResponse = await handler(apiGatewayEvent)
+
+    expect(apiGatewayResponse.statusCode).toBe(200)
+    expect(apiGatewayResponse.multiValueHeaders).toHaveProperty('set-cookie', [testCookie])
+
+    const apiGatewayEventV2 = {
+      httpMethod: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      rawPath: '/cookie',
+      rawQueryString: '',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: testApiGatewayRequestContext,
+    }
+
+    const apiGatewayResponseV2 = await handler(apiGatewayEventV2)
+
+    expect(apiGatewayResponseV2.statusCode).toBe(200)
+    expect(apiGatewayResponseV2).toHaveProperty('cookies', [testCookie])
+  })
+
+  it('Shoul handle a POST request and return a 200 response if cookies match (APIGatewayProxyEvent V1 and V2)', async () => {
+    const apiGatewayEvent = {
+      httpMethod: 'GET',
+      headers: { 'content-type': 'text/plain', cookie: testCookie },
+      path: '/cookie',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: testApiGatewayRequestContext,
+    }
+
+    const apiGatewayResponse = await handler(apiGatewayEvent)
+
+    expect(apiGatewayResponse.statusCode).toBe(200)
+    expect(apiGatewayResponse.body).toBe('Valid Cookies')
+    expect(apiGatewayResponse.headers['content-type']).toMatch(/^text\/plain/)
+    expect(apiGatewayResponse.isBase64Encoded).toBe(false)
+
+    const apiGatewayEventV2 = {
+      httpMethod: 'GET',
+      headers: { 'content-type': 'text/plain' },
+      rawPath: '/cookie',
+      cookies: [testCookie],
+      rawQueryString: '',
+      body: null,
+      isBase64Encoded: false,
+      requestContext: testApiGatewayRequestContext,
+    }
+
+    const apiGatewayResponseV2 = await handler(apiGatewayEventV2)
+
+    expect(apiGatewayResponseV2.statusCode).toBe(200)
+    expect(apiGatewayResponseV2.body).toBe('Valid Cookies')
+    expect(apiGatewayResponseV2.headers['content-type']).toMatch(/^text\/plain/)
+    expect(apiGatewayResponseV2.isBase64Encoded).toBe(false)
   })
 })


### PR DESCRIPTION
### Issue: Unable to set multiple cookies when using aws-lambda adapter
The `getCookie`  and `setCookie` helpers don't work properly when handling multiple cookies with aws-lambda adapter because of different versions of request and response payload in `API Gateway Proxy Event`.

### Fix implementation: 
I created two functions `getCookies` and `setCookies` in src/adapter/aws-lambda/handler.ts file to get and set cookies payload/header corresponding to the version of the `API Gateway Proxy Event`. Additionally, two tests for this implementation are added in the lambda runtime test file.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno