### PR TITLE
feat(dev): add `callback` option to `showRoutes()`

### DIFF
--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -2,15 +2,16 @@ import type { Hono } from '../../hono.ts'
 import { COMPOSED_HANDLER } from '../../hono-base.ts'
 import type { Env, RouterRoute } from '../../types.ts'
 
-interface ShowRoutesOptions {
-  verbose?: boolean
-}
-
 interface RouteData {
   path: string
   method: string
   name: string
   isMiddleware: boolean
+}
+
+interface ShowRoutesOptions {
+  verbose?: boolean
+  callback?: (data: { method: string; path: string; routes: RouteData[] }) => void
 }
 
 const isMiddleware = (handler: Function) => handler.length > 1
@@ -58,6 +59,12 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
       if (!data) {
         return
       }
+
+      if (opts?.callback) {
+        opts.callback(data)
+        return
+      }
+
       const { method, path, routes } = data
 
       console.log(`\x1b[32m${method}\x1b[0m ${' '.repeat(maxMethodLength - method.length)} ${path}`)

--- a/src/helper/dev/index.test.ts
+++ b/src/helper/dev/index.test.ts
@@ -110,6 +110,24 @@ describe('showRoutes()', () => {
       '           [handler]',
     ])
   })
+
+  it('should render output specified by the `callback` option', async () => {
+    showRoutes(app, {
+      callback: ({ method, path }) => {
+        console.log(`${method} ${path}`)
+      },
+    })
+    expect(logs).toEqual([
+      'GET /',
+      'GET /named',
+      'POST /',
+      'PUT /',
+      'PATCH /',
+      'DELETE /',
+      'OPTIONS /',
+      'GET /static',
+    ])
+  })
 })
 
 describe('geRouterName()', () => {

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -2,15 +2,16 @@ import type { Hono } from '../../hono'
 import { COMPOSED_HANDLER } from '../../hono-base'
 import type { Env, RouterRoute } from '../../types'
 
-interface ShowRoutesOptions {
-  verbose?: boolean
-}
-
 interface RouteData {
   path: string
   method: string
   name: string
   isMiddleware: boolean
+}
+
+interface ShowRoutesOptions {
+  verbose?: boolean
+  callback?: (data: { method: string; path: string; routes: RouteData[] }) => void
 }
 
 const isMiddleware = (handler: Function) => handler.length > 1
@@ -58,6 +59,12 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
       if (!data) {
         return
       }
+
+      if (opts?.callback) {
+        opts.callback(data)
+        return
+      }
+
       const { method, path, routes } = data
 
       console.log(`\x1b[32m${method}\x1b[0m ${' '.repeat(maxMethodLength - method.length)} ${path}`)


### PR DESCRIPTION
This PR introduces `callback` option for `showRoutes()` in `hono/dev`. 

This allows users to define their own custom outputs.

```ts
import { Hono } from 'hono'
import { showRoutes } from 'hono/dev'

const app = new Hono()
app.get('/', (c) => c.text('/'))
app.get('/foo', (c) => c.text('foo'))

showRoutes(app, {
  callback: ({ method, path }) => {
    console.log(`${method} ${path}`)
  },
})
```

Resolves #1881




### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
