### PR TITLE
feat: Add Type to request for Lambda@Edge adapter to support S3 origin

### DIFF
--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -27,6 +27,17 @@ interface CloudFrontCustomOrigin {
   readTimeout: number
   sslProtocols: string[]
 }
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
+interface CloudFrontS3Origin {
+  authMethod: 'origin-access-identity' | 'none'
+  customHeaders: CloudFrontHeaders
+  domainName: string
+  path: string
+  region: string
+}
+type CloudFrontOrigin =
+  | { s3: CloudFrontS3Origin; custom?: never }
+  | { custom: CloudFrontCustomOrigin; s3?: never }
 
 export interface CloudFrontRequest {
   clientIp: string
@@ -40,9 +51,7 @@ export interface CloudFrontRequest {
     encoding: string
     data: string
   }
-  origin?: {
-    custom: CloudFrontCustomOrigin
-  }
+  origin?: CloudFrontOrigin
 }
 
 export interface CloudFrontResponse {


### PR DESCRIPTION
The origin field in the request object in the Lambda@Edge adapter is assumed to be only a custom origin.

Referring to 
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html ,
I have defined a TypeScript type that is also compatible with S3 origins.


### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
