### PR TITLE
fix(`package.json`): export types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,6 +262,12 @@
   },
   "typesVersions": {
     "*": {
+      "types": [
+        "./dist/types/types"
+      ],
+      "hono-base": [
+        "./dist/types/hono-base"
+      ],
       "tiny": [
         "./dist/types/preset/tiny"
       ],


### PR DESCRIPTION
### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
