### PR TITLE
fix: await generate hook

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -240,6 +240,6 @@ export const toSSG: ToSSGInterface = async (app, fs, options) => {
     const errorObj = error instanceof Error ? error : new Error(String(error))
     result = { success: false, error: errorObj }
   }
-  options?.afterGenerateHook?.(result)
+  await options?.afterGenerateHook?.(result)
   return result
 }

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -240,6 +240,6 @@ export const toSSG: ToSSGInterface = async (app, fs, options) => {
     const errorObj = error instanceof Error ? error : new Error(String(error))
     result = { success: false, error: errorObj }
   }
-  options?.afterGenerateHook?.(result)
+  await options?.afterGenerateHook?.(result)
   return result
 }


### PR DESCRIPTION
ref https://github.com/honojs/hono/pull/2054

The test appears to be failing accidentally. This is probably due to something not awaiting generatehook

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
