### PR TITLE
feat!(cloudflare-workers): make `manifest` required

### DIFF
--- a/src/adapter/cloudflare-workers/serve-static-module.ts
+++ b/src/adapter/cloudflare-workers/serve-static-module.ts
@@ -1,16 +1,10 @@
 // @denoify-ignore
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 // For ES module mode
-import manifest from '__STATIC_CONTENT_MANIFEST'
 import type { Env } from '../../types'
 import type { ServeStaticOptions } from './serve-static'
 import { serveStatic } from './serve-static'
 
-const module = <E extends Env = Env>(
-  options: Omit<ServeStaticOptions<E>, 'namespace'> = { root: '' }
-) => {
-  options.manifest ??= manifest
+const module = <E extends Env = Env>(options: Omit<ServeStaticOptions<E>, 'namespace'>) => {
   return serveStatic<E>(options)
 }
 

--- a/src/adapter/cloudflare-workers/serve-static.test.ts
+++ b/src/adapter/cloudflare-workers/serve-static.test.ts
@@ -32,13 +32,14 @@ Object.assign(global, {
 describe('ServeStatic Middleware', () => {
   const app = new Hono()
   const onNotFound = vi.fn(() => {})
-  app.use('/static/*', serveStatic({ root: './assets', onNotFound }))
-  app.use('/static-no-root/*', serveStatic())
+  app.use('/static/*', serveStatic({ root: './assets', onNotFound, manifest }))
+  app.use('/static-no-root/*', serveStatic({ manifest }))
   app.use(
     '/dot-static/*',
     serveStatic({
       root: './assets',
       rewriteRequestPath: (path) => path.replace(/^\/dot-static/, '/.static'),
+      manifest,
     })
   )
 
@@ -106,8 +107,8 @@ describe('With options', () => {
 
 describe('With `file` options', () => {
   const app = new Hono()
-  app.get('/foo/*', serveStatic({ path: './assets/static/hono.html' }))
-  app.get('/bar/*', serveStatic({ path: './static/hono.html', root: './assets' }))
+  app.get('/foo/*', serveStatic({ path: './assets/static/hono.html', manifest }))
+  app.get('/bar/*', serveStatic({ path: './static/hono.html', root: './assets', manifest }))
 
   it('Should return hono.html', async () => {
     const res = await app.request('http://localhost/foo/fallback')
@@ -135,7 +136,7 @@ describe('With middleware', () => {
 
   app.use('/static/*', md1)
   app.use('/static/*', md2)
-  app.use('/static/*', serveStatic({ root: './assets' }))
+  app.use('/static/*', serveStatic({ root: './assets', manifest }))
   app.get('/static/foo', (c) => {
     return c.text('bar')
   })
@@ -171,6 +172,7 @@ describe('Types of middleware', () => {
         onNotFound: (_, c) => {
           expectTypeOf(c.env).toEqualTypeOf<Env['Bindings']>()
         },
+        manifest,
       })
     )
   })

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -9,7 +9,7 @@ import { getContentFromKVAsset } from './utils'
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
-  manifest?: object | string
+  manifest: object | string
   namespace?: KVNamespace
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
@@ -19,7 +19,7 @@ const DEFAULT_DOCUMENT = 'index.html'
 
 // This middleware is available only on Cloudflare Workers.
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E> = { root: '' }
+  options: ServeStaticOptions<E>
 ): MiddlewareHandler => {
   return async (c, next) => {
     // Do nothing if Response is already set


### PR DESCRIPTION
Fixes #1127 #1093

This is the same as #1804 by @Code-Hex .

With this PR, if you use the Cloudflare Workers adapter's `serve-static`, you should specify the `manifest` option.

```ts
import manifest from '__STATIC_CONTENT_MANIFEST'

// ...

app.use('/static/*', serveStatic({ root: './assets', manifest }))
```

This avoids a compile error if there is an import of "`__STATIC_CONTENT_MANIFEST`" in Hono core's code.

This is a BREAKING CHANGE, so we need to write the migration instructions in the migration guide.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
