### PR TITLE
feat: improve `ssgParams` flexibility

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -69,20 +69,22 @@ interface SSGParam {
 }
 type SSGParams = SSGParam[]
 
+interface SSGParamsMiddleware {
+  <E extends Env = Env>(
+    generateParams: (c: Context<E>) => SSGParams | Promise<SSGParams>
+  ): MiddlewareHandler<E>
+}
+
 type AddedSSGDataRequest = Request & {
   ssgParams?: SSGParams
 }
 /**
  * Define SSG Route
  */
-export const ssgParams =
-  <E extends Env = Env>(
-    params: ((c: Context<E>) => SSGParams | Promise<SSGParams>) | SSGParams
-  ): MiddlewareHandler<E> =>
-  async (c, next) => {
-    ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
-    await next()
-  }
+export const ssgParams: SSGParamsMiddleware = (params) => async (c, next) => {
+  ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
+  await next()
+}
 
 export interface ToSSGOptions {
   dir?: string

--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -73,6 +73,7 @@ interface SSGParamsMiddleware {
   <E extends Env = Env>(
     generateParams: (c: Context<E>) => SSGParams | Promise<SSGParams>
   ): MiddlewareHandler<E>
+  <E extends Env = Env>(params: SSGParams): MiddlewareHandler<E>
 }
 
 type AddedSSGDataRequest = Request & {

--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -68,19 +68,21 @@ interface SSGParam {
   [key: string]: string
 }
 type SSGParams = SSGParam[]
-interface SSGParamsMiddleware {
-  (generateParams: (c: Context) => SSGParams | Promise<SSGParams>): MiddlewareHandler
-}
+
 type AddedSSGDataRequest = Request & {
   ssgParams?: SSGParams
 }
 /**
  * Define SSG Route
  */
-export const ssgParams: SSGParamsMiddleware = (generateParams) => async (c, next) => {
-  ;(c.req.raw as AddedSSGDataRequest).ssgParams = await generateParams(c)
-  await next()
-}
+export const ssgParams =
+  <E extends Env = Env>(
+    params: ((c: Context<E>) => SSGParams | Promise<SSGParams>) | SSGParams
+  ): MiddlewareHandler<E> =>
+  async (c, next) => {
+    ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
+    await next()
+  }
 
 export interface ToSSGOptions {
   dir?: string

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -46,18 +46,18 @@ describe('toSSG function', () => {
 
     type Env = {
       Bindings: {
-        HOGE_DB: string
+        FOO_DB: string
       }
       Variables: {
-        HOGE_VAR: string
+        FOO_VAR: string
       }
     }
 
     app.get(
       '/env-type-check',
       ssgParams<Env>((c) => {
-        expectTypeOf<typeof c.env.HOGE_DB>().toBeString()
-        expectTypeOf<typeof c.var.HOGE_VAR>().toBeString()
+        expectTypeOf<typeof c.env.FOO_DB>().toBeString()
+        expectTypeOf<typeof c.var.FOO_VAR>().toBeString()
         return []
       })
     )

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -44,6 +44,12 @@ describe('toSSG function', () => {
       (c) => c.html(<h1>{c.req.param('post')}</h1>)
     )
 
+    app.get(
+      '/user/:user_id',
+      ssgParams([{ user_id: '1' }, { user_id: '2' }, { user_id: '3' }]),
+      (c) => c.html(<h1>{c.req.param('user_id')}</h1>)
+    )
+
     type Env = {
       Bindings: {
         FOO_DB: string
@@ -73,6 +79,11 @@ describe('toSSG function', () => {
     for (const postParam of postParams) {
       const html = htmlMap.get(`/post/${postParam.post}`)
       expect(html?.content).toBe(`<h1>${postParam.post}</h1>`)
+    }
+
+    for (let i = 1; i <= 3; i++) {
+      const html = htmlMap.get(`/user/${i}`)
+      expect(html?.content).toBe(`<h1>${i}</h1>`)
     }
 
     const files = await saveContentToFiles(htmlMap, fsMock, './static')

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -43,6 +43,24 @@ describe('toSSG function', () => {
       ssgParams(() => postParams),
       (c) => c.html(<h1>{c.req.param('post')}</h1>)
     )
+
+    type Env = {
+      Bindings: {
+        HOGE_DB: string
+      }
+      Variables: {
+        HOGE_VAR: string
+      }
+    }
+
+    app.get(
+      '/env-type-check',
+      ssgParams<Env>((c) => {
+        expectTypeOf<typeof c.env.HOGE_DB>().toBeString()
+        expectTypeOf<typeof c.var.HOGE_VAR>().toBeString()
+        return []
+      })
+    )
   })
   it('Should correctly generate static HTML files for Hono routes', async () => {
     const fsMock: FileSystemModule = {

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -67,19 +67,21 @@ interface SSGParam {
   [key: string]: string
 }
 type SSGParams = SSGParam[]
-interface SSGParamsMiddleware {
-  (generateParams: (c: Context) => SSGParams | Promise<SSGParams>): MiddlewareHandler
-}
+
 type AddedSSGDataRequest = Request & {
   ssgParams?: SSGParams
 }
 /**
  * Define SSG Route
  */
-export const ssgParams: SSGParamsMiddleware = (generateParams) => async (c, next) => {
-  ;(c.req.raw as AddedSSGDataRequest).ssgParams = await generateParams(c)
-  await next()
-}
+export const ssgParams =
+  <E extends Env = Env>(
+    generateParams: (c: Context<E>) => SSGParams | Promise<SSGParams>
+  ): MiddlewareHandler<E> =>
+  async (c, next) => {
+    ;(c.req.raw as AddedSSGDataRequest).ssgParams = await generateParams(c)
+    await next()
+  }
 
 export interface ToSSGOptions {
   dir?: string

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -76,10 +76,10 @@ type AddedSSGDataRequest = Request & {
  */
 export const ssgParams =
   <E extends Env = Env>(
-    generateParams: (c: Context<E>) => SSGParams | Promise<SSGParams>
+    params: ((c: Context<E>) => SSGParams | Promise<SSGParams>) | SSGParams
   ): MiddlewareHandler<E> =>
   async (c, next) => {
-    ;(c.req.raw as AddedSSGDataRequest).ssgParams = await generateParams(c)
+    ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
     await next()
   }
 

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -68,20 +68,22 @@ interface SSGParam {
 }
 type SSGParams = SSGParam[]
 
+interface SSGParamsMiddleware {
+  <E extends Env = Env>(
+    generateParams: (c: Context<E>) => SSGParams | Promise<SSGParams>
+  ): MiddlewareHandler<E>
+}
+
 type AddedSSGDataRequest = Request & {
   ssgParams?: SSGParams
 }
 /**
  * Define SSG Route
  */
-export const ssgParams =
-  <E extends Env = Env>(
-    params: ((c: Context<E>) => SSGParams | Promise<SSGParams>) | SSGParams
-  ): MiddlewareHandler<E> =>
-  async (c, next) => {
-    ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
-    await next()
-  }
+export const ssgParams: SSGParamsMiddleware = (params) => async (c, next) => {
+  ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
+  await next()
+}
 
 export interface ToSSGOptions {
   dir?: string

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -72,6 +72,7 @@ interface SSGParamsMiddleware {
   <E extends Env = Env>(
     generateParams: (c: Context<E>) => SSGParams | Promise<SSGParams>
   ): MiddlewareHandler<E>
+  <E extends Env = Env>(params: SSGParams): MiddlewareHandler<E>
 }
 
 type AddedSSGDataRequest = Request & {


### PR DESCRIPTION
### Author should do the followings, if applicable

Context Env generics support for `ssgParams` middleware.
use a simple array for `ssgParams` middleware's argument.


- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
