### PR TITLE
feat(dev): add `getRouterName()`

### DIFF
--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -60,3 +60,8 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
       })
     })
 }
+
+export const getRouterName = <E extends Env>(app: Hono<E>) => {
+  app.router.match('GET', '/')
+  return app.router.name
+}

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -236,6 +236,11 @@ class Hono<
     return this
   }
 
+  /**
+   * @deprecated
+   * `app.routerName()` will be removed in v4.
+   * Use `getRouterName()` in `hono/dev` instead of `app.routerName()`.
+   */
   get routerName() {
     this.matchRoute('GET', '/')
     return this.router.name

--- a/src/helper/dev/index.test.ts
+++ b/src/helper/dev/index.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from '../../hono'
+import { RegExpRouter } from '../../router/reg-exp-router'
 import type { Handler, MiddlewareHandler } from '../../types'
-import { inspectRoutes, showRoutes } from '.'
+import { inspectRoutes, showRoutes, getRouterName } from '.'
 
 const namedMiddleware: MiddlewareHandler = (_, next) => next()
 const namedHandler: Handler = (c) => c.text('hi')
@@ -90,5 +91,14 @@ describe('showRoutes()', () => {
       '\x1b[32mGET\x1b[0m      /static',
       '           [handler]',
     ])
+  })
+})
+
+describe('geRouterName()', () => {
+  it('Should return the correct router name', async () => {
+    const app = new Hono({
+      router: new RegExpRouter(),
+    })
+    expect(getRouterName(app)).toBe('RegExpRouter')
   })
 })

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -60,3 +60,8 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
       })
     })
 }
+
+export const getRouterName = <E extends Env>(app: Hono<E>) => {
+  app.router.match('GET', '/')
+  return app.router.name
+}

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -236,6 +236,11 @@ class Hono<
     return this
   }
 
+  /**
+   * @deprecated
+   * `app.routerName()` will be removed in v4.
+   * Use `getRouterName()` in `hono/dev` instead of `app.routerName()`.
+   */
   get routerName() {
     this.matchRoute('GET', '/')
     return this.router.name


### PR DESCRIPTION
This PR introduces `getRouterName()` function in `hono/dev` helper and deprecates `app.routerName()`.

I think `app.routerName()` is not used by many users, and if users use it, the purpose is debugging in most cases. So, we can place it in `hono/dev` is better.

Usage:

```ts
import { Hono } from 'hono'
import { getRouterName } from 'hono/dev'

const app = new Hono()

//...

console.log(getRouterName(app))
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
