### PR TITLE
fix: add missing tail to svg regex

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -4,6 +4,8 @@ describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
     expect(isContentTypeBinary('image/png')).toBe(true)
     expect(isContentTypeBinary('font/woff2')).toBe(true)
+    expect(isContentTypeBinary('image/svg+xml')).toBe(false)
+    expect(isContentTypeBinary('image/svg+xml; charset=UTF-8')).toBe(false)
     expect(isContentTypeBinary('text/plain')).toBe(false)
     expect(isContentTypeBinary('text/plain; charset=UTF-8')).toBe(false)
     expect(isContentTypeBinary('text/css')).toBe(false)

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -261,7 +261,7 @@ const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => 
 }
 
 export const isContentTypeBinary = (contentType: string) => {
-  return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml)$/.test(
+  return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
     contentType
   )
 }

--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -4,6 +4,8 @@ describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
     expect(isContentTypeBinary('image/png')).toBe(true)
     expect(isContentTypeBinary('font/woff2')).toBe(true)
+    expect(isContentTypeBinary('image/svg+xml')).toBe(false)
+    expect(isContentTypeBinary('image/svg+xml; charset=UTF-8')).toBe(false)
     expect(isContentTypeBinary('text/plain')).toBe(false)
     expect(isContentTypeBinary('text/plain; charset=UTF-8')).toBe(false)
     expect(isContentTypeBinary('text/css')).toBe(false)

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -158,7 +158,7 @@ const createRequest = (event: CloudFrontEdgeEvent) => {
 }
 
 export const isContentTypeBinary = (contentType: string) => {
-  return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml)$/.test(
+  return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
     contentType
   )
 }


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

closes #1787