### PR TITLE
feat(dev): add `colorize` option for `showRoutes()`

### DIFF
--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -4,6 +4,7 @@ import type { Env, RouterRoute } from '../../types.ts'
 
 interface ShowRoutesOptions {
   verbose?: boolean
+  colorize?: boolean
 }
 
 interface RouteData {
@@ -60,7 +61,8 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
       }
       const { method, path, routes } = data
 
-      console.log(`\x1b[32m${method}\x1b[0m ${' '.repeat(maxMethodLength - method.length)} ${path}`)
+      const methodStr = opts?.colorize ?? true ? `\x1b[32m${method}\x1b[0m` : method
+      console.log(`${methodStr} ${' '.repeat(maxMethodLength - method.length)} ${path}`)
 
       if (!opts?.verbose) {
         return

--- a/src/helper/dev/index.test.ts
+++ b/src/helper/dev/index.test.ts
@@ -110,6 +110,20 @@ describe('showRoutes()', () => {
       '           [handler]',
     ])
   })
+
+  it('should render not colorized output', async () => {
+    showRoutes(app, { colorize: false })
+    expect(logs).toEqual([
+      'GET      /',
+      'GET      /named',
+      'POST     /',
+      'PUT      /',
+      'PATCH    /',
+      'DELETE   /',
+      'OPTIONS  /',
+      'GET      /static',
+    ])
+  })
 })
 
 describe('geRouterName()', () => {

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -4,6 +4,7 @@ import type { Env, RouterRoute } from '../../types'
 
 interface ShowRoutesOptions {
   verbose?: boolean
+  colorize?: boolean
 }
 
 interface RouteData {
@@ -60,7 +61,8 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
       }
       const { method, path, routes } = data
 
-      console.log(`\x1b[32m${method}\x1b[0m ${' '.repeat(maxMethodLength - method.length)} ${path}`)
+      const methodStr = opts?.colorize ?? true ? `\x1b[32m${method}\x1b[0m` : method
+      console.log(`${methodStr} ${' '.repeat(maxMethodLength - method.length)} ${path}`)
 
       if (!opts?.verbose) {
         return


### PR DESCRIPTION
This PR introduces the `colorize` option for `showRoutes()` in `hono/dev`.

You can disable colorizing the output if you set the option as `false`:

```ts
showRoutes(app, {
  colorize: false,
})
```

Resolves #1881, related to #1883.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
