### PR TITLE
feat: types for JSX elements

### DIFF
--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -12,7 +12,9 @@ declare global {
     interface ElementChildrenAttribute {
       children: Child
     }
-    type IntrinsicElements = IntrinsicElementsDefined & { [tagName: string]: Props }
+    interface IntrinsicElements extends IntrinsicElementsDefined {
+      [tagName: string]: Props
+    }
   }
 }
 

--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -1,5 +1,6 @@
 import { escapeToBuffer } from '../utils/html.ts'
 import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../utils/html.ts'
+import type { IntrinsicElements as IntrinsicElementsDefined } from './intrinsic-elements.ts'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Props = Record<string, any>
@@ -11,9 +12,7 @@ declare global {
     interface ElementChildrenAttribute {
       children: Child
     }
-    interface IntrinsicElements {
-      [tagName: string]: Props
-    }
+    type IntrinsicElements = IntrinsicElementsDefined & { [tagName: string]: Props }
   }
 }
 

--- a/deno_dist/jsx/intrinsic-elements.ts
+++ b/deno_dist/jsx/intrinsic-elements.ts
@@ -1,0 +1,605 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * This code is based on React.
+ * https://github.com/facebook/react
+ * MIT License
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ */
+
+type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
+type CSSProperties = {}
+type AnyAttributes = { [attributeName: string]: any }
+
+interface JSXAttributes {
+  dangerouslySetInnerHTML?: {
+    __html: string
+  }
+}
+
+interface HTMLAttributes extends JSXAttributes, AnyAttributes {
+  accessKey?: string | undefined
+  autofocus?: boolean | undefined
+  class?: string | undefined
+  contenteditable?: boolean | 'inherit' | undefined
+  contextmenu?: string | undefined
+  dir?: string | undefined
+  draggable?: boolean | undefined
+  hidden?: boolean | undefined
+  id?: string | undefined
+  lang?: string | undefined
+  nonce?: string | undefined
+  placeholder?: string | undefined
+  slot?: string | undefined
+  spellcheck?: boolean | undefined
+  style?: CSSProperties | undefined
+  tabindex?: number | undefined
+  title?: string | undefined
+  translate?: 'yes' | 'no' | undefined
+}
+
+type HTMLAttributeReferrerPolicy =
+  | ''
+  | 'no-referrer'
+  | 'no-referrer-when-downgrade'
+  | 'origin'
+  | 'origin-when-cross-origin'
+  | 'same-origin'
+  | 'strict-origin'
+  | 'strict-origin-when-cross-origin'
+  | 'unsafe-url'
+
+type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
+
+interface AnchorHTMLAttributes extends HTMLAttributes {
+  download?: any
+  href?: string | undefined
+  hreflang?: string | undefined
+  media?: string | undefined
+  ping?: string | undefined
+  target?: HTMLAttributeAnchorTarget | undefined
+  type?: string | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+}
+
+interface AudioHTMLAttributes extends MediaHTMLAttributes {}
+
+interface AreaHTMLAttributes extends HTMLAttributes {
+  alt?: string | undefined
+  coords?: string | undefined
+  download?: any
+  href?: string | undefined
+  hreflang?: string | undefined
+  media?: string | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+  shape?: string | undefined
+  target?: string | undefined
+}
+
+interface BaseHTMLAttributes extends HTMLAttributes {
+  href?: string | undefined
+  target?: string | undefined
+}
+
+interface BlockquoteHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+}
+
+interface ButtonHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  form?: string | undefined
+  formenctype?: string | undefined
+  formmethod?: string | undefined
+  formnovalidate?: boolean | undefined
+  formtarget?: string | undefined
+  name?: string | undefined
+  type?: 'submit' | 'reset' | 'button' | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface CanvasHTMLAttributes extends HTMLAttributes {
+  height?: number | string | undefined
+  width?: number | string | undefined
+}
+
+interface ColHTMLAttributes extends HTMLAttributes {
+  span?: number | undefined
+  width?: number | string | undefined
+}
+
+interface ColgroupHTMLAttributes extends HTMLAttributes {
+  span?: number | undefined
+}
+
+interface DataHTMLAttributes extends HTMLAttributes {
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface DetailsHTMLAttributes extends HTMLAttributes {
+  open?: boolean | undefined
+  ontoggle?: string | undefined
+}
+
+interface DelHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+  dateTime?: string | undefined
+}
+
+interface DialogHTMLAttributes extends HTMLAttributes {
+  oncancel?: string | undefined
+  onclose?: string | undefined
+  open?: boolean | undefined
+}
+
+interface EmbedHTMLAttributes extends HTMLAttributes {
+  height?: number | string | undefined
+  src?: string | undefined
+  type?: string | undefined
+  width?: number | string | undefined
+}
+
+interface FieldsetHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  form?: string | undefined
+  name?: string | undefined
+}
+
+interface FormHTMLAttributes extends HTMLAttributes {
+  'accept-charset'?: string | undefined
+  autocomplete?: string | undefined
+  enctype?: string | undefined
+  method?: string | undefined
+  name?: string | undefined
+  novalidate?: boolean | undefined
+  target?: string | undefined
+}
+
+interface HtmlHTMLAttributes extends HTMLAttributes {
+  manifest?: string | undefined
+}
+
+interface IframeHTMLAttributes extends HTMLAttributes {
+  allow?: string | undefined
+  allowfullScreen?: boolean | undefined
+  height?: number | string | undefined
+  loading?: 'eager' | 'lazy' | undefined
+  name?: string | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+  sandbox?: string | undefined
+  seamless?: boolean | undefined
+  src?: string | undefined
+  srcDoc?: string | undefined
+  width?: number | string | undefined
+}
+
+interface ImgHTMLAttributes extends HTMLAttributes {
+  alt?: string | undefined
+  crossorigin?: CrossOrigin
+  decoding?: 'async' | 'auto' | 'sync' | undefined
+  height?: number | string | undefined
+  loading?: 'eager' | 'lazy' | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+  sizes?: string | undefined
+  src?: string | undefined
+  srcset?: string | undefined
+  usemap?: string | undefined
+  width?: number | string | undefined
+}
+
+interface InsHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+  datetime?: string | undefined
+}
+
+type HTMLInputTypeAttribute =
+  | 'button'
+  | 'checkbox'
+  | 'color'
+  | 'date'
+  | 'datetime-local'
+  | 'email'
+  | 'file'
+  | 'hidden'
+  | 'image'
+  | 'month'
+  | 'number'
+  | 'password'
+  | 'radio'
+  | 'range'
+  | 'reset'
+  | 'search'
+  | 'submit'
+  | 'tel'
+  | 'text'
+  | 'time'
+  | 'url'
+  | 'week'
+  | string
+
+interface InputHTMLAttributes extends HTMLAttributes {
+  accept?: string | undefined
+  alt?: string | undefined
+  autocomplete?: string | undefined
+  capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+  checked?: boolean | undefined
+  disabled?: boolean | undefined
+  enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
+  form?: string | undefined
+  formenctype?: string | undefined
+  formmethod?: string | undefined
+  formnovalidate?: boolean | undefined
+  formtarget?: string | undefined
+  height?: number | string | undefined
+  list?: string | undefined
+  max?: number | string | undefined
+  maxlength?: number | undefined
+  min?: number | string | undefined
+  minlength?: number | undefined
+  multiple?: boolean | undefined
+  name?: string | undefined
+  pattern?: string | undefined
+  placeholder?: string | undefined
+  readonly?: boolean | undefined
+  required?: boolean | undefined
+  size?: number | undefined
+  src?: string | undefined
+  step?: number | string | undefined
+  type?: HTMLInputTypeAttribute | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+  width?: number | string | undefined
+  onchange?: string | undefined
+}
+
+interface KeygenHTMLAttributes extends HTMLAttributes {
+  challenge?: string | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  keytype?: string | undefined
+  name?: string | undefined
+}
+
+interface LabelHTMLAttributes extends HTMLAttributes {
+  form?: string | undefined
+  for?: string | undefined
+}
+
+interface LiHTMLAttributes extends HTMLAttributes {
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface LinkHTMLAttributes extends HTMLAttributes {
+  as?: string | undefined
+  crossorigin?: CrossOrigin
+  href?: string | undefined
+  hreflang?: string | undefined
+  integrity?: string | undefined
+  media?: string | undefined
+  imagesrcset?: string | undefined
+  imagesizes?: string | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+  sizes?: string | undefined
+  type?: string | undefined
+  charSet?: string | undefined
+}
+
+interface MapHTMLAttributes extends HTMLAttributes {
+  name?: string | undefined
+}
+
+interface MenuHTMLAttributes extends HTMLAttributes {
+  type?: string | undefined
+}
+
+interface MediaHTMLAttributes extends HTMLAttributes {
+  autoplay?: boolean | undefined
+  controls?: boolean | undefined
+  controlslist?: string | undefined
+  crossorigin?: CrossOrigin
+  loop?: boolean | undefined
+  mediagroup?: string | undefined
+  muted?: boolean | undefined
+  playsinline?: boolean | undefined
+  preload?: string | undefined
+  src?: string | undefined
+}
+
+interface MetaHTMLAttributes extends HTMLAttributes {
+  charset?: string | undefined
+  'http-equiv'?: string | undefined
+  name?: string | undefined
+  media?: string | undefined
+  content?: string | undefined
+}
+
+interface MeterHTMLAttributes extends HTMLAttributes {
+  form?: string | undefined
+  high?: number | undefined
+  low?: number | undefined
+  max?: number | string | undefined
+  min?: number | string | undefined
+  optimum?: number | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface QuoteHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+}
+
+interface ObjectHTMLAttributes extends HTMLAttributes {
+  data?: string | undefined
+  form?: string | undefined
+  height?: number | string | undefined
+  name?: string | undefined
+  type?: string | undefined
+  usemap?: string | undefined
+  width?: number | string | undefined
+}
+
+interface OlHTMLAttributes extends HTMLAttributes {
+  reversed?: boolean | undefined
+  start?: number | undefined
+  type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined
+}
+
+interface OptgroupHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  label?: string | undefined
+}
+
+interface OptionHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  label?: string | undefined
+  selected?: boolean | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface OutputHTMLAttributes extends HTMLAttributes {
+  form?: string | undefined
+  for?: string | undefined
+  name?: string | undefined
+}
+
+interface ParamHTMLAttributes extends HTMLAttributes {
+  name?: string | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface ProgressHTMLAttributes extends HTMLAttributes {
+  max?: number | string | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface SlotHTMLAttributes extends HTMLAttributes {
+  name?: string | undefined
+}
+
+interface ScriptHTMLAttributes extends HTMLAttributes {
+  async?: boolean | undefined
+  crossorigin?: CrossOrigin
+  defer?: boolean | undefined
+  integrity?: string | undefined
+  nomodule?: boolean | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+  src?: string | undefined
+  type?: string | undefined
+}
+
+interface SelectHTMLAttributes extends HTMLAttributes {
+  autocomplete?: string | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  multiple?: boolean | undefined
+  name?: string | undefined
+  required?: boolean | undefined
+  size?: number | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+  onchange?: string | undefined
+}
+
+interface SourceHTMLAttributes extends HTMLAttributes {
+  height?: number | string | undefined
+  media?: string | undefined
+  sizes?: string | undefined
+  src?: string | undefined
+  srcset?: string | undefined
+  type?: string | undefined
+  width?: number | string | undefined
+}
+
+interface StyleHTMLAttributes extends HTMLAttributes {
+  media?: string | undefined
+  scoped?: boolean | undefined
+  type?: string | undefined
+}
+
+interface TableHTMLAttributes extends HTMLAttributes {
+  align?: 'left' | 'center' | 'right' | undefined
+  bgcolor?: string | undefined
+  border?: number | undefined
+  cellpadding?: number | string | undefined
+  cellspacing?: number | string | undefined
+  frame?: boolean | undefined
+  rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
+  summary?: string | undefined
+  width?: number | string | undefined
+}
+
+interface TextareaHTMLAttributes extends HTMLAttributes {
+  autocomplete?: string | undefined
+  cols?: number | undefined
+  dirname?: string | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  maxlength?: number | undefined
+  minlength?: number | undefined
+  name?: string | undefined
+  placeholder?: string | undefined
+  readonly?: boolean | undefined
+  required?: boolean | undefined
+  rows?: number | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+  wrap?: string | undefined
+  onchange?: string | undefined
+}
+
+interface TdHTMLAttributes extends HTMLAttributes {
+  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+  colspan?: number | undefined
+  headers?: string | undefined
+  rowspan?: number | undefined
+  scope?: string | undefined
+  abbr?: string | undefined
+  height?: number | string | undefined
+  width?: number | string | undefined
+  valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined
+}
+
+interface ThHTMLAttributes extends HTMLAttributes {
+  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+  colspan?: number | undefined
+  headers?: string | undefined
+  rowspan?: number | undefined
+  scope?: string | undefined
+  abbr?: string | undefined
+}
+
+interface TimeHTMLAttributes extends HTMLAttributes {
+  datetime?: string | undefined
+}
+
+interface TrackHTMLAttributes extends HTMLAttributes {
+  default?: boolean | undefined
+  kind?: string | undefined
+  label?: string | undefined
+  src?: string | undefined
+  srclang?: string | undefined
+}
+
+interface VideoHTMLAttributes extends MediaHTMLAttributes {
+  height?: number | string | undefined
+  playsinline?: boolean | undefined
+  poster?: string | undefined
+  width?: number | string | undefined
+  disablepictureInpicture?: boolean | undefined
+  disableremoteplayback?: boolean | undefined
+}
+
+export interface IntrinsicElements {
+  a: AnchorHTMLAttributes
+  abbr: HTMLAttributes
+  address: HTMLAttributes
+  area: AreaHTMLAttributes
+  article: HTMLAttributes
+  aside: HTMLAttributes
+  audio: AudioHTMLAttributes
+  b: HTMLAttributes
+  base: BaseHTMLAttributes
+  bdi: HTMLAttributes
+  bdo: HTMLAttributes
+  big: HTMLAttributes
+  blockquote: BlockquoteHTMLAttributes
+  body: HTMLAttributes
+  br: HTMLAttributes
+  button: ButtonHTMLAttributes
+  canvas: CanvasHTMLAttributes
+  caption: HTMLAttributes
+  center: HTMLAttributes
+  cite: HTMLAttributes
+  code: HTMLAttributes
+  col: ColHTMLAttributes
+  colgroup: ColgroupHTMLAttributes
+  data: DataHTMLAttributes
+  datalist: HTMLAttributes
+  dd: HTMLAttributes
+  del: DelHTMLAttributes
+  details: DetailsHTMLAttributes
+  dfn: HTMLAttributes
+  dialog: DialogHTMLAttributes
+  div: HTMLAttributes
+  dl: HTMLAttributes
+  dt: HTMLAttributes
+  em: HTMLAttributes
+  embed: EmbedHTMLAttributes
+  fieldset: FieldsetHTMLAttributes
+  figcaption: HTMLAttributes
+  figure: HTMLAttributes
+  footer: HTMLAttributes
+  form: FormHTMLAttributes
+  h1: HTMLAttributes
+  h2: HTMLAttributes
+  h3: HTMLAttributes
+  h4: HTMLAttributes
+  h5: HTMLAttributes
+  h6: HTMLAttributes
+  head: HTMLAttributes
+  header: HTMLAttributes
+  hgroup: HTMLAttributes
+  hr: HTMLAttributes
+  html: HtmlHTMLAttributes
+  i: HTMLAttributes
+  iframe: IframeHTMLAttributes
+  img: ImgHTMLAttributes
+  input: InputHTMLAttributes
+  ins: InsHTMLAttributes
+  kbd: HTMLAttributes
+  keygen: KeygenHTMLAttributes
+  label: LabelHTMLAttributes
+  legend: HTMLAttributes
+  li: LiHTMLAttributes
+  link: LinkHTMLAttributes
+  main: HTMLAttributes
+  map: MapHTMLAttributes
+  mark: HTMLAttributes
+  menu: MenuHTMLAttributes
+  menuitem: HTMLAttributes
+  meta: MetaHTMLAttributes
+  meter: MeterHTMLAttributes
+  nav: HTMLAttributes
+  noscript: HTMLAttributes
+  object: ObjectHTMLAttributes
+  ol: OlHTMLAttributes
+  optgroup: OptgroupHTMLAttributes
+  option: OptionHTMLAttributes
+  output: OutputHTMLAttributes
+  p: HTMLAttributes
+  param: ParamHTMLAttributes
+  picture: HTMLAttributes
+  pre: HTMLAttributes
+  progress: ProgressHTMLAttributes
+  q: QuoteHTMLAttributes
+  rp: HTMLAttributes
+  rt: HTMLAttributes
+  ruby: HTMLAttributes
+  s: HTMLAttributes
+  samp: HTMLAttributes
+  search: HTMLAttributes
+  slot: SlotHTMLAttributes
+  script: ScriptHTMLAttributes
+  section: HTMLAttributes
+  select: SelectHTMLAttributes
+  small: HTMLAttributes
+  source: SourceHTMLAttributes
+  span: HTMLAttributes
+  strong: HTMLAttributes
+  style: StyleHTMLAttributes
+  sub: HTMLAttributes
+  summary: HTMLAttributes
+  sup: HTMLAttributes
+  table: TableHTMLAttributes
+  template: HTMLAttributes
+  tbody: HTMLAttributes
+  td: TdHTMLAttributes
+  textarea: TextareaHTMLAttributes
+  tfoot: HTMLAttributes
+  th: ThHTMLAttributes
+  thead: HTMLAttributes
+  time: TimeHTMLAttributes
+  title: HTMLAttributes
+  tr: HTMLAttributes
+  track: TrackHTMLAttributes
+  u: HTMLAttributes
+  ul: HTMLAttributes
+  var: HTMLAttributes
+  video: VideoHTMLAttributes
+  wbr: HTMLAttributes
+}

--- a/deno_dist/jsx/intrinsic-elements.ts
+++ b/deno_dist/jsx/intrinsic-elements.ts
@@ -18,7 +18,7 @@ interface JSXAttributes {
 }
 
 interface HTMLAttributes extends JSXAttributes, AnyAttributes {
-  accessKey?: string | undefined
+  accesskey?: string | undefined
   autofocus?: boolean | undefined
   class?: string | undefined
   contenteditable?: boolean | 'inherit' | undefined
@@ -160,7 +160,7 @@ interface HtmlHTMLAttributes extends HTMLAttributes {
 
 interface IframeHTMLAttributes extends HTMLAttributes {
   allow?: string | undefined
-  allowfullScreen?: boolean | undefined
+  allowfullscreen?: boolean | undefined
   height?: number | string | undefined
   loading?: 'eager' | 'lazy' | undefined
   name?: string | undefined
@@ -168,7 +168,7 @@ interface IframeHTMLAttributes extends HTMLAttributes {
   sandbox?: string | undefined
   seamless?: boolean | undefined
   src?: string | undefined
-  srcDoc?: string | undefined
+  srcdoc?: string | undefined
   width?: number | string | undefined
 }
 
@@ -480,8 +480,8 @@ interface VideoHTMLAttributes extends MediaHTMLAttributes {
   playsinline?: boolean | undefined
   poster?: string | undefined
   width?: number | string | undefined
-  disablepictureInpicture?: boolean | undefined
-  disableremoteplayback?: boolean | undefined
+  disablePictureInPicture?: boolean | undefined
+  disableRemotePlayback?: boolean | undefined
 }
 
 export interface IntrinsicElements {

--- a/deno_dist/jsx/intrinsic-elements.ts
+++ b/deno_dist/jsx/intrinsic-elements.ts
@@ -7,599 +7,600 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  */
 
-type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
-type CSSProperties = {}
-type AnyAttributes = { [attributeName: string]: any }
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Hono {
+    type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
+    type CSSProperties = {}
+    type AnyAttributes = { [attributeName: string]: any }
 
-interface JSXAttributes {
-  dangerouslySetInnerHTML?: {
-    __html: string
+    interface JSXAttributes {
+      dangerouslySetInnerHTML?: {
+        __html: string
+      }
+    }
+
+    interface HTMLAttributes extends JSXAttributes, AnyAttributes {
+      accesskey?: string | undefined
+      autofocus?: boolean | undefined
+      class?: string | undefined
+      contenteditable?: boolean | 'inherit' | undefined
+      contextmenu?: string | undefined
+      dir?: string | undefined
+      draggable?: boolean | undefined
+      hidden?: boolean | undefined
+      id?: string | undefined
+      lang?: string | undefined
+      nonce?: string | undefined
+      placeholder?: string | undefined
+      slot?: string | undefined
+      spellcheck?: boolean | undefined
+      style?: CSSProperties | undefined
+      tabindex?: number | undefined
+      title?: string | undefined
+      translate?: 'yes' | 'no' | undefined
+    }
+
+    type HTMLAttributeReferrerPolicy =
+      | ''
+      | 'no-referrer'
+      | 'no-referrer-when-downgrade'
+      | 'origin'
+      | 'origin-when-cross-origin'
+      | 'same-origin'
+      | 'strict-origin'
+      | 'strict-origin-when-cross-origin'
+      | 'unsafe-url'
+
+    type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
+
+    interface AnchorHTMLAttributes extends HTMLAttributes {
+      download?: any
+      href?: string | undefined
+      hreflang?: string | undefined
+      media?: string | undefined
+      ping?: string | undefined
+      target?: HTMLAttributeAnchorTarget | undefined
+      type?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+    }
+
+    interface AudioHTMLAttributes extends MediaHTMLAttributes {}
+
+    interface AreaHTMLAttributes extends HTMLAttributes {
+      alt?: string | undefined
+      coords?: string | undefined
+      download?: any
+      href?: string | undefined
+      hreflang?: string | undefined
+      media?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      shape?: string | undefined
+      target?: string | undefined
+    }
+
+    interface BaseHTMLAttributes extends HTMLAttributes {
+      href?: string | undefined
+      target?: string | undefined
+    }
+
+    interface BlockquoteHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+    }
+
+    interface ButtonHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      form?: string | undefined
+      formenctype?: string | undefined
+      formmethod?: string | undefined
+      formnovalidate?: boolean | undefined
+      formtarget?: string | undefined
+      name?: string | undefined
+      type?: 'submit' | 'reset' | 'button' | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface CanvasHTMLAttributes extends HTMLAttributes {
+      height?: number | string | undefined
+      width?: number | string | undefined
+    }
+
+    interface ColHTMLAttributes extends HTMLAttributes {
+      span?: number | undefined
+      width?: number | string | undefined
+    }
+
+    interface ColgroupHTMLAttributes extends HTMLAttributes {
+      span?: number | undefined
+    }
+
+    interface DataHTMLAttributes extends HTMLAttributes {
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface DetailsHTMLAttributes extends HTMLAttributes {
+      open?: boolean | undefined
+    }
+
+    interface DelHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+      dateTime?: string | undefined
+    }
+
+    interface DialogHTMLAttributes extends HTMLAttributes {
+      open?: boolean | undefined
+    }
+
+    interface EmbedHTMLAttributes extends HTMLAttributes {
+      height?: number | string | undefined
+      src?: string | undefined
+      type?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface FieldsetHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      form?: string | undefined
+      name?: string | undefined
+    }
+
+    interface FormHTMLAttributes extends HTMLAttributes {
+      'accept-charset'?: string | undefined
+      autocomplete?: string | undefined
+      enctype?: string | undefined
+      method?: string | undefined
+      name?: string | undefined
+      novalidate?: boolean | undefined
+      target?: string | undefined
+    }
+
+    interface HtmlHTMLAttributes extends HTMLAttributes {
+      manifest?: string | undefined
+    }
+
+    interface IframeHTMLAttributes extends HTMLAttributes {
+      allow?: string | undefined
+      allowfullscreen?: boolean | undefined
+      height?: number | string | undefined
+      loading?: 'eager' | 'lazy' | undefined
+      name?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      sandbox?: string | undefined
+      seamless?: boolean | undefined
+      src?: string | undefined
+      srcdoc?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface ImgHTMLAttributes extends HTMLAttributes {
+      alt?: string | undefined
+      crossorigin?: CrossOrigin
+      decoding?: 'async' | 'auto' | 'sync' | undefined
+      height?: number | string | undefined
+      loading?: 'eager' | 'lazy' | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      sizes?: string | undefined
+      src?: string | undefined
+      srcset?: string | undefined
+      usemap?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface InsHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+      datetime?: string | undefined
+    }
+
+    type HTMLInputTypeAttribute =
+      | 'button'
+      | 'checkbox'
+      | 'color'
+      | 'date'
+      | 'datetime-local'
+      | 'email'
+      | 'file'
+      | 'hidden'
+      | 'image'
+      | 'month'
+      | 'number'
+      | 'password'
+      | 'radio'
+      | 'range'
+      | 'reset'
+      | 'search'
+      | 'submit'
+      | 'tel'
+      | 'text'
+      | 'time'
+      | 'url'
+      | 'week'
+      | string
+
+    interface InputHTMLAttributes extends HTMLAttributes {
+      accept?: string | undefined
+      alt?: string | undefined
+      autocomplete?: string | undefined
+      capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+      checked?: boolean | undefined
+      disabled?: boolean | undefined
+      enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
+      form?: string | undefined
+      formenctype?: string | undefined
+      formmethod?: string | undefined
+      formnovalidate?: boolean | undefined
+      formtarget?: string | undefined
+      height?: number | string | undefined
+      list?: string | undefined
+      max?: number | string | undefined
+      maxlength?: number | undefined
+      min?: number | string | undefined
+      minlength?: number | undefined
+      multiple?: boolean | undefined
+      name?: string | undefined
+      pattern?: string | undefined
+      placeholder?: string | undefined
+      readonly?: boolean | undefined
+      required?: boolean | undefined
+      size?: number | undefined
+      src?: string | undefined
+      step?: number | string | undefined
+      type?: HTMLInputTypeAttribute | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+      width?: number | string | undefined
+    }
+
+    interface KeygenHTMLAttributes extends HTMLAttributes {
+      challenge?: string | undefined
+      disabled?: boolean | undefined
+      form?: string | undefined
+      keytype?: string | undefined
+      name?: string | undefined
+    }
+
+    interface LabelHTMLAttributes extends HTMLAttributes {
+      form?: string | undefined
+      for?: string | undefined
+    }
+
+    interface LiHTMLAttributes extends HTMLAttributes {
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface LinkHTMLAttributes extends HTMLAttributes {
+      as?: string | undefined
+      crossorigin?: CrossOrigin
+      href?: string | undefined
+      hreflang?: string | undefined
+      integrity?: string | undefined
+      media?: string | undefined
+      imagesrcset?: string | undefined
+      imagesizes?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      sizes?: string | undefined
+      type?: string | undefined
+      charSet?: string | undefined
+    }
+
+    interface MapHTMLAttributes extends HTMLAttributes {
+      name?: string | undefined
+    }
+
+    interface MenuHTMLAttributes extends HTMLAttributes {
+      type?: string | undefined
+    }
+
+    interface MediaHTMLAttributes extends HTMLAttributes {
+      autoplay?: boolean | undefined
+      controls?: boolean | undefined
+      controlslist?: string | undefined
+      crossorigin?: CrossOrigin
+      loop?: boolean | undefined
+      mediagroup?: string | undefined
+      muted?: boolean | undefined
+      playsinline?: boolean | undefined
+      preload?: string | undefined
+      src?: string | undefined
+    }
+
+    interface MetaHTMLAttributes extends HTMLAttributes {
+      charset?: string | undefined
+      'http-equiv'?: string | undefined
+      name?: string | undefined
+      media?: string | undefined
+      content?: string | undefined
+    }
+
+    interface MeterHTMLAttributes extends HTMLAttributes {
+      form?: string | undefined
+      high?: number | undefined
+      low?: number | undefined
+      max?: number | string | undefined
+      min?: number | string | undefined
+      optimum?: number | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface QuoteHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+    }
+
+    interface ObjectHTMLAttributes extends HTMLAttributes {
+      data?: string | undefined
+      form?: string | undefined
+      height?: number | string | undefined
+      name?: string | undefined
+      type?: string | undefined
+      usemap?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface OlHTMLAttributes extends HTMLAttributes {
+      reversed?: boolean | undefined
+      start?: number | undefined
+      type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined
+    }
+
+    interface OptgroupHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      label?: string | undefined
+    }
+
+    interface OptionHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      label?: string | undefined
+      selected?: boolean | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface OutputHTMLAttributes extends HTMLAttributes {
+      form?: string | undefined
+      for?: string | undefined
+      name?: string | undefined
+    }
+
+    interface ParamHTMLAttributes extends HTMLAttributes {
+      name?: string | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface ProgressHTMLAttributes extends HTMLAttributes {
+      max?: number | string | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface SlotHTMLAttributes extends HTMLAttributes {
+      name?: string | undefined
+    }
+
+    interface ScriptHTMLAttributes extends HTMLAttributes {
+      async?: boolean | undefined
+      crossorigin?: CrossOrigin
+      defer?: boolean | undefined
+      integrity?: string | undefined
+      nomodule?: boolean | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      src?: string | undefined
+      type?: string | undefined
+    }
+
+    interface SelectHTMLAttributes extends HTMLAttributes {
+      autocomplete?: string | undefined
+      disabled?: boolean | undefined
+      form?: string | undefined
+      multiple?: boolean | undefined
+      name?: string | undefined
+      required?: boolean | undefined
+      size?: number | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface SourceHTMLAttributes extends HTMLAttributes {
+      height?: number | string | undefined
+      media?: string | undefined
+      sizes?: string | undefined
+      src?: string | undefined
+      srcset?: string | undefined
+      type?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface StyleHTMLAttributes extends HTMLAttributes {
+      media?: string | undefined
+      scoped?: boolean | undefined
+      type?: string | undefined
+    }
+
+    interface TableHTMLAttributes extends HTMLAttributes {
+      align?: 'left' | 'center' | 'right' | undefined
+      bgcolor?: string | undefined
+      border?: number | undefined
+      cellpadding?: number | string | undefined
+      cellspacing?: number | string | undefined
+      frame?: boolean | undefined
+      rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
+      summary?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface TextareaHTMLAttributes extends HTMLAttributes {
+      autocomplete?: string | undefined
+      cols?: number | undefined
+      dirname?: string | undefined
+      disabled?: boolean | undefined
+      form?: string | undefined
+      maxlength?: number | undefined
+      minlength?: number | undefined
+      name?: string | undefined
+      placeholder?: string | undefined
+      readonly?: boolean | undefined
+      required?: boolean | undefined
+      rows?: number | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+      wrap?: string | undefined
+    }
+
+    interface TdHTMLAttributes extends HTMLAttributes {
+      align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+      colspan?: number | undefined
+      headers?: string | undefined
+      rowspan?: number | undefined
+      scope?: string | undefined
+      abbr?: string | undefined
+      height?: number | string | undefined
+      width?: number | string | undefined
+      valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined
+    }
+
+    interface ThHTMLAttributes extends HTMLAttributes {
+      align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+      colspan?: number | undefined
+      headers?: string | undefined
+      rowspan?: number | undefined
+      scope?: string | undefined
+      abbr?: string | undefined
+    }
+
+    interface TimeHTMLAttributes extends HTMLAttributes {
+      datetime?: string | undefined
+    }
+
+    interface TrackHTMLAttributes extends HTMLAttributes {
+      default?: boolean | undefined
+      kind?: string | undefined
+      label?: string | undefined
+      src?: string | undefined
+      srclang?: string | undefined
+    }
+
+    interface VideoHTMLAttributes extends MediaHTMLAttributes {
+      height?: number | string | undefined
+      playsinline?: boolean | undefined
+      poster?: string | undefined
+      width?: number | string | undefined
+      disablePictureInPicture?: boolean | undefined
+      disableRemotePlayback?: boolean | undefined
+    }
+
+    interface IntrinsicElements {
+      a: AnchorHTMLAttributes
+      abbr: HTMLAttributes
+      address: HTMLAttributes
+      area: AreaHTMLAttributes
+      article: HTMLAttributes
+      aside: HTMLAttributes
+      audio: AudioHTMLAttributes
+      b: HTMLAttributes
+      base: BaseHTMLAttributes
+      bdi: HTMLAttributes
+      bdo: HTMLAttributes
+      big: HTMLAttributes
+      blockquote: BlockquoteHTMLAttributes
+      body: HTMLAttributes
+      br: HTMLAttributes
+      button: ButtonHTMLAttributes
+      canvas: CanvasHTMLAttributes
+      caption: HTMLAttributes
+      center: HTMLAttributes
+      cite: HTMLAttributes
+      code: HTMLAttributes
+      col: ColHTMLAttributes
+      colgroup: ColgroupHTMLAttributes
+      data: DataHTMLAttributes
+      datalist: HTMLAttributes
+      dd: HTMLAttributes
+      del: DelHTMLAttributes
+      details: DetailsHTMLAttributes
+      dfn: HTMLAttributes
+      dialog: DialogHTMLAttributes
+      div: HTMLAttributes
+      dl: HTMLAttributes
+      dt: HTMLAttributes
+      em: HTMLAttributes
+      embed: EmbedHTMLAttributes
+      fieldset: FieldsetHTMLAttributes
+      figcaption: HTMLAttributes
+      figure: HTMLAttributes
+      footer: HTMLAttributes
+      form: FormHTMLAttributes
+      h1: HTMLAttributes
+      h2: HTMLAttributes
+      h3: HTMLAttributes
+      h4: HTMLAttributes
+      h5: HTMLAttributes
+      h6: HTMLAttributes
+      head: HTMLAttributes
+      header: HTMLAttributes
+      hgroup: HTMLAttributes
+      hr: HTMLAttributes
+      html: HtmlHTMLAttributes
+      i: HTMLAttributes
+      iframe: IframeHTMLAttributes
+      img: ImgHTMLAttributes
+      input: InputHTMLAttributes
+      ins: InsHTMLAttributes
+      kbd: HTMLAttributes
+      keygen: KeygenHTMLAttributes
+      label: LabelHTMLAttributes
+      legend: HTMLAttributes
+      li: LiHTMLAttributes
+      link: LinkHTMLAttributes
+      main: HTMLAttributes
+      map: MapHTMLAttributes
+      mark: HTMLAttributes
+      menu: MenuHTMLAttributes
+      menuitem: HTMLAttributes
+      meta: MetaHTMLAttributes
+      meter: MeterHTMLAttributes
+      nav: HTMLAttributes
+      noscript: HTMLAttributes
+      object: ObjectHTMLAttributes
+      ol: OlHTMLAttributes
+      optgroup: OptgroupHTMLAttributes
+      option: OptionHTMLAttributes
+      output: OutputHTMLAttributes
+      p: HTMLAttributes
+      param: ParamHTMLAttributes
+      picture: HTMLAttributes
+      pre: HTMLAttributes
+      progress: ProgressHTMLAttributes
+      q: QuoteHTMLAttributes
+      rp: HTMLAttributes
+      rt: HTMLAttributes
+      ruby: HTMLAttributes
+      s: HTMLAttributes
+      samp: HTMLAttributes
+      search: HTMLAttributes
+      slot: SlotHTMLAttributes
+      script: ScriptHTMLAttributes
+      section: HTMLAttributes
+      select: SelectHTMLAttributes
+      small: HTMLAttributes
+      source: SourceHTMLAttributes
+      span: HTMLAttributes
+      strong: HTMLAttributes
+      style: StyleHTMLAttributes
+      sub: HTMLAttributes
+      summary: HTMLAttributes
+      sup: HTMLAttributes
+      table: TableHTMLAttributes
+      template: HTMLAttributes
+      tbody: HTMLAttributes
+      td: TdHTMLAttributes
+      textarea: TextareaHTMLAttributes
+      tfoot: HTMLAttributes
+      th: ThHTMLAttributes
+      thead: HTMLAttributes
+      time: TimeHTMLAttributes
+      title: HTMLAttributes
+      tr: HTMLAttributes
+      track: TrackHTMLAttributes
+      u: HTMLAttributes
+      ul: HTMLAttributes
+      var: HTMLAttributes
+      video: VideoHTMLAttributes
+      wbr: HTMLAttributes
+    }
   }
 }
 
-interface HTMLAttributes extends JSXAttributes, AnyAttributes {
-  accesskey?: string | undefined
-  autofocus?: boolean | undefined
-  class?: string | undefined
-  contenteditable?: boolean | 'inherit' | undefined
-  contextmenu?: string | undefined
-  dir?: string | undefined
-  draggable?: boolean | undefined
-  hidden?: boolean | undefined
-  id?: string | undefined
-  lang?: string | undefined
-  nonce?: string | undefined
-  placeholder?: string | undefined
-  slot?: string | undefined
-  spellcheck?: boolean | undefined
-  style?: CSSProperties | undefined
-  tabindex?: number | undefined
-  title?: string | undefined
-  translate?: 'yes' | 'no' | undefined
-}
-
-type HTMLAttributeReferrerPolicy =
-  | ''
-  | 'no-referrer'
-  | 'no-referrer-when-downgrade'
-  | 'origin'
-  | 'origin-when-cross-origin'
-  | 'same-origin'
-  | 'strict-origin'
-  | 'strict-origin-when-cross-origin'
-  | 'unsafe-url'
-
-type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
-
-interface AnchorHTMLAttributes extends HTMLAttributes {
-  download?: any
-  href?: string | undefined
-  hreflang?: string | undefined
-  media?: string | undefined
-  ping?: string | undefined
-  target?: HTMLAttributeAnchorTarget | undefined
-  type?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-}
-
-interface AudioHTMLAttributes extends MediaHTMLAttributes {}
-
-interface AreaHTMLAttributes extends HTMLAttributes {
-  alt?: string | undefined
-  coords?: string | undefined
-  download?: any
-  href?: string | undefined
-  hreflang?: string | undefined
-  media?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  shape?: string | undefined
-  target?: string | undefined
-}
-
-interface BaseHTMLAttributes extends HTMLAttributes {
-  href?: string | undefined
-  target?: string | undefined
-}
-
-interface BlockquoteHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-}
-
-interface ButtonHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  form?: string | undefined
-  formenctype?: string | undefined
-  formmethod?: string | undefined
-  formnovalidate?: boolean | undefined
-  formtarget?: string | undefined
-  name?: string | undefined
-  type?: 'submit' | 'reset' | 'button' | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface CanvasHTMLAttributes extends HTMLAttributes {
-  height?: number | string | undefined
-  width?: number | string | undefined
-}
-
-interface ColHTMLAttributes extends HTMLAttributes {
-  span?: number | undefined
-  width?: number | string | undefined
-}
-
-interface ColgroupHTMLAttributes extends HTMLAttributes {
-  span?: number | undefined
-}
-
-interface DataHTMLAttributes extends HTMLAttributes {
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface DetailsHTMLAttributes extends HTMLAttributes {
-  open?: boolean | undefined
-  ontoggle?: string | undefined
-}
-
-interface DelHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-  dateTime?: string | undefined
-}
-
-interface DialogHTMLAttributes extends HTMLAttributes {
-  oncancel?: string | undefined
-  onclose?: string | undefined
-  open?: boolean | undefined
-}
-
-interface EmbedHTMLAttributes extends HTMLAttributes {
-  height?: number | string | undefined
-  src?: string | undefined
-  type?: string | undefined
-  width?: number | string | undefined
-}
-
-interface FieldsetHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  form?: string | undefined
-  name?: string | undefined
-}
-
-interface FormHTMLAttributes extends HTMLAttributes {
-  'accept-charset'?: string | undefined
-  autocomplete?: string | undefined
-  enctype?: string | undefined
-  method?: string | undefined
-  name?: string | undefined
-  novalidate?: boolean | undefined
-  target?: string | undefined
-}
-
-interface HtmlHTMLAttributes extends HTMLAttributes {
-  manifest?: string | undefined
-}
-
-interface IframeHTMLAttributes extends HTMLAttributes {
-  allow?: string | undefined
-  allowfullscreen?: boolean | undefined
-  height?: number | string | undefined
-  loading?: 'eager' | 'lazy' | undefined
-  name?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  sandbox?: string | undefined
-  seamless?: boolean | undefined
-  src?: string | undefined
-  srcdoc?: string | undefined
-  width?: number | string | undefined
-}
-
-interface ImgHTMLAttributes extends HTMLAttributes {
-  alt?: string | undefined
-  crossorigin?: CrossOrigin
-  decoding?: 'async' | 'auto' | 'sync' | undefined
-  height?: number | string | undefined
-  loading?: 'eager' | 'lazy' | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  sizes?: string | undefined
-  src?: string | undefined
-  srcset?: string | undefined
-  usemap?: string | undefined
-  width?: number | string | undefined
-}
-
-interface InsHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-  datetime?: string | undefined
-}
-
-type HTMLInputTypeAttribute =
-  | 'button'
-  | 'checkbox'
-  | 'color'
-  | 'date'
-  | 'datetime-local'
-  | 'email'
-  | 'file'
-  | 'hidden'
-  | 'image'
-  | 'month'
-  | 'number'
-  | 'password'
-  | 'radio'
-  | 'range'
-  | 'reset'
-  | 'search'
-  | 'submit'
-  | 'tel'
-  | 'text'
-  | 'time'
-  | 'url'
-  | 'week'
-  | string
-
-interface InputHTMLAttributes extends HTMLAttributes {
-  accept?: string | undefined
-  alt?: string | undefined
-  autocomplete?: string | undefined
-  capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
-  checked?: boolean | undefined
-  disabled?: boolean | undefined
-  enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
-  form?: string | undefined
-  formenctype?: string | undefined
-  formmethod?: string | undefined
-  formnovalidate?: boolean | undefined
-  formtarget?: string | undefined
-  height?: number | string | undefined
-  list?: string | undefined
-  max?: number | string | undefined
-  maxlength?: number | undefined
-  min?: number | string | undefined
-  minlength?: number | undefined
-  multiple?: boolean | undefined
-  name?: string | undefined
-  pattern?: string | undefined
-  placeholder?: string | undefined
-  readonly?: boolean | undefined
-  required?: boolean | undefined
-  size?: number | undefined
-  src?: string | undefined
-  step?: number | string | undefined
-  type?: HTMLInputTypeAttribute | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-  width?: number | string | undefined
-  onchange?: string | undefined
-}
-
-interface KeygenHTMLAttributes extends HTMLAttributes {
-  challenge?: string | undefined
-  disabled?: boolean | undefined
-  form?: string | undefined
-  keytype?: string | undefined
-  name?: string | undefined
-}
-
-interface LabelHTMLAttributes extends HTMLAttributes {
-  form?: string | undefined
-  for?: string | undefined
-}
-
-interface LiHTMLAttributes extends HTMLAttributes {
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface LinkHTMLAttributes extends HTMLAttributes {
-  as?: string | undefined
-  crossorigin?: CrossOrigin
-  href?: string | undefined
-  hreflang?: string | undefined
-  integrity?: string | undefined
-  media?: string | undefined
-  imagesrcset?: string | undefined
-  imagesizes?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  sizes?: string | undefined
-  type?: string | undefined
-  charSet?: string | undefined
-}
-
-interface MapHTMLAttributes extends HTMLAttributes {
-  name?: string | undefined
-}
-
-interface MenuHTMLAttributes extends HTMLAttributes {
-  type?: string | undefined
-}
-
-interface MediaHTMLAttributes extends HTMLAttributes {
-  autoplay?: boolean | undefined
-  controls?: boolean | undefined
-  controlslist?: string | undefined
-  crossorigin?: CrossOrigin
-  loop?: boolean | undefined
-  mediagroup?: string | undefined
-  muted?: boolean | undefined
-  playsinline?: boolean | undefined
-  preload?: string | undefined
-  src?: string | undefined
-}
-
-interface MetaHTMLAttributes extends HTMLAttributes {
-  charset?: string | undefined
-  'http-equiv'?: string | undefined
-  name?: string | undefined
-  media?: string | undefined
-  content?: string | undefined
-}
-
-interface MeterHTMLAttributes extends HTMLAttributes {
-  form?: string | undefined
-  high?: number | undefined
-  low?: number | undefined
-  max?: number | string | undefined
-  min?: number | string | undefined
-  optimum?: number | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface QuoteHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-}
-
-interface ObjectHTMLAttributes extends HTMLAttributes {
-  data?: string | undefined
-  form?: string | undefined
-  height?: number | string | undefined
-  name?: string | undefined
-  type?: string | undefined
-  usemap?: string | undefined
-  width?: number | string | undefined
-}
-
-interface OlHTMLAttributes extends HTMLAttributes {
-  reversed?: boolean | undefined
-  start?: number | undefined
-  type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined
-}
-
-interface OptgroupHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  label?: string | undefined
-}
-
-interface OptionHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  label?: string | undefined
-  selected?: boolean | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface OutputHTMLAttributes extends HTMLAttributes {
-  form?: string | undefined
-  for?: string | undefined
-  name?: string | undefined
-}
-
-interface ParamHTMLAttributes extends HTMLAttributes {
-  name?: string | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface ProgressHTMLAttributes extends HTMLAttributes {
-  max?: number | string | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface SlotHTMLAttributes extends HTMLAttributes {
-  name?: string | undefined
-}
-
-interface ScriptHTMLAttributes extends HTMLAttributes {
-  async?: boolean | undefined
-  crossorigin?: CrossOrigin
-  defer?: boolean | undefined
-  integrity?: string | undefined
-  nomodule?: boolean | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  src?: string | undefined
-  type?: string | undefined
-}
-
-interface SelectHTMLAttributes extends HTMLAttributes {
-  autocomplete?: string | undefined
-  disabled?: boolean | undefined
-  form?: string | undefined
-  multiple?: boolean | undefined
-  name?: string | undefined
-  required?: boolean | undefined
-  size?: number | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-  onchange?: string | undefined
-}
-
-interface SourceHTMLAttributes extends HTMLAttributes {
-  height?: number | string | undefined
-  media?: string | undefined
-  sizes?: string | undefined
-  src?: string | undefined
-  srcset?: string | undefined
-  type?: string | undefined
-  width?: number | string | undefined
-}
-
-interface StyleHTMLAttributes extends HTMLAttributes {
-  media?: string | undefined
-  scoped?: boolean | undefined
-  type?: string | undefined
-}
-
-interface TableHTMLAttributes extends HTMLAttributes {
-  align?: 'left' | 'center' | 'right' | undefined
-  bgcolor?: string | undefined
-  border?: number | undefined
-  cellpadding?: number | string | undefined
-  cellspacing?: number | string | undefined
-  frame?: boolean | undefined
-  rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
-  summary?: string | undefined
-  width?: number | string | undefined
-}
-
-interface TextareaHTMLAttributes extends HTMLAttributes {
-  autocomplete?: string | undefined
-  cols?: number | undefined
-  dirname?: string | undefined
-  disabled?: boolean | undefined
-  form?: string | undefined
-  maxlength?: number | undefined
-  minlength?: number | undefined
-  name?: string | undefined
-  placeholder?: string | undefined
-  readonly?: boolean | undefined
-  required?: boolean | undefined
-  rows?: number | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-  wrap?: string | undefined
-  onchange?: string | undefined
-}
-
-interface TdHTMLAttributes extends HTMLAttributes {
-  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
-  colspan?: number | undefined
-  headers?: string | undefined
-  rowspan?: number | undefined
-  scope?: string | undefined
-  abbr?: string | undefined
-  height?: number | string | undefined
-  width?: number | string | undefined
-  valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined
-}
-
-interface ThHTMLAttributes extends HTMLAttributes {
-  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
-  colspan?: number | undefined
-  headers?: string | undefined
-  rowspan?: number | undefined
-  scope?: string | undefined
-  abbr?: string | undefined
-}
-
-interface TimeHTMLAttributes extends HTMLAttributes {
-  datetime?: string | undefined
-}
-
-interface TrackHTMLAttributes extends HTMLAttributes {
-  default?: boolean | undefined
-  kind?: string | undefined
-  label?: string | undefined
-  src?: string | undefined
-  srclang?: string | undefined
-}
-
-interface VideoHTMLAttributes extends MediaHTMLAttributes {
-  height?: number | string | undefined
-  playsinline?: boolean | undefined
-  poster?: string | undefined
-  width?: number | string | undefined
-  disablePictureInPicture?: boolean | undefined
-  disableRemotePlayback?: boolean | undefined
-}
-
-export interface IntrinsicElements {
-  a: AnchorHTMLAttributes
-  abbr: HTMLAttributes
-  address: HTMLAttributes
-  area: AreaHTMLAttributes
-  article: HTMLAttributes
-  aside: HTMLAttributes
-  audio: AudioHTMLAttributes
-  b: HTMLAttributes
-  base: BaseHTMLAttributes
-  bdi: HTMLAttributes
-  bdo: HTMLAttributes
-  big: HTMLAttributes
-  blockquote: BlockquoteHTMLAttributes
-  body: HTMLAttributes
-  br: HTMLAttributes
-  button: ButtonHTMLAttributes
-  canvas: CanvasHTMLAttributes
-  caption: HTMLAttributes
-  center: HTMLAttributes
-  cite: HTMLAttributes
-  code: HTMLAttributes
-  col: ColHTMLAttributes
-  colgroup: ColgroupHTMLAttributes
-  data: DataHTMLAttributes
-  datalist: HTMLAttributes
-  dd: HTMLAttributes
-  del: DelHTMLAttributes
-  details: DetailsHTMLAttributes
-  dfn: HTMLAttributes
-  dialog: DialogHTMLAttributes
-  div: HTMLAttributes
-  dl: HTMLAttributes
-  dt: HTMLAttributes
-  em: HTMLAttributes
-  embed: EmbedHTMLAttributes
-  fieldset: FieldsetHTMLAttributes
-  figcaption: HTMLAttributes
-  figure: HTMLAttributes
-  footer: HTMLAttributes
-  form: FormHTMLAttributes
-  h1: HTMLAttributes
-  h2: HTMLAttributes
-  h3: HTMLAttributes
-  h4: HTMLAttributes
-  h5: HTMLAttributes
-  h6: HTMLAttributes
-  head: HTMLAttributes
-  header: HTMLAttributes
-  hgroup: HTMLAttributes
-  hr: HTMLAttributes
-  html: HtmlHTMLAttributes
-  i: HTMLAttributes
-  iframe: IframeHTMLAttributes
-  img: ImgHTMLAttributes
-  input: InputHTMLAttributes
-  ins: InsHTMLAttributes
-  kbd: HTMLAttributes
-  keygen: KeygenHTMLAttributes
-  label: LabelHTMLAttributes
-  legend: HTMLAttributes
-  li: LiHTMLAttributes
-  link: LinkHTMLAttributes
-  main: HTMLAttributes
-  map: MapHTMLAttributes
-  mark: HTMLAttributes
-  menu: MenuHTMLAttributes
-  menuitem: HTMLAttributes
-  meta: MetaHTMLAttributes
-  meter: MeterHTMLAttributes
-  nav: HTMLAttributes
-  noscript: HTMLAttributes
-  object: ObjectHTMLAttributes
-  ol: OlHTMLAttributes
-  optgroup: OptgroupHTMLAttributes
-  option: OptionHTMLAttributes
-  output: OutputHTMLAttributes
-  p: HTMLAttributes
-  param: ParamHTMLAttributes
-  picture: HTMLAttributes
-  pre: HTMLAttributes
-  progress: ProgressHTMLAttributes
-  q: QuoteHTMLAttributes
-  rp: HTMLAttributes
-  rt: HTMLAttributes
-  ruby: HTMLAttributes
-  s: HTMLAttributes
-  samp: HTMLAttributes
-  search: HTMLAttributes
-  slot: SlotHTMLAttributes
-  script: ScriptHTMLAttributes
-  section: HTMLAttributes
-  select: SelectHTMLAttributes
-  small: HTMLAttributes
-  source: SourceHTMLAttributes
-  span: HTMLAttributes
-  strong: HTMLAttributes
-  style: StyleHTMLAttributes
-  sub: HTMLAttributes
-  summary: HTMLAttributes
-  sup: HTMLAttributes
-  table: TableHTMLAttributes
-  template: HTMLAttributes
-  tbody: HTMLAttributes
-  td: TdHTMLAttributes
-  textarea: TextareaHTMLAttributes
-  tfoot: HTMLAttributes
-  th: ThHTMLAttributes
-  thead: HTMLAttributes
-  time: TimeHTMLAttributes
-  title: HTMLAttributes
-  tr: HTMLAttributes
-  track: TrackHTMLAttributes
-  u: HTMLAttributes
-  ul: HTMLAttributes
-  var: HTMLAttributes
-  video: VideoHTMLAttributes
-  wbr: HTMLAttributes
-}
+export interface IntrinsicElements extends Hono.IntrinsicElements {}

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -12,7 +12,9 @@ declare global {
     interface ElementChildrenAttribute {
       children: Child
     }
-    type IntrinsicElements = IntrinsicElementsDefined & { [tagName: string]: Props }
+    interface IntrinsicElements extends IntrinsicElementsDefined {
+      [tagName: string]: Props
+    }
   }
 }
 

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -9,7 +9,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     type Element = HtmlEscapedString
-    type IntrinsicElements = IntrinsicElementsDefined
+    type IntrinsicElements = IntrinsicElementsDefined & { [tagName: string]: Props }
   }
 }
 

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -9,6 +9,9 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     type Element = HtmlEscapedString
+    interface ElementChildrenAttribute {
+      children: Child
+    }
     type IntrinsicElements = IntrinsicElementsDefined & { [tagName: string]: Props }
   }
 }

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -1,5 +1,6 @@
 import { escapeToBuffer } from '../utils/html'
 import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../utils/html'
+import type { IntrinsicElements as IntrinsicElementsDefined } from './intrinsic-elements'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Props = Record<string, any>
@@ -8,12 +9,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     type Element = HtmlEscapedString
-    interface ElementChildrenAttribute {
-      children: Child
-    }
-    interface IntrinsicElements {
-      [tagName: string]: Props
-    }
+    type IntrinsicElements = IntrinsicElementsDefined
   }
 }
 

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -122,7 +122,7 @@ interface DetailsHTMLAttributes extends HTMLAttributes {
 
 interface DelHTMLAttributes extends HTMLAttributes {
   cite?: string | undefined
-  dateTime?: string | undefined
+  datetime?: string | undefined
 }
 
 interface DialogHTMLAttributes extends HTMLAttributes {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -120,7 +120,6 @@ declare global {
 
     interface DetailsHTMLAttributes extends HTMLAttributes {
       open?: boolean | undefined
-      ontoggle?: string | undefined
     }
 
     interface DelHTMLAttributes extends HTMLAttributes {
@@ -129,8 +128,6 @@ declare global {
     }
 
     interface DialogHTMLAttributes extends HTMLAttributes {
-      oncancel?: string | undefined
-      onclose?: string | undefined
       open?: boolean | undefined
     }
 
@@ -250,7 +247,6 @@ declare global {
       type?: HTMLInputTypeAttribute | undefined
       value?: string | ReadonlyArray<string> | number | undefined
       width?: number | string | undefined
-      onchange?: string | undefined
     }
 
     interface KeygenHTMLAttributes extends HTMLAttributes {
@@ -396,7 +392,6 @@ declare global {
       required?: boolean | undefined
       size?: number | undefined
       value?: string | ReadonlyArray<string> | number | undefined
-      onchange?: string | undefined
     }
 
     interface SourceHTMLAttributes extends HTMLAttributes {
@@ -442,7 +437,6 @@ declare global {
       rows?: number | undefined
       value?: string | ReadonlyArray<string> | number | undefined
       wrap?: string | undefined
-      onchange?: string | undefined
     }
 
     interface TdHTMLAttributes extends HTMLAttributes {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -9,178 +9,20 @@
 
 type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
 type CSSProperties = {}
+type AnyAttributes = { [attributeName: string]: any }
 
-interface DOMAttributes {
+interface JSXAttributes {
   dangerouslySetInnerHTML?: {
     __html: string
   }
-  key?: string // For compatibility
 }
 
-interface AriaAttributes {
-  'aria-activedescendant'?: string | undefined
-  'aria-atomic'?: boolean | undefined
-  'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined
-  'aria-braillelabel'?: string | undefined
-  'aria-brailleroledescription'?: string | undefined
-  'aria-busy'?: boolean | undefined
-  'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined
-  'aria-colcount'?: number | undefined
-  'aria-colindex'?: number | undefined
-  'aria-colindextext'?: string | undefined
-  'aria-colspan'?: number | undefined
-  'aria-controls'?: string | undefined
-  'aria-current'?:
-    | boolean
-    | 'false'
-    | 'true'
-    | 'page'
-    | 'step'
-    | 'location'
-    | 'date'
-    | 'time'
-    | undefined
-  'aria-describedby'?: string | undefined
-  'aria-description'?: string | undefined
-  'aria-details'?: string | undefined
-  'aria-disabled'?: boolean | undefined
-  'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined
-  'aria-errormessage'?: string | undefined
-  'aria-expanded'?: boolean | undefined
-  'aria-flowto'?: string | undefined
-  'aria-grabbed'?: boolean | undefined
-  'aria-haspopup'?:
-    | boolean
-    | 'false'
-    | 'true'
-    | 'menu'
-    | 'listbox'
-    | 'tree'
-    | 'grid'
-    | 'dialog'
-    | undefined
-  'aria-hidden'?: boolean | undefined
-  'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined
-  'aria-keyshortcuts'?: string | undefined
-  'aria-label'?: string | undefined
-  'aria-labelledby'?: string | undefined
-  'aria-level'?: number | undefined
-  'aria-live'?: 'off' | 'assertive' | 'polite' | undefined
-  'aria-modal'?: boolean | undefined
-  'aria-multiline'?: boolean | undefined
-  'aria-multiselectable'?: boolean | undefined
-  'aria-orientation'?: 'horizontal' | 'vertical' | undefined
-  'aria-owns'?: string | undefined
-  'aria-placeholder'?: string | undefined
-  'aria-posinset'?: number | undefined
-  'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined
-  'aria-readonly'?: boolean | undefined
-  'aria-relevant'?:
-    | 'additions'
-    | 'additions removals'
-    | 'additions text'
-    | 'all'
-    | 'removals'
-    | 'removals additions'
-    | 'removals text'
-    | 'text'
-    | 'text additions'
-    | 'text removals'
-    | undefined
-  'aria-required'?: boolean | undefined
-  'aria-roledescription'?: string | undefined
-  'aria-rowcount'?: number | undefined
-  'aria-rowindex'?: number | undefined
-  'aria-rowindextext'?: string | undefined
-  'aria-rowspan'?: number | undefined
-  'aria-selected'?: boolean | undefined
-  'aria-setsize'?: number | undefined
-  'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined
-  'aria-valuemax'?: number | undefined
-  'aria-valuemin'?: number | undefined
-  'aria-valuenow'?: number | undefined
-  'aria-valuetext'?: string | undefined
-}
-
-type AriaRole =
-  | 'alert'
-  | 'alertdialog'
-  | 'application'
-  | 'article'
-  | 'banner'
-  | 'button'
-  | 'cell'
-  | 'checkbox'
-  | 'columnheader'
-  | 'combobox'
-  | 'complementary'
-  | 'contentinfo'
-  | 'definition'
-  | 'dialog'
-  | 'directory'
-  | 'document'
-  | 'feed'
-  | 'figure'
-  | 'form'
-  | 'grid'
-  | 'gridcell'
-  | 'group'
-  | 'heading'
-  | 'img'
-  | 'link'
-  | 'list'
-  | 'listbox'
-  | 'listitem'
-  | 'log'
-  | 'main'
-  | 'marquee'
-  | 'math'
-  | 'menu'
-  | 'menubar'
-  | 'menuitem'
-  | 'menuitemcheckbox'
-  | 'menuitemradio'
-  | 'navigation'
-  | 'none'
-  | 'note'
-  | 'option'
-  | 'presentation'
-  | 'progressbar'
-  | 'radio'
-  | 'radiogroup'
-  | 'region'
-  | 'row'
-  | 'rowgroup'
-  | 'rowheader'
-  | 'scrollbar'
-  | 'search'
-  | 'searchbox'
-  | 'separator'
-  | 'slider'
-  | 'spinbutton'
-  | 'status'
-  | 'switch'
-  | 'tab'
-  | 'table'
-  | 'tablist'
-  | 'tabpanel'
-  | 'term'
-  | 'textbox'
-  | 'timer'
-  | 'toolbar'
-  | 'tooltip'
-  | 'tree'
-  | 'treegrid'
-  | 'treeitem'
-  | (string & {})
-
-interface HTMLAttributes extends AriaAttributes, DOMAttributes {
-  // Standard HTML Attributes
+interface HTMLAttributes extends JSXAttributes, AnyAttributes {
   accessKey?: string | undefined
-  autoFocus?: boolean | undefined
-  className?: string | undefined
-  contentEditable?: boolean | 'inherit' | undefined
-  contextMenu?: string | undefined
+  autofocus?: boolean | undefined
+  class?: string | undefined
+  contenteditable?: boolean | 'inherit' | undefined
+  contextmenu?: string | undefined
   dir?: string | undefined
   draggable?: boolean | undefined
   hidden?: boolean | undefined
@@ -189,64 +31,11 @@ interface HTMLAttributes extends AriaAttributes, DOMAttributes {
   nonce?: string | undefined
   placeholder?: string | undefined
   slot?: string | undefined
-  spellCheck?: boolean | undefined
+  spellcheck?: boolean | undefined
   style?: CSSProperties | undefined
-  tabIndex?: number | undefined
+  tabindex?: number | undefined
   title?: string | undefined
   translate?: 'yes' | 'no' | undefined
-
-  // Unknown
-  radioGroup?: string | undefined // <command>, <menuitem
-  // WAI-ARIA
-  role?: AriaRole | undefined
-
-  // RDFa Attributes
-  about?: string | undefined
-  content?: string | undefined
-  datatype?: string | undefined
-  inlist?: any
-  prefix?: string | undefined
-  property?: string | undefined
-  rel?: string | undefined
-  resource?: string | undefined
-  rev?: string | undefined
-  typeof?: string | undefined
-  vocab?: string | undefined
-
-  // Non-standard Attributes
-  autoCapitalize?: string | undefined
-  autoCorrect?: string | undefined
-  autoSave?: string | undefined
-  color?: string | undefined
-  itemProp?: string | undefined
-  itemScope?: boolean | undefined
-  itemType?: string | undefined
-  itemID?: string | undefined
-  itemRef?: string | undefined
-  results?: number | undefined
-  security?: string | undefined
-  unselectable?: 'on' | 'off' | undefined
-
-  // Living Standard
-  /**
-   * Hints at the type of data that might be entered by the user while editing the element or its contents
-   * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
-   */
-  inputMode?:
-    | 'none'
-    | 'text'
-    | 'tel'
-    | 'url'
-    | 'email'
-    | 'numeric'
-    | 'decimal'
-    | 'search'
-    | undefined
-  /**
-   * Specify that a standard HTML element should behave like a defined custom built-in element
-   * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
-   */
-  is?: string | undefined
 }
 
 type HTMLAttributeReferrerPolicy =
@@ -260,17 +49,17 @@ type HTMLAttributeReferrerPolicy =
   | 'strict-origin-when-cross-origin'
   | 'unsafe-url'
 
-type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {})
+type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
 
 interface AnchorHTMLAttributes extends HTMLAttributes {
   download?: any
   href?: string | undefined
-  hrefLang?: string | undefined
+  hreflang?: string | undefined
   media?: string | undefined
   ping?: string | undefined
   target?: HTMLAttributeAnchorTarget | undefined
   type?: string | undefined
-  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
 }
 
 interface AudioHTMLAttributes extends MediaHTMLAttributes {}
@@ -280,9 +69,9 @@ interface AreaHTMLAttributes extends HTMLAttributes {
   coords?: string | undefined
   download?: any
   href?: string | undefined
-  hrefLang?: string | undefined
+  hreflang?: string | undefined
   media?: string | undefined
-  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
   shape?: string | undefined
   target?: string | undefined
 }
@@ -299,10 +88,10 @@ interface BlockquoteHTMLAttributes extends HTMLAttributes {
 interface ButtonHTMLAttributes extends HTMLAttributes {
   disabled?: boolean | undefined
   form?: string | undefined
-  formEncType?: string | undefined
-  formMethod?: string | undefined
-  formNoValidate?: boolean | undefined
-  formTarget?: string | undefined
+  formenctype?: string | undefined
+  formmethod?: string | undefined
+  formnovalidate?: boolean | undefined
+  formtarget?: string | undefined
   name?: string | undefined
   type?: 'submit' | 'reset' | 'button' | undefined
   value?: string | ReadonlyArray<string> | number | undefined
@@ -328,7 +117,7 @@ interface DataHTMLAttributes extends HTMLAttributes {
 
 interface DetailsHTMLAttributes extends HTMLAttributes {
   open?: boolean | undefined
-  onToggle?: string | undefined
+  ontoggle?: string | undefined
 }
 
 interface DelHTMLAttributes extends HTMLAttributes {
@@ -337,8 +126,8 @@ interface DelHTMLAttributes extends HTMLAttributes {
 }
 
 interface DialogHTMLAttributes extends HTMLAttributes {
-  onCancel?: string | undefined
-  onClose?: string | undefined
+  oncancel?: string | undefined
+  onclose?: string | undefined
   open?: boolean | undefined
 }
 
@@ -356,12 +145,12 @@ interface FieldsetHTMLAttributes extends HTMLAttributes {
 }
 
 interface FormHTMLAttributes extends HTMLAttributes {
-  acceptCharset?: string | undefined
-  autoComplete?: string | undefined
-  encType?: string | undefined
+  'accept-charset'?: string | undefined
+  autocomplete?: string | undefined
+  enctype?: string | undefined
   method?: string | undefined
   name?: string | undefined
-  noValidate?: boolean | undefined
+  novalidate?: boolean | undefined
   target?: string | undefined
 }
 
@@ -371,21 +160,12 @@ interface HtmlHTMLAttributes extends HTMLAttributes {
 
 interface IframeHTMLAttributes extends HTMLAttributes {
   allow?: string | undefined
-  allowFullScreen?: boolean | undefined
-  allowTransparency?: boolean | undefined
-  /** @deprecated */
-  frameBorder?: number | string | undefined
+  allowfullScreen?: boolean | undefined
   height?: number | string | undefined
   loading?: 'eager' | 'lazy' | undefined
-  /** @deprecated */
-  marginHeight?: number | undefined
-  /** @deprecated */
-  marginWidth?: number | undefined
   name?: string | undefined
-  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
   sandbox?: string | undefined
-  /** @deprecated */
-  scrolling?: string | undefined
   seamless?: boolean | undefined
   src?: string | undefined
   srcDoc?: string | undefined
@@ -394,21 +174,21 @@ interface IframeHTMLAttributes extends HTMLAttributes {
 
 interface ImgHTMLAttributes extends HTMLAttributes {
   alt?: string | undefined
-  crossOrigin?: CrossOrigin
+  crossorigin?: CrossOrigin
   decoding?: 'async' | 'auto' | 'sync' | undefined
   height?: number | string | undefined
   loading?: 'eager' | 'lazy' | undefined
-  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
   sizes?: string | undefined
   src?: string | undefined
-  srcSet?: string | undefined
-  useMap?: string | undefined
+  srcset?: string | undefined
+  usemap?: string | undefined
   width?: number | string | undefined
 }
 
 interface InsHTMLAttributes extends HTMLAttributes {
   cite?: string | undefined
-  dateTime?: string | undefined
+  datetime?: string | undefined
 }
 
 type HTMLInputTypeAttribute =
@@ -434,32 +214,32 @@ type HTMLInputTypeAttribute =
   | 'time'
   | 'url'
   | 'week'
-  | (string & {})
+  | string
 
 interface InputHTMLAttributes extends HTMLAttributes {
   accept?: string | undefined
   alt?: string | undefined
-  autoComplete?: string | undefined
+  autocomplete?: string | undefined
   capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
   checked?: boolean | undefined
   disabled?: boolean | undefined
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
+  enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
   form?: string | undefined
-  formEncType?: string | undefined
-  formMethod?: string | undefined
-  formNoValidate?: boolean | undefined
-  formTarget?: string | undefined
+  formenctype?: string | undefined
+  formmethod?: string | undefined
+  formnovalidate?: boolean | undefined
+  formtarget?: string | undefined
   height?: number | string | undefined
   list?: string | undefined
   max?: number | string | undefined
-  maxLength?: number | undefined
+  maxlength?: number | undefined
   min?: number | string | undefined
-  minLength?: number | undefined
+  minlength?: number | undefined
   multiple?: boolean | undefined
   name?: string | undefined
   pattern?: string | undefined
   placeholder?: string | undefined
-  readOnly?: boolean | undefined
+  readonly?: boolean | undefined
   required?: boolean | undefined
   size?: number | undefined
   src?: string | undefined
@@ -467,22 +247,20 @@ interface InputHTMLAttributes extends HTMLAttributes {
   type?: HTMLInputTypeAttribute | undefined
   value?: string | ReadonlyArray<string> | number | undefined
   width?: number | string | undefined
-
-  onChange?: string | undefined
+  onchange?: string | undefined
 }
 
 interface KeygenHTMLAttributes extends HTMLAttributes {
   challenge?: string | undefined
   disabled?: boolean | undefined
   form?: string | undefined
-  keyType?: string | undefined
-  keyParams?: string | undefined
+  keytype?: string | undefined
   name?: string | undefined
 }
 
 interface LabelHTMLAttributes extends HTMLAttributes {
   form?: string | undefined
-  htmlFor?: string | undefined
+  for?: string | undefined
 }
 
 interface LiHTMLAttributes extends HTMLAttributes {
@@ -491,15 +269,14 @@ interface LiHTMLAttributes extends HTMLAttributes {
 
 interface LinkHTMLAttributes extends HTMLAttributes {
   as?: string | undefined
-  crossOrigin?: CrossOrigin
-  fetchPriority?: 'high' | 'low' | 'auto'
+  crossorigin?: CrossOrigin
   href?: string | undefined
-  hrefLang?: string | undefined
+  hreflang?: string | undefined
   integrity?: string | undefined
   media?: string | undefined
-  imageSrcSet?: string | undefined
-  imageSizes?: string | undefined
-  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  imagesrcset?: string | undefined
+  imagesizes?: string | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
   sizes?: string | undefined
   type?: string | undefined
   charSet?: string | undefined
@@ -514,21 +291,21 @@ interface MenuHTMLAttributes extends HTMLAttributes {
 }
 
 interface MediaHTMLAttributes extends HTMLAttributes {
-  autoPlay?: boolean | undefined
+  autoplay?: boolean | undefined
   controls?: boolean | undefined
-  controlsList?: string | undefined
-  crossOrigin?: CrossOrigin
+  controlslist?: string | undefined
+  crossorigin?: CrossOrigin
   loop?: boolean | undefined
-  mediaGroup?: string | undefined
+  mediagroup?: string | undefined
   muted?: boolean | undefined
-  playsInline?: boolean | undefined
+  playsinline?: boolean | undefined
   preload?: string | undefined
   src?: string | undefined
 }
 
 interface MetaHTMLAttributes extends HTMLAttributes {
-  charSet?: string | undefined
-  httpEquiv?: string | undefined
+  charset?: string | undefined
+  'http-equiv'?: string | undefined
   name?: string | undefined
   media?: string | undefined
   content?: string | undefined
@@ -549,15 +326,13 @@ interface QuoteHTMLAttributes extends HTMLAttributes {
 }
 
 interface ObjectHTMLAttributes extends HTMLAttributes {
-  classID?: string | undefined
   data?: string | undefined
   form?: string | undefined
   height?: number | string | undefined
   name?: string | undefined
   type?: string | undefined
-  useMap?: string | undefined
+  usemap?: string | undefined
   width?: number | string | undefined
-  wmode?: string | undefined
 }
 
 interface OlHTMLAttributes extends HTMLAttributes {
@@ -580,7 +355,7 @@ interface OptionHTMLAttributes extends HTMLAttributes {
 
 interface OutputHTMLAttributes extends HTMLAttributes {
   form?: string | undefined
-  htmlFor?: string | undefined
+  for?: string | undefined
   name?: string | undefined
 }
 
@@ -600,19 +375,17 @@ interface SlotHTMLAttributes extends HTMLAttributes {
 
 interface ScriptHTMLAttributes extends HTMLAttributes {
   async?: boolean | undefined
-  /** @deprecated */
-  charSet?: string | undefined
-  crossOrigin?: CrossOrigin
+  crossorigin?: CrossOrigin
   defer?: boolean | undefined
   integrity?: string | undefined
-  noModule?: boolean | undefined
-  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  nomodule?: boolean | undefined
+  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
   src?: string | undefined
   type?: string | undefined
 }
 
 interface SelectHTMLAttributes extends HTMLAttributes {
-  autoComplete?: string | undefined
+  autocomplete?: string | undefined
   disabled?: boolean | undefined
   form?: string | undefined
   multiple?: boolean | undefined
@@ -620,7 +393,7 @@ interface SelectHTMLAttributes extends HTMLAttributes {
   required?: boolean | undefined
   size?: number | undefined
   value?: string | ReadonlyArray<string> | number | undefined
-  onChange?: string | undefined
+  onchange?: string | undefined
 }
 
 interface SourceHTMLAttributes extends HTMLAttributes {
@@ -628,7 +401,7 @@ interface SourceHTMLAttributes extends HTMLAttributes {
   media?: string | undefined
   sizes?: string | undefined
   src?: string | undefined
-  srcSet?: string | undefined
+  srcset?: string | undefined
   type?: string | undefined
   width?: number | string | undefined
 }
@@ -643,8 +416,8 @@ interface TableHTMLAttributes extends HTMLAttributes {
   align?: 'left' | 'center' | 'right' | undefined
   bgcolor?: string | undefined
   border?: number | undefined
-  cellPadding?: number | string | undefined
-  cellSpacing?: number | string | undefined
+  cellpadding?: number | string | undefined
+  cellspacing?: number | string | undefined
   frame?: boolean | undefined
   rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
   summary?: string | undefined
@@ -652,28 +425,28 @@ interface TableHTMLAttributes extends HTMLAttributes {
 }
 
 interface TextareaHTMLAttributes extends HTMLAttributes {
-  autoComplete?: string | undefined
+  autocomplete?: string | undefined
   cols?: number | undefined
-  dirName?: string | undefined
+  dirname?: string | undefined
   disabled?: boolean | undefined
   form?: string | undefined
-  maxLength?: number | undefined
-  minLength?: number | undefined
+  maxlength?: number | undefined
+  minlength?: number | undefined
   name?: string | undefined
   placeholder?: string | undefined
-  readOnly?: boolean | undefined
+  readonly?: boolean | undefined
   required?: boolean | undefined
   rows?: number | undefined
   value?: string | ReadonlyArray<string> | number | undefined
   wrap?: string | undefined
-  onChange?: string | undefined
+  onchange?: string | undefined
 }
 
 interface TdHTMLAttributes extends HTMLAttributes {
   align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
-  colSpan?: number | undefined
+  colspan?: number | undefined
   headers?: string | undefined
-  rowSpan?: number | undefined
+  rowspan?: number | undefined
   scope?: string | undefined
   abbr?: string | undefined
   height?: number | string | undefined
@@ -683,15 +456,15 @@ interface TdHTMLAttributes extends HTMLAttributes {
 
 interface ThHTMLAttributes extends HTMLAttributes {
   align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
-  colSpan?: number | undefined
+  colspan?: number | undefined
   headers?: string | undefined
-  rowSpan?: number | undefined
+  rowspan?: number | undefined
   scope?: string | undefined
   abbr?: string | undefined
 }
 
 interface TimeHTMLAttributes extends HTMLAttributes {
-  dateTime?: string | undefined
+  datetime?: string | undefined
 }
 
 interface TrackHTMLAttributes extends HTMLAttributes {
@@ -699,16 +472,16 @@ interface TrackHTMLAttributes extends HTMLAttributes {
   kind?: string | undefined
   label?: string | undefined
   src?: string | undefined
-  srcLang?: string | undefined
+  srclang?: string | undefined
 }
 
 interface VideoHTMLAttributes extends MediaHTMLAttributes {
   height?: number | string | undefined
-  playsInline?: boolean | undefined
+  playsinline?: boolean | undefined
   poster?: string | undefined
   width?: number | string | undefined
-  disablePictureInPicture?: boolean | undefined
-  disableRemotePlayback?: boolean | undefined
+  disablepictureInpicture?: boolean | undefined
+  disableremoteplayback?: boolean | undefined
 }
 
 export interface IntrinsicElements {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -18,7 +18,7 @@ interface JSXAttributes {
 }
 
 interface HTMLAttributes extends JSXAttributes, AnyAttributes {
-  accessKey?: string | undefined
+  accesskey?: string | undefined
   autofocus?: boolean | undefined
   class?: string | undefined
   contenteditable?: boolean | 'inherit' | undefined
@@ -160,7 +160,7 @@ interface HtmlHTMLAttributes extends HTMLAttributes {
 
 interface IframeHTMLAttributes extends HTMLAttributes {
   allow?: string | undefined
-  allowfullScreen?: boolean | undefined
+  allowfullscreen?: boolean | undefined
   height?: number | string | undefined
   loading?: 'eager' | 'lazy' | undefined
   name?: string | undefined
@@ -168,7 +168,7 @@ interface IframeHTMLAttributes extends HTMLAttributes {
   sandbox?: string | undefined
   seamless?: boolean | undefined
   src?: string | undefined
-  srcDoc?: string | undefined
+  srcdoc?: string | undefined
   width?: number | string | undefined
 }
 
@@ -480,8 +480,8 @@ interface VideoHTMLAttributes extends MediaHTMLAttributes {
   playsinline?: boolean | undefined
   poster?: string | undefined
   width?: number | string | undefined
-  disablepictureInpicture?: boolean | undefined
-  disableremoteplayback?: boolean | undefined
+  disablePictureInPicture?: boolean | undefined
+  disableRemotePlayback?: boolean | undefined
 }
 
 export interface IntrinsicElements {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -1,0 +1,832 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * This code is based on React.
+ * https://github.com/facebook/react
+ * MIT License
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ */
+
+type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
+type CSSProperties = {}
+
+interface DOMAttributes {
+  dangerouslySetInnerHTML?: {
+    __html: string
+  }
+  key?: string // For compatibility
+}
+
+interface AriaAttributes {
+  'aria-activedescendant'?: string | undefined
+  'aria-atomic'?: boolean | undefined
+  'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined
+  'aria-braillelabel'?: string | undefined
+  'aria-brailleroledescription'?: string | undefined
+  'aria-busy'?: boolean | undefined
+  'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined
+  'aria-colcount'?: number | undefined
+  'aria-colindex'?: number | undefined
+  'aria-colindextext'?: string | undefined
+  'aria-colspan'?: number | undefined
+  'aria-controls'?: string | undefined
+  'aria-current'?:
+    | boolean
+    | 'false'
+    | 'true'
+    | 'page'
+    | 'step'
+    | 'location'
+    | 'date'
+    | 'time'
+    | undefined
+  'aria-describedby'?: string | undefined
+  'aria-description'?: string | undefined
+  'aria-details'?: string | undefined
+  'aria-disabled'?: boolean | undefined
+  'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined
+  'aria-errormessage'?: string | undefined
+  'aria-expanded'?: boolean | undefined
+  'aria-flowto'?: string | undefined
+  'aria-grabbed'?: boolean | undefined
+  'aria-haspopup'?:
+    | boolean
+    | 'false'
+    | 'true'
+    | 'menu'
+    | 'listbox'
+    | 'tree'
+    | 'grid'
+    | 'dialog'
+    | undefined
+  'aria-hidden'?: boolean | undefined
+  'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined
+  'aria-keyshortcuts'?: string | undefined
+  'aria-label'?: string | undefined
+  'aria-labelledby'?: string | undefined
+  'aria-level'?: number | undefined
+  'aria-live'?: 'off' | 'assertive' | 'polite' | undefined
+  'aria-modal'?: boolean | undefined
+  'aria-multiline'?: boolean | undefined
+  'aria-multiselectable'?: boolean | undefined
+  'aria-orientation'?: 'horizontal' | 'vertical' | undefined
+  'aria-owns'?: string | undefined
+  'aria-placeholder'?: string | undefined
+  'aria-posinset'?: number | undefined
+  'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined
+  'aria-readonly'?: boolean | undefined
+  'aria-relevant'?:
+    | 'additions'
+    | 'additions removals'
+    | 'additions text'
+    | 'all'
+    | 'removals'
+    | 'removals additions'
+    | 'removals text'
+    | 'text'
+    | 'text additions'
+    | 'text removals'
+    | undefined
+  'aria-required'?: boolean | undefined
+  'aria-roledescription'?: string | undefined
+  'aria-rowcount'?: number | undefined
+  'aria-rowindex'?: number | undefined
+  'aria-rowindextext'?: string | undefined
+  'aria-rowspan'?: number | undefined
+  'aria-selected'?: boolean | undefined
+  'aria-setsize'?: number | undefined
+  'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined
+  'aria-valuemax'?: number | undefined
+  'aria-valuemin'?: number | undefined
+  'aria-valuenow'?: number | undefined
+  'aria-valuetext'?: string | undefined
+}
+
+type AriaRole =
+  | 'alert'
+  | 'alertdialog'
+  | 'application'
+  | 'article'
+  | 'banner'
+  | 'button'
+  | 'cell'
+  | 'checkbox'
+  | 'columnheader'
+  | 'combobox'
+  | 'complementary'
+  | 'contentinfo'
+  | 'definition'
+  | 'dialog'
+  | 'directory'
+  | 'document'
+  | 'feed'
+  | 'figure'
+  | 'form'
+  | 'grid'
+  | 'gridcell'
+  | 'group'
+  | 'heading'
+  | 'img'
+  | 'link'
+  | 'list'
+  | 'listbox'
+  | 'listitem'
+  | 'log'
+  | 'main'
+  | 'marquee'
+  | 'math'
+  | 'menu'
+  | 'menubar'
+  | 'menuitem'
+  | 'menuitemcheckbox'
+  | 'menuitemradio'
+  | 'navigation'
+  | 'none'
+  | 'note'
+  | 'option'
+  | 'presentation'
+  | 'progressbar'
+  | 'radio'
+  | 'radiogroup'
+  | 'region'
+  | 'row'
+  | 'rowgroup'
+  | 'rowheader'
+  | 'scrollbar'
+  | 'search'
+  | 'searchbox'
+  | 'separator'
+  | 'slider'
+  | 'spinbutton'
+  | 'status'
+  | 'switch'
+  | 'tab'
+  | 'table'
+  | 'tablist'
+  | 'tabpanel'
+  | 'term'
+  | 'textbox'
+  | 'timer'
+  | 'toolbar'
+  | 'tooltip'
+  | 'tree'
+  | 'treegrid'
+  | 'treeitem'
+  | (string & {})
+
+interface HTMLAttributes extends AriaAttributes, DOMAttributes {
+  // Standard HTML Attributes
+  accessKey?: string | undefined
+  autoFocus?: boolean | undefined
+  className?: string | undefined
+  contentEditable?: boolean | 'inherit' | undefined
+  contextMenu?: string | undefined
+  dir?: string | undefined
+  draggable?: boolean | undefined
+  hidden?: boolean | undefined
+  id?: string | undefined
+  lang?: string | undefined
+  nonce?: string | undefined
+  placeholder?: string | undefined
+  slot?: string | undefined
+  spellCheck?: boolean | undefined
+  style?: CSSProperties | undefined
+  tabIndex?: number | undefined
+  title?: string | undefined
+  translate?: 'yes' | 'no' | undefined
+
+  // Unknown
+  radioGroup?: string | undefined // <command>, <menuitem
+  // WAI-ARIA
+  role?: AriaRole | undefined
+
+  // RDFa Attributes
+  about?: string | undefined
+  content?: string | undefined
+  datatype?: string | undefined
+  inlist?: any
+  prefix?: string | undefined
+  property?: string | undefined
+  rel?: string | undefined
+  resource?: string | undefined
+  rev?: string | undefined
+  typeof?: string | undefined
+  vocab?: string | undefined
+
+  // Non-standard Attributes
+  autoCapitalize?: string | undefined
+  autoCorrect?: string | undefined
+  autoSave?: string | undefined
+  color?: string | undefined
+  itemProp?: string | undefined
+  itemScope?: boolean | undefined
+  itemType?: string | undefined
+  itemID?: string | undefined
+  itemRef?: string | undefined
+  results?: number | undefined
+  security?: string | undefined
+  unselectable?: 'on' | 'off' | undefined
+
+  // Living Standard
+  /**
+   * Hints at the type of data that might be entered by the user while editing the element or its contents
+   * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+   */
+  inputMode?:
+    | 'none'
+    | 'text'
+    | 'tel'
+    | 'url'
+    | 'email'
+    | 'numeric'
+    | 'decimal'
+    | 'search'
+    | undefined
+  /**
+   * Specify that a standard HTML element should behave like a defined custom built-in element
+   * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+   */
+  is?: string | undefined
+}
+
+type HTMLAttributeReferrerPolicy =
+  | ''
+  | 'no-referrer'
+  | 'no-referrer-when-downgrade'
+  | 'origin'
+  | 'origin-when-cross-origin'
+  | 'same-origin'
+  | 'strict-origin'
+  | 'strict-origin-when-cross-origin'
+  | 'unsafe-url'
+
+type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {})
+
+interface AnchorHTMLAttributes extends HTMLAttributes {
+  download?: any
+  href?: string | undefined
+  hrefLang?: string | undefined
+  media?: string | undefined
+  ping?: string | undefined
+  target?: HTMLAttributeAnchorTarget | undefined
+  type?: string | undefined
+  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+}
+
+interface AudioHTMLAttributes extends MediaHTMLAttributes {}
+
+interface AreaHTMLAttributes extends HTMLAttributes {
+  alt?: string | undefined
+  coords?: string | undefined
+  download?: any
+  href?: string | undefined
+  hrefLang?: string | undefined
+  media?: string | undefined
+  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  shape?: string | undefined
+  target?: string | undefined
+}
+
+interface BaseHTMLAttributes extends HTMLAttributes {
+  href?: string | undefined
+  target?: string | undefined
+}
+
+interface BlockquoteHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+}
+
+interface ButtonHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  form?: string | undefined
+  formEncType?: string | undefined
+  formMethod?: string | undefined
+  formNoValidate?: boolean | undefined
+  formTarget?: string | undefined
+  name?: string | undefined
+  type?: 'submit' | 'reset' | 'button' | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface CanvasHTMLAttributes extends HTMLAttributes {
+  height?: number | string | undefined
+  width?: number | string | undefined
+}
+
+interface ColHTMLAttributes extends HTMLAttributes {
+  span?: number | undefined
+  width?: number | string | undefined
+}
+
+interface ColgroupHTMLAttributes extends HTMLAttributes {
+  span?: number | undefined
+}
+
+interface DataHTMLAttributes extends HTMLAttributes {
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface DetailsHTMLAttributes extends HTMLAttributes {
+  open?: boolean | undefined
+  onToggle?: string | undefined
+}
+
+interface DelHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+  dateTime?: string | undefined
+}
+
+interface DialogHTMLAttributes extends HTMLAttributes {
+  onCancel?: string | undefined
+  onClose?: string | undefined
+  open?: boolean | undefined
+}
+
+interface EmbedHTMLAttributes extends HTMLAttributes {
+  height?: number | string | undefined
+  src?: string | undefined
+  type?: string | undefined
+  width?: number | string | undefined
+}
+
+interface FieldsetHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  form?: string | undefined
+  name?: string | undefined
+}
+
+interface FormHTMLAttributes extends HTMLAttributes {
+  acceptCharset?: string | undefined
+  autoComplete?: string | undefined
+  encType?: string | undefined
+  method?: string | undefined
+  name?: string | undefined
+  noValidate?: boolean | undefined
+  target?: string | undefined
+}
+
+interface HtmlHTMLAttributes extends HTMLAttributes {
+  manifest?: string | undefined
+}
+
+interface IframeHTMLAttributes extends HTMLAttributes {
+  allow?: string | undefined
+  allowFullScreen?: boolean | undefined
+  allowTransparency?: boolean | undefined
+  /** @deprecated */
+  frameBorder?: number | string | undefined
+  height?: number | string | undefined
+  loading?: 'eager' | 'lazy' | undefined
+  /** @deprecated */
+  marginHeight?: number | undefined
+  /** @deprecated */
+  marginWidth?: number | undefined
+  name?: string | undefined
+  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  sandbox?: string | undefined
+  /** @deprecated */
+  scrolling?: string | undefined
+  seamless?: boolean | undefined
+  src?: string | undefined
+  srcDoc?: string | undefined
+  width?: number | string | undefined
+}
+
+interface ImgHTMLAttributes extends HTMLAttributes {
+  alt?: string | undefined
+  crossOrigin?: CrossOrigin
+  decoding?: 'async' | 'auto' | 'sync' | undefined
+  height?: number | string | undefined
+  loading?: 'eager' | 'lazy' | undefined
+  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  sizes?: string | undefined
+  src?: string | undefined
+  srcSet?: string | undefined
+  useMap?: string | undefined
+  width?: number | string | undefined
+}
+
+interface InsHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+  dateTime?: string | undefined
+}
+
+type HTMLInputTypeAttribute =
+  | 'button'
+  | 'checkbox'
+  | 'color'
+  | 'date'
+  | 'datetime-local'
+  | 'email'
+  | 'file'
+  | 'hidden'
+  | 'image'
+  | 'month'
+  | 'number'
+  | 'password'
+  | 'radio'
+  | 'range'
+  | 'reset'
+  | 'search'
+  | 'submit'
+  | 'tel'
+  | 'text'
+  | 'time'
+  | 'url'
+  | 'week'
+  | (string & {})
+
+interface InputHTMLAttributes extends HTMLAttributes {
+  accept?: string | undefined
+  alt?: string | undefined
+  autoComplete?: string | undefined
+  capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+  checked?: boolean | undefined
+  disabled?: boolean | undefined
+  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
+  form?: string | undefined
+  formEncType?: string | undefined
+  formMethod?: string | undefined
+  formNoValidate?: boolean | undefined
+  formTarget?: string | undefined
+  height?: number | string | undefined
+  list?: string | undefined
+  max?: number | string | undefined
+  maxLength?: number | undefined
+  min?: number | string | undefined
+  minLength?: number | undefined
+  multiple?: boolean | undefined
+  name?: string | undefined
+  pattern?: string | undefined
+  placeholder?: string | undefined
+  readOnly?: boolean | undefined
+  required?: boolean | undefined
+  size?: number | undefined
+  src?: string | undefined
+  step?: number | string | undefined
+  type?: HTMLInputTypeAttribute | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+  width?: number | string | undefined
+
+  onChange?: string | undefined
+}
+
+interface KeygenHTMLAttributes extends HTMLAttributes {
+  challenge?: string | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  keyType?: string | undefined
+  keyParams?: string | undefined
+  name?: string | undefined
+}
+
+interface LabelHTMLAttributes extends HTMLAttributes {
+  form?: string | undefined
+  htmlFor?: string | undefined
+}
+
+interface LiHTMLAttributes extends HTMLAttributes {
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface LinkHTMLAttributes extends HTMLAttributes {
+  as?: string | undefined
+  crossOrigin?: CrossOrigin
+  fetchPriority?: 'high' | 'low' | 'auto'
+  href?: string | undefined
+  hrefLang?: string | undefined
+  integrity?: string | undefined
+  media?: string | undefined
+  imageSrcSet?: string | undefined
+  imageSizes?: string | undefined
+  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  sizes?: string | undefined
+  type?: string | undefined
+  charSet?: string | undefined
+}
+
+interface MapHTMLAttributes extends HTMLAttributes {
+  name?: string | undefined
+}
+
+interface MenuHTMLAttributes extends HTMLAttributes {
+  type?: string | undefined
+}
+
+interface MediaHTMLAttributes extends HTMLAttributes {
+  autoPlay?: boolean | undefined
+  controls?: boolean | undefined
+  controlsList?: string | undefined
+  crossOrigin?: CrossOrigin
+  loop?: boolean | undefined
+  mediaGroup?: string | undefined
+  muted?: boolean | undefined
+  playsInline?: boolean | undefined
+  preload?: string | undefined
+  src?: string | undefined
+}
+
+interface MetaHTMLAttributes extends HTMLAttributes {
+  charSet?: string | undefined
+  httpEquiv?: string | undefined
+  name?: string | undefined
+  media?: string | undefined
+  content?: string | undefined
+}
+
+interface MeterHTMLAttributes extends HTMLAttributes {
+  form?: string | undefined
+  high?: number | undefined
+  low?: number | undefined
+  max?: number | string | undefined
+  min?: number | string | undefined
+  optimum?: number | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface QuoteHTMLAttributes extends HTMLAttributes {
+  cite?: string | undefined
+}
+
+interface ObjectHTMLAttributes extends HTMLAttributes {
+  classID?: string | undefined
+  data?: string | undefined
+  form?: string | undefined
+  height?: number | string | undefined
+  name?: string | undefined
+  type?: string | undefined
+  useMap?: string | undefined
+  width?: number | string | undefined
+  wmode?: string | undefined
+}
+
+interface OlHTMLAttributes extends HTMLAttributes {
+  reversed?: boolean | undefined
+  start?: number | undefined
+  type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined
+}
+
+interface OptgroupHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  label?: string | undefined
+}
+
+interface OptionHTMLAttributes extends HTMLAttributes {
+  disabled?: boolean | undefined
+  label?: string | undefined
+  selected?: boolean | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface OutputHTMLAttributes extends HTMLAttributes {
+  form?: string | undefined
+  htmlFor?: string | undefined
+  name?: string | undefined
+}
+
+interface ParamHTMLAttributes extends HTMLAttributes {
+  name?: string | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface ProgressHTMLAttributes extends HTMLAttributes {
+  max?: number | string | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+}
+
+interface SlotHTMLAttributes extends HTMLAttributes {
+  name?: string | undefined
+}
+
+interface ScriptHTMLAttributes extends HTMLAttributes {
+  async?: boolean | undefined
+  /** @deprecated */
+  charSet?: string | undefined
+  crossOrigin?: CrossOrigin
+  defer?: boolean | undefined
+  integrity?: string | undefined
+  noModule?: boolean | undefined
+  referrerPolicy?: HTMLAttributeReferrerPolicy | undefined
+  src?: string | undefined
+  type?: string | undefined
+}
+
+interface SelectHTMLAttributes extends HTMLAttributes {
+  autoComplete?: string | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  multiple?: boolean | undefined
+  name?: string | undefined
+  required?: boolean | undefined
+  size?: number | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+  onChange?: string | undefined
+}
+
+interface SourceHTMLAttributes extends HTMLAttributes {
+  height?: number | string | undefined
+  media?: string | undefined
+  sizes?: string | undefined
+  src?: string | undefined
+  srcSet?: string | undefined
+  type?: string | undefined
+  width?: number | string | undefined
+}
+
+interface StyleHTMLAttributes extends HTMLAttributes {
+  media?: string | undefined
+  scoped?: boolean | undefined
+  type?: string | undefined
+}
+
+interface TableHTMLAttributes extends HTMLAttributes {
+  align?: 'left' | 'center' | 'right' | undefined
+  bgcolor?: string | undefined
+  border?: number | undefined
+  cellPadding?: number | string | undefined
+  cellSpacing?: number | string | undefined
+  frame?: boolean | undefined
+  rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
+  summary?: string | undefined
+  width?: number | string | undefined
+}
+
+interface TextareaHTMLAttributes extends HTMLAttributes {
+  autoComplete?: string | undefined
+  cols?: number | undefined
+  dirName?: string | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  maxLength?: number | undefined
+  minLength?: number | undefined
+  name?: string | undefined
+  placeholder?: string | undefined
+  readOnly?: boolean | undefined
+  required?: boolean | undefined
+  rows?: number | undefined
+  value?: string | ReadonlyArray<string> | number | undefined
+  wrap?: string | undefined
+  onChange?: string | undefined
+}
+
+interface TdHTMLAttributes extends HTMLAttributes {
+  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+  colSpan?: number | undefined
+  headers?: string | undefined
+  rowSpan?: number | undefined
+  scope?: string | undefined
+  abbr?: string | undefined
+  height?: number | string | undefined
+  width?: number | string | undefined
+  valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined
+}
+
+interface ThHTMLAttributes extends HTMLAttributes {
+  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+  colSpan?: number | undefined
+  headers?: string | undefined
+  rowSpan?: number | undefined
+  scope?: string | undefined
+  abbr?: string | undefined
+}
+
+interface TimeHTMLAttributes extends HTMLAttributes {
+  dateTime?: string | undefined
+}
+
+interface TrackHTMLAttributes extends HTMLAttributes {
+  default?: boolean | undefined
+  kind?: string | undefined
+  label?: string | undefined
+  src?: string | undefined
+  srcLang?: string | undefined
+}
+
+interface VideoHTMLAttributes extends MediaHTMLAttributes {
+  height?: number | string | undefined
+  playsInline?: boolean | undefined
+  poster?: string | undefined
+  width?: number | string | undefined
+  disablePictureInPicture?: boolean | undefined
+  disableRemotePlayback?: boolean | undefined
+}
+
+export interface IntrinsicElements {
+  a: AnchorHTMLAttributes
+  abbr: HTMLAttributes
+  address: HTMLAttributes
+  area: AreaHTMLAttributes
+  article: HTMLAttributes
+  aside: HTMLAttributes
+  audio: AudioHTMLAttributes
+  b: HTMLAttributes
+  base: BaseHTMLAttributes
+  bdi: HTMLAttributes
+  bdo: HTMLAttributes
+  big: HTMLAttributes
+  blockquote: BlockquoteHTMLAttributes
+  body: HTMLAttributes
+  br: HTMLAttributes
+  button: ButtonHTMLAttributes
+  canvas: CanvasHTMLAttributes
+  caption: HTMLAttributes
+  center: HTMLAttributes
+  cite: HTMLAttributes
+  code: HTMLAttributes
+  col: ColHTMLAttributes
+  colgroup: ColgroupHTMLAttributes
+  data: DataHTMLAttributes
+  datalist: HTMLAttributes
+  dd: HTMLAttributes
+  del: DelHTMLAttributes
+  details: DetailsHTMLAttributes
+  dfn: HTMLAttributes
+  dialog: DialogHTMLAttributes
+  div: HTMLAttributes
+  dl: HTMLAttributes
+  dt: HTMLAttributes
+  em: HTMLAttributes
+  embed: EmbedHTMLAttributes
+  fieldset: FieldsetHTMLAttributes
+  figcaption: HTMLAttributes
+  figure: HTMLAttributes
+  footer: HTMLAttributes
+  form: FormHTMLAttributes
+  h1: HTMLAttributes
+  h2: HTMLAttributes
+  h3: HTMLAttributes
+  h4: HTMLAttributes
+  h5: HTMLAttributes
+  h6: HTMLAttributes
+  head: HTMLAttributes
+  header: HTMLAttributes
+  hgroup: HTMLAttributes
+  hr: HTMLAttributes
+  html: HtmlHTMLAttributes
+  i: HTMLAttributes
+  iframe: IframeHTMLAttributes
+  img: ImgHTMLAttributes
+  input: InputHTMLAttributes
+  ins: InsHTMLAttributes
+  kbd: HTMLAttributes
+  keygen: KeygenHTMLAttributes
+  label: LabelHTMLAttributes
+  legend: HTMLAttributes
+  li: LiHTMLAttributes
+  link: LinkHTMLAttributes
+  main: HTMLAttributes
+  map: MapHTMLAttributes
+  mark: HTMLAttributes
+  menu: MenuHTMLAttributes
+  menuitem: HTMLAttributes
+  meta: MetaHTMLAttributes
+  meter: MeterHTMLAttributes
+  nav: HTMLAttributes
+  noscript: HTMLAttributes
+  object: ObjectHTMLAttributes
+  ol: OlHTMLAttributes
+  optgroup: OptgroupHTMLAttributes
+  option: OptionHTMLAttributes
+  output: OutputHTMLAttributes
+  p: HTMLAttributes
+  param: ParamHTMLAttributes
+  picture: HTMLAttributes
+  pre: HTMLAttributes
+  progress: ProgressHTMLAttributes
+  q: QuoteHTMLAttributes
+  rp: HTMLAttributes
+  rt: HTMLAttributes
+  ruby: HTMLAttributes
+  s: HTMLAttributes
+  samp: HTMLAttributes
+  search: HTMLAttributes
+  slot: SlotHTMLAttributes
+  script: ScriptHTMLAttributes
+  section: HTMLAttributes
+  select: SelectHTMLAttributes
+  small: HTMLAttributes
+  source: SourceHTMLAttributes
+  span: HTMLAttributes
+  strong: HTMLAttributes
+  style: StyleHTMLAttributes
+  sub: HTMLAttributes
+  summary: HTMLAttributes
+  sup: HTMLAttributes
+  table: TableHTMLAttributes
+  template: HTMLAttributes
+  tbody: HTMLAttributes
+  td: TdHTMLAttributes
+  textarea: TextareaHTMLAttributes
+  tfoot: HTMLAttributes
+  th: ThHTMLAttributes
+  thead: HTMLAttributes
+  time: TimeHTMLAttributes
+  title: HTMLAttributes
+  tr: HTMLAttributes
+  track: TrackHTMLAttributes
+  u: HTMLAttributes
+  ul: HTMLAttributes
+  var: HTMLAttributes
+  video: VideoHTMLAttributes
+  wbr: HTMLAttributes
+}

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -117,7 +117,6 @@ interface DataHTMLAttributes extends HTMLAttributes {
 
 interface DetailsHTMLAttributes extends HTMLAttributes {
   open?: boolean | undefined
-  ontoggle?: string | undefined
 }
 
 interface DelHTMLAttributes extends HTMLAttributes {
@@ -126,8 +125,6 @@ interface DelHTMLAttributes extends HTMLAttributes {
 }
 
 interface DialogHTMLAttributes extends HTMLAttributes {
-  oncancel?: string | undefined
-  onclose?: string | undefined
   open?: boolean | undefined
 }
 
@@ -247,7 +244,6 @@ interface InputHTMLAttributes extends HTMLAttributes {
   type?: HTMLInputTypeAttribute | undefined
   value?: string | ReadonlyArray<string> | number | undefined
   width?: number | string | undefined
-  onchange?: string | undefined
 }
 
 interface KeygenHTMLAttributes extends HTMLAttributes {
@@ -393,7 +389,6 @@ interface SelectHTMLAttributes extends HTMLAttributes {
   required?: boolean | undefined
   size?: number | undefined
   value?: string | ReadonlyArray<string> | number | undefined
-  onchange?: string | undefined
 }
 
 interface SourceHTMLAttributes extends HTMLAttributes {
@@ -439,7 +434,6 @@ interface TextareaHTMLAttributes extends HTMLAttributes {
   rows?: number | undefined
   value?: string | ReadonlyArray<string> | number | undefined
   wrap?: string | undefined
-  onchange?: string | undefined
 }
 
 interface TdHTMLAttributes extends HTMLAttributes {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -7,593 +7,606 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  */
 
-type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
-type CSSProperties = {}
-type AnyAttributes = { [attributeName: string]: any }
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Hono {
+    type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
+    type CSSProperties = {}
+    type AnyAttributes = { [attributeName: string]: any }
 
-interface JSXAttributes {
-  dangerouslySetInnerHTML?: {
-    __html: string
+    interface JSXAttributes {
+      dangerouslySetInnerHTML?: {
+        __html: string
+      }
+    }
+
+    interface HTMLAttributes extends JSXAttributes, AnyAttributes {
+      accesskey?: string | undefined
+      autofocus?: boolean | undefined
+      class?: string | undefined
+      contenteditable?: boolean | 'inherit' | undefined
+      contextmenu?: string | undefined
+      dir?: string | undefined
+      draggable?: boolean | undefined
+      hidden?: boolean | undefined
+      id?: string | undefined
+      lang?: string | undefined
+      nonce?: string | undefined
+      placeholder?: string | undefined
+      slot?: string | undefined
+      spellcheck?: boolean | undefined
+      style?: CSSProperties | undefined
+      tabindex?: number | undefined
+      title?: string | undefined
+      translate?: 'yes' | 'no' | undefined
+    }
+
+    type HTMLAttributeReferrerPolicy =
+      | ''
+      | 'no-referrer'
+      | 'no-referrer-when-downgrade'
+      | 'origin'
+      | 'origin-when-cross-origin'
+      | 'same-origin'
+      | 'strict-origin'
+      | 'strict-origin-when-cross-origin'
+      | 'unsafe-url'
+
+    type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
+
+    interface AnchorHTMLAttributes extends HTMLAttributes {
+      download?: any
+      href?: string | undefined
+      hreflang?: string | undefined
+      media?: string | undefined
+      ping?: string | undefined
+      target?: HTMLAttributeAnchorTarget | undefined
+      type?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+    }
+
+    interface AudioHTMLAttributes extends MediaHTMLAttributes {}
+
+    interface AreaHTMLAttributes extends HTMLAttributes {
+      alt?: string | undefined
+      coords?: string | undefined
+      download?: any
+      href?: string | undefined
+      hreflang?: string | undefined
+      media?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      shape?: string | undefined
+      target?: string | undefined
+    }
+
+    interface BaseHTMLAttributes extends HTMLAttributes {
+      href?: string | undefined
+      target?: string | undefined
+    }
+
+    interface BlockquoteHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+    }
+
+    interface ButtonHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      form?: string | undefined
+      formenctype?: string | undefined
+      formmethod?: string | undefined
+      formnovalidate?: boolean | undefined
+      formtarget?: string | undefined
+      name?: string | undefined
+      type?: 'submit' | 'reset' | 'button' | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface CanvasHTMLAttributes extends HTMLAttributes {
+      height?: number | string | undefined
+      width?: number | string | undefined
+    }
+
+    interface ColHTMLAttributes extends HTMLAttributes {
+      span?: number | undefined
+      width?: number | string | undefined
+    }
+
+    interface ColgroupHTMLAttributes extends HTMLAttributes {
+      span?: number | undefined
+    }
+
+    interface DataHTMLAttributes extends HTMLAttributes {
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface DetailsHTMLAttributes extends HTMLAttributes {
+      open?: boolean | undefined
+      ontoggle?: string | undefined
+    }
+
+    interface DelHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+      dateTime?: string | undefined
+    }
+
+    interface DialogHTMLAttributes extends HTMLAttributes {
+      oncancel?: string | undefined
+      onclose?: string | undefined
+      open?: boolean | undefined
+    }
+
+    interface EmbedHTMLAttributes extends HTMLAttributes {
+      height?: number | string | undefined
+      src?: string | undefined
+      type?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface FieldsetHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      form?: string | undefined
+      name?: string | undefined
+    }
+
+    interface FormHTMLAttributes extends HTMLAttributes {
+      'accept-charset'?: string | undefined
+      autocomplete?: string | undefined
+      enctype?: string | undefined
+      method?: string | undefined
+      name?: string | undefined
+      novalidate?: boolean | undefined
+      target?: string | undefined
+    }
+
+    interface HtmlHTMLAttributes extends HTMLAttributes {
+      manifest?: string | undefined
+    }
+
+    interface IframeHTMLAttributes extends HTMLAttributes {
+      allow?: string | undefined
+      allowfullscreen?: boolean | undefined
+      height?: number | string | undefined
+      loading?: 'eager' | 'lazy' | undefined
+      name?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      sandbox?: string | undefined
+      seamless?: boolean | undefined
+      src?: string | undefined
+      srcdoc?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface ImgHTMLAttributes extends HTMLAttributes {
+      alt?: string | undefined
+      crossorigin?: CrossOrigin
+      decoding?: 'async' | 'auto' | 'sync' | undefined
+      height?: number | string | undefined
+      loading?: 'eager' | 'lazy' | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      sizes?: string | undefined
+      src?: string | undefined
+      srcset?: string | undefined
+      usemap?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface InsHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+      datetime?: string | undefined
+    }
+
+    type HTMLInputTypeAttribute =
+      | 'button'
+      | 'checkbox'
+      | 'color'
+      | 'date'
+      | 'datetime-local'
+      | 'email'
+      | 'file'
+      | 'hidden'
+      | 'image'
+      | 'month'
+      | 'number'
+      | 'password'
+      | 'radio'
+      | 'range'
+      | 'reset'
+      | 'search'
+      | 'submit'
+      | 'tel'
+      | 'text'
+      | 'time'
+      | 'url'
+      | 'week'
+      | string
+
+    interface InputHTMLAttributes extends HTMLAttributes {
+      accept?: string | undefined
+      alt?: string | undefined
+      autocomplete?: string | undefined
+      capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+      checked?: boolean | undefined
+      disabled?: boolean | undefined
+      enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
+      form?: string | undefined
+      formenctype?: string | undefined
+      formmethod?: string | undefined
+      formnovalidate?: boolean | undefined
+      formtarget?: string | undefined
+      height?: number | string | undefined
+      list?: string | undefined
+      max?: number | string | undefined
+      maxlength?: number | undefined
+      min?: number | string | undefined
+      minlength?: number | undefined
+      multiple?: boolean | undefined
+      name?: string | undefined
+      pattern?: string | undefined
+      placeholder?: string | undefined
+      readonly?: boolean | undefined
+      required?: boolean | undefined
+      size?: number | undefined
+      src?: string | undefined
+      step?: number | string | undefined
+      type?: HTMLInputTypeAttribute | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+      width?: number | string | undefined
+      onchange?: string | undefined
+    }
+
+    interface KeygenHTMLAttributes extends HTMLAttributes {
+      challenge?: string | undefined
+      disabled?: boolean | undefined
+      form?: string | undefined
+      keytype?: string | undefined
+      name?: string | undefined
+    }
+
+    interface LabelHTMLAttributes extends HTMLAttributes {
+      form?: string | undefined
+      for?: string | undefined
+    }
+
+    interface LiHTMLAttributes extends HTMLAttributes {
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface LinkHTMLAttributes extends HTMLAttributes {
+      as?: string | undefined
+      crossorigin?: CrossOrigin
+      href?: string | undefined
+      hreflang?: string | undefined
+      integrity?: string | undefined
+      media?: string | undefined
+      imagesrcset?: string | undefined
+      imagesizes?: string | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      sizes?: string | undefined
+      type?: string | undefined
+      charSet?: string | undefined
+    }
+
+    interface MapHTMLAttributes extends HTMLAttributes {
+      name?: string | undefined
+    }
+
+    interface MenuHTMLAttributes extends HTMLAttributes {
+      type?: string | undefined
+    }
+
+    interface MediaHTMLAttributes extends HTMLAttributes {
+      autoplay?: boolean | undefined
+      controls?: boolean | undefined
+      controlslist?: string | undefined
+      crossorigin?: CrossOrigin
+      loop?: boolean | undefined
+      mediagroup?: string | undefined
+      muted?: boolean | undefined
+      playsinline?: boolean | undefined
+      preload?: string | undefined
+      src?: string | undefined
+    }
+
+    interface MetaHTMLAttributes extends HTMLAttributes {
+      charset?: string | undefined
+      'http-equiv'?: string | undefined
+      name?: string | undefined
+      media?: string | undefined
+      content?: string | undefined
+    }
+
+    interface MeterHTMLAttributes extends HTMLAttributes {
+      form?: string | undefined
+      high?: number | undefined
+      low?: number | undefined
+      max?: number | string | undefined
+      min?: number | string | undefined
+      optimum?: number | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface QuoteHTMLAttributes extends HTMLAttributes {
+      cite?: string | undefined
+    }
+
+    interface ObjectHTMLAttributes extends HTMLAttributes {
+      data?: string | undefined
+      form?: string | undefined
+      height?: number | string | undefined
+      name?: string | undefined
+      type?: string | undefined
+      usemap?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface OlHTMLAttributes extends HTMLAttributes {
+      reversed?: boolean | undefined
+      start?: number | undefined
+      type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined
+    }
+
+    interface OptgroupHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      label?: string | undefined
+    }
+
+    interface OptionHTMLAttributes extends HTMLAttributes {
+      disabled?: boolean | undefined
+      label?: string | undefined
+      selected?: boolean | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface OutputHTMLAttributes extends HTMLAttributes {
+      form?: string | undefined
+      for?: string | undefined
+      name?: string | undefined
+    }
+
+    interface ParamHTMLAttributes extends HTMLAttributes {
+      name?: string | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface ProgressHTMLAttributes extends HTMLAttributes {
+      max?: number | string | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+    }
+
+    interface SlotHTMLAttributes extends HTMLAttributes {
+      name?: string | undefined
+    }
+
+    interface ScriptHTMLAttributes extends HTMLAttributes {
+      async?: boolean | undefined
+      crossorigin?: CrossOrigin
+      defer?: boolean | undefined
+      integrity?: string | undefined
+      nomodule?: boolean | undefined
+      referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
+      src?: string | undefined
+      type?: string | undefined
+    }
+
+    interface SelectHTMLAttributes extends HTMLAttributes {
+      autocomplete?: string | undefined
+      disabled?: boolean | undefined
+      form?: string | undefined
+      multiple?: boolean | undefined
+      name?: string | undefined
+      required?: boolean | undefined
+      size?: number | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+      onchange?: string | undefined
+    }
+
+    interface SourceHTMLAttributes extends HTMLAttributes {
+      height?: number | string | undefined
+      media?: string | undefined
+      sizes?: string | undefined
+      src?: string | undefined
+      srcset?: string | undefined
+      type?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface StyleHTMLAttributes extends HTMLAttributes {
+      media?: string | undefined
+      scoped?: boolean | undefined
+      type?: string | undefined
+    }
+
+    interface TableHTMLAttributes extends HTMLAttributes {
+      align?: 'left' | 'center' | 'right' | undefined
+      bgcolor?: string | undefined
+      border?: number | undefined
+      cellpadding?: number | string | undefined
+      cellspacing?: number | string | undefined
+      frame?: boolean | undefined
+      rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
+      summary?: string | undefined
+      width?: number | string | undefined
+    }
+
+    interface TextareaHTMLAttributes extends HTMLAttributes {
+      autocomplete?: string | undefined
+      cols?: number | undefined
+      dirname?: string | undefined
+      disabled?: boolean | undefined
+      form?: string | undefined
+      maxlength?: number | undefined
+      minlength?: number | undefined
+      name?: string | undefined
+      placeholder?: string | undefined
+      readonly?: boolean | undefined
+      required?: boolean | undefined
+      rows?: number | undefined
+      value?: string | ReadonlyArray<string> | number | undefined
+      wrap?: string | undefined
+      onchange?: string | undefined
+    }
+
+    interface TdHTMLAttributes extends HTMLAttributes {
+      align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+      colspan?: number | undefined
+      headers?: string | undefined
+      rowspan?: number | undefined
+      scope?: string | undefined
+      abbr?: string | undefined
+      height?: number | string | undefined
+      width?: number | string | undefined
+      valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined
+    }
+
+    interface ThHTMLAttributes extends HTMLAttributes {
+      align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
+      colspan?: number | undefined
+      headers?: string | undefined
+      rowspan?: number | undefined
+      scope?: string | undefined
+      abbr?: string | undefined
+    }
+
+    interface TimeHTMLAttributes extends HTMLAttributes {
+      datetime?: string | undefined
+    }
+
+    interface TrackHTMLAttributes extends HTMLAttributes {
+      default?: boolean | undefined
+      kind?: string | undefined
+      label?: string | undefined
+      src?: string | undefined
+      srclang?: string | undefined
+    }
+
+    interface VideoHTMLAttributes extends MediaHTMLAttributes {
+      height?: number | string | undefined
+      playsinline?: boolean | undefined
+      poster?: string | undefined
+      width?: number | string | undefined
+      disablePictureInPicture?: boolean | undefined
+      disableRemotePlayback?: boolean | undefined
+    }
+
+    interface IntrinsicElements {
+      a: AnchorHTMLAttributes
+      abbr: HTMLAttributes
+      address: HTMLAttributes
+      area: AreaHTMLAttributes
+      article: HTMLAttributes
+      aside: HTMLAttributes
+      audio: AudioHTMLAttributes
+      b: HTMLAttributes
+      base: BaseHTMLAttributes
+      bdi: HTMLAttributes
+      bdo: HTMLAttributes
+      big: HTMLAttributes
+      blockquote: BlockquoteHTMLAttributes
+      body: HTMLAttributes
+      br: HTMLAttributes
+      button: ButtonHTMLAttributes
+      canvas: CanvasHTMLAttributes
+      caption: HTMLAttributes
+      center: HTMLAttributes
+      cite: HTMLAttributes
+      code: HTMLAttributes
+      col: ColHTMLAttributes
+      colgroup: ColgroupHTMLAttributes
+      data: DataHTMLAttributes
+      datalist: HTMLAttributes
+      dd: HTMLAttributes
+      del: DelHTMLAttributes
+      details: DetailsHTMLAttributes
+      dfn: HTMLAttributes
+      dialog: DialogHTMLAttributes
+      div: HTMLAttributes
+      dl: HTMLAttributes
+      dt: HTMLAttributes
+      em: HTMLAttributes
+      embed: EmbedHTMLAttributes
+      fieldset: FieldsetHTMLAttributes
+      figcaption: HTMLAttributes
+      figure: HTMLAttributes
+      footer: HTMLAttributes
+      form: FormHTMLAttributes
+      h1: HTMLAttributes
+      h2: HTMLAttributes
+      h3: HTMLAttributes
+      h4: HTMLAttributes
+      h5: HTMLAttributes
+      h6: HTMLAttributes
+      head: HTMLAttributes
+      header: HTMLAttributes
+      hgroup: HTMLAttributes
+      hr: HTMLAttributes
+      html: HtmlHTMLAttributes
+      i: HTMLAttributes
+      iframe: IframeHTMLAttributes
+      img: ImgHTMLAttributes
+      input: InputHTMLAttributes
+      ins: InsHTMLAttributes
+      kbd: HTMLAttributes
+      keygen: KeygenHTMLAttributes
+      label: LabelHTMLAttributes
+      legend: HTMLAttributes
+      li: LiHTMLAttributes
+      link: LinkHTMLAttributes
+      main: HTMLAttributes
+      map: MapHTMLAttributes
+      mark: HTMLAttributes
+      menu: MenuHTMLAttributes
+      menuitem: HTMLAttributes
+      meta: MetaHTMLAttributes
+      meter: MeterHTMLAttributes
+      nav: HTMLAttributes
+      noscript: HTMLAttributes
+      object: ObjectHTMLAttributes
+      ol: OlHTMLAttributes
+      optgroup: OptgroupHTMLAttributes
+      option: OptionHTMLAttributes
+      output: OutputHTMLAttributes
+      p: HTMLAttributes
+      param: ParamHTMLAttributes
+      picture: HTMLAttributes
+      pre: HTMLAttributes
+      progress: ProgressHTMLAttributes
+      q: QuoteHTMLAttributes
+      rp: HTMLAttributes
+      rt: HTMLAttributes
+      ruby: HTMLAttributes
+      s: HTMLAttributes
+      samp: HTMLAttributes
+      search: HTMLAttributes
+      slot: SlotHTMLAttributes
+      script: ScriptHTMLAttributes
+      section: HTMLAttributes
+      select: SelectHTMLAttributes
+      small: HTMLAttributes
+      source: SourceHTMLAttributes
+      span: HTMLAttributes
+      strong: HTMLAttributes
+      style: StyleHTMLAttributes
+      sub: HTMLAttributes
+      summary: HTMLAttributes
+      sup: HTMLAttributes
+      table: TableHTMLAttributes
+      template: HTMLAttributes
+      tbody: HTMLAttributes
+      td: TdHTMLAttributes
+      textarea: TextareaHTMLAttributes
+      tfoot: HTMLAttributes
+      th: ThHTMLAttributes
+      thead: HTMLAttributes
+      time: TimeHTMLAttributes
+      title: HTMLAttributes
+      tr: HTMLAttributes
+      track: TrackHTMLAttributes
+      u: HTMLAttributes
+      ul: HTMLAttributes
+      var: HTMLAttributes
+      video: VideoHTMLAttributes
+      wbr: HTMLAttributes
+    }
   }
 }
 
-interface HTMLAttributes extends JSXAttributes, AnyAttributes {
-  accesskey?: string | undefined
-  autofocus?: boolean | undefined
-  class?: string | undefined
-  contenteditable?: boolean | 'inherit' | undefined
-  contextmenu?: string | undefined
-  dir?: string | undefined
-  draggable?: boolean | undefined
-  hidden?: boolean | undefined
-  id?: string | undefined
-  lang?: string | undefined
-  nonce?: string | undefined
-  placeholder?: string | undefined
-  slot?: string | undefined
-  spellcheck?: boolean | undefined
-  style?: CSSProperties | undefined
-  tabindex?: number | undefined
-  title?: string | undefined
-  translate?: 'yes' | 'no' | undefined
-}
-
-type HTMLAttributeReferrerPolicy =
-  | ''
-  | 'no-referrer'
-  | 'no-referrer-when-downgrade'
-  | 'origin'
-  | 'origin-when-cross-origin'
-  | 'same-origin'
-  | 'strict-origin'
-  | 'strict-origin-when-cross-origin'
-  | 'unsafe-url'
-
-type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
-
-interface AnchorHTMLAttributes extends HTMLAttributes {
-  download?: any
-  href?: string | undefined
-  hreflang?: string | undefined
-  media?: string | undefined
-  ping?: string | undefined
-  target?: HTMLAttributeAnchorTarget | undefined
-  type?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-}
-
-interface AudioHTMLAttributes extends MediaHTMLAttributes {}
-
-interface AreaHTMLAttributes extends HTMLAttributes {
-  alt?: string | undefined
-  coords?: string | undefined
-  download?: any
-  href?: string | undefined
-  hreflang?: string | undefined
-  media?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  shape?: string | undefined
-  target?: string | undefined
-}
-
-interface BaseHTMLAttributes extends HTMLAttributes {
-  href?: string | undefined
-  target?: string | undefined
-}
-
-interface BlockquoteHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-}
-
-interface ButtonHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  form?: string | undefined
-  formenctype?: string | undefined
-  formmethod?: string | undefined
-  formnovalidate?: boolean | undefined
-  formtarget?: string | undefined
-  name?: string | undefined
-  type?: 'submit' | 'reset' | 'button' | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface CanvasHTMLAttributes extends HTMLAttributes {
-  height?: number | string | undefined
-  width?: number | string | undefined
-}
-
-interface ColHTMLAttributes extends HTMLAttributes {
-  span?: number | undefined
-  width?: number | string | undefined
-}
-
-interface ColgroupHTMLAttributes extends HTMLAttributes {
-  span?: number | undefined
-}
-
-interface DataHTMLAttributes extends HTMLAttributes {
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface DetailsHTMLAttributes extends HTMLAttributes {
-  open?: boolean | undefined
-}
-
-interface DelHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-  datetime?: string | undefined
-}
-
-interface DialogHTMLAttributes extends HTMLAttributes {
-  open?: boolean | undefined
-}
-
-interface EmbedHTMLAttributes extends HTMLAttributes {
-  height?: number | string | undefined
-  src?: string | undefined
-  type?: string | undefined
-  width?: number | string | undefined
-}
-
-interface FieldsetHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  form?: string | undefined
-  name?: string | undefined
-}
-
-interface FormHTMLAttributes extends HTMLAttributes {
-  'accept-charset'?: string | undefined
-  autocomplete?: string | undefined
-  enctype?: string | undefined
-  method?: string | undefined
-  name?: string | undefined
-  novalidate?: boolean | undefined
-  target?: string | undefined
-}
-
-interface HtmlHTMLAttributes extends HTMLAttributes {
-  manifest?: string | undefined
-}
-
-interface IframeHTMLAttributes extends HTMLAttributes {
-  allow?: string | undefined
-  allowfullscreen?: boolean | undefined
-  height?: number | string | undefined
-  loading?: 'eager' | 'lazy' | undefined
-  name?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  sandbox?: string | undefined
-  seamless?: boolean | undefined
-  src?: string | undefined
-  srcdoc?: string | undefined
-  width?: number | string | undefined
-}
-
-interface ImgHTMLAttributes extends HTMLAttributes {
-  alt?: string | undefined
-  crossorigin?: CrossOrigin
-  decoding?: 'async' | 'auto' | 'sync' | undefined
-  height?: number | string | undefined
-  loading?: 'eager' | 'lazy' | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  sizes?: string | undefined
-  src?: string | undefined
-  srcset?: string | undefined
-  usemap?: string | undefined
-  width?: number | string | undefined
-}
-
-interface InsHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-  datetime?: string | undefined
-}
-
-type HTMLInputTypeAttribute =
-  | 'button'
-  | 'checkbox'
-  | 'color'
-  | 'date'
-  | 'datetime-local'
-  | 'email'
-  | 'file'
-  | 'hidden'
-  | 'image'
-  | 'month'
-  | 'number'
-  | 'password'
-  | 'radio'
-  | 'range'
-  | 'reset'
-  | 'search'
-  | 'submit'
-  | 'tel'
-  | 'text'
-  | 'time'
-  | 'url'
-  | 'week'
-  | string
-
-interface InputHTMLAttributes extends HTMLAttributes {
-  accept?: string | undefined
-  alt?: string | undefined
-  autocomplete?: string | undefined
-  capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
-  checked?: boolean | undefined
-  disabled?: boolean | undefined
-  enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
-  form?: string | undefined
-  formenctype?: string | undefined
-  formmethod?: string | undefined
-  formnovalidate?: boolean | undefined
-  formtarget?: string | undefined
-  height?: number | string | undefined
-  list?: string | undefined
-  max?: number | string | undefined
-  maxlength?: number | undefined
-  min?: number | string | undefined
-  minlength?: number | undefined
-  multiple?: boolean | undefined
-  name?: string | undefined
-  pattern?: string | undefined
-  placeholder?: string | undefined
-  readonly?: boolean | undefined
-  required?: boolean | undefined
-  size?: number | undefined
-  src?: string | undefined
-  step?: number | string | undefined
-  type?: HTMLInputTypeAttribute | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-  width?: number | string | undefined
-}
-
-interface KeygenHTMLAttributes extends HTMLAttributes {
-  challenge?: string | undefined
-  disabled?: boolean | undefined
-  form?: string | undefined
-  keytype?: string | undefined
-  name?: string | undefined
-}
-
-interface LabelHTMLAttributes extends HTMLAttributes {
-  form?: string | undefined
-  for?: string | undefined
-}
-
-interface LiHTMLAttributes extends HTMLAttributes {
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface LinkHTMLAttributes extends HTMLAttributes {
-  as?: string | undefined
-  crossorigin?: CrossOrigin
-  href?: string | undefined
-  hreflang?: string | undefined
-  integrity?: string | undefined
-  media?: string | undefined
-  imagesrcset?: string | undefined
-  imagesizes?: string | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  sizes?: string | undefined
-  type?: string | undefined
-  charSet?: string | undefined
-}
-
-interface MapHTMLAttributes extends HTMLAttributes {
-  name?: string | undefined
-}
-
-interface MenuHTMLAttributes extends HTMLAttributes {
-  type?: string | undefined
-}
-
-interface MediaHTMLAttributes extends HTMLAttributes {
-  autoplay?: boolean | undefined
-  controls?: boolean | undefined
-  controlslist?: string | undefined
-  crossorigin?: CrossOrigin
-  loop?: boolean | undefined
-  mediagroup?: string | undefined
-  muted?: boolean | undefined
-  playsinline?: boolean | undefined
-  preload?: string | undefined
-  src?: string | undefined
-}
-
-interface MetaHTMLAttributes extends HTMLAttributes {
-  charset?: string | undefined
-  'http-equiv'?: string | undefined
-  name?: string | undefined
-  media?: string | undefined
-  content?: string | undefined
-}
-
-interface MeterHTMLAttributes extends HTMLAttributes {
-  form?: string | undefined
-  high?: number | undefined
-  low?: number | undefined
-  max?: number | string | undefined
-  min?: number | string | undefined
-  optimum?: number | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface QuoteHTMLAttributes extends HTMLAttributes {
-  cite?: string | undefined
-}
-
-interface ObjectHTMLAttributes extends HTMLAttributes {
-  data?: string | undefined
-  form?: string | undefined
-  height?: number | string | undefined
-  name?: string | undefined
-  type?: string | undefined
-  usemap?: string | undefined
-  width?: number | string | undefined
-}
-
-interface OlHTMLAttributes extends HTMLAttributes {
-  reversed?: boolean | undefined
-  start?: number | undefined
-  type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined
-}
-
-interface OptgroupHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  label?: string | undefined
-}
-
-interface OptionHTMLAttributes extends HTMLAttributes {
-  disabled?: boolean | undefined
-  label?: string | undefined
-  selected?: boolean | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface OutputHTMLAttributes extends HTMLAttributes {
-  form?: string | undefined
-  for?: string | undefined
-  name?: string | undefined
-}
-
-interface ParamHTMLAttributes extends HTMLAttributes {
-  name?: string | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface ProgressHTMLAttributes extends HTMLAttributes {
-  max?: number | string | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface SlotHTMLAttributes extends HTMLAttributes {
-  name?: string | undefined
-}
-
-interface ScriptHTMLAttributes extends HTMLAttributes {
-  async?: boolean | undefined
-  crossorigin?: CrossOrigin
-  defer?: boolean | undefined
-  integrity?: string | undefined
-  nomodule?: boolean | undefined
-  referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
-  src?: string | undefined
-  type?: string | undefined
-}
-
-interface SelectHTMLAttributes extends HTMLAttributes {
-  autocomplete?: string | undefined
-  disabled?: boolean | undefined
-  form?: string | undefined
-  multiple?: boolean | undefined
-  name?: string | undefined
-  required?: boolean | undefined
-  size?: number | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-}
-
-interface SourceHTMLAttributes extends HTMLAttributes {
-  height?: number | string | undefined
-  media?: string | undefined
-  sizes?: string | undefined
-  src?: string | undefined
-  srcset?: string | undefined
-  type?: string | undefined
-  width?: number | string | undefined
-}
-
-interface StyleHTMLAttributes extends HTMLAttributes {
-  media?: string | undefined
-  scoped?: boolean | undefined
-  type?: string | undefined
-}
-
-interface TableHTMLAttributes extends HTMLAttributes {
-  align?: 'left' | 'center' | 'right' | undefined
-  bgcolor?: string | undefined
-  border?: number | undefined
-  cellpadding?: number | string | undefined
-  cellspacing?: number | string | undefined
-  frame?: boolean | undefined
-  rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined
-  summary?: string | undefined
-  width?: number | string | undefined
-}
-
-interface TextareaHTMLAttributes extends HTMLAttributes {
-  autocomplete?: string | undefined
-  cols?: number | undefined
-  dirname?: string | undefined
-  disabled?: boolean | undefined
-  form?: string | undefined
-  maxlength?: number | undefined
-  minlength?: number | undefined
-  name?: string | undefined
-  placeholder?: string | undefined
-  readonly?: boolean | undefined
-  required?: boolean | undefined
-  rows?: number | undefined
-  value?: string | ReadonlyArray<string> | number | undefined
-  wrap?: string | undefined
-}
-
-interface TdHTMLAttributes extends HTMLAttributes {
-  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
-  colspan?: number | undefined
-  headers?: string | undefined
-  rowspan?: number | undefined
-  scope?: string | undefined
-  abbr?: string | undefined
-  height?: number | string | undefined
-  width?: number | string | undefined
-  valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined
-}
-
-interface ThHTMLAttributes extends HTMLAttributes {
-  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined
-  colspan?: number | undefined
-  headers?: string | undefined
-  rowspan?: number | undefined
-  scope?: string | undefined
-  abbr?: string | undefined
-}
-
-interface TimeHTMLAttributes extends HTMLAttributes {
-  datetime?: string | undefined
-}
-
-interface TrackHTMLAttributes extends HTMLAttributes {
-  default?: boolean | undefined
-  kind?: string | undefined
-  label?: string | undefined
-  src?: string | undefined
-  srclang?: string | undefined
-}
-
-interface VideoHTMLAttributes extends MediaHTMLAttributes {
-  height?: number | string | undefined
-  playsinline?: boolean | undefined
-  poster?: string | undefined
-  width?: number | string | undefined
-  disablePictureInPicture?: boolean | undefined
-  disableRemotePlayback?: boolean | undefined
-}
-
-export interface IntrinsicElements {
-  a: AnchorHTMLAttributes
-  abbr: HTMLAttributes
-  address: HTMLAttributes
-  area: AreaHTMLAttributes
-  article: HTMLAttributes
-  aside: HTMLAttributes
-  audio: AudioHTMLAttributes
-  b: HTMLAttributes
-  base: BaseHTMLAttributes
-  bdi: HTMLAttributes
-  bdo: HTMLAttributes
-  big: HTMLAttributes
-  blockquote: BlockquoteHTMLAttributes
-  body: HTMLAttributes
-  br: HTMLAttributes
-  button: ButtonHTMLAttributes
-  canvas: CanvasHTMLAttributes
-  caption: HTMLAttributes
-  center: HTMLAttributes
-  cite: HTMLAttributes
-  code: HTMLAttributes
-  col: ColHTMLAttributes
-  colgroup: ColgroupHTMLAttributes
-  data: DataHTMLAttributes
-  datalist: HTMLAttributes
-  dd: HTMLAttributes
-  del: DelHTMLAttributes
-  details: DetailsHTMLAttributes
-  dfn: HTMLAttributes
-  dialog: DialogHTMLAttributes
-  div: HTMLAttributes
-  dl: HTMLAttributes
-  dt: HTMLAttributes
-  em: HTMLAttributes
-  embed: EmbedHTMLAttributes
-  fieldset: FieldsetHTMLAttributes
-  figcaption: HTMLAttributes
-  figure: HTMLAttributes
-  footer: HTMLAttributes
-  form: FormHTMLAttributes
-  h1: HTMLAttributes
-  h2: HTMLAttributes
-  h3: HTMLAttributes
-  h4: HTMLAttributes
-  h5: HTMLAttributes
-  h6: HTMLAttributes
-  head: HTMLAttributes
-  header: HTMLAttributes
-  hgroup: HTMLAttributes
-  hr: HTMLAttributes
-  html: HtmlHTMLAttributes
-  i: HTMLAttributes
-  iframe: IframeHTMLAttributes
-  img: ImgHTMLAttributes
-  input: InputHTMLAttributes
-  ins: InsHTMLAttributes
-  kbd: HTMLAttributes
-  keygen: KeygenHTMLAttributes
-  label: LabelHTMLAttributes
-  legend: HTMLAttributes
-  li: LiHTMLAttributes
-  link: LinkHTMLAttributes
-  main: HTMLAttributes
-  map: MapHTMLAttributes
-  mark: HTMLAttributes
-  menu: MenuHTMLAttributes
-  menuitem: HTMLAttributes
-  meta: MetaHTMLAttributes
-  meter: MeterHTMLAttributes
-  nav: HTMLAttributes
-  noscript: HTMLAttributes
-  object: ObjectHTMLAttributes
-  ol: OlHTMLAttributes
-  optgroup: OptgroupHTMLAttributes
-  option: OptionHTMLAttributes
-  output: OutputHTMLAttributes
-  p: HTMLAttributes
-  param: ParamHTMLAttributes
-  picture: HTMLAttributes
-  pre: HTMLAttributes
-  progress: ProgressHTMLAttributes
-  q: QuoteHTMLAttributes
-  rp: HTMLAttributes
-  rt: HTMLAttributes
-  ruby: HTMLAttributes
-  s: HTMLAttributes
-  samp: HTMLAttributes
-  search: HTMLAttributes
-  slot: SlotHTMLAttributes
-  script: ScriptHTMLAttributes
-  section: HTMLAttributes
-  select: SelectHTMLAttributes
-  small: HTMLAttributes
-  source: SourceHTMLAttributes
-  span: HTMLAttributes
-  strong: HTMLAttributes
-  style: StyleHTMLAttributes
-  sub: HTMLAttributes
-  summary: HTMLAttributes
-  sup: HTMLAttributes
-  table: TableHTMLAttributes
-  template: HTMLAttributes
-  tbody: HTMLAttributes
-  td: TdHTMLAttributes
-  textarea: TextareaHTMLAttributes
-  tfoot: HTMLAttributes
-  th: ThHTMLAttributes
-  thead: HTMLAttributes
-  time: TimeHTMLAttributes
-  title: HTMLAttributes
-  tr: HTMLAttributes
-  track: TrackHTMLAttributes
-  u: HTMLAttributes
-  ul: HTMLAttributes
-  var: HTMLAttributes
-  video: VideoHTMLAttributes
-  wbr: HTMLAttributes
-}
+export interface IntrinsicElements extends Hono.IntrinsicElements {}


### PR DESCRIPTION
This PR introduces type definitions for JSX elements to enhance the developer experience.

### Approach

There are several ways to add types to JSX elements. With this PR, the approach taken is as follows:

* Define types manually, without referring to the DOM lib.
* Main tags are ported from React's definitions: https://www.npmjs.com/package/@types/react?activeTab=code
* Removed some elements and attributes such as ARIA's to keep it minimum.
* Renamed some properties for HTML compatibility, e.g., `readOnly` to `readonly`.
* For compatibility with unknown elements and attributes, it allows any elements and attributes.

### Screenshots

<img width="1098" alt="Screenshot 2023-10-23 at 17 47 03" src="https://github.com/honojs/hono/assets/10682/ce0587b8-1369-4ba3-ac02-9cd644553843">

<img width="637" alt="Screenshot 2023-10-23 at 17 49 03" src="https://github.com/honojs/hono/assets/10682/3d1104be-a59b-4367-8643-ae924e27f544">

### Allowing any elements and attributes

In this PR, any elements and any attributes are allowed. This is defined as follows:

Attributes:

```ts
type AnyAttributes = { [attributeName: string]: any }

//...

interface HTMLAttributes extends JSXAttributes, AnyAttributes {
```

Elements:

```ts
type IntrinsicElements = IntrinsicElementsDefined & { [tagName: string]: Props }
```

This means that the feature doesn't support type safety completely, but it offers flexibility. You can use user-defined tags and maintain backward compatibility.

This doesn't throw an error.

<img width="443" alt="Screenshot 2023-10-23 at 18 06 09" src="https://github.com/honojs/hono/assets/10682/b4220351-0a25-4c82-a446-d0b5df2b28ea">

I believe it shouldn't be too strict in this case for JSX, as flexibility is important and this approach can sufficiently improve DX.

---

Resolves #1409