### PR TITLE
feat(css): Introduce pseudo global selector and class name based extend syntax

### DIFF
--- a/deno_dist/helper/css/index.ts
+++ b/deno_dist/helper/css/index.ts
@@ -178,7 +178,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
     const thisSelector =
       (isPseudoGlobal ? PSEUDO_GLOBAL_SELECTOR : '') + toHash(label + thisStyleString)
     const className = new String(
-      isPseudoGlobal ? '' : [thisSelector, ...externalClassNames].join(' ')
+      (isPseudoGlobal ? selectors.map(String) : [thisSelector, ...externalClassNames]).join(' ')
     ) as CssClassName
 
     const appendStyle: HtmlEscapedCallback = ({ buffer, context }): Promise<string> | undefined => {
@@ -288,7 +288,12 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
     return className
   }
 
-  const Style = () => raw(`<style id="${id}"></style>`)
+  const Style = ({ children }: { children?: Promise<string> } = {}) =>
+    children
+      ? children.then((cssData) =>
+          raw(`<style id="${id}">${(cssData as CssClassName)[STYLE_STRING]}</style>`)
+        )
+      : raw(`<style id="${id}"></style>`)
 
   return {
     css,

--- a/src/helper/css/index.test.tsx
+++ b/src/helper/css/index.test.tsx
@@ -246,6 +246,30 @@ describe('CSS Helper', () => {
     })
 
     it('Should be inserted to global if style string starts with :-hono-root', async () => {
+      const globalClass = css`
+        :-hono-global {
+          html {
+            color: red;
+          }
+          body {
+            display: flex;
+          }
+        }
+      `
+      const template = (
+        <>
+          <Style />
+          <div class={globalClass}>
+            <h1>Hello!</h1>
+          </div>
+        </>
+      )
+      expect(await toString(template)).toBe(
+        '<style id="hono-css">html{color:red}body{display:flex}</style><div class=""><h1>Hello!</h1></div>'
+      )
+    })
+
+    it('Should be inserted to global if style string starts with :-hono-root and extends class name', async () => {
       const headerClass = css`
         display: flex;
       `
@@ -267,7 +291,57 @@ describe('CSS Helper', () => {
         </>
       )
       expect(await toString(template)).toBe(
-        '<style id="hono-css">.css-3980466870{h1{color:red}}.css-3980466870{display:flex}</style><div class=""><h1>Hello!</h1></div>'
+        '<style id="hono-css">.css-3980466870{h1{color:red}}.css-3980466870{display:flex}</style><div class="css-3980466870"><h1>Hello!</h1></div>'
+      )
+    })
+
+    it('Should be inserted as global css if passed css`` to Style component', async () => {
+      const headerClass = css`
+        font-size: 1rem;
+      `
+      const template = (
+        <>
+          <Style>{css`
+            html {
+              color: red;
+            }
+            body {
+              display: flex;
+            }
+          `}</Style>
+          <div>
+            <h1 class={headerClass}>Hello!</h1>
+          </div>
+        </>
+      )
+      expect(await toString(template)).toBe(
+        '<style id="hono-css">html{color:red}body{display:flex}.css-1740067317{font-size:1rem}</style><div><h1 class="css-1740067317">Hello!</h1></div>'
+      )
+    })
+
+    it('Should be ignored :-hono-root inside Style component', async () => {
+      const headerClass = css`
+        font-size: 1rem;
+      `
+      const template = (
+        <>
+          <Style>{css`
+            :-hono-global {
+              html {
+                color: red;
+              }
+              body {
+                display: flex;
+              }
+            }
+          `}</Style>
+          <div>
+            <h1 class={headerClass}>Hello!</h1>
+          </div>
+        </>
+      )
+      expect(await toString(template)).toBe(
+        '<style id="hono-css">html{color:red}body{display:flex}.css-1740067317{font-size:1rem}</style><div><h1 class="css-1740067317">Hello!</h1></div>'
       )
     })
 

--- a/src/helper/css/index.test.tsx
+++ b/src/helper/css/index.test.tsx
@@ -221,6 +221,56 @@ describe('CSS Helper', () => {
       )
     })
 
+    it('Should be used as a class name for syntax `${className} {`', async () => {
+      const headerClass = css`
+        font-weight: bold;
+      `
+      const containerClass = css`
+        ${headerClass} {
+          h1 {
+            color: red;
+          }
+        }
+      `
+      const template = (
+        <>
+          <Style />
+          <div class={containerClass}>
+            <h1 class={headerClass}>Hello!</h1>
+          </div>
+        </>
+      )
+      expect(await toString(template)).toBe(
+        '<style id="hono-css">.css-4220297002{.css-1032195302{h1{color:red}}}.css-1032195302{font-weight:bold}</style><div class="css-4220297002"><h1 class="css-1032195302">Hello!</h1></div>'
+      )
+    })
+
+    it('Should be inserted to global if style string starts with :-hono-root`', async () => {
+      const headerClass = css`
+        display: flex;
+      `
+      const specialHeaderClass = css`
+        :-hono-global {
+          ${headerClass} {
+            h1 {
+              color: red;
+            }
+          }
+        }
+      `
+      const template = (
+        <>
+          <Style />
+          <div class={specialHeaderClass}>
+            <h1>Hello!</h1>
+          </div>
+        </>
+      )
+      expect(await toString(template)).toBe(
+        '<style id="hono-css">.css-3980466870{h1{color:red}}.css-3980466870{display:flex}</style><div class=""><h1>Hello!</h1></div>'
+      )
+    })
+
     describe('Booleans, Null, and Undefined Are Ignored', () => {
       it.each([true, false, undefined, null])('%s', async (value) => {
         const headerClass = css`

--- a/src/helper/css/index.test.tsx
+++ b/src/helper/css/index.test.tsx
@@ -245,7 +245,7 @@ describe('CSS Helper', () => {
       )
     })
 
-    it('Should be inserted to global if style string starts with :-hono-root`', async () => {
+    it('Should be inserted to global if style string starts with :-hono-root', async () => {
       const headerClass = css`
         display: flex;
       `
@@ -268,6 +268,27 @@ describe('CSS Helper', () => {
       )
       expect(await toString(template)).toBe(
         '<style id="hono-css">.css-3980466870{h1{color:red}}.css-3980466870{display:flex}</style><div class=""><h1>Hello!</h1></div>'
+      )
+    })
+
+    it('Should be generated deferent class name for deferent first line comment even if the content is the same', async () => {
+      const headerClassA = css`
+        /* class A */
+        display: flex;
+      `
+      const headerClassB = css`
+        /* class B */
+        display: flex;
+      `
+      const template = (
+        <>
+          <Style />
+          <h1 class={headerClassA}>Hello!</h1>
+          <h1 class={headerClassB}>Hello!</h1>
+        </>
+      )
+      expect(await toString(template)).toBe(
+        '<style id="hono-css">.css-3170754153{display:flex}.css-896513246{display:flex}</style><h1 class="css-3170754153">Hello!</h1><h1 class="css-896513246">Hello!</h1>'
       )
     })
 

--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -178,7 +178,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
     const thisSelector =
       (isPseudoGlobal ? PSEUDO_GLOBAL_SELECTOR : '') + toHash(label + thisStyleString)
     const className = new String(
-      isPseudoGlobal ? '' : [thisSelector, ...externalClassNames].join(' ')
+      (isPseudoGlobal ? selectors.map(String) : [thisSelector, ...externalClassNames]).join(' ')
     ) as CssClassName
 
     const appendStyle: HtmlEscapedCallback = ({ buffer, context }): Promise<string> | undefined => {
@@ -288,7 +288,12 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
     return className
   }
 
-  const Style = () => raw(`<style id="${id}"></style>`)
+  const Style = ({ children }: { children?: Promise<string> } = {}) =>
+    children
+      ? children.then((cssData) =>
+          raw(`<style id="${id}">${(cssData as CssClassName)[STYLE_STRING]}</style>`)
+        )
+      : raw(`<style id="${id}"></style>`)
 
   return {
     css,


### PR DESCRIPTION
### Global selector

If you wrap the whole thing (not just part of it) in a pseudo-selector called `:-hono-global`. The output of the  `css` is not wrapped in the generated class name, but is interpreted as a top-level specification.

```ts
css`
:-hono-global {
  body {
    font-size: 10px;
  }
}
`
```

### Class name based extend syntax

You can extend it by embedding the class name by writing it in the following syntax `${baseClass} {`

```ts
const baseClass = css`display: flex`
const extendedByContent = css`
  ${baseClass}
  flex-direction: column;
` // This is already possible
const extendedByClassName = css`
  ${baseClass} {
    flex-direction: column;
    p {
      color: red;
    }
  }
` // This is made possible by this PR
```


### Use both "Global selector" and "Class name based extend syntax"

The following can be written to place the media query at the top level so that it can be interpreted by older browsers that do not support nesting.

```ts
const baseClass = css`display: flex`
const globalClass = css`
:-hono-global {
  @media (min-width: 768px) {
    ${baseClass} {
      flex-direction: column;
    }
  }
}
`
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
