### PR TITLE
feat(types): Support types until 10 handlers

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -85,7 +85,7 @@ export interface HandlerInterface<
     handler: H<E2, P, I, R>
   ): Hono<E & E2, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
-  // app.get(handler, handler)
+  // app.get(handler x2)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
@@ -94,7 +94,7 @@ export interface HandlerInterface<
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
   ): Hono<E & E2 & E3, S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
@@ -108,7 +108,7 @@ export interface HandlerInterface<
     E3 extends Env = E,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
   ): Hono<E & E2 & E3 & E4, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
@@ -124,7 +124,7 @@ export interface HandlerInterface<
     E4 extends Env = E,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>, H<E5, P, I4, R>]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
   ): Hono<E & E2 & E3 & E4 & E5, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 5)
@@ -134,7 +134,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     E2 extends Env = E,
     E3 extends Env = E,
@@ -142,13 +142,7 @@ export interface HandlerInterface<
     E5 extends Env = E,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
   >(
-    ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>
-    ]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
     S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
@@ -162,7 +156,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     E2 extends Env = E,
@@ -173,11 +167,11 @@ export interface HandlerInterface<
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
       H<E7, P, I6, R>
     ]
   ): Hono<
@@ -193,7 +187,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -206,12 +200,12 @@ export interface HandlerInterface<
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
       H<E8, P, I7, R>
     ]
   ): Hono<
@@ -227,7 +221,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -242,13 +236,13 @@ export interface HandlerInterface<
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
-      H<E8, P, I7, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
+      H<E8, P, I7>,
       H<E9, P, I8, R>
     ]
   ): Hono<
@@ -264,7 +258,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -281,14 +275,14 @@ export interface HandlerInterface<
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
-      H<E8, P, I7, R>,
-      H<E9, P, I8, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
+      H<E8, P, I7>,
+      H<E9, P, I8>,
       H<E10, P, I9, R>
     ]
   ): Hono<
@@ -304,7 +298,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -323,15 +317,15 @@ export interface HandlerInterface<
     E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
-      H<E8, P, I7, R>,
-      H<E9, P, I8, R>,
-      H<E10, P, I9, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
+      H<E8, P, I7>,
+      H<E9, P, I8>,
+      H<E10, P, I9>,
       H<E11, P, I10, R>
     ]
   ): Hono<
@@ -363,24 +357,19 @@ export interface HandlerInterface<
   // app.get(path, handler)
   <
     P extends string,
-    P2 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     E2 extends Env = E
   >(
     path: P,
-    handler: H<E2, MergePath<BasePath, P2>, I, R>
-  ): Hono<
-    E & E2,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<E & E2, S & ToSchema<M, MergedPath, I['in'], MergeTypedResponseData<R>>, BasePath>
 
-  // app.get(path, handler, handler)
+  // app.get(path, handler x2)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -388,19 +377,13 @@ export interface HandlerInterface<
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     path: P,
-    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I2, R>]
-  ): Hono<
-    E & E2 & E3,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<E & E2 & E3, S & ToSchema<M, MergedPath, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x3)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -410,24 +393,17 @@ export interface HandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
   >(
     path: P,
-    ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>
-    ]
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     E & E2 & E3 & E4,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I3['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x4)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -440,30 +416,26 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I4['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x5)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     E2 extends Env = E,
     E3 extends Env = E,
@@ -473,32 +445,27 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I5['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x6)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     E2 extends Env = E,
@@ -510,34 +477,28 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I6['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x7)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -551,36 +512,29 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I7['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x8)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
-    P9 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -596,38 +550,30 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>,
-      H<E9, MergePath<BasePath, P9>, I8, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I8['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x9)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
-    P9 extends string = P,
-    P10 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -645,40 +591,31 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>,
-      H<E9, MergePath<BasePath, P9>, I8, R>,
-      H<E10, MergePath<BasePath, P10>, I9, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I9['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x10)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
-    P9 extends string = P,
-    P10 extends string = P,
-    P11 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -698,20 +635,20 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>,
-      H<E9, MergePath<BasePath, P9>, I8, R>,
-      H<E10, MergePath<BasePath, P10>, I9, R>,
-      H<E11, MergePath<BasePath, P11>, I10, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>,
+      H<E11, MergedPath, I10, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
-    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -756,29 +693,41 @@ export interface OnHandlerInterface<
   S extends Schema = {},
   BasePath extends string = '/'
 > {
-  // app.on(method, path, handler, handler)
+  // app.on(method, path, handler)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
+    E2 extends Env = E
+  >(
+    method: M,
+    path: P,
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<E & E2, S & ToSchema<M, MergedPath, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  // app.on(method, path, handler x2)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     method: M,
     path: P,
-    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I, R>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<E & E2 & E3, S & ToSchema<M, MergedPath, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
-  // app.get(method, path, handler x3)
+  // app.on(method, path, handler x3)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -789,20 +738,18 @@ export interface OnHandlerInterface<
   >(
     method: M,
     path: P,
-    ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
-  // app.get(method, path, handler x4)
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+  ): Hono<
+    E & E2 & E3 & E4,
+    S & ToSchema<M, MergedPath, I3['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x4)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -816,22 +763,22 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<
+    E & E2 & E3 & E4 & E5,
+    S & ToSchema<M, MergedPath, I4['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 
-  // app.get(method, path, handler x5)
+  // app.on(method, path, handler x5)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -847,19 +794,552 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6,
+    S & ToSchema<M, MergedPath, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 
+  // app.on(method, path, handler x6)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<M, MergedPath, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x7)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<M, MergedPath, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x8)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<M, MergedPath, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x9)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<M, MergedPath, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x10)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>,
+      H<E11, MergedPath, I10>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<M, MergedPath, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    BasePath
+  >
+
+  // app.get(method, path, ...handler)
   <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  // app.get(method[], path, handler)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    E2 extends Env = E
+  >(
+    methods: Ms,
+    path: P,
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<
+    E & E2,
+    S & ToSchema<Ms[number], MergedPath, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x2)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    E2 extends Env = E,
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<
+    E & E2 & E3,
+    S & ToSchema<Ms[number], MergedPath, I2['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x3)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+  ): Hono<
+    E & E2 & E3 & E4,
+    S & ToSchema<Ms[number], MergedPath, I3['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x4)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5,
+    S & ToSchema<Ms[number], MergedPath, I4['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x5)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6,
+    S & ToSchema<Ms[number], MergedPath, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x6)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<Ms[number], MergedPath, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x7)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<Ms[number], MergedPath, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x8)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<Ms[number], MergedPath, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x9)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<Ms[number], MergedPath, I9['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x10)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>,
+      H<E11, MergedPath, I10>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<Ms[number], MergedPath, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    BasePath
+  >
 
   // app.on(method[], path, ...handler)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -89,12 +89,13 @@ export interface HandlerInterface<
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
+    I2 extends Input = I,
     R extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I, R>]
-  ): Hono<E & E2 & E3, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>]
+  ): Hono<E & E2 & E3, S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
   <
@@ -145,12 +146,197 @@ export interface HandlerInterface<
       H<E2, P, I, R>,
       H<E3, P, I2, R>,
       H<E4, P, I3, R>,
-      H<E5, P, I3, R>,
-      H<E6, P, I3, R>
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
     S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 6)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<M, P, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 7)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 8)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>,
+      H<E9, P, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<M, P, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 9)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>,
+      H<E9, P, I8, R>,
+      H<E10, P, I9, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 10)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>,
+      H<E9, P, I8, R>,
+      H<E10, P, I9, R>,
+      H<E11, P, I10, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<M, P, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -197,14 +383,15 @@ export interface HandlerInterface<
     P3 extends string = P,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
+    I2 extends Input = I,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     path: P,
-    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I, R>]
+    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I2, R>]
   ): Hono<
     E & E2 & E3,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -295,6 +482,236 @@ export interface HandlerInterface<
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
     S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x6)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x7)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x8)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    P9 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>,
+      H<E9, MergePath<BasePath, P9>, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x9)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    P9 extends string = P,
+    P10 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>,
+      H<E9, MergePath<BasePath, P9>, I8, R>,
+      H<E10, MergePath<BasePath, P10>, I9, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x10)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    P9 extends string = P,
+    P10 extends string = P,
+    P11 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>,
+      H<E9, MergePath<BasePath, P9>, I8, R>,
+      H<E10, MergePath<BasePath, P10>, I9, R>,
+      H<E11, MergePath<BasePath, P11>, I10, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2513,6 +2513,61 @@ describe('c.var - with testing types', () => {
       await next()
     }
 
+  const mw6 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo6: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo6', (str) => str)
+      await next()
+    }
+
+  const mw7 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo7: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo7', (str) => str)
+      await next()
+    }
+
+  const mw8 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo8: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo8', (str) => str)
+      await next()
+    }
+
+  const mw9 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo9: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo9', (str) => str)
+      await next()
+    }
+
+  const mw10 =
+    (): MiddlewareHandler<{
+      Variables: {
+        echo10: (str: string) => string
+      }
+    }> =>
+    async (c, next) => {
+      c.set('echo10', (str) => str)
+      await next()
+    }
+
   app.use('/no-path/1').get(mw(), (c) => {
     return c.text(c.var.echo('hello'))
   })
@@ -2531,21 +2586,103 @@ describe('c.var - with testing types', () => {
     )
   })
 
-  // @ts-expect-error
   app.use('/no-path/5').get(mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
     return c.text(
-      // @ts-expect-error
       c.var.echo('hello') +
-        // @ts-expect-error
         c.var.echo2('hello2') +
-        // @ts-expect-error
         c.var.echo3('hello3') +
-        // @ts-expect-error
         c.var.echo4('hello4') +
-        // @ts-expect-error
         c.var.echo5('hello5')
     )
   })
+
+  app.use('/no-path/6').get(mw(), mw2(), mw3(), mw4(), mw5(), mw6(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6')
+    )
+  })
+
+  app.use('/no-path/7').get(mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7')
+    )
+  })
+
+  app.use('/no-path/8').get(mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8')
+    )
+  })
+
+  app.use('/no-path/9').get(mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), mw9(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8') +
+        c.var.echo9('hello9')
+    )
+  })
+
+  app.use('/no-path/10').get(
+    // @ts-expect-error
+    mw(),
+    mw2(),
+    mw3(),
+    mw4(),
+    mw5(),
+    mw6(),
+    mw7(),
+    mw8(),
+    mw9(),
+    mw10(),
+    (c) => {
+      return c.text(
+        // @ts-expect-error
+        c.var.echo('hello') +
+          // @ts-expect-error
+          c.var.echo2('hello2') +
+          // @ts-expect-error
+          c.var.echo3('hello3') +
+          // @ts-expect-error
+          c.var.echo4('hello4') +
+          // @ts-expect-error
+          c.var.echo5('hello5') +
+          // @ts-expect-error
+          c.var.echo6('hello6') +
+          // @ts-expect-error
+          c.var.echo7('hello7') +
+          // @ts-expect-error
+          c.var.echo8('hello8') +
+          // @ts-expect-error
+          c.var.echo9('hello9') +
+          // @ts-expect-error
+          c.var.echo10('hello10')
+      )
+    }
+  )
 
   app.get('*', mw())
 
@@ -2567,8 +2704,68 @@ describe('c.var - with testing types', () => {
     )
   })
 
-  // @ts-expect-error
   app.get('/path/5', mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5')
+    )
+  })
+
+  app.get('/path/6', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6')
+    )
+  })
+
+  app.get('/path/7', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7')
+    )
+  })
+
+  app.get('/path/8', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8')
+    )
+  })
+
+  app.get('/path/9', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), mw9(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8') +
+        c.var.echo9('hello9')
+    )
+  })
+
+  // @ts-expect-error
+  app.get('/path/10', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), mw9(), mw10(), (c) => {
     return c.text(
       // @ts-expect-error
       c.var.echo('hello') +
@@ -2579,7 +2776,17 @@ describe('c.var - with testing types', () => {
         // @ts-expect-error
         c.var.echo4('hello4') +
         // @ts-expect-error
-        c.var.echo5('hello5')
+        c.var.echo5('hello5') +
+        // @ts-expect-error
+        c.var.echo6('hello6') +
+        // @ts-expect-error
+        c.var.echo7('hello7') +
+        // @ts-expect-error
+        c.var.echo8('hello8') +
+        // @ts-expect-error
+        c.var.echo9('hello9') +
+        // @ts-expect-error
+        c.var.echo10('hello10')
     )
   })
 

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2808,21 +2808,236 @@ describe('c.var - with testing types', () => {
     )
   })
 
-  // @ts-expect-error
   app.on('GET', '/on/5', mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
     return c.text(
-      // @ts-expect-error
       c.var.echo('hello') +
-        // @ts-expect-error
         c.var.echo2('hello2') +
-        // @ts-expect-error
         c.var.echo3('hello3') +
-        // @ts-expect-error
         c.var.echo4('hello4') +
-        // @ts-expect-error
         c.var.echo5('hello5')
     )
   })
+
+  app.on('GET', '/on/6', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6')
+    )
+  })
+
+  app.on('GET', '/on/7', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7')
+    )
+  })
+
+  app.on('GET', '/on/8', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8')
+    )
+  })
+
+  app.on('GET', '/on/9', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), mw9(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8') +
+        c.var.echo9('hello9')
+    )
+  })
+
+  // @ts-expect-error
+  app.on(
+    'GET',
+    '/on/10',
+    mw(),
+    mw2(),
+    mw3(),
+    mw4(),
+    mw5(),
+    mw6(),
+    mw7(),
+    mw8(),
+    mw9(),
+    mw10(),
+    (c) => {
+      return c.text(
+        // @ts-expect-error
+        c.var.echo('hello') +
+          // @ts-expect-error
+          c.var.echo2('hello2') +
+          // @ts-expect-error
+          c.var.echo3('hello3') +
+          // @ts-expect-error
+          c.var.echo4('hello4') +
+          // @ts-expect-error
+          c.var.echo5('hello5') +
+          // @ts-expect-error
+          c.var.echo6('hello6') +
+          // @ts-expect-error
+          c.var.echo7('hello7') +
+          // @ts-expect-error
+          c.var.echo8('hello8') +
+          // @ts-expect-error
+          c.var.echo9('hello9') +
+          // @ts-expect-error
+          c.var.echo10('hello10')
+      )
+    }
+  )
+
+  app.on(['GET', 'POST'], '/on/1', mw(), (c) => {
+    return c.text(c.var.echo('hello'))
+  })
+
+  app.on(['GET', 'POST'], '/on/2', mw(), mw2(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2'))
+  })
+
+  app.on(['GET', 'POST'], '/on/3', mw(), mw2(), mw3(), (c) => {
+    return c.text(c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3'))
+  })
+
+  app.on(['GET', 'POST'], '/on/4', mw(), mw2(), mw3(), mw4(), (c) => {
+    return c.text(
+      c.var.echo('hello') + c.var.echo2('hello2') + c.var.echo3('hello3') + c.var.echo4('hello4')
+    )
+  })
+
+  app.on(['GET', 'POST'], '/on/5', mw(), mw2(), mw3(), mw4(), mw5(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5')
+    )
+  })
+
+  app.on(['GET', 'POST'], '/on/6', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6')
+    )
+  })
+
+  app.on(['GET', 'POST'], '/on/7', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7')
+    )
+  })
+
+  app.on(['GET', 'POST'], '/on/8', mw(), mw2(), mw3(), mw4(), mw5(), mw6(), mw7(), mw8(), (c) => {
+    return c.text(
+      c.var.echo('hello') +
+        c.var.echo2('hello2') +
+        c.var.echo3('hello3') +
+        c.var.echo4('hello4') +
+        c.var.echo5('hello5') +
+        c.var.echo6('hello6') +
+        c.var.echo7('hello7') +
+        c.var.echo8('hello8')
+    )
+  })
+
+  app.on(
+    ['GET', 'POST'],
+    '/on/9',
+    mw(),
+    mw2(),
+    mw3(),
+    mw4(),
+    mw5(),
+    mw6(),
+    mw7(),
+    mw8(),
+    mw9(),
+    (c) => {
+      return c.text(
+        c.var.echo('hello') +
+          c.var.echo2('hello2') +
+          c.var.echo3('hello3') +
+          c.var.echo4('hello4') +
+          c.var.echo5('hello5') +
+          c.var.echo6('hello6') +
+          c.var.echo7('hello7') +
+          c.var.echo8('hello8') +
+          c.var.echo9('hello9')
+      )
+    }
+  )
+
+  // @ts-expect-error
+  app.on(
+    ['GET', 'POST'],
+    '/on/10',
+    mw(),
+    mw2(),
+    mw3(),
+    mw4(),
+    mw5(),
+    mw6(),
+    mw7(),
+    mw8(),
+    mw9(),
+    mw10(),
+    (c) => {
+      return c.text(
+        // @ts-expect-error
+        c.var.echo('hello') +
+          // @ts-expect-error
+          c.var.echo2('hello2') +
+          // @ts-expect-error
+          c.var.echo3('hello3') +
+          // @ts-expect-error
+          c.var.echo4('hello4') +
+          // @ts-expect-error
+          c.var.echo5('hello5') +
+          // @ts-expect-error
+          c.var.echo6('hello6') +
+          // @ts-expect-error
+          c.var.echo7('hello7') +
+          // @ts-expect-error
+          c.var.echo8('hello8') +
+          // @ts-expect-error
+          c.var.echo9('hello9') +
+          // @ts-expect-error
+          c.var.echo10('hello10')
+      )
+    }
+  )
 
   it('Should return the correct response - no-path', async () => {
     let res = await app.request('/no-path/1')

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -652,11 +652,56 @@ describe('jsonT() in an async handler', () => {
  * This tests are only for types.
  */
 describe('c.var with chaining - test only types', () => {
-  const mw1 = createMiddleware<{ Variables: { foo1: string } }>(async () => {})
-  const mw2 = createMiddleware<{ Variables: { foo2: string } }>(async () => {})
-  const mw3 = createMiddleware<{ Variables: { foo3: string } }>(async () => {})
-  const mw4 = createMiddleware<{ Variables: { foo4: string } }>(async () => {})
-  const mw5 = createMiddleware<{ Variables: { foo5: string } }>(async () => {})
+  const mw1 = createMiddleware<
+    { Variables: { foo1: string } },
+    string,
+    { out: { query: { bar1: number } } }
+  >(async () => {})
+  const mw2 = createMiddleware<
+    { Variables: { foo2: string } },
+    string,
+    { out: { query: { bar2: number } } }
+  >(async () => {})
+  const mw3 = createMiddleware<
+    { Variables: { foo3: string } },
+    string,
+    { out: { query: { bar3: number } } }
+  >(async () => {})
+  const mw4 = createMiddleware<
+    { Variables: { foo4: string } },
+    string,
+    { out: { query: { bar4: number } } }
+  >(async () => {})
+  const mw5 = createMiddleware<
+    { Variables: { foo5: string } },
+    string,
+    { out: { query: { bar5: number } } }
+  >(async () => {})
+  const mw6 = createMiddleware<
+    { Variables: { foo6: string } },
+    string,
+    { out: { query: { bar6: number } } }
+  >(async () => {})
+  const mw7 = createMiddleware<
+    { Variables: { foo7: string } },
+    string,
+    { out: { query: { bar7: number } } }
+  >(async () => {})
+  const mw8 = createMiddleware<
+    { Variables: { foo8: string } },
+    string,
+    { out: { query: { bar8: number } } }
+  >(async () => {})
+  const mw9 = createMiddleware<
+    { Variables: { foo9: string } },
+    string,
+    { out: { query: { bar9: number } } }
+  >(async () => {})
+  const mw10 = createMiddleware<
+    { Variables: { foo10: string } },
+    string,
+    { out: { query: { bar10: number } } }
+  >(async () => {})
 
   it('Should not throw type errors', () => {
     // app.get(handler...)
@@ -696,6 +741,82 @@ describe('c.var with chaining - test only types', () => {
       return c.json(0)
     })
 
+    new Hono().get(mw1, mw2, mw3, mw4, mw5, mw6).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get(mw1, mw2, mw3, mw4, mw5, mw6, mw7).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get(mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo8).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get(mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, mw9).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo8).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo9).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get(mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, mw9, mw10).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo8).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo9).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo10).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get(mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, mw9, (c) => {
+      expectTypeOf(c.req.valid('query')).toMatchTypeOf<{
+        bar1: number
+        bar2: number
+        bar3: number
+        bar4: number
+        bar5: number
+        bar6: number
+        bar7: number
+        bar8: number
+        bar9: number
+      }>()
+
+      return c.jsonT(0)
+    })
+
     // app.get('/', handler...)
 
     new Hono().get('/', mw1).get('/', (c) => {
@@ -731,6 +852,82 @@ describe('c.var with chaining - test only types', () => {
       expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
       expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
       return c.json(0)
+    })
+
+    new Hono().get('/', mw1, mw2, mw3, mw4, mw5, mw6).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo8).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, mw9).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo8).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo9).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, mw9, mw10).get('/', (c) => {
+      expectTypeOf(c.var.foo1).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo2).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo3).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo4).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo5).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo6).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo7).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo8).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo9).toEqualTypeOf<string>()
+      expectTypeOf(c.var.foo10).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+
+    new Hono().get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, mw9, (c) => {
+      expectTypeOf(c.req.valid('query')).toMatchTypeOf<{
+        bar1: number
+        bar2: number
+        bar3: number
+        bar4: number
+        bar5: number
+        bar6: number
+        bar7: number
+        bar8: number
+        bar9: number
+      }>()
+
+      return c.jsonT(0)
     })
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface HandlerInterface<
     handler: H<E2, P, I, R>
   ): Hono<E & E2, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
-  // app.get(handler, handler)
+  // app.get(handler x2)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
@@ -94,7 +94,7 @@ export interface HandlerInterface<
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
   ): Hono<E & E2 & E3, S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
@@ -108,7 +108,7 @@ export interface HandlerInterface<
     E3 extends Env = E,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
   ): Hono<E & E2 & E3 & E4, S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 4)
@@ -124,7 +124,7 @@ export interface HandlerInterface<
     E4 extends Env = E,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>, H<E5, P, I4, R>]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
   ): Hono<E & E2 & E3 & E4 & E5, S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 5)
@@ -134,7 +134,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     E2 extends Env = E,
     E3 extends Env = E,
@@ -142,13 +142,7 @@ export interface HandlerInterface<
     E5 extends Env = E,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
   >(
-    ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>
-    ]
+    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
     S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
@@ -162,7 +156,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     E2 extends Env = E,
@@ -173,11 +167,11 @@ export interface HandlerInterface<
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
       H<E7, P, I6, R>
     ]
   ): Hono<
@@ -193,7 +187,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -206,12 +200,12 @@ export interface HandlerInterface<
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
       H<E8, P, I7, R>
     ]
   ): Hono<
@@ -227,7 +221,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -242,13 +236,13 @@ export interface HandlerInterface<
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
-      H<E8, P, I7, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
+      H<E8, P, I7>,
       H<E9, P, I8, R>
     ]
   ): Hono<
@@ -264,7 +258,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -281,14 +275,14 @@ export interface HandlerInterface<
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
-      H<E8, P, I7, R>,
-      H<E9, P, I8, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
+      H<E8, P, I7>,
+      H<E9, P, I8>,
       H<E10, P, I9, R>
     ]
   ): Hono<
@@ -304,7 +298,7 @@ export interface HandlerInterface<
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -323,15 +317,15 @@ export interface HandlerInterface<
     E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
   >(
     ...handlers: [
-      H<E2, P, I, R>,
-      H<E3, P, I2, R>,
-      H<E4, P, I3, R>,
-      H<E5, P, I4, R>,
-      H<E6, P, I5, R>,
-      H<E7, P, I6, R>,
-      H<E8, P, I7, R>,
-      H<E9, P, I8, R>,
-      H<E10, P, I9, R>,
+      H<E2, P, I>,
+      H<E3, P, I2>,
+      H<E4, P, I3>,
+      H<E5, P, I4>,
+      H<E6, P, I5>,
+      H<E7, P, I6>,
+      H<E8, P, I7>,
+      H<E9, P, I8>,
+      H<E10, P, I9>,
       H<E11, P, I10, R>
     ]
   ): Hono<
@@ -363,24 +357,19 @@ export interface HandlerInterface<
   // app.get(path, handler)
   <
     P extends string,
-    P2 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     E2 extends Env = E
   >(
     path: P,
-    handler: H<E2, MergePath<BasePath, P2>, I, R>
-  ): Hono<
-    E & E2,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<E & E2, S & ToSchema<M, MergedPath, I['in'], MergeTypedResponseData<R>>, BasePath>
 
-  // app.get(path, handler, handler)
+  // app.get(path, handler x2)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -388,19 +377,13 @@ export interface HandlerInterface<
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     path: P,
-    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I2, R>]
-  ): Hono<
-    E & E2 & E3,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<E & E2 & E3, S & ToSchema<M, MergedPath, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler x3)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -410,24 +393,17 @@ export interface HandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
   >(
     path: P,
-    ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>
-    ]
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     E & E2 & E3 & E4,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I3['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x4)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -440,30 +416,26 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I4['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x5)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     E2 extends Env = E,
     E3 extends Env = E,
@@ -473,32 +445,27 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I5['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x6)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     E2 extends Env = E,
@@ -510,34 +477,28 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I6['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x7)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -551,36 +512,29 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I7['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x8)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
-    P9 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -596,38 +550,30 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>,
-      H<E9, MergePath<BasePath, P9>, I8, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I8['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x9)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
-    P9 extends string = P,
-    P10 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -645,40 +591,31 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>,
-      H<E9, MergePath<BasePath, P9>, I8, R>,
-      H<E10, MergePath<BasePath, P10>, I9, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I9['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
   // app.get(path, handler x10)
   <
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
-    P7 extends string = P,
-    P8 extends string = P,
-    P9 extends string = P,
-    P10 extends string = P,
-    P11 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
     I3 extends Input = I & I2,
-    I4 extends Input = I2 & I3,
+    I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
@@ -698,20 +635,20 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>,
-      H<E7, MergePath<BasePath, P7>, I6, R>,
-      H<E8, MergePath<BasePath, P8>, I7, R>,
-      H<E9, MergePath<BasePath, P9>, I8, R>,
-      H<E10, MergePath<BasePath, P10>, I9, R>,
-      H<E11, MergePath<BasePath, P11>, I10, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>,
+      H<E11, MergedPath, I10, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
-    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergedPath, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -756,29 +693,41 @@ export interface OnHandlerInterface<
   S extends Schema = {},
   BasePath extends string = '/'
 > {
-  // app.on(method, path, handler, handler)
+  // app.on(method, path, handler)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
+    E2 extends Env = E
+  >(
+    method: M,
+    path: P,
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<E & E2, S & ToSchema<M, MergedPath, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  // app.on(method, path, handler x2)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     method: M,
     path: P,
-    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I, R>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<E & E2 & E3, S & ToSchema<M, MergedPath, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
-  // app.get(method, path, handler x3)
+  // app.on(method, path, handler x3)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -789,20 +738,18 @@ export interface OnHandlerInterface<
   >(
     method: M,
     path: P,
-    ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
-  // app.get(method, path, handler x4)
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+  ): Hono<
+    E & E2 & E3 & E4,
+    S & ToSchema<M, MergedPath, I3['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x4)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -816,22 +763,22 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<
+    E & E2 & E3 & E4 & E5,
+    S & ToSchema<M, MergedPath, I4['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 
-  // app.get(method, path, handler x5)
+  // app.on(method, path, handler x5)
   <
     M extends string,
     P extends string,
-    P2 extends string = P,
-    P3 extends string = P,
-    P4 extends string = P,
-    P5 extends string = P,
-    P6 extends string = P,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
     I2 extends Input = I,
@@ -847,19 +794,552 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergePath<BasePath, P2>, I, R>,
-      H<E3, MergePath<BasePath, P3>, I2, R>,
-      H<E4, MergePath<BasePath, P4>, I3, R>,
-      H<E5, MergePath<BasePath, P5>, I4, R>,
-      H<E6, MergePath<BasePath, P6>, I5, R>
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
     ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6,
+    S & ToSchema<M, MergedPath, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 
+  // app.on(method, path, handler x6)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<M, MergedPath, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x7)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<M, MergedPath, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x8)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<M, MergedPath, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x9)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<M, MergedPath, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.on(method, path, handler x10)
+  <
+    M extends string,
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    method: M,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>,
+      H<E11, MergedPath, I10>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<M, MergedPath, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    BasePath
+  >
+
+  // app.get(method, path, ...handler)
   <M extends string, P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  // app.get(method[], path, handler)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    E2 extends Env = E
+  >(
+    methods: Ms,
+    path: P,
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<
+    E & E2,
+    S & ToSchema<Ms[number], MergedPath, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x2)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    E2 extends Env = E,
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<
+    E & E2 & E3,
+    S & ToSchema<Ms[number], MergedPath, I2['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x3)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+  ): Hono<
+    E & E2 & E3 & E4,
+    S & ToSchema<Ms[number], MergedPath, I3['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x4)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5,
+    S & ToSchema<Ms[number], MergedPath, I4['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x5)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6,
+    S & ToSchema<Ms[number], MergedPath, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x6)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<Ms[number], MergedPath, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x7)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<Ms[number], MergedPath, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x8)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<Ms[number], MergedPath, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x9)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<Ms[number], MergedPath, I9['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    BasePath
+  >
+
+  // app.get(method[], path, handler x10)
+  <
+    Ms extends string[],
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    methods: Ms,
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9>,
+      H<E11, MergedPath, I10>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<Ms[number], MergedPath, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    BasePath
+  >
 
   // app.on(method[], path, ...handler)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,12 +89,13 @@ export interface HandlerInterface<
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
     I extends Input = {},
+    I2 extends Input = I,
     R extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
-    ...handlers: [H<E2, P, I, R>, H<E3, P, I, R>]
-  ): Hono<E & E2 & E3, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+    ...handlers: [H<E2, P, I, R>, H<E3, P, I2, R>]
+  ): Hono<E & E2 & E3, S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(handler x 3)
   <
@@ -145,12 +146,197 @@ export interface HandlerInterface<
       H<E2, P, I, R>,
       H<E3, P, I2, R>,
       H<E4, P, I3, R>,
-      H<E5, P, I3, R>,
-      H<E6, P, I3, R>
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>
     ]
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
     S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 6)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<M, P, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 7)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 8)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>,
+      H<E9, P, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<M, P, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 9)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>,
+      H<E9, P, I8, R>,
+      H<E10, P, I9, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(handler x 10)
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    ...handlers: [
+      H<E2, P, I, R>,
+      H<E3, P, I2, R>,
+      H<E4, P, I3, R>,
+      H<E5, P, I4, R>,
+      H<E6, P, I5, R>,
+      H<E7, P, I6, R>,
+      H<E8, P, I7, R>,
+      H<E9, P, I8, R>,
+      H<E10, P, I9, R>,
+      H<E11, P, I10, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<M, P, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -197,14 +383,15 @@ export interface HandlerInterface<
     P3 extends string = P,
     R extends HandlerResponse<any> = any,
     I extends Input = {},
+    I2 extends Input = I,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     path: P,
-    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I, R>]
+    ...handlers: [H<E2, MergePath<BasePath, P2>, I, R>, H<E3, MergePath<BasePath, P3>, I2, R>]
   ): Hono<
     E & E2 & E3,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -295,6 +482,236 @@ export interface HandlerInterface<
   ): Hono<
     E & E2 & E3 & E4 & E5 & E6,
     S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x6)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x7)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x8)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    P9 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>,
+      H<E9, MergePath<BasePath, P9>, I8, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x9)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    P9 extends string = P,
+    P10 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>,
+      H<E9, MergePath<BasePath, P9>, I8, R>,
+      H<E10, MergePath<BasePath, P10>, I9, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x10)
+  <
+    P extends string,
+    P2 extends string = P,
+    P3 extends string = P,
+    P4 extends string = P,
+    P5 extends string = P,
+    P6 extends string = P,
+    P7 extends string = P,
+    P8 extends string = P,
+    P9 extends string = P,
+    P10 extends string = P,
+    P11 extends string = P,
+    R extends HandlerResponse<any> = any,
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = E,
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergePath<BasePath, P2>, I, R>,
+      H<E3, MergePath<BasePath, P3>, I2, R>,
+      H<E4, MergePath<BasePath, P4>, I3, R>,
+      H<E5, MergePath<BasePath, P5>, I4, R>,
+      H<E6, MergePath<BasePath, P6>, I5, R>,
+      H<E7, MergePath<BasePath, P7>, I6, R>,
+      H<E8, MergePath<BasePath, P8>, I7, R>,
+      H<E9, MergePath<BasePath, P9>, I8, R>,
+      H<E10, MergePath<BasePath, P10>, I9, R>,
+      H<E11, MergePath<BasePath, P11>, I10, R>
+    ]
+  ): Hono<
+    E & E2 & E3 & E4 & E5 & E6 & E7 & E8 & E9 & E10 & E11,
+    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 


### PR DESCRIPTION
Handle until 10 handlers on `app.method([path], ...handlers)` by simple adding more overloads.

This is not optimal by far. I'm compromised to find a better and beautiful solution, but until then I think this will cover more use cases, like I'm personally facing now.

### Author should do the followings, if applicable

- [X] Add tests
- [X] Run tests
- [X] `yarn denoify` to generate files for Deno
