### PR TITLE
fix(compose): allow `onError()` handler to be async

### DIFF
--- a/deno_dist/compose.ts
+++ b/deno_dist/compose.ts
@@ -48,7 +48,7 @@ export const compose = <C extends ComposeContext, E extends Env = Env>(
         } catch (err) {
           if (err instanceof Error && context instanceof Context && onError) {
             context.error = err
-            res = onError(err, context)
+            res = await onError(err, context)
             isError = true
           } else {
             throw err

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -264,6 +264,22 @@ describe('compose with Context - 500 error', () => {
     expect(context.finalized).toBe(true)
   })
 
+  it('Error on handler - async', async () => {
+    const handler = () => {
+      throw new Error()
+    }
+
+    middleware.push(buildMiddlewareTuple(handler))
+    const onError = async (_error: Error, c: Context) => c.text('onError', 500)
+
+    const composed = compose<Context>(middleware, onError)
+    const context = await composed(c)
+    expect(context.res).not.toBeNull()
+    expect(context.res.status).toBe(500)
+    expect(await context.res.text()).toBe('onError')
+    expect(context.finalized).toBe(true)
+  })
+
   it('Run all the middlewares', async () => {
     const ctx: C = { req: {}, res: {}, finalized: false }
     const stack: number[] = []

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -48,7 +48,7 @@ export const compose = <C extends ComposeContext, E extends Env = Env>(
         } catch (err) {
           if (err instanceof Error && context instanceof Context && onError) {
             context.error = err
-            res = onError(err, context)
+            res = await onError(err, context)
             isError = true
           } else {
             throw err


### PR DESCRIPTION
### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
