### PR TITLE
fix(routers): RegExpRouter and LinearRouter support multiple optional params

### DIFF
--- a/deno_dist/router/linear-router/router.ts
+++ b/deno_dist/router/linear-router/router.ts
@@ -1,5 +1,6 @@
 import type { Router, Result, Params } from '../../router.ts'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router.ts'
+import { checkOptionalParameter } from '../../utils/url.ts'
 
 type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] }
 
@@ -12,13 +13,9 @@ export class LinearRouter<T> implements Router<T> {
   routes: [string, string, T][] = []
 
   add(method: string, path: string, handler: T) {
-    if (path.charCodeAt(path.length - 1) === 63) {
-      // /path/to/:label? means /path/to/:label or /path/to
-      this.routes.push([method, path.slice(0, -1), handler])
-      this.routes.push([method, path.replace(/\/[^/]+$/, ''), handler])
-    } else {
-      this.routes.push([method, path, handler])
-    }
+    ;(checkOptionalParameter(path) || [path]).forEach((p) => {
+      this.routes.push([method, p, handler])
+    })
   }
 
   match(method: string, path: string): Result<T> {

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -198,10 +198,7 @@ export class RegExpRouter<T> implements Router<T> {
               findMiddleware(middleware[METHOD_NAME_ALL], path) ||
               []),
           ]
-          routes[m][path].push([
-            handler,
-            paths.length === 2 && i === 0 ? paramCount - 1 : paramCount,
-          ])
+          routes[m][path].push([handler, paramCount - len + i + 1])
         }
       })
     }

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -172,6 +172,28 @@ describe('Optional route', () => {
     expect(res[0][0]).toEqual('animals')
     expect(res[0][1]['type']).toBeUndefined()
   })
+  router.add('GET', '/v1/:version?/:platform?', 'result')
+  it('GET /v1/123/abc', () => {
+    const [res] = router.match('GET', '/v1/123/abc')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBe('123')
+    expect(res[0][1]['platform']).toBe('abc')
+  })
+  it('GET /v1/123', () => {
+    const [res] = router.match('GET', '/v1/123')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBe('123')
+    expect(res[0][1]['platform']).toBeUndefined()
+  })
+  it('GET /v1', () => {
+    const [res] = router.match('GET', '/v1')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBeUndefined()
+    expect(res[0][1]['platform']).toBeUndefined()
+  })
 })
 
 describe('Trailing slash', () => {

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -1,5 +1,6 @@
 import type { Router, Result, Params } from '../../router'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
+import { checkOptionalParameter } from '../../utils/url'
 
 type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number][] }
 
@@ -12,13 +13,9 @@ export class LinearRouter<T> implements Router<T> {
   routes: [string, string, T][] = []
 
   add(method: string, path: string, handler: T) {
-    if (path.charCodeAt(path.length - 1) === 63) {
-      // /path/to/:label? means /path/to/:label or /path/to
-      this.routes.push([method, path.slice(0, -1), handler])
-      this.routes.push([method, path.replace(/\/[^/]+$/, ''), handler])
-    } else {
-      this.routes.push([method, path, handler])
-    }
+    ;(checkOptionalParameter(path) || [path]).forEach((p) => {
+      this.routes.push([method, p, handler])
+    })
   }
 
   match(method: string, path: string): Result<T> {

--- a/src/router/pattern-router/router.test.ts
+++ b/src/router/pattern-router/router.test.ts
@@ -171,6 +171,28 @@ describe('Optional route', () => {
     expect(res[0][0]).toEqual('animals')
     expect(res[0][1]['type']).toBeUndefined()
   })
+  router.add('GET', '/v1/:version?/:platform?', 'result')
+  it('GET /v1/123/abc', () => {
+    const [res] = router.match('GET', '/v1/123/abc')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBe('123')
+    expect(res[0][1]['platform']).toBe('abc')
+  })
+  it('GET /v1/123', () => {
+    const [res] = router.match('GET', '/v1/123')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBe('123')
+    expect(res[0][1]['platform']).toBeUndefined()
+  })
+  it('GET /v1', () => {
+    const [res] = router.match('GET', '/v1')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBeUndefined()
+    expect(res[0][1]['platform']).toBeUndefined()
+  })
 })
 
 describe('routing order with named parameters', () => {

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -344,6 +344,28 @@ describe('Optional route', () => {
     expect(res[0][0]).toEqual('animals')
     expect(stash?.[res[0][1]['type'] as number]).toBeUndefined()
   })
+  router.add('GET', '/v1/:version?/:platform?', 'result')
+  it('GET /v1/123/abc', () => {
+    const [res, stash] = router.match('GET', '/v1/123/abc')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(stash?.[res[0][1]['version'] as number]).toBe('123')
+    expect(stash?.[res[0][1]['platform'] as number]).toBe('abc')
+  })
+  it('GET /v1/123', () => {
+    const [res, stash] = router.match('GET', '/v1/123')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(stash?.[res[0][1]['version'] as number]).toBe('123')
+    expect(stash?.[res[0][1]['platform'] as number]).toBeUndefined()
+  })
+  it('GET /v1', () => {
+    const [res, stash] = router.match('GET', '/v1')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(stash?.[res[0][1]['version'] as number]).toBeUndefined()
+    expect(stash?.[res[0][1]['platform'] as number]).toBeUndefined()
+  })
 })
 
 describe('All', () => {

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -198,10 +198,7 @@ export class RegExpRouter<T> implements Router<T> {
               findMiddleware(middleware[METHOD_NAME_ALL], path) ||
               []),
           ]
-          routes[m][path].push([
-            handler,
-            paths.length === 2 && i === 0 ? paramCount - 1 : paramCount,
-          ])
+          routes[m][path].push([handler, paths.length > 1 ? i : paramCount])
         }
       })
     }

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -198,7 +198,7 @@ export class RegExpRouter<T> implements Router<T> {
               findMiddleware(middleware[METHOD_NAME_ALL], path) ||
               []),
           ]
-          routes[m][path].push([handler, paths.length > 1 ? i : paramCount])
+          routes[m][path].push([handler, paramCount - len + i + 1])
         }
       })
     }

--- a/src/router/trie-router/router.test.ts
+++ b/src/router/trie-router/router.test.ts
@@ -172,6 +172,28 @@ describe('Optional route', () => {
     expect(res[0][0]).toEqual('animals')
     expect(res[0][1]['type']).toBeUndefined()
   })
+  router.add('GET', '/v1/:version?/:platform?', 'result')
+  it('GET /v1/123/abc', () => {
+    const [res] = router.match('GET', '/v1/123/abc')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBe('123')
+    expect(res[0][1]['platform']).toBe('abc')
+  })
+  it('GET /v1/123', () => {
+    const [res] = router.match('GET', '/v1/123')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBe('123')
+    expect(res[0][1]['platform']).toBeUndefined()
+  })
+  it('GET /v1', () => {
+    const [res] = router.match('GET', '/v1')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('result')
+    expect(res[0][1]['version']).toBeUndefined()
+    expect(res[0][1]['platform']).toBeUndefined()
+  })
 })
 
 describe('routing order with named parameters', () => {


### PR DESCRIPTION
Fixes #1925

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
