### PR TITLE
fix(types): Added `E` env type argument to `showRoutes` & `inspectRoutes` `hono` parameter

### DIFF
--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -17,7 +17,7 @@ const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
 
-export const inspectRoutes = <TEnv extends Env>(hono: Hono<TEnv>): RouteData[] => {
+export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {
   return hono.routes.map(({ path, method, handler }: RouterRoute) => ({
     path,
     method,
@@ -26,7 +26,7 @@ export const inspectRoutes = <TEnv extends Env>(hono: Hono<TEnv>): RouteData[] =
   }))
 }
 
-export const showRoutes = <TEnv extends Env>(hono: Hono<TEnv>, opts?: ShowRoutesOptions) => {
+export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOptions) => {
   const routeData: Record<string, RouteData[]> = {}
   let maxMethodLength = 0
   let maxPathLength = 0

--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -1,5 +1,5 @@
 import type { Hono } from '../../hono.ts'
-import type { RouterRoute } from '../../types.ts'
+import type { Env, RouterRoute } from '../../types.ts'
 
 interface ShowRoutesOptions {
   verbose?: boolean
@@ -17,7 +17,7 @@ const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
 
-export const inspectRoutes = (hono: Hono): RouteData[] => {
+export const inspectRoutes = <TEnv extends Env>(hono: Hono<TEnv>): RouteData[] => {
   return hono.routes.map(({ path, method, handler }: RouterRoute) => ({
     path,
     method,
@@ -26,7 +26,7 @@ export const inspectRoutes = (hono: Hono): RouteData[] => {
   }))
 }
 
-export const showRoutes = (hono: Hono, opts?: ShowRoutesOptions) => {
+export const showRoutes = <TEnv extends Env>(hono: Hono<TEnv>, opts?: ShowRoutesOptions) => {
   const routeData: Record<string, RouteData[]> = {}
   let maxMethodLength = 0
   let maxPathLength = 0

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -185,11 +185,11 @@ class Hono<
 
   /**
    * @deprecated
-   * Use `showRoutes()` utility methods provided by 'hono/helper' instead of `app.showRoutes()`.
+   * Use `showRoutes()` utility methods provided by 'hono/dev' instead of `app.showRoutes()`.
    * `app.showRoutes()` will be removed in v4.
    * @example
    * You could rewrite `app.showRoutes()` as follows
-   * import { showRoutes } from 'hono/helper'
+   * import { showRoutes } from 'hono/dev'
    * showRoutes(app)
    */
   showRoutes() {

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -1,5 +1,5 @@
 import type { Hono } from '../../hono'
-import type { RouterRoute } from '../../types'
+import type { Env, RouterRoute } from '../../types'
 
 interface ShowRoutesOptions {
   verbose?: boolean
@@ -17,7 +17,7 @@ const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
 
-export const inspectRoutes = (hono: Hono): RouteData[] => {
+export const inspectRoutes = <TEnv extends Env>(hono: Hono<TEnv>): RouteData[] => {
   return hono.routes.map(({ path, method, handler }: RouterRoute) => ({
     path,
     method,
@@ -26,7 +26,7 @@ export const inspectRoutes = (hono: Hono): RouteData[] => {
   }))
 }
 
-export const showRoutes = (hono: Hono, opts?: ShowRoutesOptions) => {
+export const showRoutes = <TEnv extends Env>(hono: Hono<TEnv>, opts?: ShowRoutesOptions) => {
   const routeData: Record<string, RouteData[]> = {}
   let maxMethodLength = 0
   let maxPathLength = 0

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -17,7 +17,7 @@ const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
 
-export const inspectRoutes = <TEnv extends Env>(hono: Hono<TEnv>): RouteData[] => {
+export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {
   return hono.routes.map(({ path, method, handler }: RouterRoute) => ({
     path,
     method,
@@ -26,7 +26,7 @@ export const inspectRoutes = <TEnv extends Env>(hono: Hono<TEnv>): RouteData[] =
   }))
 }
 
-export const showRoutes = <TEnv extends Env>(hono: Hono<TEnv>, opts?: ShowRoutesOptions) => {
+export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOptions) => {
   const routeData: Record<string, RouteData[]> = {}
   let maxMethodLength = 0
   let maxPathLength = 0

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -185,11 +185,11 @@ class Hono<
 
   /**
    * @deprecated
-   * Use `showRoutes()` utility methods provided by 'hono/helper' instead of `app.showRoutes()`.
+   * Use `showRoutes()` utility methods provided by 'hono/dev' instead of `app.showRoutes()`.
    * `app.showRoutes()` will be removed in v4.
    * @example
    * You could rewrite `app.showRoutes()` as follows
-   * import { showRoutes } from 'hono/helper'
+   * import { showRoutes } from 'hono/dev'
    * showRoutes(app)
    */
   showRoutes() {


### PR DESCRIPTION
### What's been changed?

 - Updated `showRoutes` deprecated doc comments to provide the correct import path (`/dev` instead of `/helper`)
 - Added `TEnv` type argument to both `showRoutes` & `inspectRoutes` helpers & passed to the first (`hono: Hono`) parameter. 
	 - This fixes a type error where if you pass in a Hono instance with a custom environment type these 2 functions will complain as it does not match the default / base `Hono` type(s).

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
