### PR TITLE
fix(utils/filepath): filepath supports Windows

### DIFF
--- a/deno_dist/utils/filepath.ts
+++ b/deno_dist/utils/filepath.ts
@@ -6,7 +6,7 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/(?:^|\/)\.\.(?:$|\/)/.test(filename)) return
+  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) return
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'
@@ -20,7 +20,10 @@ export const getFilePath = (options: FilePathOptions): string | undefined => {
   }
 
   // /foo.html => foo.html
-  filename = filename.replace(/^\.?\//, '')
+  filename = filename.replace(/^\.?[\/\\]/, '')
+
+  // foo\bar.txt => foo/bar.txt
+  filename = filename.replace(/\\/, '/')
 
   // assets/ => assets
   root = root.replace(/\/$/, '')

--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -25,5 +25,18 @@ describe('getFilePath', () => {
     expect(getFilePath({ filename: './..foo/bar.txt' })).toBe('..foo/bar.txt')
     expect(getFilePath({ filename: './foo../bar.txt' })).toBe('foo../bar.txt')
     expect(getFilePath({ filename: './..foo../bar.txt' })).toBe('..foo../bar.txt')
+
+    expect(getFilePath({ filename: slashToBackslash('/../foo') })).toBeUndefined()
+    expect(getFilePath({ filename: slashToBackslash('./../foo') })).toBeUndefined()
+    expect(getFilePath({ filename: slashToBackslash('foo..bar.txt') })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: slashToBackslash('/foo..bar.txt') })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: slashToBackslash('./foo..bar.txt') })).toBe('foo..bar.txt')
+    expect(getFilePath({ filename: slashToBackslash('./..foo/bar.txt') })).toBe('..foo/bar.txt')
+    expect(getFilePath({ filename: slashToBackslash('./foo../bar.txt') })).toBe('foo../bar.txt')
+    expect(getFilePath({ filename: slashToBackslash('./..foo../bar.txt') })).toBe('..foo../bar.txt')
   })
 })
+
+function slashToBackslash(filename: string) {
+  return filename.split('/').join('\\')
+}

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -6,7 +6,7 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/(?:^|\/)\.\.(?:$|\/)/.test(filename)) return
+  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) return
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'
@@ -20,7 +20,10 @@ export const getFilePath = (options: FilePathOptions): string | undefined => {
   }
 
   // /foo.html => foo.html
-  filename = filename.replace(/^\.?\//, '')
+  filename = filename.replace(/^\.?[\/\\]/, '')
+
+  // foo\bar.txt => foo/bar.txt
+  filename = filename.replace(/\\/, '/')
 
   // assets/ => assets
   root = root.replace(/\/$/, '')


### PR DESCRIPTION
This PR makes `filepath` util supports Windows and prevents the path traversal on Windows.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
