### PR TITLE
refactor(ssg): SSG works without `node:path`

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -2,38 +2,7 @@ import { Buffer } from "node:buffer";
 import { inspectRoutes } from '../../helper/dev/index.ts'
 import type { Hono } from '../../hono.ts'
 import type { Env, Schema } from '../../types.ts'
-
-export const dirname = (path: string) => {
-  const splitedPath = path.split(/[\/\\]/)
-
-  return splitedPath.slice(0, -1).join('/') // Windows supports slash path
-}
-export const joinPaths = (...paths: string[]) => {
-  const nomalizedPaths: string[] = []
-  for (const path of paths) {
-    const nomalizedPath = path.replace(/(\\)/g, '/').replace(/\/$/g, '')
-    nomalizedPaths.push(nomalizedPath)
-  }
-  const resultPaths: string[] = []
-  for (let path of nomalizedPaths.join('/').split('/')) {
-    // Handle `..` or `../`
-    if (path === '..') {
-      if (resultPaths.length === 0) {
-        resultPaths.push('..')
-      } else {
-        resultPaths.pop()
-      }
-      continue
-    } else {
-      // Handle `.` or `./`
-      path = path.replace(/^\./g, '')
-    }
-    if (path !== ''){
-      resultPaths.push(path)
-    }
-  }
-  return resultPaths.join('/')
-}
+import { joinPaths, dirname } from './utils.ts'
 
 export interface FileSystemModule {
   writeFile(path: string, data: string | Buffer): Promise<void>

--- a/deno_dist/helper/ssg/utils.ts
+++ b/deno_dist/helper/ssg/utils.ts
@@ -30,5 +30,5 @@ export const joinPaths = (...paths: string[]) => {
       resultPaths.push(path)
     }
   }
-  return resultPaths.join('/')
+  return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
 }

--- a/deno_dist/helper/ssg/utils.ts
+++ b/deno_dist/helper/ssg/utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Get dirname
+ * @param path File Path
+ * @returns Parent dir path
+ */
+export const dirname = (path: string) => {
+  const splitedPath = path.split(/[\/\\]/)
+  return splitedPath.slice(0, -1).join('/') // Windows supports slash path
+}
+
+export const joinPaths = (...paths: string[]) => {
+  paths = paths.map((path) => {
+    return path.replace(/(\\)/g, '/').replace(/\/$/g, '')
+  })
+  const resultPaths: string[] = []
+  for (let path of paths.join('/').split('/')) {
+    // Handle `..` or `../`
+    if (path === '..') {
+      if (resultPaths.length === 0) {
+        resultPaths.push('..')
+      } else {
+        resultPaths.pop()
+      }
+      continue
+    } else {
+      // Handle `.` or `./`
+      path = path.replace(/^\./g, '')
+    }
+    if (path !== '') {
+      resultPaths.push(path)
+    }
+  }
+  return resultPaths.join('/')
+}

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { Hono } from '../../hono'
 import { jsx } from '../../jsx'
-import { dirname, generateHtmlMap, joinPaths, saveHtmlToLocal, toSSG } from './index'
+import { generateHtmlMap, saveHtmlToLocal, toSSG } from './index'
 import type { FileSystemModule } from './index'
 
 describe('toSSG function', () => {
@@ -151,18 +151,5 @@ describe('toSSG function', () => {
     expect(result.success).toBe(false)
     expect(result.error).toBeDefined()
     expect(result.files).toBeUndefined()
-  })
-})
-
-describe('Path utils', () => {
-  it('Should joined path is valid.', () => {
-    expect(joinPaths('test', 'test2')).toBe('test/test2')
-    expect(joinPaths('test', 'test2', '../test3')).toBe('test/test3')
-    expect(joinPaths('.', '../')).toBe('..')
-    expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')
-  })
-  it('Should dirname is valid.', () => {
-    expect(dirname('parent/child')).toBe('parent')
-    expect(dirname('windows\\test.txt')).toBe('windows')
   })
 })

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { Hono } from '../../hono'
 import { jsx } from '../../jsx'
-import { generateHtmlMap, saveHtmlToLocal, toSSG } from './index'
+import { dirname, generateHtmlMap, joinPaths, saveHtmlToLocal, toSSG } from './index'
 import type { FileSystemModule } from './index'
 
 describe('toSSG function', () => {
@@ -151,5 +151,18 @@ describe('toSSG function', () => {
     expect(result.success).toBe(false)
     expect(result.error).toBeDefined()
     expect(result.files).toBeUndefined()
+  })
+})
+
+describe('Path utils', () => {
+  it('Should joined path is valid.', () => {
+    expect(joinPaths('test', 'test2')).toBe('test/test2')
+    expect(joinPaths('test', 'test2', '../test3')).toBe('test/test3')
+    expect(joinPaths('.', '../')).toBe('..')
+    expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')
+  })
+  it('Should dirname is valid.', () => {
+    expect(dirname('parent/child')).toBe('parent')
+    expect(dirname('windows\\test.txt')).toBe('windows')
   })
 })

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -1,38 +1,7 @@
 import { inspectRoutes } from '../../helper/dev'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
-
-export const dirname = (path: string) => {
-  const splitedPath = path.split(/[\/\\]/)
-
-  return splitedPath.slice(0, -1).join('/') // Windows supports slash path
-}
-export const joinPaths = (...paths: string[]) => {
-  const nomalizedPaths: string[] = []
-  for (const path of paths) {
-    const nomalizedPath = path.replace(/(\\)/g, '/').replace(/\/$/g, '')
-    nomalizedPaths.push(nomalizedPath)
-  }
-  const resultPaths: string[] = []
-  for (let path of nomalizedPaths.join('/').split('/')) {
-    // Handle `..` or `../`
-    if (path === '..') {
-      if (resultPaths.length === 0) {
-        resultPaths.push('..')
-      } else {
-        resultPaths.pop()
-      }
-      continue
-    } else {
-      // Handle `.` or `./`
-      path = path.replace(/^\./g, '')
-    }
-    if (path !== '') {
-      resultPaths.push(path)
-    }
-  }
-  return resultPaths.join('/')
-}
+import { joinPaths, dirname } from './utils'
 
 export interface FileSystemModule {
   writeFile(path: string, data: string | Buffer): Promise<void>

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -1,7 +1,38 @@
-import * as path from 'path'
 import { inspectRoutes } from '../../helper/dev'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
+
+export const dirname = (path: string) => {
+  const splitedPath = path.split(/[\/\\]/)
+
+  return splitedPath.slice(0, -1).join('/') // Windows supports slash path
+}
+export const joinPaths = (...paths: string[]) => {
+  const nomalizedPaths: string[] = []
+  for (const path of paths) {
+    const nomalizedPath = path.replace(/(\\)/g, '/').replace(/\/$/g, '')
+    nomalizedPaths.push(nomalizedPath)
+  }
+  const resultPaths: string[] = []
+  for (let path of nomalizedPaths.join('/').split('/')) {
+    // Handle `..` or `../`
+    if (path === '..') {
+      if (resultPaths.length === 0) {
+        resultPaths.push('..')
+      } else {
+        resultPaths.pop()
+      }
+      continue
+    } else {
+      // Handle `.` or `./`
+      path = path.replace(/^\./g, '')
+    }
+    if (path !== ''){
+      resultPaths.push(path)
+    }
+  }
+  return resultPaths.join('/')
+}
 
 export interface FileSystemModule {
   writeFile(path: string, data: string | Buffer): Promise<void>
@@ -16,7 +47,7 @@ export interface ToSSGResult {
 
 const generateFilePath = (routePath: string, outDir: string) => {
   const fileName = routePath === '/' ? 'index.html' : routePath + '.html'
-  return path.join(outDir, fileName)
+  return joinPaths(outDir, fileName)
 }
 
 export const generateHtmlMap = async <
@@ -51,7 +82,7 @@ export const saveHtmlToLocal = async (
 
   for (const [routePath, html] of htmlMap) {
     const filePath = generateFilePath(routePath, outDir)
-    const dirPath = path.dirname(filePath)
+    const dirPath = dirname(filePath)
 
     await fsModule.mkdir(dirPath, { recursive: true })
     await fsModule.writeFile(filePath, html)

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -27,7 +27,7 @@ export const joinPaths = (...paths: string[]) => {
       // Handle `.` or `./`
       path = path.replace(/^\./g, '')
     }
-    if (path !== ''){
+    if (path !== '') {
       resultPaths.push(path)
     }
   }

--- a/src/helper/ssg/utils.test.ts
+++ b/src/helper/ssg/utils.test.ts
@@ -11,7 +11,6 @@ describe('joinPath', () => {
     expect(joinPaths('', 'test')).toBe('test') // empty path
     expect(joinPaths('/test', '/test2')).toBe('test/test2') // root path
     expect(joinPaths('../', 'test')).toBe('../test') // parent and single
-    console.log(joinPaths('/test', '/test2'))
   })
   it('Should windows path is valid.', () => {
     expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')

--- a/src/helper/ssg/utils.test.ts
+++ b/src/helper/ssg/utils.test.ts
@@ -9,7 +9,7 @@ describe('joinPath', () => {
     expect(joinPaths('test/', 'test2/')).toBe('test/test2') // trailing slashes
     expect(joinPaths('./test', './test2')).toBe('test/test2') // dot and slash
     expect(joinPaths('', 'test')).toBe('test') // empty path
-    expect(joinPaths('/test', '/test2')).toBe('test/test2') // root path
+    expect(joinPaths('/test', '/test2')).toBe('/test/test2') // root path
     expect(joinPaths('../', 'test')).toBe('../test') // parent and single
   })
   it('Should windows path is valid.', () => {

--- a/src/helper/ssg/utils.test.ts
+++ b/src/helper/ssg/utils.test.ts
@@ -6,6 +6,12 @@ describe('joinPath', () => {
     expect(joinPaths('test', 'test2')).toBe('test/test2')
     expect(joinPaths('test', 'test2', '../test3')).toBe('test/test3')
     expect(joinPaths('.', '../')).toBe('..')
+    expect(joinPaths('test/', 'test2/')).toBe('test/test2') // trailing slashes
+    expect(joinPaths('./test', './test2')).toBe('test/test2') // dot and slash
+    expect(joinPaths('', 'test')).toBe('test') // empty path
+    expect(joinPaths('/test', '/test2')).toBe('test/test2') // root path
+    expect(joinPaths('../', 'test')).toBe('../test') // parent and single
+    console.log(joinPaths('/test', '/test2'))
   })
   it('Should windows path is valid.', () => {
     expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')

--- a/src/helper/ssg/utils.test.ts
+++ b/src/helper/ssg/utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { joinPaths, dirname } from './utils'
+
+describe('joinPath', () => {
+  it('Should joined path is valid.', () => {
+    expect(joinPaths('test', 'test2')).toBe('test/test2')
+    expect(joinPaths('test', 'test2', '../test3')).toBe('test/test3')
+    expect(joinPaths('.', '../')).toBe('..')
+  })
+  it('Should windows path is valid.', () => {
+    expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')
+  })
+})
+describe('dirname', () => {
+  it('Should dirname is valid.', () => {
+    expect(dirname('parent/child')).toBe('parent')
+    expect(dirname('windows\\test.txt')).toBe('windows')
+  })
+})

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Get dirname
+ * @param path File Path
+ * @returns Parent dir path
+ */
+export const dirname = (path: string) => {
+  const splitedPath = path.split(/[\/\\]/)
+  return splitedPath.slice(0, -1).join('/') // Windows supports slash path
+}
+
+export const joinPaths = (...paths: string[]) => {
+  paths = paths.map(path => {
+    return path.replace(/(\\)/g, '/').replace(/\/$/g, '')
+  })
+  const resultPaths: string[] = []
+  for (let path of paths.join('/').split('/')) {
+    // Handle `..` or `../`
+    if (path === '..') {
+      if (resultPaths.length === 0) {
+        resultPaths.push('..')
+      } else {
+        resultPaths.pop()
+      }
+      continue
+    } else {
+      // Handle `.` or `./`
+      path = path.replace(/^\./g, '')
+    }
+    if (path !== '') {
+      resultPaths.push(path)
+    }
+  }
+  return resultPaths.join('/')
+}
+

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -30,5 +30,5 @@ export const joinPaths = (...paths: string[]) => {
       resultPaths.push(path)
     }
   }
-  return resultPaths.join('/')
+  return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
 }

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -9,7 +9,7 @@ export const dirname = (path: string) => {
 }
 
 export const joinPaths = (...paths: string[]) => {
-  paths = paths.map(path => {
+  paths = paths.map((path) => {
     return path.replace(/(\\)/g, '/').replace(/\/$/g, '')
   })
   const resultPaths: string[] = []
@@ -32,4 +32,3 @@ export const joinPaths = (...paths: string[]) => {
   }
   return resultPaths.join('/')
 }
-


### PR DESCRIPTION
You can close #1964 If you merge this PR.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
