### PR TITLE
feat(ssg): support Improve Hook Handling

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -88,11 +88,13 @@ export const ssgParams: SSGParamsMiddleware = (params) => async (c, next) => {
 
 export type BeforeRequestHook = (req: Request) => Request | false
 export type AfterResponseHook = (res: Response) => Response | false
+export type AfterGenerateHook = (result: ToSSGResult) => void | Promise<void>
 
 export interface ToSSGOptions {
   dir?: string
   beforeRequestHook?: BeforeRequestHook
   afterResponseHook?: AfterResponseHook
+  afterGenerateHook?: AfterGenerateHook
 }
 
 /**
@@ -117,8 +119,13 @@ export const fetchRoutesContent = async <
 
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
-    const forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
-    if (beforeRequestHook && !beforeRequestHook(forGetInfoURLRequest)) continue
+
+    let forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
+    if (beforeRequestHook) {
+      const maybeRequest = beforeRequestHook(forGetInfoURLRequest)
+      if (!maybeRequest) continue
+      forGetInfoURLRequest = maybeRequest as unknown as AddedSSGDataRequest
+    }
     await app.fetch(forGetInfoURLRequest)
 
     if (!forGetInfoURLRequest.ssgParams) {
@@ -128,8 +135,12 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      const response = await app.request(replacedUrlParam)
-      if (afterResponseHook && !afterResponseHook(response)) continue
+      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
+      if (afterResponseHook) {
+        const maybeResponse = afterResponseHook(response)
+        if (!maybeResponse) continue
+        response = maybeResponse
+      }
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
       htmlMap.set(replacedUrlParam, {
@@ -210,13 +221,20 @@ export interface ToSSGAdaptorInterface<
  * The API might be changed.
  */
 export const toSSG: ToSSGInterface = async (app, fs, options) => {
+  let result: ToSSGResult | undefined = undefined
   try {
     const outputDir = options?.dir ?? './static'
-    const maps = await fetchRoutesContent(app)
+    const maps = await fetchRoutesContent(
+      app,
+      options?.beforeRequestHook,
+      options?.afterResponseHook
+    )
     const files = await saveContentToFiles(maps, fs, outputDir)
-    return { success: true, files }
+    result = { success: true, files }
   } catch (error) {
     const errorObj = error instanceof Error ? error : new Error(String(error))
-    return { success: false, error: errorObj }
+    result = { success: false, error: errorObj }
   }
+  options?.afterGenerateHook?.(result)
+  return result
 }

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -199,12 +199,12 @@ describe('toSSG function', () => {
     }
     const afterGenerateHookMock: AfterGenerateHook = vi.fn((result) => {
       if (result.files) {
-        result.files.forEach(file => console.log(file))
+        result.files.forEach((file) => console.log(file))
       }
     })
-  
+
     await toSSG(app, fsMock, { dir: './static', afterGenerateHook: afterGenerateHookMock })
-  
+
     expect(afterGenerateHookMock).toHaveBeenCalled()
     expect(afterGenerateHookMock).toHaveBeenCalledWith(expect.anything())
   })

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -4,7 +4,12 @@ import { Hono } from '../../hono'
 import { jsx } from '../../jsx'
 import { poweredBy } from '../../middleware/powered-by'
 import { fetchRoutesContent, saveContentToFiles, ssgParams, toSSG } from './index'
-import type { BeforeRequestHook, AfterResponseHook, FileSystemModule } from './index'
+import type {
+  BeforeRequestHook,
+  AfterResponseHook,
+  AfterGenerateHook,
+  FileSystemModule,
+} from './index'
 
 describe('toSSG function', () => {
   let app: Hono
@@ -13,7 +18,7 @@ describe('toSSG function', () => {
 
   beforeEach(() => {
     app = new Hono()
-    app.get('/', (c) => c.html('Hello, World!'))
+    app.all('/', (c) => c.html('Hello, World!'))
     app.get('/about', (c) => c.html('About Page'))
     app.get('/about/some', (c) => c.text('About Page 2tier'))
     app.post('/about/some/thing', (c) => c.text('About Page 3tier'))
@@ -146,14 +151,18 @@ describe('toSSG function', () => {
   })
 
   it('should modify the request if the hook is provided', async () => {
-    const beforeRequest: BeforeRequestHook = (req) => {
+    const fsMock: FileSystemModule = {
+      writeFile: vi.fn(() => Promise.resolve()),
+      mkdir: vi.fn(() => Promise.resolve()),
+    }
+    const beforeRequestHook: BeforeRequestHook = (req) => {
       if (req.method === 'GET') {
         return req
       }
       return false
     }
-    const htmlMap = await fetchRoutesContent(app, beforeRequest)
-    expect(htmlMap.size).toBe(11)
+    const result = await toSSG(app, fsMock, { beforeRequestHook })
+    expect(result.files).toHaveLength(11)
   })
 
   it('should skip the route if the request hook returns false', async () => {
@@ -163,20 +172,41 @@ describe('toSSG function', () => {
   })
 
   it('should modify the response if the hook is provided', async () => {
-    const afterResponse: AfterResponseHook = (res) => {
+    const afterResponseHook: AfterResponseHook = (res) => {
       if (res.status === 200 || res.status === 500) {
         return res
       }
       return false
     }
-
-    await fetchRoutesContent(app, undefined, afterResponse)
+    const fsMock: FileSystemModule = {
+      writeFile: vi.fn(() => Promise.resolve()),
+      mkdir: vi.fn(() => Promise.resolve()),
+    }
+    const result = await toSSG(app, fsMock, { afterResponseHook })
+    expect(result.files).toHaveLength(10)
   })
 
   it('should skip the route if the response hook returns false', async () => {
     const afterResponse: AfterResponseHook = () => false
     const htmlMap = await fetchRoutesContent(app, undefined, afterResponse)
     expect(htmlMap.size).toBe(0)
+  })
+
+  it('should execute additional processing using afterGenerateHook', async () => {
+    const fsMock: FileSystemModule = {
+      writeFile: vi.fn(() => Promise.resolve()),
+      mkdir: vi.fn(() => Promise.resolve()),
+    }
+    const afterGenerateHookMock: AfterGenerateHook = vi.fn((result) => {
+      if (result.files) {
+        result.files.forEach(file => console.log(file))
+      }
+    })
+  
+    await toSSG(app, fsMock, { dir: './static', afterGenerateHook: afterGenerateHookMock })
+  
+    expect(afterGenerateHookMock).toHaveBeenCalled()
+    expect(afterGenerateHookMock).toHaveBeenCalledWith(expect.anything())
   })
 })
 

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -88,11 +88,13 @@ export const ssgParams: SSGParamsMiddleware = (params) => async (c, next) => {
 
 export type BeforeRequestHook = (req: Request) => Request | false
 export type AfterResponseHook = (res: Response) => Response | false
+export type AfterGenerateHook = (result: ToSSGResult) => void | Promise<void>
 
 export interface ToSSGOptions {
   dir?: string
   beforeRequestHook?: BeforeRequestHook
   afterResponseHook?: AfterResponseHook
+  afterGenerateHook?: AfterGenerateHook
 }
 
 /**
@@ -117,8 +119,13 @@ export const fetchRoutesContent = async <
 
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
-    const forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
-    if (beforeRequestHook && !beforeRequestHook(forGetInfoURLRequest)) continue
+
+    let forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
+    if (beforeRequestHook) {
+      const maybeRequest = beforeRequestHook(forGetInfoURLRequest)
+      if (!maybeRequest) continue
+      forGetInfoURLRequest = maybeRequest as unknown as AddedSSGDataRequest
+    }
     await app.fetch(forGetInfoURLRequest)
 
     if (!forGetInfoURLRequest.ssgParams) {
@@ -128,8 +135,12 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      const response = await app.request(replacedUrlParam)
-      if (afterResponseHook && !afterResponseHook(response)) continue
+      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
+      if (afterResponseHook) {
+        const maybeResponse = afterResponseHook(response)
+        if (!maybeResponse) continue
+        response = maybeResponse
+      }
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
       htmlMap.set(replacedUrlParam, {
@@ -210,13 +221,20 @@ export interface ToSSGAdaptorInterface<
  * The API might be changed.
  */
 export const toSSG: ToSSGInterface = async (app, fs, options) => {
+  let result: ToSSGResult | undefined = undefined
   try {
     const outputDir = options?.dir ?? './static'
-    const maps = await fetchRoutesContent(app)
+    const maps = await fetchRoutesContent(
+      app,
+      options?.beforeRequestHook,
+      options?.afterResponseHook
+    )
     const files = await saveContentToFiles(maps, fs, outputDir)
-    return { success: true, files }
+    result = { success: true, files }
   } catch (error) {
     const errorObj = error instanceof Error ? error : new Error(String(error))
-    return { success: false, error: errorObj }
+    result = { success: false, error: errorObj }
   }
+  options?.afterGenerateHook?.(result)    
+  return result
 }

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -235,6 +235,6 @@ export const toSSG: ToSSGInterface = async (app, fs, options) => {
     const errorObj = error instanceof Error ? error : new Error(String(error))
     result = { success: false, error: errorObj }
   }
-  options?.afterGenerateHook?.(result)    
+  options?.afterGenerateHook?.(result)
   return result
 }


### PR DESCRIPTION
Following @yusukebe  advice, I have created the beforeRequestHook and AfterRequestHook. Users can now prevent unexpected outputs with these hooks.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
