### PR TITLE
PoC: feat(jsx): Introduce event handler for IntrinsicElements.

### DIFF
--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -283,11 +283,11 @@ const jsxFn = (
  * The API might be changed.
  * same as `as unknown as JSXNode`
  */
-export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSXNode => {
+export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSX.Element & JSXNode => {
   if (!(node instanceof JSXNode)) {
     throw new Error('Invalid node')
   }
-  return node as JSXNode
+  return node as JSX.Element & JSXNode
 }
 
 export type FC<T = Props> = (

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -283,11 +283,11 @@ const jsxFn = (
  * The API might be changed.
  * same as `as unknown as JSXNode`
  */
-export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSXNode => {
+export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSX.Element & JSXNode => {
   if (!(node instanceof JSXNode)) {
     throw new Error('Invalid node')
   }
-  return node as JSXNode
+  return node as JSX.Element & JSXNode
 }
 
 export type FC<T = Props> = (


### PR DESCRIPTION
What about a feature like this, which would greatly expand the possibilities of JSX?

### What can we do?

The following example shows the writing of a style element using MasterCSS(@2.0.0-beta) and the embedding of the transpiled TypeScript with esbuild.

With the following script, 

```ts
import { JSXNode } from "../hono/src/jsx";
import { readFile, mkdtemp } from "fs/promises";
import { MasterCSS } from "@master/css";
import * as esbuild from "esbuild";

let resolveMasterCSS: () => void = () => {};
const resolveMasterCSSPromise = new Promise<void>(
  (resolve) => (resolveMasterCSS = resolve)
);
const masterCSS = new MasterCSS();

const filename = process.argv[2];
const template: JSXNode = (await import(`./${filename}`)).default;

template
  .on("renderToString", ({ node }) => {
    // gather all the class names
    (node.props["class"]?.toString() || "")
      .split(/\s+/)
      .forEach((c: string) => masterCSS.add(c));
  })
  .on("renderToString.style", ({ setContent }) => {
    setContent(
      resolveMasterCSSPromise.then(
        () => `<style type="text/css">${masterCSS.text}</style>`
      )
    );
  })
  .on("renderToString.script", ({ node, setContent }) => {
    setContent(
      new Promise(async (resolve) => {
        const dir = await mkdtemp("/tmp/mt-");
        const outfile = `${dir}/out.js`;
        await esbuild.build({
          entryPoints: [node.props.src as string],
          tsconfig: "tsconfig-for-frontend",
          bundle: true,
          minify: true,
          outfile,
        });
        const content = await readFile(outfile, "utf8");
        if (content.match(/<\/script>/)) {
          throw new Error("Invalid script");
        }
        resolve(`<script>${content}</script>`);
      })
    );
  })
  .on("afterRenderToString.html", resolveMasterCSS);

console.log((await template.toString()).toString());
```

The following results can be obtained

<img width="722" alt="render" src="https://github.com/honojs/hono/assets/30598/87faaeed-d73f-4a27-a37b-1ce4c9b31411">


### Will performance be degraded?

Performance was not degraded in the existing use cases that did not use `.on()`.

```
% npm run bench:node

> jsx@1.0.0 bench:node
> esbuild --bundle src/benchmark.ts | node

Hono x 414,607 ops/sec ±2.37% (97 runs sampled)
React x 57,350 ops/sec ±0.48% (99 runs sampled)
Preact x 266,016 ops/sec ±0.28% (98 runs sampled)
Nano x 61,028 ops/sec ±0.32% (101 runs sampled)
Fastest is Hono
```

### When to use`jsxNode()`?

`(<App />)` returns a `JSX.Element`, but `JSX.Element` is defined as `HtmlEscapedString | Promise<HtmlEscapedString>`, which can be converted to a `JSXNode` using `as unknown as JSXNode` or `template instanceof JSXNode`, which is a bit annoying, so we use it to convert this to a `JSXNode` type.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
