### PR TITLE
fix(ssg): fixed `isDynamicRoute` and `ssgParams` matter

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -102,7 +102,7 @@ export const fetchRoutesContent = async <
   const baseURL = 'http://localhost'
 
   for (const route of inspectRoutes(app)) {
-    if (route.isMiddleware || isDynamicRoute(route.path)) continue
+    if (route.isMiddleware) continue
 
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
@@ -110,6 +110,7 @@ export const fetchRoutesContent = async <
     await app.fetch(forGetInfoURLRequest)
 
     if (!forGetInfoURLRequest.ssgParams) {
+      if (isDynamicRoute(route.path)) continue
       forGetInfoURLRequest.ssgParams = [{}]
     }
 

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -101,7 +101,7 @@ export const fetchRoutesContent = async <
   const baseURL = 'http://localhost'
 
   for (const route of inspectRoutes(app)) {
-    if (route.isMiddleware || isDynamicRoute(route.path)) continue
+    if (route.isMiddleware) continue
 
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
@@ -109,6 +109,7 @@ export const fetchRoutesContent = async <
     await app.fetch(forGetInfoURLRequest)
 
     if (!forGetInfoURLRequest.ssgParams) {
+      if (isDynamicRoute(route.path)) continue
       forGetInfoURLRequest.ssgParams = [{}]
     }
 


### PR DESCRIPTION
When introducing `ssgParams()`, tests fail. I've fixed the matter.

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
