### PR TITLE
fix(ssg): Skip the creation of meaningless static files.

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -121,7 +121,7 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      const response = await app.request(replaceUrlParam(route.path, param))
+      const response = await app.request(replacedUrlParam)
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
       htmlMap.set(replacedUrlParam, {

--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -111,7 +111,8 @@ export const fetchRoutesContent = async <
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
     const forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
-    await app.fetch(forGetInfoURLRequest)
+    const preResponse = await app.fetch(forGetInfoURLRequest)
+    if (preResponse.status !== 200) continue
 
     if (!forGetInfoURLRequest.ssgParams) {
       if (isDynamicRoute(route.path)) continue
@@ -120,7 +121,7 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      const response = await app.request(replacedUrlParam)
+      const response = await app.request(replaceUrlParam(route.path, param))
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
       htmlMap.set(replacedUrlParam, {

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -121,7 +121,7 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      const response = await app.request(replaceUrlParam(route.path, param))
+      const response = await app.request(replacedUrlParam)
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
       htmlMap.set(replacedUrlParam, {

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -111,7 +111,8 @@ export const fetchRoutesContent = async <
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
     const forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
-    await app.fetch(forGetInfoURLRequest)
+    const preResponse = await app.fetch(forGetInfoURLRequest)
+    if (preResponse.status !== 200) continue
 
     if (!forGetInfoURLRequest.ssgParams) {
       if (isDynamicRoute(route.path)) continue
@@ -120,7 +121,7 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      const response = await app.request(replacedUrlParam)
+      const response = await app.request(replaceUrlParam(route.path, param))
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
       htmlMap.set(replacedUrlParam, {


### PR DESCRIPTION
Currently, the toSSG function can generate static files, but there are routes where unexpected content, such as 404 Not Found, is retrieved. This can be identified in advance through a fetch process and prevented from being created.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
