### PR TITLE
Export APIGatewayProxyResult from aws-lambda

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -47,7 +47,7 @@ export interface LambdaFunctionUrlEvent {
   requestContext: LambdaFunctionUrlRequestContext
 }
 
-interface APIGatewayProxyResult {
+export interface APIGatewayProxyResult {
   statusCode: number
   body: string
   headers: Record<string, string>

--- a/src/adapter/aws-lambda/index.ts
+++ b/src/adapter/aws-lambda/index.ts
@@ -1,4 +1,5 @@
 // @denoify-ignore
-export { handle, streamHandle, type APIGatewayProxyResult } from './handler'
+export { handle, streamHandle } from './handler'
+export type { APIGatewayProxyResult } from './handler'
 export type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from './custom-context'
 export type { LambdaContext } from './types'

--- a/src/adapter/aws-lambda/index.ts
+++ b/src/adapter/aws-lambda/index.ts
@@ -1,4 +1,4 @@
 // @denoify-ignore
-export { handle, streamHandle } from './handler'
+export { handle, streamHandle, type APIGatewayProxyResult } from './handler'
 export type { ApiGatewayRequestContext, LambdaFunctionUrlRequestContext } from './custom-context'
 export type { LambdaContext } from './types'


### PR DESCRIPTION
Adds an export for `APIGatewayProxyResult` so that it can be referenced from a handler:

```ts
export const handler: APIGatewayProxyResult = handle(app);
```

Without it exposed, TS complains:

```
Exported variable 'handler' has or is using name 'APIGatewayProxyResult' from external module "node_modules/.pnpm/hono@3.10.1/node_modules/hono/dist/types/adapter/aws-lambda/handler" but cannot be named.
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
