### PR TITLE
fix(client): Fix issue awaiting RPC client

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -12,6 +12,10 @@ const createProxy = (callback: Callback, path: string[]) => {
       return createProxy(callback, [...path, key])
     },
     apply(_1, _2, args) {
+      if (path.length === 1 && path[0] === "then") 
+        return Promise.resolve(this).then(...args)
+      
+
       return callback({
         path,
         args,

--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -8,14 +8,10 @@ import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './util
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
     get(_obj, key) {
-      if (typeof key !== 'string') return undefined
+      if (typeof key !== 'string' || key === 'then') return undefined
       return createProxy(callback, [...path, key])
     },
     apply(_1, _2, args) {
-      if (path.length === 1 && path[0] === "then") 
-        return Promise.resolve(this).then(...args)
-      
-
       return callback({
         path,
         args,

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -625,3 +625,13 @@ describe('$url() with a param option', () => {
     expect(url.pathname).toBe('/posts/:id/comments')
   })
 })
+
+describe('Client can be awaited', () => {
+  it('Can be awaited without side effects', async () => {
+    const client = hc('http://localhost')
+
+    const awaited = await client
+
+    expect(awaited).toEqual(client)
+  })
+})

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -12,6 +12,10 @@ const createProxy = (callback: Callback, path: string[]) => {
       return createProxy(callback, [...path, key])
     },
     apply(_1, _2, args) {
+      if (path.length === 1 && path[0] === "then") 
+        return Promise.resolve(this).then(...args)
+      
+
       return callback({
         path,
         args,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -8,14 +8,10 @@ import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './util
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
     get(_obj, key) {
-      if (typeof key !== 'string') return undefined
+      if (typeof key !== 'string' || key === 'then') return undefined
       return createProxy(callback, [...path, key])
     },
     apply(_1, _2, args) {
-      if (path.length === 1 && path[0] === "then") 
-        return Promise.resolve(this).then(...args)
-      
-
       return callback({
         path,
         args,


### PR DESCRIPTION
Right now if you await the RPC client, it produces undefined behavior and can hang the application. This also occurs if the client is returned from an async function that is then awaited. This adds a quick fix to detect that edge case, and handle it properly.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
