### PR TITLE
fix(helper): Stream SSE Helper Non-Closure

### DIFF
--- a/deno_dist/helper/streaming/index.ts
+++ b/deno_dist/helper/streaming/index.ts
@@ -40,14 +40,20 @@ export const streamSSE = (c: Context, cb: (stream: SSEStreamingApi) => Promise<v
   return c.stream(async (originalStream: StreamingApi) => {
     const { readable, writable } = new TransformStream()
     const stream = new SSEStreamingApi(writable)
-    originalStream.pipe(readable)
+
+    originalStream.pipe(readable).catch((err) => {
+      console.error('Error in stream piping: ', err)
+      stream.close()
+    })
+
     setSSEHeaders(c)
 
     try {
       await cb(stream)
     } catch (err) {
       console.error('Error during streaming: ', err)
-      stream.close()
+    } finally {
+      await stream.close()
     }
   })
 }

--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -510,10 +510,9 @@ describe('streamHandle function', () => {
 
     mockReadableStream.push('data: Message\ndata: It is 0\n\n')
     mockReadableStream.push('data: Message\ndata: It is 1\n\n')
-    mockReadableStream.push('event: close\ndata: Stream closed\n\n')
     mockReadableStream.push(null) // EOF
 
-    const res = await handler(event, mockReadableStream)
+    await handler(event, mockReadableStream)
 
     const chunks = []
     for await (const chunk of mockReadableStream) {

--- a/src/helper/streaming/index.ts
+++ b/src/helper/streaming/index.ts
@@ -40,14 +40,20 @@ export const streamSSE = (c: Context, cb: (stream: SSEStreamingApi) => Promise<v
   return c.stream(async (originalStream: StreamingApi) => {
     const { readable, writable } = new TransformStream()
     const stream = new SSEStreamingApi(writable)
-    originalStream.pipe(readable)
+
+    originalStream.pipe(readable).catch((err) => {
+      console.error('Error in stream piping: ', err)
+      stream.close()
+    })
+
     setSSEHeaders(c)
 
     try {
       await cb(stream)
     } catch (err) {
       console.error('Error during streaming: ', err)
-      stream.close()
+    } finally {
+      await stream.close()
     }
   })
 }


### PR DESCRIPTION
I fixed a bug where the Stream SSE Helper would not close, preventing the session from ending. Additionally, I've implemented error handling for the pipe.

Actually, it was known that the AWS Lambda Adaptor did not terminate during testing, so I've added tests to cover that :)

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
