### PR TITLE
feat(hono-base): `app.on` supports multiple paths

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -100,13 +100,15 @@ class Hono<
     })
 
     // Implementation of app.on(method, path, ...handlers[])
-    this.on = (method: string | string[], path: string, ...handlers: H[]) => {
+    this.on = (method: string | string[], path: string | string[], ...handlers: H[]) => {
       if (!method) return this
-      this.#path = path
-      for (const m of [method].flat()) {
-        handlers.map((handler) => {
-          this.addRoute(m.toUpperCase(), this.#path, handler)
-        })
+      for (const p of [path].flat()) {
+        this.#path = p
+        for (const m of [method].flat()) {
+          handlers.map((handler) => {
+            this.addRoute(m.toUpperCase(), this.#path, handler)
+          })
+        }
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return this as any

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1407,6 +1407,13 @@ export interface OnHandlerInterface<
     S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
     BasePath
   >
+
+  // app.on(method | method[], path[], ...handlers[])
+  <I extends Input = {}, R extends HandlerResponse<any> = any>(
+    methods: string | string[],
+    paths: string[],
+    ...handlers: H<E, any, I, R>[]
+  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponseData<R>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -100,13 +100,15 @@ class Hono<
     })
 
     // Implementation of app.on(method, path, ...handlers[])
-    this.on = (method: string | string[], path: string, ...handlers: H[]) => {
+    this.on = (method: string | string[], path: string | string[], ...handlers: H[]) => {
       if (!method) return this
-      this.#path = path
-      for (const m of [method].flat()) {
-        handlers.map((handler) => {
-          this.addRoute(m.toUpperCase(), this.#path, handler)
-        })
+      for (const p of [path].flat()) {
+        this.#path = p
+        for (const m of [method].flat()) {
+          handlers.map((handler) => {
+            this.addRoute(m.toUpperCase(), this.#path, handler)
+          })
+        }
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return this as any

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1653,6 +1653,30 @@ describe('Multiple methods with `app.on`', () => {
   })
 })
 
+describe('Multiple paths with one handler', () => {
+  const app = new Hono()
+
+  const paths = ['/hello', '/ja/hello', '/en/hello']
+  app.on('GET', paths, (c) => {
+    return c.json({
+      path: c.req.path,
+      routePath: c.req.routePath,
+    })
+  })
+
+  it('Should handle multiple paths', async () => {
+    paths.map(async (path) => {
+      const res = await app.request(path)
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data).toEqual({
+        path,
+        routePath: path,
+      })
+    })
+  })
+})
+
 describe('Multiple handler', () => {
   describe('handler + handler', () => {
     const app = new Hono()
@@ -1692,7 +1716,6 @@ describe('Multiple handler', () => {
         expect(res.ok).toBe(true)
         expect(await res.text()).toBe('type: car, url: good-car')
       })
-
       it('Should return a correct param - GET /foo/food/good-food', async () => {
         const res = await app.request('/foo/food/good-food')
         expect(res.ok).toBe(true)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1407,6 +1407,13 @@ export interface OnHandlerInterface<
     S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
     BasePath
   >
+
+  // app.on(method | method[], path[], ...handlers[])
+  <I extends Input = {}, R extends HandlerResponse<any> = any>(
+    methods: string | string[],
+    paths: string[],
+    ...handlers: H<E, any, I, R>[]
+  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponseData<R>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>


### PR DESCRIPTION
Fixes #1901

This PR enables `app.on` to handle multiple paths.

Usage:

```ts
app.on('GET', ['/hello', '/ja/hello', '/en/hello'], (c) => {
  return c.text('Hello!')
})
```

It does not support multiple paths with `app.get()`, etc.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
