### PR TITLE
feat(hono-base): add deprecated flag to `app.routerName`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -193,7 +193,7 @@ class Hono<
 
   /**
    * @deprecated
-   * Use `showRoutes()` utility methods provided by 'hono/dev' instead of `app.showRoutes()`.
+   * Use `showRoutes()` provided by `hono/dev` instead of `app.showRoutes()`.
    * `app.showRoutes()` will be removed in v4.
    * @example
    * You could rewrite `app.showRoutes()` as follows
@@ -243,6 +243,11 @@ class Hono<
     return this
   }
 
+  /**
+   * @deprecated
+   * Use `getRouterName()` provided by `hono/dev` instead of `app.routerName`.
+   * `app.getRouterName()` will be removed in v4.
+   */
   get routerName() {
     this.matchRoute('GET', '/')
     return this.router.name

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -193,7 +193,7 @@ class Hono<
 
   /**
    * @deprecated
-   * Use `showRoutes()` utility methods provided by 'hono/dev' instead of `app.showRoutes()`.
+   * Use `showRoutes()` provided by `hono/dev` instead of `app.showRoutes()`.
    * `app.showRoutes()` will be removed in v4.
    * @example
    * You could rewrite `app.showRoutes()` as follows
@@ -243,6 +243,11 @@ class Hono<
     return this
   }
 
+  /**
+   * @deprecated
+   * Use `getRouterName()` provided by `hono/dev` instead of `app.routerName`.
+   * `app.getRouterName()` will be removed in v4.
+   */
   get routerName() {
     this.matchRoute('GET', '/')
     return this.router.name


### PR DESCRIPTION
This is deprecated since the PR #1841. 

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
