### PR TITLE
feat(client): add `param` option to `$url()`

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -142,6 +142,9 @@ export const hc = <T extends Hono<any, any, any>>(
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
     if (method === 'url') {
+      if (opts.args[0] && opts.args[0].param) {
+        return new URL(replaceUrlParam(url, opts.args[0].param))
+      }
       return new URL(url)
     }
 

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -23,7 +23,13 @@ export type ClientRequest<S extends Schema> = {
       : never
     : never
 } & {
-  $url: () => URL
+  $url: (
+    arg?: S[keyof S] extends { input: infer R }
+      ? R extends { param: infer P }
+        ? { param: P }
+        : {}
+      : {}
+  ) => URL
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -605,3 +605,23 @@ describe('ClientResponse<T>.json() returns a Union type correctly', () => {
     expectTypeOf(json).toEqualTypeOf<{ data: string } | { message: string }>()
   })
 })
+
+describe('$url() with a param option', () => {
+  const app = new Hono().get('/posts/:id/comments', (c) => c.json({ ok: true }))
+  type AppType = typeof app
+  const client = hc<AppType>('http://localhost')
+
+  it('Should return the correct path - /posts/123/comments', async () => {
+    const url = client.posts[':id'].comments.$url({
+      param: {
+        id: '123',
+      },
+    })
+    expect(url.pathname).toBe('/posts/123/comments')
+  })
+
+  it('Should return the correct path - /posts/:id/comments', async () => {
+    const url = client.posts[':id'].comments.$url()
+    expect(url.pathname).toBe('/posts/:id/comments')
+  })
+})

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -142,6 +142,9 @@ export const hc = <T extends Hono<any, any, any>>(
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
     if (method === 'url') {
+      if (opts.args[0] && opts.args[0].param) {
+        return new URL(replaceUrlParam(url, opts.args[0].param))
+      }
       return new URL(url)
     }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -23,7 +23,13 @@ export type ClientRequest<S extends Schema> = {
       : never
     : never
 } & {
-  $url: () => URL
+  $url: (
+    arg?: S[keyof S] extends { input: infer R }
+      ? R extends { param: infer P }
+        ? { param: P }
+        : {}
+      : {}
+  ) => URL
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR introduces an option to the `$url()` function in Hono's client.

You can write the param values as an option of `$url()` like the following:

```ts
const route = app.get('/api/:id/bar', (c) => c.json({ foo: 'bar' }))

const client = hc<typeof route>('http://localhost:8787/')
const url = client.api[':id'].bar.$url({
  param: {
    id: '123',
  },
})
```

Inferring types are available:

https://github.com/honojs/hono/assets/10682/eaff7c97-6429-41ae-b2ca-8813387a85af

Resolves #1870

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
