### PR TITLE
Fix/response for lambda@edge adapter

### DIFF
--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -1130,6 +1130,6 @@ describe('Lambda@Edge Adapter for Hono', () => {
     const response = await handler(event)
 
     expect(response.body).toBe('RmFrZSBJbWFnZQ==') // base64 encoded "Fake Image"
-    expect(response.bodyEncoding).toBe('base64') 
+    expect(response.bodyEncoding).toBe('base64')
   })
 })

--- a/runtime_tests/lambda-edge/index.test.ts
+++ b/runtime_tests/lambda-edge/index.test.ts
@@ -1096,4 +1096,40 @@ describe('Lambda@Edge Adapter for Hono', () => {
 
     expect(called).toBe(true)
   })
+
+  it('Should return a response where bodyEncoding is "base64" with binary', async () => {
+    const event = {
+      Records: [
+        {
+          cf: {
+            config: {
+              distributionDomainName: 'example.com',
+              distributionId: 'EXAMPLE123',
+              eventType: 'viewer-request',
+              requestId: 'exampleRequestId',
+            },
+            request: {
+              clientIp: '123.123.123.123',
+              headers: {
+                host: [
+                  {
+                    key: 'Host',
+                    value: 'example.com',
+                  },
+                ],
+              },
+              method: 'GET',
+              querystring: '',
+              uri: '/binary',
+            },
+          },
+        },
+      ],
+    }
+
+    const response = await handler(event)
+
+    expect(response.body).toBe('RmFrZSBJbWFnZQ==') // base64 encoded "Fake Image"
+    expect(response.bodyEncoding).toBe('base64') 
+  })
 })

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -131,6 +131,7 @@ const createResult = async (res: Response): Promise<CloudFrontResult> => {
     status: res.status.toString(),
     headers: convertHeaders(res.headers),
     body,
+    ...(isBase64Encoded ? { bodyEncoding: 'base64' } : { }),
   }
 }
 

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -131,7 +131,7 @@ const createResult = async (res: Response): Promise<CloudFrontResult> => {
     status: res.status.toString(),
     headers: convertHeaders(res.headers),
     body,
-    ...(isBase64Encoded ? { bodyEncoding: 'base64' } : { }),
+    ...(isBase64Encoded ? { bodyEncoding: 'base64' } : {}),
   }
 }
 


### PR DESCRIPTION
In the current implementation, when lambda@Edge is launched with a CloudFront origin request, CloudFront returns an error when processing binary data.

Probably because the body is base64 but there is no bodyEncoding property.

When returning a base64 body, the bodyEncoding property should now include base64.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
