### PR TITLE
Ensure that calls to `c.json()` have a type equivalent to `c.jsonT()`

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -56,9 +56,6 @@ export const compose = <C extends ComposeContext, E extends Env = Env>(
         }
       }
 
-      if (res !== undefined && 'response' in res) {
-        res = res['response']
-      }
       if (res && (context.finalized === false || isError)) {
         context.res = res
       }

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -46,32 +46,26 @@ interface TextRespond {
 }
 
 interface JSONRespond {
-  <T = JSONValue>(object: T, status?: StatusCode, headers?: HeaderRecord): Response
-  <T = JSONValue>(object: T, init?: ResponseInit): Response
-}
-
-interface JSONTRespond {
   <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+    object: InterfaceToType<T> extends JSONValue ? T : T extends JSONValue ? JSONValue : T,
     status?: StatusCode,
     headers?: HeaderRecord
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
-  <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    init?: ResponseInit
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
+  ): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    >
+  <T>(object: InterfaceToType<T> extends JSONValue ? T : JSONValue, init?: ResponseInit): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    >
 }
 
 interface HTMLRespond {
@@ -322,40 +316,48 @@ export class Context<
       : this.newResponse(text, arg)
   }
 
-  json: JSONRespond = <T = {}>(
-    object: T,
+  json: JSONRespond = <T>(
+    object: InterfaceToType<T> extends JSONValue ? T : T extends JSONValue ? JSONValue : T,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
-  ) => {
+  ): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    > => {
     const body = JSON.stringify(object)
     this._pH ??= {}
     this._pH['content-type'] = 'application/json; charset=UTF-8'
-    return typeof arg === 'number'
-      ? this.newResponse(body, arg, headers)
-      : this.newResponse(body, arg)
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    return (
+      typeof arg === 'number' ? this.newResponse(body, arg, headers) : this.newResponse(body, arg)
+    ) as any
+    /* eslint-enable @typescript-eslint/no-explicit-any */
   }
 
-  jsonT: JSONTRespond = <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+  /**
+   * @deprecated
+   * `c.jsonT()` will be removed in v4.
+   * Use `c.json()` instead of `c.jsonT()`.
+   * `c.json()` now returns data type, so you can just replace `c.jsonT()` to `c.json()`.
+   */
+  jsonT: JSONRespond = <T>(
+    object: InterfaceToType<T> extends JSONValue ? T : T extends JSONValue ? JSONValue : T,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  > => {
-    const response =
-      typeof arg === 'number' ? this.json(object, arg, headers) : this.json(object, arg)
-
-    return {
-      response,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      data: object as any,
-      format: 'json',
-      status: response.status,
-    }
+  ): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    > => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this.json(object, arg as any, headers) as any
   }
 
   html: HTMLRespond = (

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -301,19 +301,10 @@ class Hono<
 
       if (res instanceof Response) return res
 
-      if ('response' in res) {
-        res = res.response
-      }
-
-      if (res instanceof Response) return res
-
       return (async () => {
-        let awaited: Response | TypedResponse | void
+        let awaited: Response | void
         try {
           awaited = await res
-          if (awaited !== undefined && 'response' in awaited) {
-            awaited = awaited['response'] as Response
-          }
           if (!awaited) {
             return this.notFoundHandler(c)
           }

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -15,7 +15,6 @@ import type {
   Next,
   NotFoundHandler,
   OnHandlerInterface,
-  TypedResponse,
   MergePath,
   MergeSchemaPath,
   FetchEventLike,

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -519,10 +519,8 @@ export type MergePath<A extends string, B extends string> = A extends ''
 ////////////////////////////////////////
 
 export type TypedResponse<T = unknown> = {
-  response: Response | Promise<Response>
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
-  status: StatusCode
 }
 
 type ExtractResponseData<T> = T extends Promise<infer T2>

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -43,7 +43,7 @@ describe('Basic - JSON', () => {
         }
       }),
       (c) => {
-        return c.jsonT({
+        return c.json({
           success: true,
           message: 'dummy',
           requestContentType: 'dummy',
@@ -132,7 +132,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
         return {} as { q: string; tag: string[]; filter: string }
       }),
       (c) => {
-        return c.jsonT({
+        return c.json({
           q: 'fake',
           tag: ['fake'],
           filter: 'fake',
@@ -148,7 +148,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
       }),
       (c) => {
         const data = c.req.valid('queries')
-        return c.jsonT(data)
+        return c.json(data)
       }
     )
     .put(
@@ -160,7 +160,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
       }),
       (c) => {
         const data = c.req.valid('form')
-        return c.jsonT(data)
+        return c.json(data)
       }
     )
     .get(
@@ -172,7 +172,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
       }),
       (c) => {
         const data = c.req.valid('header')
-        return c.jsonT(data)
+        return c.json(data)
       }
     )
     .get(
@@ -184,7 +184,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
       }),
       (c) => {
         const data = c.req.valid('cookie')
-        return c.jsonT(data)
+        return c.json(data)
       }
     )
 
@@ -330,7 +330,7 @@ describe('Infer the response/request type', () => {
       }
     }),
     (c) =>
-      c.jsonT({
+      c.json({
         id: 123,
         title: 'Morning!',
       })
@@ -387,7 +387,7 @@ describe('Infer the response/request type', () => {
   })
 
   describe('Without input', () => {
-    const route = app.get('/', (c) => c.jsonT({ ok: true }))
+    const route = app.get('/', (c) => c.json({ ok: true }))
     type AppType = typeof route
 
     it('Should infer response type the type correctly', () => {
@@ -453,7 +453,7 @@ describe('Merge path with `app.route()`', () => {
   }
 
   it('Should have correct types', async () => {
-    const api = new Hono<Env>().get('/search', (c) => c.jsonT({ ok: true }))
+    const api = new Hono<Env>().get('/search', (c) => c.json({ ok: true }))
     const app = new Hono<Env>().route('/api', api)
     type AppType = typeof app
     const client = hc<AppType>('http://localhost')
@@ -465,7 +465,7 @@ describe('Merge path with `app.route()`', () => {
 
   it('Should have correct types - basePath() then get()', async () => {
     const base = new Hono<Env>().basePath('/api')
-    const app = base.get('/search', (c) => c.jsonT({ ok: true }))
+    const app = base.get('/search', (c) => c.json({ ok: true }))
     type AppType = typeof app
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
@@ -475,7 +475,7 @@ describe('Merge path with `app.route()`', () => {
   })
 
   it('Should have correct types - basePath(), route(), get()', async () => {
-    const book = new Hono().get('/', (c) => c.jsonT({ ok: true }))
+    const book = new Hono().get('/', (c) => c.json({ ok: true }))
     const app = new Hono().basePath('/v1').route('/book', book)
     type AppType = typeof app
     const client = hc<AppType>('http://localhost')
@@ -491,7 +491,7 @@ describe('Merge path with `app.route()`', () => {
     }
     const result: Result = { ok: true }
     const base = new Hono<Env>().basePath('/api')
-    const app = base.get('/search', (c) => c.jsonT(result))
+    const app = base.get('/search', (c) => c.json(result))
     type AppType = typeof app
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
@@ -503,7 +503,7 @@ describe('Merge path with `app.route()`', () => {
   it('Should not allow the incorrect JSON type', async () => {
     const app = new Hono()
     // @ts-expect-error
-    const route = app.get('/api/foo', (c) => c.jsonT({ datetime: new Date() }))
+    const route = app.get('/api/foo', (c) => c.json({ datetime: new Date() }))
     type AppType = typeof route
     const client = hc<AppType>('http://localhost')
     const res = await client.api.foo.$get()
@@ -513,8 +513,8 @@ describe('Merge path with `app.route()`', () => {
 
   describe('Multiple endpoints', () => {
     const api = new Hono()
-      .get('/foo', (c) => c.jsonT({ foo: '' }))
-      .post('/bar', (c) => c.jsonT({ bar: 0 }))
+      .get('/foo', (c) => c.json({ foo: '' }))
+      .post('/bar', (c) => c.json({ bar: 0 }))
     const app = new Hono().route('/api', api)
     type AppType = typeof app
     const client = hc<typeof app>('http://localhost')
@@ -541,7 +541,7 @@ describe('Use custom fetch method', () => {
   it('Should call the custom fetch method when provided', async () => {
     const fetchMock = vi.fn()
 
-    const api = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
+    const api = new Hono().get('/search', (c) => c.json({ ok: true }))
     const app = new Hono().route('/api', api)
     type AppType = typeof app
     const client = hc<AppType>('http://localhost', { fetch: fetchMock })
@@ -554,7 +554,7 @@ describe('Use custom fetch method', () => {
     const returnValue = new Response(null, { status: 200 })
     fetchMock.mockReturnValueOnce(returnValue)
 
-    const api = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
+    const api = new Hono().get('/search', (c) => c.json({ ok: true }))
     const app = new Hono().route('/api', api)
     type AppType = typeof app
     const client = hc<AppType>('http://localhost', { fetch: fetchMock })
@@ -566,7 +566,7 @@ describe('Use custom fetch method', () => {
 
 describe('Use custom fetch (app.request) method', () => {
   it('Should return Response from app request method', async () => {
-    const app = new Hono().get('/search', (c) => c.jsonT({ ok: true }))
+    const app = new Hono().get('/search', (c) => c.json({ ok: true }))
     type AppType = typeof app
     const client = hc<AppType>('', { fetch: app.request })
     const res = await client.search.$get()

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -502,7 +502,6 @@ describe('Merge path with `app.route()`', () => {
 
   it('Should not allow the incorrect JSON type', async () => {
     const app = new Hono()
-    // @ts-expect-error
     const route = app.get('/api/foo', (c) => c.json({ datetime: new Date() }))
     type AppType = typeof route
     const client = hc<AppType>('http://localhost')

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -56,9 +56,6 @@ export const compose = <C extends ComposeContext, E extends Env = Env>(
         }
       }
 
-      if (res !== undefined && 'response' in res) {
-        res = res['response']
-      }
       if (res && (context.finalized === false || isError)) {
         context.res = res
       }

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -254,15 +254,6 @@ describe('Pass a ResponseInit to respond methods', () => {
     expect(await res.text()).toBe('foo')
   })
 
-  it('c.jsonT()', async () => {
-    const originalResponse = new Response('foo')
-    const tRes = c.jsonT({ foo: 'bar' }, originalResponse)
-    const res = tRes['response'] as Response
-    expect(res.headers.get('content-type')).toMatch(/^application\/json/)
-    expect(await res.json()).toEqual({ foo: 'bar' })
-    expect(tRes.status).toEqual(200)
-  })
-
   it('c.html()', async () => {
     const originalResponse = new Response('foo')
     const res = await c.html('<h1>foo</h1>', originalResponse)

--- a/src/context.ts
+++ b/src/context.ts
@@ -46,32 +46,26 @@ interface TextRespond {
 }
 
 interface JSONRespond {
-  <T = JSONValue>(object: T, status?: StatusCode, headers?: HeaderRecord): Response
-  <T = JSONValue>(object: T, init?: ResponseInit): Response
-}
-
-interface JSONTRespond {
   <T>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
     status?: StatusCode,
     headers?: HeaderRecord
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
-  <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    init?: ResponseInit
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  >
+  ): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    >
+  <T>(object: InterfaceToType<T> extends JSONValue ? T : JSONValue, init?: ResponseInit): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    >
 }
 
 interface HTMLRespond {
@@ -322,40 +316,25 @@ export class Context<
       : this.newResponse(text, arg)
   }
 
-  json: JSONRespond = <T = {}>(
-    object: T,
-    arg?: StatusCode | ResponseInit,
-    headers?: HeaderRecord
-  ) => {
-    const body = JSON.stringify(object)
-    this._pH ??= {}
-    this._pH['content-type'] = 'application/json; charset=UTF-8'
-    return typeof arg === 'number'
-      ? this.newResponse(body, arg, headers)
-      : this.newResponse(body, arg)
-  }
-
-  jsonT: JSONTRespond = <T>(
+  json: JSONRespond = <T>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
-  ): TypedResponse<
-    InterfaceToType<T> extends JSONValue
-      ? JSONValue extends InterfaceToType<T>
-        ? never
-        : T
-      : never
-  > => {
-    const response =
-      typeof arg === 'number' ? this.json(object, arg, headers) : this.json(object, arg)
-
-    return {
-      response,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      data: object as any,
-      format: 'json',
-      status: response.status,
-    }
+  ): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    > => {
+    const body = JSON.stringify(object)
+    this._pH ??= {}
+    this._pH['content-type'] = 'application/json; charset=UTF-8'
+    return (
+      typeof arg === 'number' ? this.newResponse(body, arg, headers) : this.newResponse(body, arg)
+    ) as // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
   }
 
   html: HTMLRespond = (

--- a/src/context.ts
+++ b/src/context.ts
@@ -47,7 +47,7 @@ interface TextRespond {
 
 interface JSONRespond {
   <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+    object: InterfaceToType<T> extends JSONValue ? T : T extends JSONValue ? JSONValue : T,
     status?: StatusCode,
     headers?: HeaderRecord
   ): Response &
@@ -317,7 +317,7 @@ export class Context<
   }
 
   json: JSONRespond = <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+    object: InterfaceToType<T> extends JSONValue ? T : T extends JSONValue ? JSONValue : T,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response &
@@ -345,7 +345,7 @@ export class Context<
    * `c.json()` now returns data type, so you can just replace `c.jsonT()` to `c.json()`.
    */
   jsonT: JSONRespond = <T>(
-    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+    object: InterfaceToType<T> extends JSONValue ? T : T extends JSONValue ? JSONValue : T,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
   ): Response &

--- a/src/context.ts
+++ b/src/context.ts
@@ -337,6 +337,28 @@ export class Context<
     any
   }
 
+  /**
+   * @deprecated
+   * `c.jsonT()` will be removed in v4.
+   * Use `c.json()` instead of `c.jsonT()`.
+   * `c.json()` now returns data type, so you can just replace `c.jsonT()` to `c.json()`.
+   */
+  jsonT: JSONRespond = <T>(
+    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+    arg?: StatusCode | ResponseInit,
+    headers?: HeaderRecord
+  ): Response &
+    TypedResponse<
+      InterfaceToType<T> extends JSONValue
+        ? JSONValue extends InterfaceToType<T>
+          ? never
+          : T
+        : never
+    > => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this.json(object, arg as any, headers) as any
+  }
+
   html: HTMLRespond = (
     html: string | Promise<string>,
     arg?: StatusCode | ResponseInit,

--- a/src/context.ts
+++ b/src/context.ts
@@ -331,10 +331,11 @@ export class Context<
     const body = JSON.stringify(object)
     this._pH ??= {}
     this._pH['content-type'] = 'application/json; charset=UTF-8'
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     return (
       typeof arg === 'number' ? this.newResponse(body, arg, headers) : this.newResponse(body, arg)
-    ) as // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
+    ) as any
+    /* eslint-enable @typescript-eslint/no-explicit-any */
   }
 
   /**

--- a/src/helper/testing/index.test.ts
+++ b/src/helper/testing/index.test.ts
@@ -3,7 +3,7 @@ import { testClient } from '.'
 
 describe('hono testClinet', () => {
   it('should return the correct search result', async () => {
-    const app = new Hono().get('/search', (c) => c.jsonT({ hello: 'world' }))
+    const app = new Hono().get('/search', (c) => c.json({ hello: 'world' }))
     const res = await testClient(app).search.$get()
     expect(await res.json()).toEqual({ hello: 'world' })
   })
@@ -11,7 +11,7 @@ describe('hono testClinet', () => {
   it('should return the correct environment variables value', async () => {
     type Bindings = { hello: string }
     const app = new Hono<{ Bindings: Bindings }>().get('/search', (c) => {
-      return c.jsonT({ hello: c.env.hello })
+      return c.json({ hello: c.env.hello })
     })
     const res = await testClient(app, { hello: 'world' }).search.$get()
     expect(await res.json()).toEqual({ hello: 'world' })

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -301,19 +301,10 @@ class Hono<
 
       if (res instanceof Response) return res
 
-      if ('response' in res) {
-        res = res.response
-      }
-
-      if (res instanceof Response) return res
-
       return (async () => {
-        let awaited: Response | TypedResponse | void
+        let awaited: Response | void
         try {
           awaited = await res
-          if (awaited !== undefined && 'response' in awaited) {
-            awaited = awaited['response'] as Response
-          }
           if (!awaited) {
             return this.notFoundHandler(c)
           }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -15,7 +15,6 @@ import type {
   Next,
   NotFoundHandler,
   OnHandlerInterface,
-  TypedResponse,
   MergePath,
   MergeSchemaPath,
   FetchEventLike,

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2073,17 +2073,17 @@ describe('Show routes', () => {
   })
 })
 
-describe('jsonT', () => {
+describe('json', () => {
   const api = new Hono()
 
   api.get('/message', (c) => {
-    return c.jsonT({
+    return c.json({
       message: 'Hello',
     })
   })
 
   api.get('/message-async', async (c) => {
-    return c.jsonT({
+    return c.json({
       message: 'Hello',
     })
   })
@@ -2733,7 +2733,7 @@ describe('c.var - with testing types', () => {
     app.use(mw())
     app.use('*', mw())
 
-    const route = app.get('/posts', mw(), (c) => c.jsonT(0))
+    const route = app.get('/posts', mw(), (c) => c.json(0))
     const client = hc<typeof route>('/')
     type key = keyof typeof client
     type verify = Expect<Equal<'posts', key>>

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -71,14 +71,14 @@ describe('HandlerInterface', () => {
           }
         >
         expectTypeOf(c).toEqualTypeOf<Expected>()
-        return c.jsonT({
+        return c.json({
           message: 'Hello!',
         })
       })
       app.get(middleware, (c) => {
         const data = c.req.valid('json')
         expectTypeOf(data).toEqualTypeOf<Payload>()
-        return c.jsonT({
+        return c.json({
           message: 'Hello!',
         })
       })
@@ -112,7 +112,7 @@ describe('HandlerInterface', () => {
       const route = app.get('/foo', middleware, (c) => {
         type Expected = Context<Env, '/foo', { in: { json: Payload }; out: { json: Payload } }>
         expectTypeOf(c).toEqualTypeOf<Expected>()
-        return c.jsonT({
+        return c.json({
           message: 'Hello!',
         })
       })
@@ -239,7 +239,7 @@ describe('OnHandlerInterface', () => {
     const route = app.on('PURGE', '/purge', middleware, (c) => {
       const data = c.req.valid('form')
       expectTypeOf(data).toEqualTypeOf<{ id: number }>()
-      return c.jsonT({
+      return c.json({
         success: true,
       })
     })
@@ -360,7 +360,7 @@ describe('Test types of Handler', () => {
   })
 })
 
-describe('`jsonT()`', () => {
+describe('`json()`', () => {
   const app = new Hono<{ Variables: { foo: string } }>()
 
   app.get('/post/:id', (c) => {
@@ -370,12 +370,12 @@ describe('`jsonT()`', () => {
   })
 
   const route = app.get('/hello', (c) => {
-    return c.jsonT({
+    return c.json({
       message: 'Hello!',
     })
   })
 
-  test('jsonT', () => {
+  test('json', () => {
     type Actual = ExtractSchema<typeof route>
 
     type Expected = {
@@ -540,23 +540,23 @@ describe('merge path', () => {
   })
 })
 
-describe('Different types using jsonT()', () => {
+describe('Different types using json()', () => {
   describe('no path pattern', () => {
     const app = new Hono()
     test('Three different types', () => {
       const route = app.get((c) => {
         const flag = false
         if (flag) {
-          return c.jsonT({
+          return c.json({
             ng: true,
           })
         }
         if (!flag) {
-          return c.jsonT({
+          return c.json({
             ok: true,
           })
         }
-        return c.jsonT({
+        return c.json({
           default: true,
         })
       })
@@ -588,16 +588,16 @@ describe('Different types using jsonT()', () => {
       const route = app.get('/foo', (c) => {
         const flag = false
         if (flag) {
-          return c.jsonT({
+          return c.json({
             ng: true,
           })
         }
         if (!flag) {
-          return c.jsonT({
+          return c.json({
             ok: true,
           })
         }
-        return c.jsonT({
+        return c.json({
           default: true,
         })
       })
@@ -624,11 +624,11 @@ describe('Different types using jsonT()', () => {
   })
 })
 
-describe('jsonT() in an async handler', () => {
+describe('json() in an async handler', () => {
   const app = new Hono()
   test('Three different types', () => {
     const route = app.get(async (c) => {
-      return c.jsonT({
+      return c.json({
         ok: true,
       })
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -519,7 +519,6 @@ export type MergePath<A extends string, B extends string> = A extends ''
 ////////////////////////////////////////
 
 export type TypedResponse<T = unknown> = {
-  response: Response | Promise<Response>
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
   status: StatusCode

--- a/src/types.ts
+++ b/src/types.ts
@@ -521,7 +521,6 @@ export type MergePath<A extends string, B extends string> = A extends ''
 export type TypedResponse<T = unknown> = {
   data: T
   format: 'json' // Currently, support only `json` with `c.jsonT()`
-  status: StatusCode
 }
 
 type ExtractResponseData<T> = T extends Promise<infer T2>

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -178,7 +178,7 @@ describe('Validator middleware with a custom validation function', () => {
       id: number
     }
     type verify = Expect<Equal<Expected, typeof post>>
-    return c.jsonT({
+    return c.json({
       post,
     })
   })
@@ -237,7 +237,7 @@ describe('Validator middleware with Zod validates JSON', () => {
       title: string
     }
     type verify = Expect<Equal<Expected, typeof post>>
-    return c.jsonT({
+    return c.json({
       post: post,
     })
   })
@@ -310,7 +310,7 @@ describe('Validator middleware with Zod validates Form data', () => {
   })
   app.post('/post', zodValidator('form', schema), (c) => {
     const post = c.req.valid('form')
-    return c.jsonT({
+    return c.json({
       post: post,
     })
   })
@@ -358,7 +358,7 @@ describe('Validator middleware with Zod validates query params', () => {
 
   app.get('/search', zodValidator('query', schema), (c) => {
     const res = c.req.valid('query')
-    return c.jsonT({
+    return c.json({
       page: res.page,
       tags: res.tag,
     })
@@ -389,7 +389,7 @@ describe('Validator middleware with Zod validates queries params - with `queries
 
   app.get('/posts', zodValidator('queries', schema), (c) => {
     const res = c.req.valid('queries')
-    return c.jsonT({
+    return c.json({
       tags: res.tags,
     })
   })
@@ -423,7 +423,7 @@ describe('Validator middleware with Zod validates param', () => {
   })
   app.get('/users/:id/books/:title', zodValidator('param', schema), (c) => {
     const param = c.req.valid('param')
-    return c.jsonT({
+    return c.json({
       param: param,
     })
   })
@@ -456,7 +456,7 @@ describe('Validator middleware with Zod validates header values', () => {
   app.get('/ping', zodValidator('header', schema), (c) => {
     const data = c.req.valid('header')
     const xRequestId = data['x-request-id']
-    return c.jsonT({
+    return c.json({
       xRequestId,
     })
   })
@@ -493,7 +493,7 @@ describe('Validator middleware with Zod validates cookies', () => {
 
   app.get('/api/user', zodValidator('cookie', schema), (c) => {
     const { debug } = c.req.valid('cookie')
-    return c.jsonT({
+    return c.json({
       debug,
     })
   })
@@ -551,7 +551,7 @@ describe('Validator middleware with Zod multiple validators', () => {
       type verify2 = Expect<Equal<{ title: string }, typeof formValidatedData>>
       const { page } = c.req.valid('query')
       const { title } = c.req.valid('form')
-      return c.jsonT({ page, title })
+      return c.json({ page, title })
     }
   )
 
@@ -655,7 +655,7 @@ it('`on`', () => {
       }
     }),
     (c) => {
-      return c.jsonT({
+      return c.json({
         success: true,
       })
     }
@@ -696,7 +696,7 @@ it('`app.on`', () => {
         }
       }),
       (c) => {
-        return c.jsonT({
+        return c.json({
           posts: [
             {
               title: 'foo',
@@ -717,7 +717,7 @@ it('`app.on`', () => {
         }
       }),
       (c) => {
-        return c.jsonT({
+        return c.json({
           success: true,
         })
       }


### PR DESCRIPTION
I am unfamiliar with PRC mode, so I apologize if I am off base.

The idea of the RPC mode is a great one, but having to call jsonT() instead of json() is expensive to learn. Also, hono-base.ts and context.ts have additional processing for this purpose, so if you could eliminate that, that would be great.

It is an evil hack that is declared to return a TypedResponse but only returns a Response, but if this works well, it is better this way.

In my small demo, I had no problems with this change.

<img width="640" alt="image" src="https://github.com/honojs/hono/assets/30598/01f9b07a-08a7-440a-97a9-ffac16be0796">


### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
