### PR TITLE
POC: feat: enable to write jsx to streaming api

### DIFF
--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -1,3 +1,5 @@
+import { HtmlEscapedCallbackPhase, resolveCallback } from './html.ts'
+
 export class StreamingApi {
   private writer: WritableStreamDefaultWriter<Uint8Array>
   private encoder: TextEncoder
@@ -27,10 +29,23 @@ export class StreamingApi {
     })
   }
 
-  async write(input: Uint8Array | string) {
+  async write(input: Uint8Array | string | Promise<string>) {
     try {
+      // JSX handling is a same process as c.html
+      if (typeof input === 'object' && !(input instanceof Uint8Array)) {
+        // this is a JSXNode
+        if (!(input instanceof Promise)) {
+          input = (input as string).toString() // HtmlEscapedString object to string
+        }
+        if (input instanceof Promise) {
+          ;(input as unknown as Promise<string>)
+            .then((html) => resolveCallback(html, HtmlEscapedCallbackPhase.Stringify, false, {}))
+            .then((html) => this.write(html))
+          return this
+        }
+      }
       if (typeof input === 'string') {
-        input = this.encoder.encode(input)
+        input = this.encoder.encode(input.toString())
       }
       await this.writer.write(input)
     } catch (e) {


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

If JSX can be delivered via streamingAPI, as in the tweet below, it would be a nice match with the shadowrootmode of web components and allow components to be changed dynamically from the server without client JS.

https://x.com/shou_study/status/1743996737696764069?s=20

Demo:

<details><summary>Code</summary>
<p>

```tsx
import { Hono } from "hono";
import { stream } from "hono/streaming";

const app = new Hono();

app.get("/", (c) => {
  return stream(c, async (stream) => {
    await stream.write(
      <html lang="en">
        <body>
          <template shadowrootmode="open">
            <slot name="component1">
              <p>Loading...</p>
            </slot>
          </template>
        </body>
      </html>
    );
    await stream.sleep(1000);
    await stream.write(
      <div slot="component1">
        <h1>Hello Hono!</h1>
      </div>
    );
  });
});

export default app;
```

</p>
</details> 

https://github.com/honojs/hono/assets/80559385/c2e494a0-f75b-4274-9749-b680d5f301ef