### PR TITLE
perf: The doctype is determined on initialization, not on request.

### DIFF
--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -14,17 +14,19 @@ type RendererOptions = {
   docType?: boolean | string
 }
 
-const createRenderer =
-  (c: Context, component?: FC<PropsForRenderer>, options?: RendererOptions) =>
-  (children: JSXNode, props: PropsForRenderer) => {
-    let docType = ''
-    if (options?.docType) {
-      if (typeof options.docType === 'string') {
-        docType = options.docType
-      } else if (typeof options.docType === 'boolean' && options.docType === true) {
-        docType = '<!DOCTYPE html>'
-      }
-    }
+const createRenderer = (
+  c: Context,
+  component?: FC<PropsForRenderer>,
+  options?: RendererOptions
+) => {
+  const docType =
+    typeof options?.docType === 'string'
+      ? options.docType
+      : options?.docType === true
+      ? '<!DOCTYPE html>'
+      : ''
+
+  return (children: JSXNode, props: PropsForRenderer) => {
     return c.html(
       (docType +
         /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -35,6 +37,7 @@ const createRenderer =
         )) as any
     )
   }
+}
 
 export const jsxRenderer =
   (component?: FC<PropsForRenderer>, options?: RendererOptions): MiddlewareHandler =>

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -14,17 +14,19 @@ type RendererOptions = {
   docType?: boolean | string
 }
 
-const createRenderer =
-  (c: Context, component?: FC<PropsForRenderer>, options?: RendererOptions) =>
-  (children: JSXNode, props: PropsForRenderer) => {
-    let docType = ''
-    if (options?.docType) {
-      if (typeof options.docType === 'string') {
-        docType = options.docType
-      } else if (typeof options.docType === 'boolean' && options.docType === true) {
-        docType = '<!DOCTYPE html>'
-      }
-    }
+const createRenderer = (
+  c: Context,
+  component?: FC<PropsForRenderer>,
+  options?: RendererOptions
+) => {
+  const docType =
+    typeof options?.docType === 'string'
+      ? options.docType
+      : options?.docType === true
+      ? '<!DOCTYPE html>'
+      : ''
+
+  return (children: JSXNode, props: PropsForRenderer) => {
     return c.html(
       (docType +
         /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -35,6 +37,7 @@ const createRenderer =
         )) as any
     )
   }
+}
 
 export const jsxRenderer =
   (component?: FC<PropsForRenderer>, options?: RendererOptions): MiddlewareHandler =>


### PR DESCRIPTION
If the initialized app handles multiple requests, it is better to determine the docType at the time of the createRenderer call.

However, in an environment where only a single request is handled (such as where LinearRouter is active), it is better to determine docType at request time (since the response may not be rendered in JSX). If the focus is on that use case, I don't think this PR is necessary.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
