### PR TITLE
feat: `next()` without `await`

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -20,7 +20,7 @@ export type Env = {
   Variables?: Variables
 }
 
-export type Next = () => Promise<void>
+export type Next = () => void | Promise<void>
 
 export type Input = {
   in?: Partial<ValidationTargets>
@@ -46,7 +46,7 @@ export type MiddlewareHandler<
   E extends Env = any,
   P extends string = string,
   I extends Input = {}
-> = (c: Context<E, P, I>, next: Next) => Promise<Response | void>
+> = (c: Context<E, P, I>, next: Next) => Response | void | Promise<Response | void>
 
 export type H<
   E extends Env = any,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type Env = {
   Variables?: Variables
 }
 
-export type Next = () => Promise<void>
+export type Next = () => void | Promise<void>
 
 export type Input = {
   in?: Partial<ValidationTargets>
@@ -46,7 +46,7 @@ export type MiddlewareHandler<
   E extends Env = any,
   P extends string = string,
   I extends Input = {}
-> = (c: Context<E, P, I>, next: Next) => Promise<Response | void>
+> = (c: Context<E, P, I>, next: Next) => Response | void | Promise<Response | void>
 
 export type H<
   E extends Env = any,


### PR DESCRIPTION
I realized that we don't have to write `await` for `next()` in middleware. This means if it does not have async functions in middleware, you can write like the following:

```ts
app.get('*', (c, next) => {
  console.log('this is middleware')
  next()
  c.res.headers.append('foo', 'bar')
})
```

If so, this improves performance when using middleware. Using `await` will be slow with many middlewares.

I've taken a benchmark. The code is here:

```ts
import { Hono } from 'hono'
import { createMiddleware } from 'hono/factory'

const app = new Hono()

const mwWithAwait = createMiddleware(async (c, next) => {
  const foo = 'foo'
  await next()
})

const mwWithoutAwait = createMiddleware((c, next) => {
  const foo = 'foo'
  next()
})

app.get('/', (c) => c.text('hi'))
app.get('/mwWithAwait', mwWithAwait, mwWithAwait, mwWithAwait, mwWithAwait, mwWithAwait, (c) => c.text('hi'))
app.get('/mwWithoutAwait', mwWithoutAwait, mwWithoutAwait, mwWithoutAwait, mwWithoutAwait, mwWithoutAwait, (c) =>
  c.text('hi')
)
```

And the result:

<img width="823" alt="Screenshot 2023-11-12 at 18 08 57" src="https://github.com/honojs/hono/assets/10682/bb2a892a-776c-4da2-8ff9-7c777d2ca611">

We can use `next()` without `await`, we just haven't done it that way until now.

In this PR, I've added tests for without `await` and fixed the type definitions.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
