### PR TITLE
[PoC] feat(jsx-renderer): introduce `css`

### DIFF
--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -283,11 +283,11 @@ const jsxFn = (
  * The API might be changed.
  * same as `as unknown as JSXNode`
  */
-export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSXNode => {
+export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSX.Element & JSXNode => {
   if (!(node instanceof JSXNode)) {
     throw new Error('Invalid node')
   }
-  return node as JSXNode
+  return node as JSX.Element & JSXNode
 }
 
 export type FC<T = Props> = (

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -283,11 +283,11 @@ const jsxFn = (
  * The API might be changed.
  * same as `as unknown as JSXNode`
  */
-export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSXNode => {
+export const jsxNode = (node: HtmlEscaped | Promise<HtmlEscaped>): JSX.Element & JSXNode => {
   if (!(node instanceof JSXNode)) {
     throw new Error('Invalid node')
   }
-  return node as JSXNode
+  return node as JSX.Element & JSXNode
 }
 
 export type FC<T = Props> = (

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -44,7 +44,7 @@ const createRenderer =
       { value: c },
       (component
         ? (component({ children: children, ...(props || {}) }) as unknown as JSXNode)
-            .on('renderToString.cssStyle', ({ setContent }) => {
+            .on('renderToString.css', ({ setContent }) => {
               setContent(
                 finalizePromise.then(() => {
                   return `<style>${Object.entries(c.get(stylesVariableName))


### PR DESCRIPTION
Usage: 

```ts
import { Hono } from 'hono'
import { jsxRenderer, css } from 'hono/jsx-renderer'

const app = new Hono()

app.get(
  '*',
  jsxRenderer(({ children }) => {
    return (
      <html>
        <css />
        <body>{children}</body>
      </html>
    )
  })
)

const Header = () => {
  const HeaderClass = css`
    background-color: blue;
    color: white;
    padding: 1rem;
  `
  return <h1 class={HeaderClass}>Hello!</h1>
}

app.get('/', (c) => {
  return c.render(
    <html>
      <body>
        <Header />
      </body>
    </html>
  )
})
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
