### PR TITLE
refactor(jsx/dom): invoke update() in microtask

### DIFF
--- a/deno_dist/jsx/dom/render.ts
+++ b/deno_dist/jsx/dom/render.ts
@@ -48,11 +48,12 @@ export type PendingType =
   | 0 // no pending
   | 1 // global
   | 2 // hook
+export type UpdateHook = (cb: () => void) => Promise<void>
 export type Context =
   | [
       PendingType, // PendingType
       boolean, // got an error
-      boolean // with startViewTransition
+      UpdateHook // update hook
     ]
   | [PendingType, boolean]
   | [PendingType]
@@ -311,9 +312,8 @@ export const build = (
     node.vR = vChildrenToRemove
   } catch (e) {
     if (errorHandler) {
-      const withStartViewTransition = context[2]
       const fallback = errorHandler(e, () =>
-        update([], topLevelErrorHandlerNode as NodeObject, !!withStartViewTransition)
+        update([0, false, context[2] as UpdateHook], topLevelErrorHandlerNode as NodeObject)
       )
       if (fallback) {
         if (context[0] === 1) {
@@ -355,18 +355,43 @@ const updateSync = (context: Context, node: NodeObject) => {
   }
 }
 
-export const update = (context: Context, node: NodeObject, withStartViewTransition: boolean) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (withStartViewTransition && (document as any).startViewTransition) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(document as any).startViewTransition(() => {
-      const localContext: Context = [...context]
-      localContext[2] = true
-      updateSync(localContext, node)
-    })
-  } else {
-    updateSync(context, node)
+type UpdateMapResolve = (node: NodeObject | undefined) => void
+const updateMap = new WeakMap<NodeObject, [UpdateMapResolve, Function]>()
+export const update = async (
+  context: Context,
+  node: NodeObject
+): Promise<NodeObject | undefined> => {
+  const existing = updateMap.get(node)
+  if (existing) {
+    // execute only the last update() call, so the previous update will be canceled.
+    existing[0](undefined)
   }
+
+  let resolve: UpdateMapResolve | undefined
+  const promise = new Promise<NodeObject | undefined>((r) => (resolve = r))
+  updateMap.set(node, [
+    resolve as UpdateMapResolve,
+    () => {
+      if (context[2]) {
+        context[2](() => {
+          updateSync(context, node)
+        }).then(() => (resolve as UpdateMapResolve)(node))
+      } else {
+        updateSync(context, node)
+        ;(resolve as UpdateMapResolve)(node)
+      }
+    },
+  ])
+
+  await Promise.resolve()
+
+  const latest = updateMap.get(node)
+  if (latest) {
+    updateMap.delete(node)
+    latest[1]()
+  }
+
+  return promise
 }
 
 export const render = (jsxNode: unknown, container: Container) => {

--- a/deno_dist/jsx/dom/render.ts
+++ b/deno_dist/jsx/dom/render.ts
@@ -192,14 +192,19 @@ const findInsertBefore = (node: Node | undefined): ChildNode | null => {
 }
 
 const removeNode = (node: Node) => {
-  node.e?.remove()
   if (!isNodeString(node)) {
     node[STASH]?.[1][STASH_EFFECT]?.forEach((data: EffectData) => data[2]?.())
     node.vC?.forEach(removeNode)
   }
+  node.e?.remove()
+  node.tag = undefined
 }
 
 const apply = (node: NodeObject, container: Container) => {
+  if (node.tag === undefined) {
+    return
+  }
+
   node.c = container
   applyNodeObject(node, container)
 }
@@ -256,6 +261,10 @@ export const build = (
   topLevelErrorHandlerNode: NodeObject | undefined,
   children?: Child[]
 ): void => {
+  if (node.tag === undefined) {
+    return
+  }
+
   let errorHandler: ErrorHandler | undefined
   children ||= typeof node.tag == 'function' ? invokeTag(context, node) : node.children
   if ((children[0] as JSXNode)?.tag === '') {
@@ -395,7 +404,7 @@ export const update = async (
 }
 
 export const render = (jsxNode: unknown, container: Container) => {
-  const node = buildNode({ children: [jsxNode] } as JSXNode) as NodeObject
+  const node = buildNode({ tag: '', children: [jsxNode] } as JSXNode) as NodeObject
   build([], node, undefined)
 
   const fragment = document.createDocumentFragment()

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -48,11 +48,12 @@ export type PendingType =
   | 0 // no pending
   | 1 // global
   | 2 // hook
+export type UpdateHook = (cb: () => void) => Promise<void>
 export type Context =
   | [
       PendingType, // PendingType
       boolean, // got an error
-      boolean // with startViewTransition
+      UpdateHook // update hook
     ]
   | [PendingType, boolean]
   | [PendingType]
@@ -311,9 +312,8 @@ export const build = (
     node.vR = vChildrenToRemove
   } catch (e) {
     if (errorHandler) {
-      const withStartViewTransition = context[2]
       const fallback = errorHandler(e, () =>
-        update([], topLevelErrorHandlerNode as NodeObject, !!withStartViewTransition)
+        update([0, false, context[2] as UpdateHook], topLevelErrorHandlerNode as NodeObject)
       )
       if (fallback) {
         if (context[0] === 1) {
@@ -355,18 +355,43 @@ const updateSync = (context: Context, node: NodeObject) => {
   }
 }
 
-export const update = (context: Context, node: NodeObject, withStartViewTransition: boolean) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (withStartViewTransition && (document as any).startViewTransition) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(document as any).startViewTransition(() => {
-      const localContext: Context = [...context]
-      localContext[2] = true
-      updateSync(localContext, node)
-    })
-  } else {
-    updateSync(context, node)
+type UpdateMapResolve = (node: NodeObject | undefined) => void
+const updateMap = new WeakMap<NodeObject, [UpdateMapResolve, Function]>()
+export const update = async (
+  context: Context,
+  node: NodeObject
+): Promise<NodeObject | undefined> => {
+  const existing = updateMap.get(node)
+  if (existing) {
+    // execute only the last update() call, so the previous update will be canceled.
+    existing[0](undefined)
   }
+
+  let resolve: UpdateMapResolve | undefined
+  const promise = new Promise<NodeObject | undefined>((r) => (resolve = r))
+  updateMap.set(node, [
+    resolve as UpdateMapResolve,
+    () => {
+      if (context[2]) {
+        context[2](() => {
+          updateSync(context, node)
+        }).then(() => (resolve as UpdateMapResolve)(node))
+      } else {
+        updateSync(context, node)
+        ;(resolve as UpdateMapResolve)(node)
+      }
+    },
+  ])
+
+  await Promise.resolve()
+
+  const latest = updateMap.get(node)
+  if (latest) {
+    updateMap.delete(node)
+    latest[1]()
+  }
+
+  return promise
 }
 
 export const render = (jsxNode: unknown, container: Container) => {

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -192,14 +192,19 @@ const findInsertBefore = (node: Node | undefined): ChildNode | null => {
 }
 
 const removeNode = (node: Node) => {
-  node.e?.remove()
   if (!isNodeString(node)) {
     node[STASH]?.[1][STASH_EFFECT]?.forEach((data: EffectData) => data[2]?.())
     node.vC?.forEach(removeNode)
   }
+  node.e?.remove()
+  node.tag = undefined
 }
 
 const apply = (node: NodeObject, container: Container) => {
+  if (node.tag === undefined) {
+    return
+  }
+
   node.c = container
   applyNodeObject(node, container)
 }
@@ -256,6 +261,10 @@ export const build = (
   topLevelErrorHandlerNode: NodeObject | undefined,
   children?: Child[]
 ): void => {
+  if (node.tag === undefined) {
+    return
+  }
+
   let errorHandler: ErrorHandler | undefined
   children ||= typeof node.tag == 'function' ? invokeTag(context, node) : node.children
   if ((children[0] as JSXNode)?.tag === '') {
@@ -395,7 +404,7 @@ export const update = async (
 }
 
 export const render = (jsxNode: unknown, container: Container) => {
-  const node = buildNode({ children: [jsxNode] } as JSXNode) as NodeObject
+  const node = buildNode({ tag: '', children: [jsxNode] } as JSXNode) as NodeObject
   build([], node, undefined)
 
   const fragment = document.createDocumentFragment()

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -1,5 +1,5 @@
 import { buildDataStack, update, build, STASH } from '../dom/render'
-import type { Node, NodeObject, Context, PendingType } from '../dom/render'
+import type { Node, NodeObject, Context, PendingType, UpdateHook } from '../dom/render'
 
 type UpdateStateFunction<T> = (newState: T | ((currentState: T) => T)) => void
 
@@ -16,27 +16,41 @@ export type EffectData = [
 
 const resolvedPromiseValueMap = new WeakMap<Promise<unknown>, unknown>()
 
-let updateWithStartViewTransition = false
+let updateHook: UpdateHook | undefined = undefined
+
 export const startViewTransition = (callback: () => void): void => {
-  updateWithStartViewTransition = true
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (!(document as any).startViewTransition) {
+    callback()
+    return
+  }
+
+  updateHook = (cb) => {
+    let resolve: (() => void) | undefined
+    const promise = new Promise<void>((r) => (resolve = r))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(document as any).startViewTransition(() => {
+      cb()
+      ;(resolve as () => void)()
+    })
+    return promise
+  }
+
   try {
     callback()
   } finally {
-    updateWithStartViewTransition = false
+    updateHook = undefined
   }
 }
 
-type PendingStackItem = [PendingType, Map<Node, Function>]
-const pendingStack: PendingStackItem[] = []
+const pendingStack: PendingType[] = []
 const runCallback = (type: PendingType, callback: Function): void => {
-  const map = new Map()
-  pendingStack.push([type, map])
+  pendingStack.push(type)
   try {
     callback()
   } finally {
     pendingStack.pop()
   }
-  map.forEach((cb) => cb())
 }
 
 export const startTransition = (callback: () => void): void => {
@@ -89,6 +103,7 @@ export const useState = <T>(initialState: T | (() => T)): [T, UpdateStateFunctio
   return (stateArray[hookIndex] ||= [
     resolveInitialState(),
     (newState: T | ((currentState: T) => T)) => {
+      const localUpdateHook = updateHook
       const stateData = stateArray[hookIndex]
       if (typeof newState === 'function') {
         newState = (newState as (currentState: T) => T)(stateData[0])
@@ -97,11 +112,21 @@ export const useState = <T>(initialState: T | (() => T)): [T, UpdateStateFunctio
       if (newState !== stateData[0]) {
         stateData[0] = newState
         if (pendingStack.length) {
-          const [type, map] = pendingStack.at(-1) as PendingStackItem
-          map.set(node, () => {
-            const context: Context = [type, false]
-            if (type === 2) {
-              setTimeout(async () => {
+          const pendingType = pendingStack.at(-1) as PendingType
+          update([pendingType, false, localUpdateHook as UpdateHook], node).then((node) => {
+            if (!node || pendingType !== 2) {
+              return
+            }
+
+            const lastVC = node.vC
+
+            const addUpdateTask = () => {
+              setTimeout(() => {
+                // `node` is not rerendered after current transition
+                if (lastVC !== node.vC) {
+                  return
+                }
+
                 const shadowNode = Object.assign({}, node) as NodeObject
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -109,19 +134,20 @@ export const useState = <T>(initialState: T | (() => T)): [T, UpdateStateFunctio
                 build([], shadowNode, undefined)
                 setShadow(shadowNode) // save the `shadowNode.vC` of the virtual DOM of the build result as a result of shadow virtual DOM `shadowNode.s`
 
-                // `node` is not rerendered after current transition
-                if (lastVC === node.vC) {
-                  node.s = shadowNode.s
-                  update([], node, false)
-                }
+                node.s = shadowNode.s
+                update([0, false, localUpdateHook as UpdateHook], node)
               })
             }
 
-            update(context, node, false)
-            const lastVC = node.vC
+            if (localUpdateHook) {
+              // wait for next animation frame, then invoke `update()`
+              requestAnimationFrame(addUpdateTask)
+            } else {
+              addUpdateTask()
+            }
           })
         } else {
-          update([], node, updateWithStartViewTransition)
+          update([0, false, localUpdateHook as UpdateHook], node)
         }
       }
     },


### PR DESCRIPTION
This PR contains two refactorings, and fixes. This is the last PR regarding "jsx/dom" for v4 and is intended to be a feature freeze. (Continue to fix bugs and support CSS helpers.)

### refactor(jsx/dom): invoke update() in microtask

This improves the following two issues

* Multiple updates of stete in a single callback will now invoke `update()` only once.
    * https://github.com/honojs/hono/compare/v4...usualoma:hono:feat/jsx-dom-render-in-microtask?expand=1#diff-8f050239e20450fd8425feb7efbda60df851ebbc32bec8139d6d9ad1b53a7bc0R189-R217
* `useTransition` and `startViewTransition` can be used at the same time.

```ts
/** @jsxRuntime automatic @jsxImportSource ./src/jsx/dom */
import { render } from './src/jsx/dom'
import { useState, useTransition, startViewTransition } from './src/jsx/hooks'

const HeavyContent = ({ count }) => {
  const startTime = performance.now()
  while (performance.now() - startTime < 1000) {}
  return <div>HeavyContent!!! {count}</div>
}

const Transition = () => {
  const [isPending, startTransition] = useTransition()
  const [count, setCount] = useState(0)
  const [showHeavy, setShowHeavy] = useState(false)
  return (
    <div>
      <button
        onClick={() => {
          startViewTransition(() => {
            startTransition(() => {
              setShowHeavy(true)
              setCount((c) => c + 1)
            })
          })
        }}
      >
        {'Click me'}
      </button>
      {showHeavy && (
        <button
          onClick={() => {
            startViewTransition(() => {
              setShowHeavy(false)
            })
          }}
          style='margin-left: 10px;'
        >
          Hide HeavyContent
        </button>
      )}
      <div>{showHeavy ? isPending ? '...' : <HeavyContent count={count} /> : count}</div>
    </div>
  )
}

export const App = () => {
  return (
    <div>
      <div>
        <div>
          <h3>useTransition</h3>
          <Transition />
        </div>
      </div>
    </div>
  )
}

render(<App />, document.getElementById('root'))
```

https://github.com/honojs/hono/assets/30598/c92a6f61-2246-44c8-ad36-df81680e8eee

#### fix(jsx/dom): should not render removed node

Stable behavior when Suspense is shown and hidden repeatedly in a short period of time.

https://github.com/honojs/hono/compare/v4...usualoma:hono:feat/jsx-dom-render-in-microtask?expand=1#diff-00be452f071d90d2904b8acdd0b15dc607fee092c4545b38387e2f52a6eba35fR95-R131

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
