### PR TITLE
fix(jsx): Write the raw value if the value is a HtmlEscaped string

### DIFF
--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -130,10 +130,10 @@ export class JSXNode implements HtmlEscaped {
         buffer[0] += ` ${key}="`
         escapeToBuffer(v, buffer)
         buffer[0] += '"'
-      } else if (typeof v === 'number') {
-        buffer[0] += ` ${key}="${v}"`
       } else if (v === null || v === undefined) {
         // Do nothing
+      } else if (typeof v === 'number' || (v as HtmlEscaped).isEscaped) {
+        buffer[0] += ` ${key}="${v}"`
       } else if (typeof v === 'boolean' && booleanAttributes.includes(key)) {
         if (v) {
           buffer[0] += ` ${key}=""`

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -365,6 +365,14 @@ describe('render to string', () => {
       expect(template.toString()).toBe('<h1 style="color:red;font-size:small">Hello</h1>')
     })
   })
+
+  describe('HtmlEscaped in props', () => {
+    it('should not be double-escaped', () => {
+      const escapedString = html`${'<html-escaped-string>'}`
+      const template = <span data-text={escapedString}>Hello</span>
+      expect(template.toString()).toBe('<span data-text="&lt;html-escaped-string&gt;">Hello</span>')
+    })
+  })
 })
 
 describe('memo', () => {

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -130,10 +130,10 @@ export class JSXNode implements HtmlEscaped {
         buffer[0] += ` ${key}="`
         escapeToBuffer(v, buffer)
         buffer[0] += '"'
-      } else if (typeof v === 'number') {
-        buffer[0] += ` ${key}="${v}"`
       } else if (v === null || v === undefined) {
         // Do nothing
+      } else if (typeof v === 'number' || (v as HtmlEscaped).isEscaped) {
+        buffer[0] += ` ${key}="${v}"`
       } else if (typeof v === 'boolean' && booleanAttributes.includes(key)) {
         if (v) {
           buffer[0] += ` ${key}=""`


### PR DESCRIPTION
Fix a double escaping problem when an escaped string is passed as an HTML attribute value.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
