### PR TITLE
feat(jsx-renderer): `docType` option

### DIFF
--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -17,14 +17,13 @@ type RendererOptions = {
 const createRenderer =
   (c: Context, component?: FC<PropsForRenderer>, options?: RendererOptions) =>
   (children: JSXNode, props: PropsForRenderer) => {
-    let docType = ''
-    if (options?.docType) {
-      if (typeof options.docType === 'string') {
-        docType = options.docType
-      } else if (typeof options.docType === 'boolean' && options.docType === true) {
-        docType = '<!DOCTYPE html>'
-      }
-    }
+    const docType =
+      typeof options?.docType === 'string'
+        ? options.docType
+        : options?.docType === true
+        ? '<!DOCTYPE html>'
+        : ''
+
     return c.html(
       (docType +
         /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -10,22 +10,37 @@ type PropsForRenderer = [...Required<Parameters<Renderer>>] extends [unknown, in
   ? Props
   : unknown
 
+type RendererOptions = {
+  docType?: boolean | string
+}
+
 const createRenderer =
-  (c: Context, component?: FC<PropsForRenderer>) => (children: JSXNode, props: PropsForRenderer) =>
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    c.html(
-      jsx(
-        RequestContext.Provider,
-        { value: c },
-        (component ? component({ children, ...(props || {}) }) : children) as any
-      ) as any
+  (c: Context, component?: FC<PropsForRenderer>, options?: RendererOptions) =>
+  (children: JSXNode, props: PropsForRenderer) => {
+    let docType = ''
+    if (options?.docType) {
+      if (typeof options.docType === 'string') {
+        docType = options.docType
+      } else if (typeof options.docType === 'boolean' && options.docType === true) {
+        docType = '<!DOCTYPE html>'
+      }
+    }
+    return c.html(
+      (docType +
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        jsx(
+          RequestContext.Provider,
+          { value: c },
+          (component ? component({ children, ...(props || {}) }) : children) as any
+        )) as any
     )
+  }
 
 export const jsxRenderer =
-  (component?: FC<PropsForRenderer>): MiddlewareHandler =>
+  (component?: FC<PropsForRenderer>, options?: RendererOptions): MiddlewareHandler =>
   (c, next) => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    c.setRenderer(createRenderer(c, component) as any)
+    c.setRenderer(createRenderer(c, component, options) as any)
     return next()
   }
 

--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -56,6 +56,55 @@ describe('JSX renderer', () => {
     expect(await res.text()).toBe('<h1>http://localhost/</h1>')
   })
 
+  it('Should return a default doctype', async () => {
+    const app = new Hono()
+    app.use(
+      '*',
+      jsxRenderer(
+        ({ children }) => {
+          return (
+            <html>
+              <body>{children}</body>
+            </html>
+          )
+        },
+        { docType: true }
+      )
+    )
+    app.get('/', (c) => c.render(<h1>Hello</h1>, { title: 'Title' }))
+    const res = await app.request('/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('<!DOCTYPE html><html><body><h1>Hello</h1></body></html>')
+  })
+
+  it('Should return a custom doctype', async () => {
+    const app = new Hono()
+    app.use(
+      '*',
+      jsxRenderer(
+        ({ children }) => {
+          return (
+            <html>
+              <body>{children}</body>
+            </html>
+          )
+        },
+        {
+          docType:
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
+        }
+      )
+    )
+    app.get('/', (c) => c.render(<h1>Hello</h1>, { title: 'Title' }))
+    const res = await app.request('/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe(
+      '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><body><h1>Hello</h1></body></html>'
+    )
+  })
+
   it('Env', async () => {
     type JSXRendererEnv = {
       Variables: {

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -17,14 +17,13 @@ type RendererOptions = {
 const createRenderer =
   (c: Context, component?: FC<PropsForRenderer>, options?: RendererOptions) =>
   (children: JSXNode, props: PropsForRenderer) => {
-    let docType = ''
-    if (options?.docType) {
-      if (typeof options.docType === 'string') {
-        docType = options.docType
-      } else if (typeof options.docType === 'boolean' && options.docType === true) {
-        docType = '<!DOCTYPE html>'
-      }
-    }
+    const docType =
+      typeof options?.docType === 'string'
+        ? options.docType
+        : options?.docType === true
+        ? '<!DOCTYPE html>'
+        : ''
+
     return c.html(
       (docType +
         /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -10,22 +10,37 @@ type PropsForRenderer = [...Required<Parameters<Renderer>>] extends [unknown, in
   ? Props
   : unknown
 
+type RendererOptions = {
+  docType?: boolean | string
+}
+
 const createRenderer =
-  (c: Context, component?: FC<PropsForRenderer>) => (children: JSXNode, props: PropsForRenderer) =>
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    c.html(
-      jsx(
-        RequestContext.Provider,
-        { value: c },
-        (component ? component({ children, ...(props || {}) }) : children) as any
-      ) as any
+  (c: Context, component?: FC<PropsForRenderer>, options?: RendererOptions) =>
+  (children: JSXNode, props: PropsForRenderer) => {
+    let docType = ''
+    if (options?.docType) {
+      if (typeof options.docType === 'string') {
+        docType = options.docType
+      } else if (typeof options.docType === 'boolean' && options.docType === true) {
+        docType = '<!DOCTYPE html>'
+      }
+    }
+    return c.html(
+      (docType +
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        jsx(
+          RequestContext.Provider,
+          { value: c },
+          (component ? component({ children, ...(props || {}) }) : children) as any
+        )) as any
     )
+  }
 
 export const jsxRenderer =
-  (component?: FC<PropsForRenderer>): MiddlewareHandler =>
+  (component?: FC<PropsForRenderer>, options?: RendererOptions): MiddlewareHandler =>
   (c, next) => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    c.setRenderer(createRenderer(c, component) as any)
+    c.setRenderer(createRenderer(c, component, options) as any)
     return next()
   }
 


### PR DESCRIPTION
Currently, when using JSX Renderer, we can't easily add a `DOCTYPE`. This PR introduces a `docType` option for the JSX Renderer to add a `DOCTYPE`.

```tsx
app.use(
  '*',
  jsxRenderer(
    ({ children }) => {
      return (
        <html>
          <body>{children}</body>
        </html>
      )
    },
    { docType: true }
  )
)
```

If you want to customize the `DOCTYPE`, you can pass the string:

```tsx
app.use(
  '*',
  jsxRenderer(
    ({ children }) => {
      return (
        <html>
          <body>{children}</body>
        </html>
      )
    },
    {
      docType:
        '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
    }
  )
)
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
