### PR TITLE
feat(middleware/csrf): Introduce CSRF middleware

### DIFF
--- a/deno_dist/middleware.ts
+++ b/deno_dist/middleware.ts
@@ -5,6 +5,7 @@ export * from './middleware/cache/index.ts'
 export * from './helper/cookie/index.ts' // will be moved to helper.ts in v4
 export * from './middleware/compress/index.ts'
 export * from './middleware/cors/index.ts'
+export * from './middleware/csrf/index.ts'
 export * from './middleware/etag/index.ts'
 export * from './helper/html/index.ts' // will be moved to helper.ts in v4
 export * from './jsx/index.ts'

--- a/deno_dist/middleware/csrf/index.ts
+++ b/deno_dist/middleware/csrf/index.ts
@@ -1,0 +1,48 @@
+import type { Context } from '../../context.ts'
+import { HTTPException } from '../../http-exception.ts'
+import type { MiddlewareHandler } from '../../types.ts'
+
+type IsAllowedOriginHandler = (origin: string, context: Context) => boolean
+interface CSRFOptions {
+  origin?: string | string[] | IsAllowedOriginHandler
+}
+
+const isSafeMethodRe = /^(GET|HEAD)$/
+const isRequestedByFormElementRe =
+  /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/
+
+export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
+  const handler: IsAllowedOriginHandler = ((optsOrigin) => {
+    if (!optsOrigin) {
+      return (origin, c) => origin === new URL(c.req.url).origin
+    } else if (typeof optsOrigin === 'string') {
+      return (origin) => origin === optsOrigin
+    } else if (typeof optsOrigin === 'function') {
+      return optsOrigin
+    } else {
+      return (origin) => optsOrigin.includes(origin)
+    }
+  })(options?.origin)
+  const isAllowedOrigin = (origin: string | undefined, c: Context) => {
+    if (origin === undefined) {
+      // denied always when origin header is not present
+      return false
+    }
+    return handler(origin, c)
+  }
+
+  return async function cors(c, next) {
+    if (
+      !isSafeMethodRe.test(c.req.method) &&
+      isRequestedByFormElementRe.test(c.req.header('content-type') || '') &&
+      !isAllowedOrigin(c.req.header('origin'), c)
+    ) {
+      const res = new Response('Forbidden', {
+        status: 403,
+      })
+      throw new HTTPException(401, { res })
+    }
+
+    await next()
+  }
+}

--- a/deno_dist/middleware/csrf/index.ts
+++ b/deno_dist/middleware/csrf/index.ts
@@ -40,7 +40,7 @@ export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
       const res = new Response('Forbidden', {
         status: 403,
       })
-      throw new HTTPException(401, { res })
+      throw new HTTPException(403, { res })
     }
 
     await next()

--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
       "import": "./dist/middleware/cors/index.js",
       "require": "./dist/cjs/middleware/cors/index.js"
     },
+    "./csrf": {
+      "types": "./dist/types/middleware/csrf/index.d.ts",
+      "import": "./dist/middleware/csrf/index.js",
+      "require": "./dist/cjs/middleware/csrf/index.js"
+    },
     "./etag": {
       "types": "./dist/types/middleware/etag/index.d.ts",
       "import": "./dist/middleware/etag/index.js",
@@ -304,6 +309,9 @@
       ],
       "cors": [
         "./dist/types/middleware/cors"
+      ],
+      "csrf": [
+        "./dist/types/middleware/csrf"
       ],
       "etag": [
         "./dist/types/middleware/etag"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ export * from './middleware/cache'
 export * from './helper/cookie' // will be moved to helper.ts in v4
 export * from './middleware/compress'
 export * from './middleware/cors'
+export * from './middleware/csrf'
 export * from './middleware/etag'
 export * from './helper/html' // will be moved to helper.ts in v4
 export * from './jsx'

--- a/src/middleware/csrf/index.test.ts
+++ b/src/middleware/csrf/index.test.ts
@@ -1,0 +1,306 @@
+import type { Context } from '../../context'
+import { Hono } from '../../hono'
+import { csrf } from '../../middleware/csrf'
+
+const simplePostHandler = vi.fn(async (c: Context) => {
+  if (c.req.header('content-type') === 'application/json') {
+    return c.text((await c.req.json<{ name: string }>())['name'])
+  } else {
+    const body = await c.req.parseBody<{ name: string }>()
+    return c.text(body['name'])
+  }
+})
+
+const buildSimplePostRequestData = (origin?: string) => ({
+  method: 'POST',
+  headers: Object.assign(
+    {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    origin ? { origin } : {}
+  ) as Record<string, string>,
+  body: 'name=hono',
+})
+
+describe('CSRF by Middleware', () => {
+  beforeEach(() => {
+    simplePostHandler.mockClear()
+  })
+
+  describe('simple usage', () => {
+    const app = new Hono()
+
+    app.use('*', csrf())
+    app.get('/form', (c) => c.html('<form></form>'))
+    app.post('/form', simplePostHandler)
+    app.put('/form', (c) => c.text('OK'))
+    app.delete('/form', (c) => c.text('OK'))
+    app.patch('/form', (c) => c.text('OK'))
+
+    describe('GET /form', async () => {
+      it('should be 200 for any request', async () => {
+        const res = await app.request('http://localhost/form')
+
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe('<form></form>')
+      })
+    })
+
+    describe('HEAD /form', async () => {
+      it('should be 200 for any request', async () => {
+        const res = await app.request('http://localhost/form', { method: 'HEAD' })
+
+        expect(res.status).toBe(200)
+      })
+    })
+
+    describe('POST /form', async () => {
+      it('should be 200 for local request', async () => {
+        /*
+         * <form action="/form" method="POST"><input name="name" value="hono" /></form>
+         * or
+         * <script>
+         * fetch('/form', {
+         *   method: 'POST',
+         *   headers: {
+         *     'content-type': 'application/x-www-form-urlencoded',
+         *   },
+         *   body: 'name=hono',
+         * });
+         * </script>
+         */
+        const res = await app.request(
+          'http://localhost/form',
+          buildSimplePostRequestData('http://localhost')
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe('hono')
+      })
+
+      it('should be 403 for "application/x-www-form-urlencoded" cross origin', async () => {
+        /*
+         * via http://example.com
+         *
+         * <form action="http://localhost/form" method="POST">
+         *   <input name="name" value="hono" />
+         * </form>
+         * or
+         * <script>
+         * fetch('http://localhost/form', {
+         *   method: 'POST',
+         *   headers: {
+         *     'content-type': 'application/x-www-form-urlencoded',
+         *   },
+         *   body: 'name=hono',
+         * });
+         * </script>
+         */
+        const res = await app.request(
+          'http://localhost/form',
+          buildSimplePostRequestData('http://example.com')
+        )
+
+        expect(res.status).toBe(403)
+        expect(simplePostHandler).not.toHaveBeenCalled()
+      })
+    })
+
+    it('should be 403 for "multipart/form-data" cross origin', async () => {
+      /*
+       * via http://example.com
+       *
+       * <form action="http://localhost/form" method="POST" enctype="multipart/form-data">
+       *   <input name="name" value="hono" />
+       * </form>
+       * or
+       * <script>
+       * fetch('http://localhost/form', {
+       *   method: 'POST',
+       *   headers: {
+       *     'content-type': 'multipart/form-data',
+       *   },
+       *   body: 'name=hono',
+       * });
+       * </script>
+       */
+      const res = await app.request(
+        'http://localhost/form',
+        buildSimplePostRequestData('http://example.com')
+      )
+
+      expect(res.status).toBe(403)
+      expect(simplePostHandler).not.toHaveBeenCalled()
+    })
+
+    it('should be 403 for "text/plain" cross origin', async () => {
+      /*
+       * via http://example.com
+       *
+       * <form action="http://localhost/form" method="POST" enctype="text/plain">
+       *   <input name="name" value="hono" />
+       * </form>
+       * or
+       * <script>
+       * fetch('http://localhost/form', {
+       *   method: 'POST',
+       *   headers: {
+       *     'content-type': 'text/plain',
+       *   },
+       *   body: 'name=hono',
+       * });
+       * </script>
+       */
+      const res = await app.request(
+        'http://localhost/form',
+        buildSimplePostRequestData('http://example.com')
+      )
+
+      expect(res.status).toBe(403)
+      expect(simplePostHandler).not.toHaveBeenCalled()
+    })
+
+    it('should be 403 if request has no origin header', async () => {
+      const res = await app.request('http://localhost/form', buildSimplePostRequestData())
+
+      expect(res.status).toBe(403)
+      expect(simplePostHandler).not.toHaveBeenCalled()
+    })
+
+    it('should be 200 for application/json', async () => {
+      /*
+       * via http://example.com
+       * Assume localhost allows cross origin POST
+       *
+       * <script>
+       * fetch('http://localhost/form', {
+       *   method: 'POST',
+       *   headers: {
+       *     'content-type': 'application/json',
+       *   },
+       *   body: JSON.stringify({ name: 'hono' }),
+       * });
+       * </script>
+       */
+      const res = await app.request('http://localhost/form', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://example.com',
+        },
+        body: JSON.stringify({ name: 'hono' }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('hono')
+    })
+  })
+
+  describe('with origin option', () => {
+    describe('string', () => {
+      const app = new Hono()
+
+      app.use(
+        '*',
+        csrf({
+          origin: 'https://example.com',
+        })
+      )
+      app.post('/form', simplePostHandler)
+
+      it('should be 200 for allowed origin', async () => {
+        const res = await app.request(
+          'https://example.com/form',
+          buildSimplePostRequestData('https://example.com')
+        )
+        expect(res.status).toBe(200)
+      })
+
+      it('should be 403 for not allowed origin', async () => {
+        const res = await app.request(
+          'https://example.jp/form',
+          buildSimplePostRequestData('https://example.jp')
+        )
+        expect(res.status).toBe(403)
+        expect(simplePostHandler).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('string[]', () => {
+      const app = new Hono()
+
+      app.use(
+        '*',
+        csrf({
+          origin: ['https://example.com', 'https://hono.example.com'],
+        })
+      )
+      app.post('/form', simplePostHandler)
+
+      it('should be 200 for allowed origin', async () => {
+        let res = await app.request(
+          'https://hono.example.com/form',
+          buildSimplePostRequestData('https://hono.example.com')
+        )
+        expect(res.status).toBe(200)
+
+        res = await app.request(
+          'https://example.com/form',
+          buildSimplePostRequestData('https://example.com')
+        )
+        expect(res.status).toBe(200)
+      })
+
+      it('should be 403 for not allowed origin', async () => {
+        const res = await app.request(
+          'http://example.jp/form',
+          buildSimplePostRequestData('http://example.jp')
+        )
+        expect(res.status).toBe(403)
+        expect(simplePostHandler).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('IsAllowedOriginHandler', () => {
+      const app = new Hono()
+
+      app.use(
+        '*',
+        csrf({
+          origin: (origin) => /https:\/\/(\w+\.)?example\.com$/.test(origin),
+        })
+      )
+      app.post('/form', simplePostHandler)
+
+      it('should be 200 for allowed origin', async () => {
+        let res = await app.request(
+          'https://hono.example.com/form',
+          buildSimplePostRequestData('https://hono.example.com')
+        )
+        expect(res.status).toBe(200)
+
+        res = await app.request(
+          'https://example.com/form',
+          buildSimplePostRequestData('https://example.com')
+        )
+        expect(res.status).toBe(200)
+      })
+
+      it('should be 403 for not allowed origin', async () => {
+        let res = await app.request(
+          'http://honojs.hono.example.jp/form',
+          buildSimplePostRequestData('http://example.jp')
+        )
+        expect(res.status).toBe(403)
+        expect(simplePostHandler).not.toHaveBeenCalled()
+
+        res = await app.request(
+          'http://example.jp/form',
+          buildSimplePostRequestData('http://example.jp')
+        )
+        expect(res.status).toBe(403)
+        expect(simplePostHandler).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -1,0 +1,48 @@
+import type { Context } from '../../context'
+import { HTTPException } from '../../http-exception'
+import type { MiddlewareHandler } from '../../types'
+
+type IsAllowedOriginHandler = (origin: string, context: Context) => boolean
+interface CSRFOptions {
+  origin?: string | string[] | IsAllowedOriginHandler
+}
+
+const isSafeMethodRe = /^(GET|HEAD)$/
+const isRequestedByFormElementRe =
+  /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/
+
+export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
+  const handler: IsAllowedOriginHandler = ((optsOrigin) => {
+    if (!optsOrigin) {
+      return (origin, c) => origin === new URL(c.req.url).origin
+    } else if (typeof optsOrigin === 'string') {
+      return (origin) => origin === optsOrigin
+    } else if (typeof optsOrigin === 'function') {
+      return optsOrigin
+    } else {
+      return (origin) => optsOrigin.includes(origin)
+    }
+  })(options?.origin)
+  const isAllowedOrigin = (origin: string | undefined, c: Context) => {
+    if (origin === undefined) {
+      // denied always when origin header is not present
+      return false
+    }
+    return handler(origin, c)
+  }
+
+  return async function cors(c, next) {
+    if (
+      !isSafeMethodRe.test(c.req.method) &&
+      isRequestedByFormElementRe.test(c.req.header('content-type') || '') &&
+      !isAllowedOrigin(c.req.header('origin'), c)
+    ) {
+      const res = new Response('Forbidden', {
+        status: 403,
+      })
+      throw new HTTPException(401, { res })
+    }
+
+    await next()
+  }
+}

--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -40,7 +40,7 @@ export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
       const res = new Response('Forbidden', {
         status: 403,
       })
-      throw new HTTPException(401, { res })
+      throw new HTTPException(403, { res })
     }
 
     await next()


### PR DESCRIPTION
This middleware prevents CSRF attacks by checking request headers.

### All you have to do

When you need to protect against CSRF attacks (i.e. submitting with a form element) all you have to do is add the following one line

```ts
app.use('*', csrf())
```

This works well enough in most cases.
For "old browsers that do not send Origin headers" or "environments that use reverse proxies and drop Origin headers," it may not be possible to submit with false positives. If you want to support such environments, this middleware is not sufficient, and it is better to use CSRF tokens.

### Options

By default, the Origin header is compared to the requested URL. Generally, this works well enough, but sometimes an explicit specification is necessary for a variety of reasons. It is advisable to refer to the OWASP cheat sheet for the circumstances in which the specification is required and for notes on the contents of the specification.
https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#identifying-the-target-origin

In csrf middleware, as in cors middleware, "origin" can be specified as string, string[], or Function.

```ts
// string
app.use('*', csrf({origin: "myapp.example.com"}))

// string[]
app.use('*', csrf({origin: ["myapp.example.com", "development.myapp.example.com"]}))

// Function
// It is strongly recommended that the protocol be verified to ensure a match to `$`. You should *never* do a forward match.
app.use('*', csrf({origin: (origin) => /https:\/\/(\w+\.)?myapp\.example\.com$/.test(origin)})
```

### Thanks

This PR could not have been put together without the help of all those involved in the #1688 discussions. The documentation pointed to by @htunnicliff  and the Sveltekit implementation shared by @hjaber were especially helpful.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
