### PR TITLE
feat(jsx): Define jsxTemplate/jsxAttr/jsxEscape for "@jsx precompile" of Deno 1.38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           deno-version: v1.x
       - run: env NAME=Deno deno test --allow-read --allow-env runtime_tests/deno
+      - run: deno test -c runtime_tests/deno-jsx/deno.precompile.json runtime_tests/deno-jsx
+      - run: deno test -c runtime_tests/deno-jsx/deno.react-jsx.json runtime_tests/deno-jsx
 
   bun:
     name: 'Bun'

--- a/deno_dist/jsx/jsx-dev-runtime.ts
+++ b/deno_dist/jsx/jsx-dev-runtime.ts
@@ -4,7 +4,10 @@ import type { JSXNode } from './index.ts'
 export { Fragment } from './index.ts'
 
 export function jsxDEV(tag: string | Function, props: Record<string, unknown>): JSXNode {
-  const children = (props.children ?? []) as string | HtmlEscapedString
+  if (!props?.children) {
+    return jsx(tag, props)
+  }
+  const children = props.children as string | HtmlEscapedString
   delete props['children']
   return Array.isArray(children) ? jsx(tag, props, ...children) : jsx(tag, props, children)
 }

--- a/deno_dist/jsx/jsx-runtime.ts
+++ b/deno_dist/jsx/jsx-runtime.ts
@@ -1,2 +1,7 @@
 export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime.ts'
 export { jsxDEV as jsxs } from './jsx-dev-runtime.ts'
+
+import { raw, html } from '../helper/html/index.ts'
+export { html as jsxTemplate }
+export const jsxAttr = (name: string, value: string) => raw(name + '="' + html`${value}` + '"')
+export const jsxEscape = (value: string) => value

--- a/deno_dist/jsx/streaming.ts
+++ b/deno_dist/jsx/streaming.ts
@@ -72,7 +72,7 @@ export const renderToReadableStream = (
 ): ReadableStream<Uint8Array> => {
   const reader = new ReadableStream<Uint8Array>({
     async start(controller) {
-      const resolved = await str.toString()
+      const resolved = await (str instanceof Promise ? await str : str).toString()
       controller.enqueue(textEncoder.encode(resolved))
 
       let unresolvedCount = (resolved as HtmlEscapedString).promises?.length || 0

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "tsc --noEmit && vitest --run",
-    "test:deno": "env NAME=Deno deno test --allow-read --allow-env runtime_tests/deno",
+    "test:deno": "env NAME=Deno deno test --allow-read --allow-env runtime_tests/deno && deno test --no-lock -c runtime_tests/deno-jsx/deno.precompile.json runtime_tests/deno-jsx && deno test --no-lock -c runtime_tests/deno-jsx/deno.react-jsx.json runtime_tests/deno-jsx",
     "test:bun": "env NAME=Bun bun test --jsx-import-source ../../src/jsx runtime_tests/bun/index.test.tsx",
     "test:fastly": "jest --config ./runtime_tests/fastly/jest.config.js",
     "test:lagon": "start-server-and-test \"lagon dev runtime_tests/lagon/index.ts -e runtime_tests/lagon/.env.lagon\" http://127.0.0.1:1234 \"yarn vitest --run runtime_tests/lagon/index.test.ts --config runtime_tests/lagon/vitest.config.ts\"",

--- a/runtime_tests/deno-jsx/deno.precompile.json
+++ b/runtime_tests/deno-jsx/deno.precompile.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "precompile",
+    "jsxImportSource": "hono/jsx"
+  },
+  "imports": {
+    "hono": "./../deno_dist/hono.ts",
+    "hono/jsx/jsx-runtime": "../../deno_dist/jsx/jsx-runtime.ts",
+    "hono/jsx/streaming": "../../deno_dist/jsx/streaming.ts"
+  }
+}

--- a/runtime_tests/deno-jsx/deno.precompile.json
+++ b/runtime_tests/deno-jsx/deno.precompile.json
@@ -4,8 +4,7 @@
     "jsxImportSource": "hono/jsx"
   },
   "imports": {
-    "hono": "./../deno_dist/hono.ts",
     "hono/jsx/jsx-runtime": "../../deno_dist/jsx/jsx-runtime.ts",
-    "hono/jsx/streaming": "../../deno_dist/jsx/streaming.ts"
+    "../../deno_dist/jsx/jsx-runtime": "../../deno_dist/jsx/jsx-runtime.ts"
   }
 }

--- a/runtime_tests/deno-jsx/deno.react-jsx.json
+++ b/runtime_tests/deno-jsx/deno.react-jsx.json
@@ -4,8 +4,7 @@
     "jsxImportSource": "hono/jsx"
   },
   "imports": {
-    "hono": "./../deno_dist/hono.ts",
     "hono/jsx/jsx-runtime": "../../deno_dist/jsx/jsx-runtime.ts",
-    "hono/jsx/streaming": "../../deno_dist/jsx/streaming.ts"
+    "../../deno_dist/jsx/jsx-runtime": "../../deno_dist/jsx/jsx-runtime.ts"
   }
 }

--- a/runtime_tests/deno-jsx/deno.react-jsx.json
+++ b/runtime_tests/deno-jsx/deno.react-jsx.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  },
+  "imports": {
+    "hono": "./../deno_dist/hono.ts",
+    "hono/jsx/jsx-runtime": "../../deno_dist/jsx/jsx-runtime.ts",
+    "hono/jsx/streaming": "../../deno_dist/jsx/streaming.ts"
+  }
+}

--- a/runtime_tests/deno-jsx/jsx.test.tsx
+++ b/runtime_tests/deno-jsx/jsx.test.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource ../../deno_dist/jsx */
 import { Suspense, renderToReadableStream } from '../../deno_dist/jsx/streaming.ts'
 import type { HtmlEscapedString } from '../../deno_dist/utils/html.ts'
 import { assertEquals } from '../deno/deps.ts'
@@ -34,7 +35,7 @@ Deno.test('JSX: Async Component', async () => {
     </div>
   )
 
-  const chunks = []
+  const chunks: string[] = []
   const textDecoder = new TextDecoder()
   for await (const chunk of stream as any) {
     chunks.push(textDecoder.decode(chunk))
@@ -57,7 +58,7 @@ Deno.test('JSX: Suspense', async () => {
     </Suspense>
   )
 
-  const chunks = []
+  const chunks: string[] = []
   const textDecoder = new TextDecoder()
   for await (const chunk of stream as any) {
     chunks.push(textDecoder.decode(chunk))

--- a/runtime_tests/deno-jsx/jsx.test.tsx
+++ b/runtime_tests/deno-jsx/jsx.test.tsx
@@ -1,0 +1,77 @@
+import { Suspense, renderToReadableStream } from '../../deno_dist/jsx/streaming.ts'
+import type { HtmlEscapedString } from '../../deno_dist/utils/html.ts'
+import { assertEquals } from '../deno/deps.ts'
+
+Deno.test('JSX', () => {
+  const Component = ({ name }: { name: string }) => <span>{name}</span>
+  const html = (
+    <div>
+      <h1 id={'<Hello>'}>
+        <Component name={'<Hono>'} />
+      </h1>
+    </div>
+  )
+
+  assertEquals(html.toString(), '<div><h1 id="&lt;Hello&gt;"><span>&lt;Hono&gt;</span></h1></div>')
+})
+
+Deno.test('JSX: Fragment', () => {
+  const fragment = (
+    <>
+      <p>1</p>
+      <p>2</p>
+    </>
+  )
+  assertEquals(fragment.toString(), '<p>1</p><p>2</p>')
+})
+
+Deno.test('JSX: Async Component', async () => {
+  const Component = async ({ name }: { name: string }) =>
+    new Promise<HtmlEscapedString>((resolve) => setTimeout(() => resolve(<span>{name}</span>), 10))
+  const stream = renderToReadableStream(
+    <div>
+      <Component name={'<Hono>'} />
+    </div>
+  )
+
+  const chunks = []
+  const textDecoder = new TextDecoder()
+  for await (const chunk of stream as any) {
+    chunks.push(textDecoder.decode(chunk))
+  }
+
+  assertEquals(chunks.join(''), '<div><span>&lt;Hono&gt;</span></div>')
+})
+
+Deno.test('JSX: Suspense', async () => {
+  const Content = () => {
+    const content = new Promise<HtmlEscapedString>((resolve) =>
+      setTimeout(() => resolve(<h1>Hello</h1>), 10)
+    )
+    return content
+  }
+
+  const stream = renderToReadableStream(
+    <Suspense fallback={<p>Loading...</p>}>
+      <Content />
+    </Suspense>
+  )
+
+  const chunks = []
+  const textDecoder = new TextDecoder()
+  for await (const chunk of stream as any) {
+    chunks.push(textDecoder.decode(chunk))
+  }
+
+  assertEquals(chunks, [
+    '<template id="H:0"></template><p>Loading...</p><!--/$-->',
+    `<template><h1>Hello</h1></template><script>
+((d,c,n) => {
+c=d.currentScript.previousSibling
+d=d.getElementById('H:0')
+do{n=d.nextSibling;n.remove()}while(n.nodeType!=8||n.nodeValue!='/$')
+d.replaceWith(c.content)
+})(document)
+</script>`,
+  ])
+})

--- a/src/jsx/jsx-dev-runtime.ts
+++ b/src/jsx/jsx-dev-runtime.ts
@@ -4,7 +4,10 @@ import type { JSXNode } from '.'
 export { Fragment } from '.'
 
 export function jsxDEV(tag: string | Function, props: Record<string, unknown>): JSXNode {
-  const children = (props.children ?? []) as string | HtmlEscapedString
+  if (!props?.children) {
+    return jsx(tag, props)
+  }
+  const children = props.children as string | HtmlEscapedString
   delete props['children']
   return Array.isArray(children) ? jsx(tag, props, ...children) : jsx(tag, props, children)
 }

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -1,2 +1,7 @@
 export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
 export { jsxDEV as jsxs } from './jsx-dev-runtime'
+
+import { raw, html } from '../helper/html'
+export { html as jsxTemplate }
+export const jsxAttr = (name: string, value: string) => raw(name + '="' + html`${value}` + '"')
+export const jsxEscape = (value: string) => value

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom'
+import { raw } from '../helper/html'
 import type { HtmlEscapedString } from '../utils/html'
 import { Suspense, renderToReadableStream } from './streaming'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -262,7 +263,7 @@ d.replaceWith(c.content)
 
   it('renderToReadableStream(str: string)', async () => {
     const str = '<h1>Hello</h1>'
-    const stream = renderToReadableStream(str as HtmlEscapedString)
+    const stream = renderToReadableStream(raw(str))
 
     const chunks = []
     const textDecoder = new TextDecoder()
@@ -271,5 +272,17 @@ d.replaceWith(c.content)
     }
 
     expect(chunks).toEqual([str])
+  })
+
+  it('renderToReadableStream(promise: Promise<HtmlEscapedString>)', async () => {
+    const stream = renderToReadableStream(Promise.resolve(raw('<h1>Hello</h1>')))
+
+    const chunks = []
+    const textDecoder = new TextDecoder()
+    for await (const chunk of stream as any) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+
+    expect(chunks).toEqual(['<h1>Hello</h1>'])
   })
 })

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -72,7 +72,7 @@ export const renderToReadableStream = (
 ): ReadableStream<Uint8Array> => {
   const reader = new ReadableStream<Uint8Array>({
     async start(controller) {
-      const resolved = await str.toString()
+      const resolved = await (str instanceof Promise ? await str : str).toString()
       controller.enqueue(textEncoder.encode(resolved))
 
       let unresolvedCount = (resolved as HtmlEscapedString).promises?.length || 0


### PR DESCRIPTION
### What is this PR?

Merging this PR will support the JSX transforms included in Deno's 1.38
https://deno.com/blog/v1.38#fastest-jsx-transform

The async component and `renderToReadableStream()` are also working.

### Benchmark

The following benchmarks were used for comparison

```ts
import { bench, run } from 'https://esm.sh/mitata'

const title = '<Hello>'
const name = '<Deno>'
const Component = (props: { name: string }) => (
  <>
    Hello <b>{props.name}!</b>
  </>
)
const getHtml = () => (
  <div>
    <a title={title}>
      <Component name={name} />
    </a>
  </div>
)

if (getHtml().toString() !== '<div><a title="&lt;Hello&gt;">Hello <b>&lt;Deno&gt;!</b></a></div>') {
  throw new Error('failed')
}

bench('toString()', () => {
  for (let i = 0; i < 10000; i++) {
    getHtml().toString()
  }
})

await run()
```

#### "react-jsx" : Previously available

deno.json
```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxFragmentFactory": "Fragment",
    "jsxImportSource": "hono/jsx"
  },
  "imports": {
    "hono/jsx/jsx-runtime": "./deno_dist/jsx/jsx-runtime.ts",
    "hono": "./deno_dist/hono.ts"
  }
}
```

```
# deno run --allow-read bench-jsx.tsx 
cpu: unknown
runtime: deno 1.38.0 (x86_64-unknown-linux-gnu)

benchmark       time (avg)             (min … max)       p75       p99      p995
-------------------------------------------------- -----------------------------
toString()   12.31 ms/iter         (10 ms … 14 ms)     12 ms     14 ms     14 ms
```

#### "precompile" : Newly available

deno.json
```json
{
  "compilerOptions": {
    "jsx": "precompile",
    "jsxFragmentFactory": "Fragment",
    "jsxImportSource": "hono/jsx"
  },
  "imports": {
    "hono/jsx/jsx-runtime": "./deno_dist/jsx/jsx-runtime.ts",
    "hono": "./deno_dist/hono.ts"
  }
}
```

```
# deno run --allow-read bench-jsx.tsx 
cpu: unknown
runtime: deno 1.38.0 (x86_64-unknown-linux-gnu)

benchmark       time (avg)             (min … max)       p75       p99      p995
-------------------------------------------------- -----------------------------
toString()    7.65 ms/iter          (6 ms … 72 ms)      8 ms     72 ms     72 ms
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
