### PR TITLE
fix(context): set headers values correctly

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -230,17 +230,11 @@ export class Context<
       })
     }
 
-    // Return Response immediately if arg is ResponseInit.
     if (arg && typeof arg !== 'number') {
-      const res = new Response(data, arg)
-      const contentType = this.#preparedHeaders?.['content-type']
-      if (contentType) {
-        res.headers.set('content-type', contentType)
-      }
-      return res
+      this.res = new Response(data, arg)
     }
 
-    const status = arg ?? this.#status
+    let status = typeof arg === 'number' ? arg : this.#status
     this.#preparedHeaders ??= {}
 
     this.#headers ??= new Headers()
@@ -255,6 +249,7 @@ export class Context<
       for (const [k, v] of Object.entries(this.#preparedHeaders)) {
         this.#headers.set(k, v)
       }
+      status = this.#res.status
     }
 
     headers ??= {}

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -205,6 +205,16 @@ describe('Context header', () => {
     const res = c.text('foo')
     expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
   })
+
+  it('Should set header values if the #this.headers is set and the arg is ResponseInit', async () => {
+    c.header('foo', 'bar')
+    const res = c.body('foo', {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    })
+    expect(res.headers.get('foo')).toBe('bar')
+  })
 })
 
 describe('Pass a ResponseInit to respond methods', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -230,17 +230,11 @@ export class Context<
       })
     }
 
-    // Return Response immediately if arg is ResponseInit.
     if (arg && typeof arg !== 'number') {
-      const res = new Response(data, arg)
-      const contentType = this.#preparedHeaders?.['content-type']
-      if (contentType) {
-        res.headers.set('content-type', contentType)
-      }
-      return res
+      this.res = new Response(data, arg)
     }
 
-    const status = arg ?? this.#status
+    let status = typeof arg === 'number' ? arg : this.#status
     this.#preparedHeaders ??= {}
 
     this.#headers ??= new Headers()
@@ -255,6 +249,7 @@ export class Context<
       for (const [k, v] of Object.entries(this.#preparedHeaders)) {
         this.#headers.set(k, v)
       }
+      status = this.#res.status
     }
 
     headers ??= {}


### PR DESCRIPTION
In `context.ts`, I fixed a bug where header values were not set correctly if `#this.headers` was set and the `arg` was of type `ResponseInit`.

Related to #1807

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
