### PR TITLE
fix(validator): exclude Response type for returned values from `c.req.valid()`

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../context.ts'
 import { getCookie } from '../helper/cookie/index.ts'
-import type { Env, ValidationTargets, MiddlewareHandler } from '../types.ts'
+import type { Env, ValidationTargets, MiddlewareHandler, TypedResponse } from '../types.ts'
 import type { BodyData } from '../utils/body.ts'
 import { bufferToFormData } from '../utils/buffer.ts'
 
@@ -19,6 +19,9 @@ export type ValidationFunction<
   c: Context<E, P>
 ) => OutputType | Response | Promise<OutputType> | Promise<Response>
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExcludeResponseType<T> = T extends Response & TypedResponse<any> ? never : T
+
 export const validator = <
   InputType,
   P extends string,
@@ -28,10 +31,10 @@ export const validator = <
   P2 extends string = P,
   V extends {
     in: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    out: { [K in U]: OutputType }
+    out: { [K in U]: ExcludeResponseType<OutputType> }
   } = {
     in: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    out: { [K in U]: OutputType }
+    out: { [K in U]: ExcludeResponseType<OutputType> }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -822,3 +822,35 @@ describe('Async validator function', () => {
     })
   })
 })
+
+describe('Validator with using Zod directly', () => {
+  it('Should exclude Response & TypedResponse type', () => {
+    const testSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+      type: z.enum(['a']),
+    })
+    const app = new Hono()
+
+    app.post(
+      '/posts',
+      validator('json', (value, c) => {
+        const parsed = testSchema.safeParse(value)
+        if (!parsed.success) {
+          return c.json({ foo: 'bar' }, 401)
+        }
+        return parsed.data
+      }),
+      (c) => {
+        const data = c.req.valid('json')
+        expectTypeOf(data.name).toEqualTypeOf<string>()
+        return c.json(
+          {
+            message: 'Created!',
+          },
+          201
+        )
+      }
+    )
+  })
+})

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
-import type { Env, ValidationTargets, MiddlewareHandler } from '../types'
+import type { Env, ValidationTargets, MiddlewareHandler, TypedResponse } from '../types'
 import type { BodyData } from '../utils/body'
 import { bufferToFormData } from '../utils/buffer'
 
@@ -19,6 +19,9 @@ export type ValidationFunction<
   c: Context<E, P>
 ) => OutputType | Response | Promise<OutputType> | Promise<Response>
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExcludeResponseType<T> = T extends Response & TypedResponse<any> ? never : T
+
 export const validator = <
   InputType,
   P extends string,
@@ -28,10 +31,10 @@ export const validator = <
   P2 extends string = P,
   V extends {
     in: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    out: { [K in U]: OutputType }
+    out: { [K in U]: ExcludeResponseType<OutputType> }
   } = {
     in: { [K in U]: unknown extends InputType ? OutputType : InputType }
-    out: { [K in U]: OutputType }
+    out: { [K in U]: ExcludeResponseType<OutputType> }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any


### PR DESCRIPTION
Fixes #1912

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
