### PR TITLE
fix(ssg): Uniformly Convert Paths Ending with Slash to 'index.ext' Format

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -30,8 +30,13 @@ export interface ToSSGResult {
 
 const generateFilePath = (routePath: string, outDir: string, mimeType: string) => {
   const extension = determineExtension(mimeType)
-  const fileName = routePath === '/' ? `index.${extension}` : `${routePath}.${extension}`
-  return joinPaths(outDir, fileName)
+  if (routePath === '/') {
+    return joinPaths(outDir, `index.${extension}`)
+  }
+  if (routePath.endsWith('/')) {
+    return joinPaths(outDir, routePath, `index.${extension}`)
+  }
+  return joinPaths(outDir, `${routePath}.${extension}`)
 }
 
 const parseResponseContent = async (response: Response): Promise<string | ArrayBuffer> => {

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -197,6 +197,7 @@ describe('saveContentToFiles function', () => {
     htmlMap = new Map([
       ['/', { content: 'Home Page', mimeType: 'text/html' }],
       ['/about', { content: 'About Page', mimeType: 'text/html' }],
+      ['/about/', { content: 'About Page', mimeType: 'text/html' }],
     ])
   })
 
@@ -205,6 +206,7 @@ describe('saveContentToFiles function', () => {
 
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/index.html', 'Home Page')
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about.html', 'About Page')
+    expect(fsMock.writeFile).toHaveBeenCalledWith('static/about/index.html', 'About Page')
   })
 
   it('should correctly create directories if they do not exist', async () => {

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -30,8 +30,13 @@ export interface ToSSGResult {
 
 const generateFilePath = (routePath: string, outDir: string, mimeType: string) => {
   const extension = determineExtension(mimeType)
-  const fileName = routePath === '/' ? `index.${extension}` : `${routePath}.${extension}`
-  return joinPaths(outDir, fileName)
+  if (routePath === '/') {
+    return joinPaths(outDir, `index.${extension}`)
+  }
+  if (routePath.endsWith('/')) {
+    return joinPaths(outDir, routePath, `index.${extension}`)
+  }
+  return joinPaths(outDir, `${routePath}.${extension}`)
 }
 
 const parseResponseContent = async (response: Response): Promise<string | ArrayBuffer> => {


### PR DESCRIPTION
- before:  `/api/` -> `./static/api/.html`
- after:  `/api/` -> `./static/api/index.html`

@yusukebe 
Currently, the implementation uniformly converts paths like `/css/` to `/css/index.css`. Considering this, there are two possible approaches to the implementation, and I have chosen the first one:

1. Treat all paths ending with a slash uniformly as `index.ext`, even for non-HTML files. Those who dislike this approach can use paths like `/css` without the trailing slash.
2. For non-HTML files ending with a slash, complete them as `/css.css`. I did not adopt this approach as it seems counterintuitive

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
