### PR TITLE
fix(base): name `private _basePath` instead of `#basePath`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -69,7 +69,8 @@ class Hono<
   */
   router!: Router<[H, RouterRoute]>
   readonly getPath: GetPath<E>
-  #basePath: string = '/'
+  // Cannot use `#` because it requires visibility at JavaScript runtime.
+  private _basePath: string = '/'
   #path: string = '/'
 
   routes: RouterRoute[] = []
@@ -169,7 +170,7 @@ class Hono<
 
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    subApp._basePath = mergePath(this._basePath, path)
     return subApp
   }
 
@@ -207,7 +208,7 @@ class Hono<
     applicationHandler: (request: Request, ...args: any) => Response | Promise<Response>,
     optionHandler?: (c: Context) => unknown
   ): Hono<E, S, BasePath> {
-    const mergedPath = mergePath(this.#basePath, path)
+    const mergedPath = mergePath(this._basePath, path)
     const pathPrefixLength = mergedPath === '/' ? 0 : mergedPath.length
 
     const handler: MiddlewareHandler = async (c, next) => {
@@ -252,7 +253,7 @@ class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    path = mergePath(this.#basePath, path)
+    path = mergePath(this._basePath, path)
     const r: RouterRoute = { path: path, method: method, handler: handler }
     this.router.add(method, path, [handler, r])
     this.routes.push(r)

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -69,7 +69,8 @@ class Hono<
   */
   router!: Router<[H, RouterRoute]>
   readonly getPath: GetPath<E>
-  #basePath: string = '/'
+  // Cannot use `#` because it requires visibility at JavaScript runtime.
+  private _basePath: string = '/'
   #path: string = '/'
 
   routes: RouterRoute[] = []
@@ -169,7 +170,7 @@ class Hono<
 
   basePath<SubPath extends string>(path: SubPath): Hono<E, S, MergePath<BasePath, SubPath>> {
     const subApp = this.clone()
-    subApp.#basePath = mergePath(this.#basePath, path)
+    subApp._basePath = mergePath(this._basePath, path)
     return subApp
   }
 
@@ -207,7 +208,7 @@ class Hono<
     applicationHandler: (request: Request, ...args: any) => Response | Promise<Response>,
     optionHandler?: (c: Context) => unknown
   ): Hono<E, S, BasePath> {
-    const mergedPath = mergePath(this.#basePath, path)
+    const mergedPath = mergePath(this._basePath, path)
     const pathPrefixLength = mergedPath === '/' ? 0 : mergedPath.length
 
     const handler: MiddlewareHandler = async (c, next) => {
@@ -252,7 +253,7 @@ class Hono<
 
   private addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
-    path = mergePath(this.#basePath, path)
+    path = mergePath(this._basePath, path)
     const r: RouterRoute = { path: path, method: method, handler: handler }
     this.router.add(method, path, [handler, r])
     this.routes.push(r)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -3198,3 +3198,26 @@ describe('c.var - with testing types', () => {
     } catch {}
   })
 })
+
+describe('Compatible with extended Hono classes, such Zod OpenAPI Hono.', () => {
+  class ExtendedHono extends Hono {
+    // @ts-ignore
+    route(path: string, app?: Hono) {
+      super.route(path, app)
+      return this
+    }
+    // @ts-ignore
+    basePath(path: string) {
+      return new ExtendedHono(super.basePath(path))
+    }
+  }
+  const a = new ExtendedHono()
+  const sub = new Hono()
+  sub.get('/foo', (c) => c.text('foo'))
+  a.route('/sub', sub)
+
+  it('Should return 200 response', async () => {
+    const res = await a.request('/sub/foo')
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/honojs/middleware/issues/290

To maintain compatibility with Zod OpenAPI Hono, change the `basePath` property to `private _basePath` instead of using `#basePath`. Using `#basePath` causes issues in Zod OpenAPI Hono, as seen in https://github.com/honojs/middleware/issues/290.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
