### PR TITLE
docs(readme): update `hono/tiny` size

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm create hono@latest my-app
 ## Features
 
 - **Ultrafast** 🚀 - The router `RegExpRouter` is really fast. Not using linear loops. Fast.
-- **Lightweight** 🪶 - The `hono/tiny` preset is under 12kB. Hono has zero dependencies and uses only the Web Standard API.
+- **Lightweight** 🪶 - The `hono/tiny` preset is under 14kB. Hono has zero dependencies and uses only the Web Standard API.
 - **Multi-runtime** 🌍 - Works on Cloudflare Workers, Fastly Compute, Deno, Bun, Lagon, AWS Lambda, Lambda@Edge, or Node.js. The same code runs on all platforms.
 - **Batteries Included** 🔋 - Hono has built-in middleware, custom middleware, and third-party middleware. Batteries included.
 - **Delightful DX** 😃 - Super clean APIs. First-class TypeScript support. Now, we've got "Types".

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -48,7 +48,7 @@ npm create hono@latest my-app
 ## Features
 
 - **Ultrafast** 🚀 - The router `RegExpRouter` is really fast. Not using linear loops. Fast.
-- **Lightweight** 🪶 - The `hono/tiny` preset is under 12kB. Hono has zero dependencies and uses only the Web Standard API.
+- **Lightweight** 🪶 - The `hono/tiny` preset is under 14kB. Hono has zero dependencies and uses only the Web Standard API.
 - **Multi-runtime** 🌍 - Works on Cloudflare Workers, Fastly Compute, Deno, Bun, Lagon, AWS Lambda, Lambda@Edge, or Node.js. The same code runs on all platforms.
 - **Batteries Included** 🔋 - Hono has built-in middleware, custom middleware, and third-party middleware. Batteries included.
 - **Delightful DX** 😃 - Super clean APIs. First-class TypeScript support. Now, we've got "Types".


### PR DESCRIPTION
Hono have grown.
I checked the size of `hono/tiny` with following the command.
```sh
npx esbuild --outdir=dist --bundle --minify ./src/preset/tiny.ts
```
### Result
```sh
npx esbuild --outdir=dist --bundle --minify ./src/preset/tiny.ts

  dist\tiny.js  13.9kb

⚡ Done in 12ms
```
Based on the above result, I update the size in readme.
Minimal app may exceed 14kb.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `yarn denoify` to generate files for Deno
