### PR TITLE
chore: remove `jest.config.js`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,0 @@
-export default {
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/src/**/(*.)+(spec|test).+(ts|tsx|js)'],
-  transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
-  },
-  testEnvironment: 'miniflare',
-}


### PR DESCRIPTION
Now that we are going to use Vitest, we can remove it.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
