### PR TITLE
feat(cloudflare-workers): modified manifest option to be required

### DIFF
--- a/deno_dist/adapter/cloudflare-workers/server-static-module.ts
+++ b/deno_dist/adapter/cloudflare-workers/server-static-module.ts
@@ -1,5 +1,5 @@
-import type { ServeStaticOptions } from './serve-static'
-import { serveStatic } from './serve-static'
+import type { ServeStaticOptions } from './serve-static.ts'
+import { serveStatic } from './serve-static.ts'
 
 const module = (options: ServeStaticOptions) => {
   return serveStatic({

--- a/src/adapter/cloudflare-workers/serve-static.test.ts
+++ b/src/adapter/cloudflare-workers/serve-static.test.ts
@@ -31,11 +31,12 @@ Object.assign(global, {
 
 describe('ServeStatic Middleware', () => {
   const app = new Hono()
-  app.use('/static/*', serveStatic({ root: './assets' }))
-  app.use('/static-no-root/*', serveStatic())
+  app.use('/static/*', serveStatic({ root: './assets', manifest }))
+  app.use('/static-no-root/*', serveStatic({ manifest }))
   app.use(
     '/dot-static/*',
     serveStatic({
+      manifest,
       root: './assets',
       rewriteRequestPath: (path) => path.replace(/^\/dot-static/, '/.static'),
     })
@@ -100,8 +101,8 @@ describe('With options', () => {
 
 describe('With `file` options', () => {
   const app = new Hono()
-  app.get('/foo/*', serveStatic({ path: './assets/static/hono.html' }))
-  app.get('/bar/*', serveStatic({ path: './static/hono.html', root: './assets' }))
+  app.get('/foo/*', serveStatic({ manifest, path: './assets/static/hono.html' }))
+  app.get('/bar/*', serveStatic({ manifest, path: './static/hono.html', root: './assets' }))
 
   it('Should return hono.html', async () => {
     const res = await app.request('http://localhost/foo/fallback')
@@ -129,7 +130,7 @@ describe('With middleware', () => {
 
   app.use('/static/*', md1)
   app.use('/static/*', md2)
-  app.use('/static/*', serveStatic({ root: './assets' }))
+  app.use('/static/*', serveStatic({ manifest, root: './assets' }))
   app.get('/static/foo', (c) => {
     return c.text('bar')
   })

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -8,7 +8,7 @@ import { getMimeType } from '../../utils/mime'
 export type ServeStaticOptions = {
   root?: string
   path?: string
-  manifest?: object | string
+  manifest: object | string
   namespace?: KVNamespace
   rewriteRequestPath?: (path: string) => string
 }
@@ -16,7 +16,7 @@ export type ServeStaticOptions = {
 const DEFAULT_DOCUMENT = 'index.html'
 
 // This middleware is available only on Cloudflare Workers.
-export const serveStatic = (options: ServeStaticOptions = { root: '' }): MiddlewareHandler => {
+export const serveStatic = (options: ServeStaticOptions): MiddlewareHandler => {
   return async (c, next) => {
     // Do nothing if Response is already set
     if (c.finalized) {
@@ -28,7 +28,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     const filename = options.path ?? decodeURI(url.pathname)
     const path = getFilePath({
       filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,
-      root: options.root,
+      root: options.root ?? '',
       defaultDocument: DEFAULT_DOCUMENT,
     })
 


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

This is breaking change but fix: https://github.com/honojs/hono/issues/1127#issuecomment-1849001490

To resolve the issue, it may be better not to modify serveStatic (module) directly but to provide the wrapped version of serveStatic. However, I don't have any ideas on how to provide it in that case.