### PR TITLE
fix(netlify): change path in `deno_dist/adapter/netlify`

### DIFF
--- a/deno_dist/adapter/netlify/handler.ts
+++ b/deno_dist/adapter/netlify/handler.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import type { Context } from 'https://edge.netlify.com/'
-import type { Hono } from '../../index.ts'
+import type { Hono } from '../../hono.ts'
 
 export type Env = {
   Bindings: {

--- a/src/adapter/netlify/handler.ts
+++ b/src/adapter/netlify/handler.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import type { Context } from 'https://edge.netlify.com/'
-import type { Hono } from '../../'
+import type { Hono } from '../../hono'
 
 export type Env = {
   Bindings: {


### PR DESCRIPTION
### Purpose

There is an issue when using the Netlify Adapter via `deno.land/x`. https://github.com/honojs/hono/blob/8de60599aafca908b6214f047571415c6e17f8ea/deno_dist/adapter/netlify/handler.ts#L4 This line references `../../index.ts` but that doesn't exist in the root of `deno_dist/` so we much use `../../hono.ts` or `../../mod.ts`. Please let me know what you prefer. Thank you!

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno


Photo of error:
<img width="661" alt="image" src="https://github.com/honojs/hono/assets/33156025/2f79af52-362d-49a3-9960-2e874c2eb409">

