### PR TITLE
feat: Add headers option to serveStatic()

### DIFF
--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -12,6 +12,7 @@ export type ServeStaticOptions<E extends Env = Env> = {
   path?: string
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+  headers?: Headers
 }
 
 const DEFAULT_DOCUMENT = 'index.html'
@@ -50,6 +51,11 @@ export const serveStatic = <E extends Env = Env>(
       const mimeType = getMimeType(path)
       if (mimeType) {
         c.header('Content-Type', mimeType)
+      }
+      if (options.headers) {
+        for (const entry of options.headers.entries()) {
+          c.header(...entry)
+        }
       }
       // Return Response object with stream
       return c.body(file.readable)

--- a/runtime_tests/bun/index.test.tsx
+++ b/runtime_tests/bun/index.test.tsx
@@ -101,6 +101,13 @@ describe('Serve Static Middleware', () => {
     })
   )
 
+  const headers = new Headers()
+  headers.set('foo', 'bar')
+  app.all(
+    '/favicon-with-headers.ico',
+    serveStatic({ path: './runtime_tests/bun/favicon.ico', headers })
+  )
+
   beforeEach(() => onNotFound.mockClear())
 
   it('Should return static file correctly', async () => {
@@ -108,6 +115,15 @@ describe('Serve Static Middleware', () => {
     await res.arrayBuffer()
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('image/x-icon')
+    expect(res.headers.get('foo')).toBe(null)
+  })
+
+  it('Should return static file correctly with headers', async () => {
+    const res = await app.request(new Request('http://localhost/favicon-with-headers.ico'))
+    await res.arrayBuffer()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/x-icon')
+    expect(res.headers.get('foo')).toBe('bar')
   })
 
   it('Should return 404 response', async () => {

--- a/runtime_tests/deno/middleware.test.tsx
+++ b/runtime_tests/deno/middleware.test.tsx
@@ -92,10 +92,23 @@ Deno.test('Serve Static middleware', async () => {
       rewriteRequestPath: (path) => path.replace(/^\/dot-static/, './.static'),
     })
   )
+  const headers = new Headers()
+  headers.set('foo', 'bar')
+  app.all(
+    '/favicon-with-headers.ico',
+    serveStatic({ path: './runtime_tests/deno/favicon.ico', headers })
+  )
 
   let res = await app.request('http://localhost/favicon.ico')
   assertEquals(res.status, 200)
   assertEquals(res.headers.get('Content-Type'), 'image/x-icon')
+  assertEquals(res.headers.get('foo'), null)
+  await res.body?.cancel()
+
+  res = await app.request('http://localhost/favicon-with-headers.ico')
+  assertEquals(res.status, 200)
+  assertEquals(res.headers.get('Content-Type'), 'image/x-icon')
+  assertEquals(res.headers.get('foo'), 'bar')
   await res.body?.cancel()
 
   res = await app.request('http://localhost/favicon-notfound.ico')

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -14,6 +14,7 @@ export type ServeStaticOptions<E extends Env = Env> = {
   path?: string
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+  headers?: Headers
 }
 
 const DEFAULT_DOCUMENT = 'index.html'
@@ -46,6 +47,11 @@ export const serveStatic = <E extends Env = Env>(
         const mimeType = getMimeType(path)
         if (mimeType) {
           c.header('Content-Type', mimeType)
+        }
+        if (options.headers) {
+          for (const entry of options.headers.entries()) {
+            c.header(...entry)
+          }
         }
         // Return Response object
         return c.body(content)

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -13,6 +13,7 @@ export type ServeStaticOptions<E extends Env = Env> = {
   namespace?: KVNamespace
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+  headers?: Headers
 }
 
 const DEFAULT_DOCUMENT = 'index.html'
@@ -49,6 +50,11 @@ export const serveStatic = <E extends Env = Env>(
       const mimeType = getMimeType(path)
       if (mimeType) {
         c.header('Content-Type', mimeType)
+      }
+      if (options.headers) {
+        for (const entry of options.headers.entries()) {
+          c.header(...entry)
+        }
       }
       // Return Response object
       return c.body(content)

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -12,6 +12,7 @@ export type ServeStaticOptions<E extends Env = Env> = {
   path?: string
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+  headers?: Headers
 }
 
 const DEFAULT_DOCUMENT = 'index.html'
@@ -50,6 +51,11 @@ export const serveStatic = <E extends Env = Env>(
       const mimeType = getMimeType(path)
       if (mimeType) {
         c.header('Content-Type', mimeType)
+      }
+      if (options.headers) {
+        for (const entry of options.headers.entries()) {
+          c.header(...entry)
+        }
       }
       // Return Response object with stream
       return c.body(file.readable)


### PR DESCRIPTION
### Add headers option to serveStatic()

I'm encountering a situation were I need to serve static files (with Cloudflare Workers) and each of these files need to have some specific headers when served.

Currently I can do that with the help of a middleware using:
```js
app.use('something that matches my specific file', async (c, next) => {
    c.res.headers.set('foo', `bar`);
    await next()
});
```
or
```js
app.use('something more global', async (c, next) => {
    if(c.req.url.endsWith('myfilename')) {
       c.res.headers.set('foo', `bar`);
    }
    await next()
});
```

This is a proposal to add headers to `serveStatic()` via an optional `Headers` object, this way I can set the headers when serving my static files directly and I don't need to grow my current middlewares.

Example:
```js
cost headers = new Headers();
headers.set('foo', 'bar');
app.get('/mypaththatneedtoservefileswithaspecificheaders', serveStatic({ path: './script.js', headers }));
```

It's non-blocking and simply a suggestion which I think would make the `serveStatic` method more versatile to the Hono users.

It may not be a big of a problem enough to be considered, let me know.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
- [x] Files are formatted with the project prettier config
- [ ] The relevant documentation will need to be updated if the proposal is approved on the [hono/website](https://github.com/honojs/website/tree/main/getting-started) repo 
