### PR TITLE
fix(Adaptor): Lambda Response Streaming With Content Type 

### DIFF
--- a/src/adapter/aws-lambda/awslambda.d.ts
+++ b/src/adapter/aws-lambda/awslambda.d.ts
@@ -3,8 +3,27 @@
 
 import type { LambdaContext, Handler } from './types'
 
+type METADATA_PRELUDE_CONTENT_TYPE = string
+
 declare global {
   namespace awslambda {
+    export class HttpResponseStream {
+      static from(underlyingStream: NodeJS.WritableStream, prelude: Record<string, unknown>): NodeJS.WritableStream {
+        underlyingStream['setContentType'](METADATA_PRELUDE_CONTENT_TYPE)
+
+        // JSON.stringify is required. NULL byte is not allowed in metadataPrelude.
+        const metadataPrelude = JSON.stringify(prelude)
+
+        underlyingStream['_onBeforeFirstWrite'] = (write: (chunk: any) => void) => {
+          write(Buffer.from(metadataPrelude, 'utf8'))
+
+          // Write 8 null bytes after the JSON prelude.
+          write(Buffer.alloc(DELIMITER_LEN, 0))
+        }
+
+        return underlyingStream
+      } 
+    }
     function streamifyResponse(
       f: (
         event: any,

--- a/src/adapter/aws-lambda/awslambda.d.ts
+++ b/src/adapter/aws-lambda/awslambda.d.ts
@@ -3,13 +3,14 @@
 
 import type { LambdaContext, Handler } from './types'
 
-type METADATA_PRELUDE_CONTENT_TYPE = string
-
 declare global {
   namespace awslambda {
     export class HttpResponseStream {
-      static from(underlyingStream: NodeJS.WritableStream, prelude: Record<string, unknown>): NodeJS.WritableStream {
-        underlyingStream['setContentType'](METADATA_PRELUDE_CONTENT_TYPE)
+      static from(
+        underlyingStream: NodeJS.WritableStream,
+        prelude: Record<string, unknown>
+      ): NodeJS.WritableStream {
+        underlyingStream.setContentType('application/vnd.awslambda.http-integration-response')
 
         // JSON.stringify is required. NULL byte is not allowed in metadataPrelude.
         const metadataPrelude = JSON.stringify(prelude)
@@ -18,11 +19,11 @@ declare global {
           write(Buffer.from(metadataPrelude, 'utf8'))
 
           // Write 8 null bytes after the JSON prelude.
-          write(Buffer.alloc(DELIMITER_LEN, 0))
+          write(Buffer.alloc(8, 0))
         }
 
         return underlyingStream
-      } 
+      }
     }
     function streamifyResponse(
       f: (

--- a/src/adapter/aws-lambda/awslambda.d.ts
+++ b/src/adapter/aws-lambda/awslambda.d.ts
@@ -5,25 +5,13 @@ import type { LambdaContext, Handler } from './types'
 
 declare global {
   namespace awslambda {
+    // Note: Anticipated logic for AWS
+    // https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/main/src/HttpResponseStream.js
     export class HttpResponseStream {
       static from(
         underlyingStream: NodeJS.WritableStream,
         prelude: Record<string, unknown>
-      ): NodeJS.WritableStream {
-        underlyingStream.setContentType('application/vnd.awslambda.http-integration-response')
-
-        // JSON.stringify is required. NULL byte is not allowed in metadataPrelude.
-        const metadataPrelude = JSON.stringify(prelude)
-
-        underlyingStream['_onBeforeFirstWrite'] = (write: (chunk: any) => void) => {
-          write(Buffer.from(metadataPrelude, 'utf8'))
-
-          // Write 8 null bytes after the JSON prelude.
-          write(Buffer.alloc(8, 0))
-        }
-
-        return underlyingStream
-      }
+      ): NodeJS.WritableStream
     }
     function streamifyResponse(
       f: (

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -100,9 +100,15 @@ export const streamHandle = <
 
         // Check content type
         const contentType = res.headers.get('content-type')
-        if (!contentType) {
-          console.warn('Content Type is not set in the response.')
+        if (contentType) {
+          responseStream.setContentType(contentType)
+        } 
+
+        const httpResponseMetadata = {
+          statusCode: res.status,
+          headers: res.headers,
         }
+        responseStream = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata)
 
         if (res.body) {
           await streamToNodeStream(res.body.getReader(), responseStream)

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -99,19 +99,16 @@ export const streamHandle = <
         })
 
         // Check content type
-        const contentType = res.headers.get('content-type')
-        if (contentType) {
-          responseStream.setContentType(contentType)
-        } 
-
         const httpResponseMetadata = {
           statusCode: res.status,
-          headers: res.headers,
+          headers: Object.fromEntries(res.headers.entries()),
         }
-        responseStream = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata)
 
         if (res.body) {
-          await streamToNodeStream(res.body.getReader(), responseStream)
+          await streamToNodeStream(
+            res.body.getReader(),
+            awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata)
+          )
         }
       } catch (error) {
         console.error('Error processing request:', error)


### PR DESCRIPTION
fixed: https://github.com/honojs/hono/issues/1672

I'd like to share that we have completed actual device verification with AWS Lambda for the magic method awslambda.HttpResponseStream.from, which adds metadata (statusCode, Headers) to the responseStream.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
