### PR TITLE
feat(helper/html): Support Promise<string | HtmlEscapedString> in html tagged template literals

### DIFF
--- a/deno_dist/helper/html/index.ts
+++ b/deno_dist/helper/html/index.ts
@@ -42,6 +42,8 @@ export const html = (
         } else {
           buffer[0] += tmp
         }
+      } else if (child instanceof Promise) {
+        buffer.unshift('', child)
       } else {
         escapeToBuffer(child.toString(), buffer)
       }

--- a/src/helper/html/index.test.ts
+++ b/src/helper/html/index.test.ts
@@ -31,9 +31,10 @@ describe('Tagged Template Literals', () => {
 
   describe('Promise', () => {
     it('Should return Promise<string> when some variables contains Promise<string> in variables', async () => {
-      const name = Promise.resolve(`John "Johnny" Smith`)
+      const name = Promise.resolve('John "Johnny" Smith')
       const res = html`<p>I'm ${name}.</p>`
       expect(res).toBeInstanceOf(Promise)
+      // eslint-disable-next-line quotes
       expect((await res).toString()).toBe("<p>I'm John &quot;Johnny&quot; Smith.</p>")
     })
 
@@ -41,7 +42,7 @@ describe('Tagged Template Literals', () => {
       const name = Promise.resolve(raw('John "Johnny" Smith'))
       const res = html`<p>I'm ${name}.</p>`
       expect(res).toBeInstanceOf(Promise)
-      expect((await res).toString()).toBe(`<p>I'm John "Johnny" Smith.</p>`)
+      expect((await res).toString()).toBe('<p>I\'m John "Johnny" Smith.</p>')
     })
   })
 })

--- a/src/helper/html/index.test.ts
+++ b/src/helper/html/index.test.ts
@@ -28,6 +28,22 @@ describe('Tagged Template Literals', () => {
       '<p>Name:John &quot;Johnny&quot; Smith Contact:<a href="http://example.com/">My Website</a></p>'
     )
   })
+
+  describe('Promise', () => {
+    it('Should return Promise<string> when some variables contains Promise<string> in variables', async () => {
+      const name = Promise.resolve(`John "Johnny" Smith`)
+      const res = html`<p>I'm ${name}.</p>`
+      expect(res).toBeInstanceOf(Promise)
+      expect((await res).toString()).toBe("<p>I'm John &quot;Johnny&quot; Smith.</p>")
+    })
+
+    it('Should return raw value when some variables contains Promise<HtmlEscapedString> in variables', async () => {
+      const name = Promise.resolve(raw('John "Johnny" Smith'))
+      const res = html`<p>I'm ${name}.</p>`
+      expect(res).toBeInstanceOf(Promise)
+      expect((await res).toString()).toBe(`<p>I'm John "Johnny" Smith.</p>`)
+    })
+  })
 })
 
 describe('raw', () => {

--- a/src/helper/html/index.ts
+++ b/src/helper/html/index.ts
@@ -42,6 +42,8 @@ export const html = (
         } else {
           buffer[0] += tmp
         }
+      } else if (child instanceof Promise) {
+        buffer.unshift('', child)
       } else {
         escapeToBuffer(child.toString(), buffer)
       }

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -5,7 +5,23 @@ export type HtmlEscaped = {
   callbacks?: HtmlEscapedCallback[]
 }
 export type HtmlEscapedString = string & HtmlEscaped
+
+/**
+ * StringBuffer contains string and Promise<string> alternately
+ * The length of the array will be odd, the odd numbered element will be a string,
+ * and the even numbered element will be a Promise<string>.
+ * When concatenating into a single string, it must be processed from the tail.
+ * @example
+ * [
+ *   'framework.',
+ *   Promise.resolve('ultra fast'),
+ *   'a ',
+ *   Promise.resolve('is '),
+ *   'Hono',
+ * ]
+ */
 export type StringBuffer = (string | Promise<string>)[]
+
 import { raw } from '../helper/html'
 
 // The `escapeToBuffer` implementation is based on code from the MIT licensed `react-dom` package.
@@ -16,16 +32,31 @@ const escapeRe = /[&<>'"]/
 export const stringBufferToString = async (buffer: StringBuffer): Promise<HtmlEscapedString> => {
   let str = ''
   const callbacks: HtmlEscapedCallback[] = []
-  for (let i = buffer.length - 1; i >= 0; i--) {
+  for (let i = buffer.length - 1; ; i--) {
+    str += buffer[i]
+    i--
+    if (i < 0) {
+      break
+    }
+
     let r = await buffer[i]
     if (typeof r === 'object') {
       callbacks.push(...((r as HtmlEscapedString).callbacks || []))
     }
+
+    const isEscaped = (r as HtmlEscapedString).isEscaped
     r = await (typeof r === 'object' ? (r as HtmlEscapedString).toString() : r)
     if (typeof r === 'object') {
       callbacks.push(...((r as HtmlEscapedString).callbacks || []))
     }
-    str += r
+
+    if ((r as HtmlEscapedString).isEscaped ?? isEscaped) {
+      str += r
+    } else {
+      const buf = [str]
+      escapeToBuffer(r, buf)
+      str = buf[0]
+    }
   }
 
   return raw(str, callbacks)


### PR DESCRIPTION
This PR allows `Promise<string | HtmlEscapedString>` to be passed to the `html` tagFunction variables as well.

Fixes: #1812

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
