### PR TITLE
fix(types): allow arbitrary values as environment values

### DIFF
--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -10,7 +10,7 @@ export type Runtime =
   | 'lagon'
   | 'other'
 
-export const env = <T extends Record<string, string>, C extends Context = Context<{}>>(
+export const env = <T extends Record<string, unknown>, C extends Context = Context<{}>>(
   c: C,
   runtime?: Runtime
 ): T & C['env'] => {

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -10,7 +10,7 @@ export type Runtime =
   | 'lagon'
   | 'other'
 
-export const env = <T extends Record<string, string>, C extends Context = Context<{}>>(
+export const env = <T extends Record<string, unknown>, C extends Context = Context<{}>>(
   c: C,
   runtime?: Runtime
 ): T & C['env'] => {


### PR DESCRIPTION
### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

Right now it is only possible to set a string as environment value. But in my case I'm using [Cloudflare Pages Functions](https://developers.cloudflare.com/pages/platform/functions/) which allows me to [bind](https://developers.cloudflare.com/pages/platform/functions/bindings/) different kinds of Cloudflare resources.

For example I want to bind my Pages Function (which is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) in the end) to [R2](https://developers.cloudflare.com/r2/). Therefore I have to use `R2Bucket` as type:

```ts
import { env } from "hono/adapter";

type Environment = {
	readonly MY_BUCKET: R2Bucket;
}

const { MY_BUCKET } = env<Environment>(context, "workerd");
```

With the current implementation I'm just able to assign `string` to `MY_BUCKET` (compiler error message: `Type 'R2Bucket' is not assignable to type 'string'`)