### PR TITLE
feat: introduce `createFactory()` and `createHandlers()`

### DIFF
--- a/deno_dist/helper/factory/index.ts
+++ b/deno_dist/helper/factory/index.ts
@@ -1,6 +1,296 @@
-import type { Env, Input, MiddlewareHandler } from '../../types.ts'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Env, Input, MiddlewareHandler, H, HandlerResponse } from '../../types.ts'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * @experimental
+ * `Factory` class is an experimental feature.
+ * The API might be changed.
+ */
+export class Factory<E extends Env = any, P extends string = any> {
+  createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
+
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<I extends Input = {}>(handler1: H<E, P, I>): [H<E, P, I>]
+
+  // handler x2
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<I extends Input = {}, I2 extends Input = I, R extends HandlerResponse<any> = any>(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>]
+
+  // handler x3
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
+
+  // handler x4
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+
+  // handler x5
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
+
+  // handler x6
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>, H<E, P, I6, R>]
+
+  // handler x7
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>
+  ]
+
+  // handler x8
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>,
+    handler8: H<E, P, I8, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>,
+    H<E, P, I8, R>
+  ]
+
+  // handler x9
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>,
+    handler8: H<E, P, I8, R>,
+    handler9: H<E, P, I9, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>,
+    H<E, P, I8, R>,
+    H<E, P, I9, R>
+  ]
+
+  // handler x10
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>,
+    handler8: H<E, P, I8, R>,
+    handler9: H<E, P, I9, R>,
+    handler10: H<E, P, I10, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>,
+    H<E, P, I8, R>,
+    H<E, P, I9, R>,
+    H<E, P, I10, R>
+  ]
+
+  createHandlers(
+    handler1: H,
+    handler2?: H,
+    handler3?: H,
+    handler4?: H,
+    handler5?: H,
+    handler6?: H,
+    handler7?: H,
+    handler8?: H,
+    handler9?: H,
+    handler10?: H
+  ) {
+    return [
+      handler1,
+      handler2,
+      handler3,
+      handler4,
+      handler5,
+      handler6,
+      handler7,
+      handler8,
+      handler9,
+      handler10,
+    ]
+  }
+}
+
+/**
+ * @experimental
+ * `createFactory` is an experimental feature.
+ * The API might be changed.
+ */
+export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
+
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
-  middleware: MiddlewareHandler<E, P, I>
-) => middleware
+  middleware: MiddlewareHandler
+) => createFactory<E, P>().createMiddleware<I>(middleware)

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -33,7 +33,7 @@ export type Input = {
 //////                            //////
 ////////////////////////////////////////
 
-type HandlerResponse<O> = Response | TypedResponse<O> | Promise<Response | TypedResponse<O>>
+export type HandlerResponse<O> = Response | TypedResponse<O> | Promise<Response | TypedResponse<O>>
 
 export type Handler<
   E extends Env = any,

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'vitest'
 import { hc } from '../../client'
 import { Hono } from '../../index'
-import type { ExtractSchema } from '../../types'
+import type { ExtractSchema, ToSchema } from '../../types'
 import { validator } from '../../validator'
 import { createMiddleware, createFactory } from './index'
 
@@ -37,7 +37,7 @@ describe('createMiddleware', () => {
 // A fake function for testing types.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function extractSchema<T = unknown>(_: T): ExtractSchema<T> {
-  return 0 as ExtractSchema<T>
+  return true as ExtractSchema<T>
 }
 
 describe('createHandler', () => {
@@ -112,7 +112,25 @@ describe('createHandler', () => {
     }
 
     it('Should return correct types', () => {
-      expectTypeOf(extractSchema(routesA)).toEqualTypeOf<ExpectedA>()
+      expectTypeOf(routesA).toEqualTypeOf<
+        Hono<
+          Env,
+          ToSchema<
+            'get',
+            '/posts',
+            {
+              query: {
+                page: string
+              }
+            },
+            {
+              page: string
+              foo: string
+            }
+          >,
+          '/'
+        >
+      >()
     })
   })
 

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -1,6 +1,9 @@
+import { expectTypeOf } from 'vitest'
 import { hc } from '../../client'
 import { Hono } from '../../index'
-import { createMiddleware } from './index'
+import type { ExtractSchema } from '../../types'
+import { validator } from '../../validator'
+import { createMiddleware, createFactory } from './index'
 
 describe('createMiddleware', () => {
   type Env = { Variables: { foo: string } }
@@ -28,5 +31,154 @@ describe('createMiddleware', () => {
     const client = hc<typeof route>('http://localhost')
     const url = client.message.$url()
     expect(url.pathname).toBe('/message')
+  })
+})
+
+// A fake function for testing types.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function extractSchema<T = unknown>(_: T): ExtractSchema<T> {
+  return 0 as ExtractSchema<T>
+}
+
+describe('createHandler', () => {
+  const mw = (message: string) =>
+    createMiddleware(async (c, next) => {
+      await next()
+      c.header('x-message', message)
+    })
+
+  describe('Basic', () => {
+    const factory = createFactory()
+    const app = new Hono()
+
+    const handlersA = factory.createHandlers((c) => {
+      return c.text('A')
+    })
+    app.get('/a', ...handlersA)
+
+    const handlersB = factory.createHandlers(mw('B'), (c) => {
+      return c.text('B')
+    })
+    app.get('/b', ...handlersB)
+
+    it('Should return 200 response - GET /a', async () => {
+      const res = await app.request('/a')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('A')
+    })
+
+    it('Should return 200 response with a custom header - GET /b', async () => {
+      const res = await app.request('/b')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-message')).toBe('B')
+      expect(await res.text()).toBe('B')
+    })
+  })
+
+  describe('Types', () => {
+    type Env = { Variables: { foo: string } }
+
+    const factory = createFactory<Env>()
+    const app = new Hono<Env>()
+
+    const handlersA = factory.createHandlers(
+      validator('query', () => {
+        return {
+          page: '1',
+        }
+      }),
+      (c) => {
+        const foo = c.var.foo
+        const { page } = c.req.valid('query')
+        return c.jsonT({ page, foo })
+      }
+    )
+    const routesA = app.get('/posts', ...handlersA)
+
+    type ExpectedA = {
+      '/posts': {
+        $get: {
+          input: {
+            query: {
+              page: string
+            }
+          }
+          output: {
+            foo: string
+            page: string
+          }
+        }
+      }
+    }
+
+    it('Should return correct types', () => {
+      expectTypeOf(extractSchema(routesA)).toEqualTypeOf<ExpectedA>()
+    })
+  })
+
+  // It's difficult to cover all possible patterns,
+  // so these tests will only cover the minimal cases.
+
+  describe('Types - Complex', () => {
+    type Env = { Variables: { foo: string } }
+
+    const factory = createFactory<Env>()
+    const app = new Hono<Env>()
+
+    const handlersA = factory.createHandlers(
+      validator('header', () => {
+        return {
+          auth: 'token',
+        }
+      }),
+      validator('query', () => {
+        return {
+          page: '1',
+        }
+      }),
+      validator('json', () => {
+        return {
+          id: 123,
+        }
+      }),
+      (c) => {
+        const foo = c.var.foo
+        const { auth } = c.req.valid('header')
+        const { page } = c.req.valid('query')
+        const { id } = c.req.valid('json')
+        return c.jsonT({ auth, page, foo, id })
+      }
+    )
+    const routesA = app.get('/posts', ...handlersA)
+
+    type ExpectedA = {
+      '/posts': {
+        $get: {
+          input: {
+            header: {
+              auth: string
+            }
+          } & {
+            query: {
+              page: string
+            }
+          } & {
+            json: {
+              id: number
+            }
+          }
+          output: {
+            auth: string
+            page: string
+            foo: string
+            id: number
+          }
+        }
+      }
+    }
+
+    it('Should return correct types', () => {
+      expectTypeOf(extractSchema(routesA)).toEqualTypeOf<ExpectedA>()
+    })
   })
 })

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -1,6 +1,87 @@
-import type { Env, Input, MiddlewareHandler } from '../../types'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Env, Input, MiddlewareHandler, H, HandlerResponse } from '../../types'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
   middleware: MiddlewareHandler<E, P, I>
 ) => middleware
+
+export function createHandlers<E extends Env = any, P extends string = any, I extends Input = {}>(
+  handler1: H<E, P, I>
+): [H<E, P, I>]
+
+export function createHandlers<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = {},
+  I2 extends Input = I
+>(handler1: H<E, P, I>, handler2: H<E, P, I2>): [H<E, P, I>, H<E, P, I2>]
+
+export function createHandlers<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = {},
+  I2 extends Input = I,
+  I3 extends Input = I & I2,
+  R extends HandlerResponse<any> = any
+>(
+  handler1: H<E, P, I, R>,
+  handler2: H<E, P, I2, R>,
+  handler3: H<E, P, I3, R>
+): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
+
+export function createHandlers<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = {},
+  I2 extends Input = I,
+  I3 extends Input = I & I2,
+  I4 extends Input = I & I2 & I3,
+  R extends HandlerResponse<any> = any
+>(
+  handler1: H<E, P, I, R>,
+  handler2: H<E, P, I2, R>,
+  handler3: H<E, P, I3, R>,
+  handler4: H<E, P, I4, R>
+): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+
+export function createHandlers<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = {},
+  I2 extends Input = I,
+  I3 extends Input = I & I2,
+  I4 extends Input = I & I2 & I3,
+  R extends HandlerResponse<any> = any
+>(
+  handler1: H<E, P, I, R>,
+  handler2: H<E, P, I2, R>,
+  handler3: H<E, P, I3, R>,
+  handler4: H<E, P, I4, R>
+): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+
+export function createHandlers<
+  E extends Env = any,
+  P extends string = any,
+  I extends Input = {},
+  I2 extends Input = I,
+  I3 extends Input = I & I2,
+  I4 extends Input = I & I2 & I3,
+  I5 extends Input = I & I2 & I3 & I4,
+  R extends HandlerResponse<any> = any
+>(
+  handler1: H<E, P, I, R>,
+  handler2: H<E, P, I2, R>,
+  handler3: H<E, P, I3, R>,
+  handler4: H<E, P, I4, R>,
+  handler5: H<E, P, I5, R>
+): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
+
+export function createHandlers(
+  handler1: H,
+  handler2?: H,
+  handler3?: H,
+  handler4?: H,
+  handler5?: H
+) {
+  return [handler1, handler2, handler3, handler4, handler5]
+}

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -1,15 +1,38 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Env, Input, MiddlewareHandler, H, HandlerResponse } from '../../types'
 
+/**
+ * @experimental
+ * `Factory` class is an experimental feature.
+ * The API might be changed.
+ */
 export class Factory<E extends Env = any, P extends string = any> {
   createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
 
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
   createHandlers<I extends Input = {}>(handler1: H<E, P, I>): [H<E, P, I>]
+
+  // handler x2
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
   createHandlers<I extends Input = {}, I2 extends Input = I, R extends HandlerResponse<any> = any>(
     handler1: H<E, P, I, R>,
     handler2: H<E, P, I2, R>
   ): [H<E, P, I, R>, H<E, P, I2, R>]
 
+  // handler x3
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -21,6 +44,12 @@ export class Factory<E extends Env = any, P extends string = any> {
     handler3: H<E, P, I3, R>
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
 
+  // handler x4
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -34,19 +63,12 @@ export class Factory<E extends Env = any, P extends string = any> {
     handler4: H<E, P, I4, R>
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
 
-  createHandlers<
-    I extends Input = {},
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    R extends HandlerResponse<any> = any
-  >(
-    handler1: H<E, P, I, R>,
-    handler2: H<E, P, I2, R>,
-    handler3: H<E, P, I3, R>,
-    handler4: H<E, P, I4, R>
-  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
-
+  // handler x5
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -62,12 +84,213 @@ export class Factory<E extends Env = any, P extends string = any> {
     handler5: H<E, P, I5, R>
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
 
-  createHandlers(handler1: H, handler2?: H, handler3?: H, handler4?: H, handler5?: H) {
-    return [handler1, handler2, handler3, handler4, handler5]
+  // handler x6
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>, H<E, P, I6, R>]
+
+  // handler x7
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>
+  ]
+
+  // handler x8
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>,
+    handler8: H<E, P, I8, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>,
+    H<E, P, I8, R>
+  ]
+
+  // handler x9
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>,
+    handler8: H<E, P, I8, R>,
+    handler9: H<E, P, I9, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>,
+    H<E, P, I8, R>,
+    H<E, P, I9, R>
+  ]
+
+  // handler x10
+  /**
+   * @experimental
+   * `createHandlers` is an experimental feature.
+   * The API might be changed.
+   */
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>,
+    handler6: H<E, P, I6, R>,
+    handler7: H<E, P, I7, R>,
+    handler8: H<E, P, I8, R>,
+    handler9: H<E, P, I9, R>,
+    handler10: H<E, P, I10, R>
+  ): [
+    H<E, P, I, R>,
+    H<E, P, I2, R>,
+    H<E, P, I3, R>,
+    H<E, P, I4, R>,
+    H<E, P, I5, R>,
+    H<E, P, I6, R>,
+    H<E, P, I7, R>,
+    H<E, P, I8, R>,
+    H<E, P, I9, R>,
+    H<E, P, I10, R>
+  ]
+
+  createHandlers(
+    handler1: H,
+    handler2?: H,
+    handler3?: H,
+    handler4?: H,
+    handler5?: H,
+    handler6?: H,
+    handler7?: H,
+    handler8?: H,
+    handler9?: H,
+    handler10?: H
+  ) {
+    return [
+      handler1,
+      handler2,
+      handler3,
+      handler4,
+      handler5,
+      handler6,
+      handler7,
+      handler8,
+      handler9,
+      handler10,
+    ]
   }
 }
 
+/**
+ * @experimental
+ * `createFactory` is an experimental feature.
+ * The API might be changed.
+ */
 export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
+
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
   middleware: MiddlewareHandler
 ) => createFactory<E, P>().createMiddleware<I>(middleware)

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -1,87 +1,73 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Env, Input, MiddlewareHandler, H, HandlerResponse } from '../../types'
 
-export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
-  middleware: MiddlewareHandler<E, P, I>
-) => middleware
+export class Factory<E extends Env = any, P extends string = any> {
+  createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
 
-export function createHandlers<E extends Env = any, P extends string = any, I extends Input = {}>(
-  handler1: H<E, P, I>
-): [H<E, P, I>]
+  createHandlers<I extends Input = {}>(handler1: H<E, P, I>): [H<E, P, I>]
+  createHandlers<I extends Input = {}, I2 extends Input = I, R extends HandlerResponse<any> = any>(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>]
 
-export function createHandlers<
-  E extends Env = any,
-  P extends string = any,
-  I extends Input = {},
-  I2 extends Input = I
->(handler1: H<E, P, I>, handler2: H<E, P, I2>): [H<E, P, I>, H<E, P, I2>]
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
 
-export function createHandlers<
-  E extends Env = any,
-  P extends string = any,
-  I extends Input = {},
-  I2 extends Input = I,
-  I3 extends Input = I & I2,
-  R extends HandlerResponse<any> = any
->(
-  handler1: H<E, P, I, R>,
-  handler2: H<E, P, I2, R>,
-  handler3: H<E, P, I3, R>
-): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
 
-export function createHandlers<
-  E extends Env = any,
-  P extends string = any,
-  I extends Input = {},
-  I2 extends Input = I,
-  I3 extends Input = I & I2,
-  I4 extends Input = I & I2 & I3,
-  R extends HandlerResponse<any> = any
->(
-  handler1: H<E, P, I, R>,
-  handler2: H<E, P, I2, R>,
-  handler3: H<E, P, I3, R>,
-  handler4: H<E, P, I4, R>
-): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
 
-export function createHandlers<
-  E extends Env = any,
-  P extends string = any,
-  I extends Input = {},
-  I2 extends Input = I,
-  I3 extends Input = I & I2,
-  I4 extends Input = I & I2 & I3,
-  R extends HandlerResponse<any> = any
->(
-  handler1: H<E, P, I, R>,
-  handler2: H<E, P, I2, R>,
-  handler3: H<E, P, I3, R>,
-  handler4: H<E, P, I4, R>
-): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
+  createHandlers<
+    I extends Input = {},
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    R extends HandlerResponse<any> = any
+  >(
+    handler1: H<E, P, I, R>,
+    handler2: H<E, P, I2, R>,
+    handler3: H<E, P, I3, R>,
+    handler4: H<E, P, I4, R>,
+    handler5: H<E, P, I5, R>
+  ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
 
-export function createHandlers<
-  E extends Env = any,
-  P extends string = any,
-  I extends Input = {},
-  I2 extends Input = I,
-  I3 extends Input = I & I2,
-  I4 extends Input = I & I2 & I3,
-  I5 extends Input = I & I2 & I3 & I4,
-  R extends HandlerResponse<any> = any
->(
-  handler1: H<E, P, I, R>,
-  handler2: H<E, P, I2, R>,
-  handler3: H<E, P, I3, R>,
-  handler4: H<E, P, I4, R>,
-  handler5: H<E, P, I5, R>
-): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
-
-export function createHandlers(
-  handler1: H,
-  handler2?: H,
-  handler3?: H,
-  handler4?: H,
-  handler5?: H
-) {
-  return [handler1, handler2, handler3, handler4, handler5]
+  createHandlers(handler1: H, handler2?: H, handler3?: H, handler4?: H, handler5?: H) {
+    return [handler1, handler2, handler3, handler4, handler5]
+  }
 }
+
+export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
+export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
+  middleware: MiddlewareHandler
+) => createFactory<E, P>().createMiddleware<I>(middleware)

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type Input = {
 //////                            //////
 ////////////////////////////////////////
 
-type HandlerResponse<O> = Response | TypedResponse<O> | Promise<Response | TypedResponse<O>>
+export type HandlerResponse<O> = Response | TypedResponse<O> | Promise<Response | TypedResponse<O>>
 
 export type Handler<
   E extends Env = any,


### PR DESCRIPTION
I made #1722 a draft and create this new PR instead it.

This PR introduce `Factory` class, `createFactory()`, and `createHandlers()` in `Factory` exported from `hono/factory`.

```ts
import { createFactory } from 'hono/factory'
import { logger } from 'hono/logger'

const factory = createFactory<Env>()

const middleware = factory.createMiddleware(async (c, next) => {
  c.set('foo', 'bar')
  await next()
})

const handlers = factory.createHandlers(logger(), middleware, (c) => {
  return c.json(c.var.foo)
})

app.get('/api', ...handlers)
```

This is useful for defining handlers outside of `app.get('/api', ...)`. Using this approach, you can structure your application in a Ruby on Rails-like Controller pattern, as discussed in #1072.

A key feature is its ability to correctly infer types.

<img width="534" alt="Screenshot 2023-11-29 at 5 56 32" src="https://github.com/honojs/hono/assets/10682/68027eda-d442-4562-89ff-285d6ddd43be">

### Why we can't call `createHandlers()`directly

Ideally, you might write shortly as follows:

```ts
import { createHandlers } from 'helper/factory'
```

However, there is a problem that passing `Env` as follows will break other types:

```ts
createHandlers<Env>()
```

### `createMiddleware()`

You can use `createMiddleware` as before:

```ts
import { createMiddleware } from 'helper/factory'
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
