### PR TITLE
feat/allow `bearerAuth` to accept a list of token strings

### DIFF
--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -6,7 +6,7 @@ const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
 
 export const bearerAuth = (options: {
-  token: string
+  token: string | string[]
   realm?: string
   prefix?: string
   hashFunction?: Function
@@ -48,7 +48,17 @@ export const bearerAuth = (options: {
         })
         throw new HTTPException(400, { res })
       } else {
-        const equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
+        let equal = false
+        if (typeof options.token === 'string') {
+          equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
+        } else if (Array.isArray(options.token) && options.token.length > 0) {
+          for (const token of options.token) {
+            if (await timingSafeEqual(token, match[1], options.hashFunction)) {
+              equal = true
+              break
+            }
+          }
+        }
         if (!equal) {
           // Invalid Token
           const res = new Response('Unauthorized', {


### PR DESCRIPTION
This PR enables the `bearerAuth` middleware to accept a list of strings. It retains the current-state ability to accept a single string (I.e., **not** a breaking change).

This enables simple usage of multiple tokens of varying privileges. A trivial example is below.

```ts
const rToken = 'read'
const pToken = 'read+write'
const validTokens = [rToken, pToken]

api.use('/posts/:id', async (c, next) => {
  // PATCH and DELETE require the privileged token
  if (c.event.request.method === 'PATCH' || c.event.request.method === 'DELETE') {
    const bearer = bearerAuth({ token: pToken });
    return bearer(c, next);
  }
  // GET works with any valid token
  const bearer = bearerAuth({ token: validTokens });
  return bearer(c, next);
});
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno