### PR TITLE
Fix/request param keys

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -279,7 +279,7 @@ class Hono<
     const path = this.getPath(request, { env })
     const [handlers, paramStash] = this.matchRoute(method, path)
 
-    const c = new Context(new HonoRequest(request, path, paramStash || []), {
+    const c = new Context(new HonoRequest(request, path, paramStash), {
       env,
       executionCtx,
       notFoundHandler: this.notFoundHandler,

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -57,7 +57,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   param(key?: string): unknown {
     if (key) {
       const param = (this._s ? this._s[this._p[key] as any] : this._p[key]) as string | undefined
-      console.log(param)
       return param ? (/\%/.test(param) ? decodeURIComponent_(param) : param) : undefined
     } else {
       const decoded: Record<string, string> = {}

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -279,7 +279,7 @@ class Hono<
     const path = this.getPath(request, { env })
     const [handlers, paramStash] = this.matchRoute(method, path)
 
-    const c = new Context(new HonoRequest(request, path, paramStash || []), {
+    const c = new Context(new HonoRequest(request, path, paramStash), {
       env,
       executionCtx,
       notFoundHandler: this.notFoundHandler,

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -297,10 +297,6 @@ describe('Routing', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('get /book/123')
 
-    res = await app.request('http://localhost/book/keys', { method: 'GET' })
-    expect(res.status).toBe(200)
-    expect(await res.text()).toBe('get /book/keys')
-
     res = await app.request('http://localhost/book', { method: 'POST' })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('post /book')
@@ -661,6 +657,12 @@ describe('param and query', () => {
       const res = await app.request('http://localhost/entry/123')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('id is 123')
+    })
+
+    it('param of /entry/:id is found, even for Array object method names', async () => {
+      const res = await app.request('http://localhost/entry/key')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('id is key')
     })
 
     it('param of /entry/:id is decoded', async () => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -297,6 +297,10 @@ describe('Routing', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('get /book/123')
 
+    res = await app.request('http://localhost/book/keys', { method: 'GET' })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /book/keys')
+
     res = await app.request('http://localhost/book', { method: 'POST' })
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('post /book')

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -32,6 +32,39 @@ describe('Query', () => {
   })
 })
 
+describe('Param', () => {
+  test('req.param() withth ParamStash', () => {
+    const rawRequest = new Request('http://localhost?page=2&tag=A&tag=B')
+    const req = new HonoRequest<'/:id/:name'>(rawRequest, '/123/key', ['123', 'key'])
+
+    req.setParams({
+      id: 0,
+    })
+    expect(req.param('id')).toBe('123')
+    expect(req.param('name')).toBe(undefined)
+
+    req.setParams({
+      id: 0,
+      name: 1,
+    })
+    expect(req.param('id')).toBe('123')
+    expect(req.param('name')).toBe('key')
+  })
+
+  test('req.param() without ParamStash', () => {
+    const rawRequest = new Request('http://localhost?page=2&tag=A&tag=B')
+    const req = new HonoRequest<'/:id/:name'>(rawRequest)
+
+    req.setParams({
+      id: '456',
+      name: 'key',
+    })
+
+    expect(req.param('id')).toBe('456')
+    expect(req.param('name')).toBe('key')
+  })
+})
+
 describe('req.addValidatedData() and req.data()', () => {
   const rawRequest = new Request('http://localhost')
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -57,7 +57,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   param(key?: string): unknown {
     if (key) {
       const param = (this._s ? this._s[this._p[key] as any] : this._p[key]) as string | undefined
-      console.log(param)
       return param ? (/\%/.test(param) ? decodeURIComponent_(param) : param) : undefined
     } else {
       const decoded: Record<string, string> = {}


### PR DESCRIPTION
Fixes #1713

### Reproducible versions

v3.8.0 or later

### Reproducible environment

* A router other than RegExpRouter is being used.
* The value is the name of a property or method of the Array object.

### Details

Routers other than RegExpRouter do not return ParamStash, but Hono was mistakenly referring to it in HonoRequest and returning the method.

The fact that null is no longer returned below appears to be a change in behavior, but in fact there is no change in behavior because the outer `if (this._s)` has never been valid and this is unreachable.
https://github.com/honojs/hono/compare/main...usualoma:hono:fix/request-param-keys?expand=1#diff-a7eab0275ad9a7a7d3fbced508e6fabbea622ceaf3c7e9d38e08824f4687bd87L73

There also appears to be no performance degradation due to this change.



### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
