### PR TITLE
refactor(router): remove duplication `MESSAGE_MATCHER_IS_ALREADY_BUILT`

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,8 @@
 export const METHOD_NAME_ALL = 'ALL' as const
 export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
 export const METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch'] as const
+export const MESSAGE_MATCHER_IS_ALREADY_BUILT =
+  'Can not add a route since the matcher is already built.'
 
 export interface Router<T> {
   name: string

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Router, Result, ParamIndexMap } from '../../router'
-import { METHOD_NAME_ALL, METHODS, UnsupportedPathError } from '../../router'
+import {
+  METHOD_NAME_ALL,
+  METHODS,
+  UnsupportedPathError,
+  MESSAGE_MATCHER_IS_ALREADY_BUILT,
+} from '../../router'
 import { checkOptionalParameter } from '../../utils/url'
 import { PATH_ERROR, type ParamAssocArray } from './node'
 import { Trie } from './trie'
@@ -129,7 +134,7 @@ export class RegExpRouter<T> implements Router<T> {
     const { middleware, routes } = this
 
     if (!middleware || !routes) {
-      throw new Error('Can not add a route since the matcher is already built.')
+      throw new Error(MESSAGE_MATCHER_IS_ALREADY_BUILT)
     }
 
     if (methodNames.indexOf(method) === -1) methodNames.push(method)

--- a/src/router/smart-router/router.ts
+++ b/src/router/smart-router/router.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Router, Result } from '../../router'
-import { UnsupportedPathError } from '../../router'
+import { UnsupportedPathError, MESSAGE_MATCHER_IS_ALREADY_BUILT } from '../../router'
 
 export class SmartRouter<T> implements Router<T> {
   name: string = 'SmartRouter'
@@ -13,7 +13,7 @@ export class SmartRouter<T> implements Router<T> {
 
   add(method: string, path: string, handler: T) {
     if (!this.routes) {
-      throw new Error('Can not add a route since the matcher is already built.')
+      throw new Error(MESSAGE_MATCHER_IS_ALREADY_BUILT)
     }
 
     this.routes.push([method, path, handler])


### PR DESCRIPTION
To reduce a build size.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
