### PR TITLE
feat(jsx): mark `ErrorBoundary` as `experimental`

### DIFF
--- a/deno_dist/jsx/components.ts
+++ b/deno_dist/jsx/components.ts
@@ -19,6 +19,12 @@ export const childrenToString = async (children: Child[]): Promise<HtmlEscapedSt
 
 type ErrorHandler = (error: Error) => void
 type FallbackRender = (error: Error) => Child
+
+/**
+ * @experimental
+ * `ErrorBoundary` is an experimental feature.
+ * The API might be changed.
+ */
 export const ErrorBoundary: FC<{
   fallback?: Child
   fallbackRender?: FallbackRender

--- a/src/jsx/components.ts
+++ b/src/jsx/components.ts
@@ -19,6 +19,12 @@ export const childrenToString = async (children: Child[]): Promise<HtmlEscapedSt
 
 type ErrorHandler = (error: Error) => void
 type FallbackRender = (error: Error) => Child
+
+/**
+ * @experimental
+ * `ErrorBoundary` is an experimental feature.
+ * The API might be changed.
+ */
 export const ErrorBoundary: FC<{
   fallback?: Child
   fallbackRender?: FallbackRender


### PR DESCRIPTION
Make `ErrorBoundary` as `experimental` as same as `Suspense`.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
