### PR TITLE
feat(app): use `console.error()` for default `errorHandler`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -51,7 +51,7 @@ const errorHandler = (err: Error, c: Context) => {
   if (err instanceof HTTPException) {
     return err.getResponse()
   }
-  console.trace(err)
+  console.error(err)
   const message = 'Internal Server Error'
   return c.text(message, 500)
 }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -51,7 +51,7 @@ const errorHandler = (err: Error, c: Context) => {
   if (err instanceof HTTPException) {
     return err.getResponse()
   }
-  console.trace(err)
+  console.error(err)
   const message = 'Internal Server Error'
   return c.text(message, 500)
 }


### PR DESCRIPTION
Using `console.error(err)` is better than `console.trace(err)` to understand what is happening.

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
