### PR TITLE
feat(factory): remove `deprecated` from `Factory` and `createHandlers`

### DIFF
--- a/deno_dist/helper/factory/index.ts
+++ b/deno_dist/helper/factory/index.ts
@@ -1,38 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Env, Input, MiddlewareHandler, H, HandlerResponse } from '../../types.ts'
 
-/**
- * @experimental
- * `Factory` class is an experimental feature.
- * The API might be changed.
- */
 export class Factory<E extends Env = any, P extends string = any> {
   createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
 
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<I extends Input = {}>(handler1: H<E, P, I>): [H<E, P, I>]
 
   // handler x2
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<I extends Input = {}, I2 extends Input = I, R extends HandlerResponse<any> = any>(
     handler1: H<E, P, I, R>,
     handler2: H<E, P, I2, R>
   ): [H<E, P, I, R>, H<E, P, I2, R>]
 
   // handler x3
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -45,11 +25,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
 
   // handler x4
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -64,11 +39,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
 
   // handler x5
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -85,11 +55,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
 
   // handler x6
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -108,11 +73,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>, H<E, P, I6, R>]
 
   // handler x7
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -141,11 +101,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ]
 
   // handler x8
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -177,11 +132,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ]
 
   // handler x9
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -216,11 +166,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ]
 
   // handler x10
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -262,11 +207,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   }
 }
 
-/**
- * @experimental
- * `createFactory` is an experimental feature.
- * The API might be changed.
- */
 export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
 
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -1,38 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Env, Input, MiddlewareHandler, H, HandlerResponse } from '../../types'
 
-/**
- * @experimental
- * `Factory` class is an experimental feature.
- * The API might be changed.
- */
 export class Factory<E extends Env = any, P extends string = any> {
   createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
 
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<I extends Input = {}>(handler1: H<E, P, I>): [H<E, P, I>]
 
   // handler x2
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<I extends Input = {}, I2 extends Input = I, R extends HandlerResponse<any> = any>(
     handler1: H<E, P, I, R>,
     handler2: H<E, P, I2, R>
   ): [H<E, P, I, R>, H<E, P, I2, R>]
 
   // handler x3
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -45,11 +25,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>]
 
   // handler x4
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -64,11 +39,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>]
 
   // handler x5
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -85,11 +55,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>]
 
   // handler x6
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -108,11 +73,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ): [H<E, P, I, R>, H<E, P, I2, R>, H<E, P, I3, R>, H<E, P, I4, R>, H<E, P, I5, R>, H<E, P, I6, R>]
 
   // handler x7
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -141,11 +101,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ]
 
   // handler x8
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -177,11 +132,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ]
 
   // handler x9
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -216,11 +166,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   ]
 
   // handler x10
-  /**
-   * @experimental
-   * `createHandlers` is an experimental feature.
-   * The API might be changed.
-   */
   createHandlers<
     I extends Input = {},
     I2 extends Input = I,
@@ -262,11 +207,6 @@ export class Factory<E extends Env = any, P extends string = any> {
   }
 }
 
-/**
- * @experimental
- * `createFactory` is an experimental feature.
- * The API might be changed.
- */
 export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
 
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(


### PR DESCRIPTION
Fixes #1948

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
