### PR TITLE
fix(cache): Allow composing cache control directives

### DIFF
--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -1,3 +1,4 @@
+import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 
 export const cache = (options: {
@@ -9,8 +10,23 @@ export const cache = (options: {
     options.wait = false
   }
 
-  const addHeader = (response: Response) => {
-    if (options.cacheControl) response.headers.set('Cache-Control', options.cacheControl)
+  const directives = options.cacheControl?.split(',').map((directive) => directive.toLowerCase())
+
+  const addHeader = (c: Context) => {
+    if (directives) {
+      const existingDirectives =
+        c.res.headers
+          .get('Cache-Control')
+          ?.split(',')
+          .map((d) => d.trim().split('=', 1)[0]) ?? []
+      for (const directive of directives) {
+        let [name, value] = directive.trim().split('=', 2)
+        name = name.toLowerCase()
+        if (!existingDirectives.includes(name)) {
+          c.header('Cache-Control', `${name}${value ? `=${value}` : ''}`, { append: true })
+        }
+      }
+    }
   }
 
   return async function cache(c, next) {
@@ -22,7 +38,7 @@ export const cache = (options: {
       if (!c.res.ok) {
         return
       }
-      addHeader(c.res)
+      addHeader(c)
       const response = c.res.clone()
       if (options.wait) {
         await cache.put(key, response)

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -31,8 +31,23 @@ describe('Cache Middleware', () => {
   })
 
   app.use('/wait2/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
-  app.use('/wait2/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.use('/wait2/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'Max-Age=20' }))
   app.get('/wait2/', (c) => {
+    return c.text('cached')
+  })
+
+  app.use('/wait3/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.use(
+    '/wait3/private/*',
+    cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'private' })
+  )
+  app.get('/wait3/private/', (c) => {
+    return c.text('cached')
+  })
+
+  app.use('/wait4/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.get('/wait4/', (c) => {
+    c.header('Cache-Control', 'private')
     return c.text('cached')
   })
 
@@ -61,7 +76,21 @@ describe('Cache Middleware', () => {
     const res = await app.request('/wait2/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=10')
+    expect(res.headers.get('cache-control')).toBe('max-age=20')
+  })
+
+  it('Should return composed middleware header values', async () => {
+    const res = await app.request('/wait3/private/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('private, max-age=10')
+  })
+
+  it('Should return composed handler header values', async () => {
+    const res = await app.request('/wait4/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('private, max-age=10')
   })
 
   it('Should not cache if it is not found', async () => {


### PR DESCRIPTION
# Changes

Fix https://github.com/honojs/hono/issues/1915

1. Allow nested cache middlewares to compose a final Cache-Control header
2. Allow handlers to also add cache control directives

This slightly changes the implementation from raw string handling to acknowledge the existance of individual directives, this way we can avoid duplicating directives that were overriden in inner middleware/handlers.

### Author should do the followings, if applicable

- [X] Add tests
- [X] Run tests
- [X] `yarn denoify` to generate files for Deno
