### PR TITLE
feat(serve-static): `mimes` option for serve-static

### DIFF
--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -10,6 +10,7 @@ const { open } = Deno
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
+  mime?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }

--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -10,7 +10,7 @@ const { open } = Deno
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
-  mime?: Record<string, string>
+  mimes?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }

--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -1,8 +1,8 @@
-export const getMimeType = (filename: string, mime = baseMime): string | undefined => {
+export const getMimeType = (filename: string, mimes = baseMimes): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
   if (!match) return
-  let mimeType = mime[match[1]]
+  let mimeType = mimes[match[1]]
   if ((mimeType && mimeType.startsWith('text')) || mimeType === 'application/json') {
     mimeType += '; charset=utf-8'
   }
@@ -10,10 +10,10 @@ export const getMimeType = (filename: string, mime = baseMime): string | undefin
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(baseMime).find((ext) => baseMime[ext] === mimeType)
+  return Object.keys(baseMimes).find((ext) => baseMimes[ext] === mimeType)
 }
 
-const baseMime: Record<string, string> = {
+const baseMimes: Record<string, string> = {
   aac: 'audio/aac',
   abw: 'application/x-abiword',
   arc: 'application/x-freearc',

--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -1,4 +1,4 @@
-export const getMimeType = (filename: string, mime = mimes): string | undefined => {
+export const getMimeType = (filename: string, mime = baseMime): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
   if (!match) return
@@ -10,10 +10,10 @@ export const getMimeType = (filename: string, mime = mimes): string | undefined 
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(mimes).find((ext) => mimes[ext] === mimeType)
+  return Object.keys(baseMime).find((ext) => baseMime[ext] === mimeType)
 }
 
-const mimes: Record<string, string> = {
+const baseMime: Record<string, string> = {
   aac: 'audio/aac',
   abw: 'application/x-abiword',
   arc: 'application/x-freearc',

--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -1,16 +1,16 @@
-export const getMimeType = (filename: string): string | undefined => {
+export const getMimeType = (filename: string, mime = mimes): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
   if (!match) return
-  let mimeType = mimes[match[1]]
+  let mimeType = mime[match[1]]
   if ((mimeType && mimeType.startsWith('text')) || mimeType === 'application/json') {
     mimeType += '; charset=utf-8'
   }
   return mimeType
 }
 
-export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(mimes).find((ext) => mimes[ext] === mimeType)
+export const getExtension = (mimeType: string, mime = mimes): string | undefined => {
+  return Object.keys(mime).find((ext) => mime[ext] === mimeType)
 }
 
 const mimes: Record<string, string> = {

--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -9,8 +9,8 @@ export const getMimeType = (filename: string, mime = mimes): string | undefined 
   return mimeType
 }
 
-export const getExtension = (mimeType: string, mime = mimes): string | undefined => {
-  return Object.keys(mime).find((ext) => mime[ext] === mimeType)
+export const getExtension = (mimeType: string): string | undefined => {
+  return Object.keys(mimes).find((ext) => mimes[ext] === mimeType)
 }
 
 const mimes: Record<string, string> = {

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -12,6 +12,7 @@ const { file } = Bun
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
+  mime?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }
@@ -43,7 +44,7 @@ export const serveStatic = <E extends Env = Env>(
     if (existsSync(path)) {
       const content = file(path)
       if (content) {
-        const mimeType = getMimeType(path)
+        const mimeType = getMimeType(path, options.mime)
         if (mimeType) {
           c.header('Content-Type', mimeType)
         }

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -12,7 +12,7 @@ const { file } = Bun
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
-  mime?: Record<string, string>
+  mimes?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }
@@ -44,7 +44,12 @@ export const serveStatic = <E extends Env = Env>(
     if (existsSync(path)) {
       const content = file(path)
       if (content) {
-        const mimeType = getMimeType(path, options.mime)
+        let mimeType: string | undefined = undefined
+        if (options.mimes) {
+          mimeType = getMimeType(path, options.mimes) ?? getMimeType(path)
+        } else {
+          mimeType = getMimeType(path)
+        }
         if (mimeType) {
           c.header('Content-Type', mimeType)
         }

--- a/src/adapter/cloudflare-workers/serve-static.test.ts
+++ b/src/adapter/cloudflare-workers/serve-static.test.ts
@@ -126,8 +126,8 @@ describe('With `file` options', () => {
   })
 })
 
-describe('With `mime` options', () => {
-  const mime = {
+describe('With `mimes` options', () => {
+  const mimes = {
     m3u8: 'application/vnd.apple.mpegurl',
     ts: 'video/mp2t',
   }
@@ -138,7 +138,7 @@ describe('With `mime` options', () => {
   }
 
   const app = new Hono()
-  app.use('/static/*', serveStatic({ root: './assets', mime, manifest }))
+  app.use('/static/*', serveStatic({ root: './assets', mimes, manifest }))
 
   it('Should return content-type of m3u8', async () => {
     const res = await app.request('http://localhost/static/video/morning-routine.m3u8')
@@ -153,7 +153,7 @@ describe('With `mime` options', () => {
   it('Should return content-type of default', async () => {
     const res = await app.request('http://localhost/static/video/introduction.mp4')
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Type')).not.toBe('video/mp4')
+    expect(res.headers.get('Content-Type')).toBe('video/mp4')
   })
 })
 

--- a/src/adapter/cloudflare-workers/serve-static.test.ts
+++ b/src/adapter/cloudflare-workers/serve-static.test.ts
@@ -11,6 +11,9 @@ const store: Record<string, string> = {
   'static-no-root/plain.abcdef.txt': 'That is plain.txt',
   'assets/static/options/foo.abcdef.txt': 'With options',
   'assets/.static/plain.abcdef.txt': 'In the dot',
+  'assets/static/video/morning-routine.abcdef.m3u8': 'Good morning',
+  'assets/static/video/morning-routine1.abcdef.ts': 'Good',
+  'assets/static/video/introduction.abcdef.mp4': 'Let me introduce myself',
 }
 const manifest = JSON.stringify({
   'assets/static/plain.txt': 'assets/static/plain.abcdef.txt',
@@ -120,6 +123,37 @@ describe('With `file` options', () => {
     const res = await app.request('http://localhost/bar/fallback')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('<h1>Hono!</h1>')
+  })
+})
+
+describe('With `mime` options', () => {
+  const mime = {
+    m3u8: 'application/vnd.apple.mpegurl',
+    ts: 'video/mp2t',
+  }
+  const manifest = {
+    'assets/static/video/morning-routine.m3u8': 'assets/static/video/morning-routine.abcdef.m3u8',
+    'assets/static/video/morning-routine1.ts': 'assets/static/video/morning-routine1.abcdef.ts',
+    'assets/static/video/introduction.mp4': 'assets/static/video/introduction.abcdef.mp4',
+  }
+
+  const app = new Hono()
+  app.use('/static/*', serveStatic({ root: './assets', mime, manifest }))
+
+  it('Should return content-type of m3u8', async () => {
+    const res = await app.request('http://localhost/static/video/morning-routine.m3u8')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/vnd.apple.mpegurl')
+  })
+  it('Should return content-type of ts', async () => {
+    const res = await app.request('http://localhost/static/video/morning-routine1.ts')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('video/mp2t')
+  })
+  it('Should return content-type of default', async () => {
+    const res = await app.request('http://localhost/static/video/introduction.mp4')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).not.toBe('video/mp4')
   })
 })
 

--- a/src/adapter/cloudflare-workers/serve-static.test.ts
+++ b/src/adapter/cloudflare-workers/serve-static.test.ts
@@ -150,7 +150,7 @@ describe('With `mimes` options', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('video/mp2t')
   })
-  it('Should return content-type of default', async () => {
+  it('Should return content-type of default on Hono', async () => {
     const res = await app.request('http://localhost/static/video/introduction.mp4')
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('video/mp4')

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -9,6 +9,7 @@ import { getContentFromKVAsset } from './utils'
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
+  mime?: Record<string, string>
   manifest: object | string
   namespace?: KVNamespace
   rewriteRequestPath?: (path: string) => string
@@ -46,7 +47,7 @@ export const serveStatic = <E extends Env = Env>(
     })
 
     if (content) {
-      const mimeType = getMimeType(path)
+      const mimeType = getMimeType(path, options.mime)
       if (mimeType) {
         c.header('Content-Type', mimeType)
       }

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -9,7 +9,7 @@ import { getContentFromKVAsset } from './utils'
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
-  mime?: Record<string, string>
+  mimes?: Record<string, string>
   manifest: object | string
   namespace?: KVNamespace
   rewriteRequestPath?: (path: string) => string
@@ -47,7 +47,12 @@ export const serveStatic = <E extends Env = Env>(
     })
 
     if (content) {
-      const mimeType = getMimeType(path, options.mime)
+      let mimeType: string | undefined = undefined
+      if (options.mimes) {
+        mimeType = getMimeType(path, options.mimes) ?? getMimeType(path)
+      } else {
+        mimeType = getMimeType(path)
+      }
       if (mimeType) {
         c.header('Content-Type', mimeType)
       }

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -10,6 +10,7 @@ const { open } = Deno
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
+  mime?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -10,7 +10,7 @@ const { open } = Deno
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
   path?: string
-  mime?: Record<string, string>
+  mimes?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }

--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -1,5 +1,10 @@
 import { getMimeType, getExtension } from './mime'
 
+const mime = {
+  m3u8: 'application/vnd.apple.mpegurl',
+  ts: 'video/mp2t',
+}
+
 describe('mime', () => {
   it('getMimeType', () => {
     expect(getMimeType('hello.txt')).toBe('text/plain; charset=utf-8')
@@ -9,6 +14,12 @@ describe('mime', () => {
     expect(getMimeType('good.morning.hello.gif')).toBe('image/gif')
     expect(getMimeType('goodmorninghellogif')).toBeUndefined()
     expect(getMimeType('indexjs.abcd')).toBeUndefined()
+  })
+
+  it('getMimeType with custom mime', () => {
+    expect(getMimeType('morning-routine.m3u8', mime)).toBe('application/vnd.apple.mpegurl')
+    expect(getMimeType('morning-routine1.ts', mime)).toBe('video/mp2t')
+    expect(getMimeType('readme.txt', mime)).toBeUndefined()
   })
 
   it('getExtension', () => {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,8 +1,8 @@
-export const getMimeType = (filename: string, mime = baseMime): string | undefined => {
+export const getMimeType = (filename: string, mimes = baseMimes): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
   if (!match) return
-  let mimeType = mime[match[1]]
+  let mimeType = mimes[match[1]]
   if ((mimeType && mimeType.startsWith('text')) || mimeType === 'application/json') {
     mimeType += '; charset=utf-8'
   }
@@ -10,10 +10,10 @@ export const getMimeType = (filename: string, mime = baseMime): string | undefin
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(baseMime).find((ext) => baseMime[ext] === mimeType)
+  return Object.keys(baseMimes).find((ext) => baseMimes[ext] === mimeType)
 }
 
-const baseMime: Record<string, string> = {
+const baseMimes: Record<string, string> = {
   aac: 'audio/aac',
   abw: 'application/x-abiword',
   arc: 'application/x-freearc',

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,4 +1,4 @@
-export const getMimeType = (filename: string, mime = mimes): string | undefined => {
+export const getMimeType = (filename: string, mime = baseMime): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
   if (!match) return
@@ -10,10 +10,10 @@ export const getMimeType = (filename: string, mime = mimes): string | undefined 
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(mimes).find((ext) => mimes[ext] === mimeType)
+  return Object.keys(baseMime).find((ext) => baseMime[ext] === mimeType)
 }
 
-const mimes: Record<string, string> = {
+const baseMime: Record<string, string> = {
   aac: 'audio/aac',
   abw: 'application/x-abiword',
   arc: 'application/x-freearc',

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,16 +1,16 @@
-export const getMimeType = (filename: string): string | undefined => {
+export const getMimeType = (filename: string, mime = mimes): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
   if (!match) return
-  let mimeType = mimes[match[1]]
+  let mimeType = mime[match[1]]
   if ((mimeType && mimeType.startsWith('text')) || mimeType === 'application/json') {
     mimeType += '; charset=utf-8'
   }
   return mimeType
 }
 
-export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(mimes).find((ext) => mimes[ext] === mimeType)
+export const getExtension = (mimeType: string, mime = mimes): string | undefined => {
+  return Object.keys(mime).find((ext) => mime[ext] === mimeType)
 }
 
 const mimes: Record<string, string> = {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -9,8 +9,8 @@ export const getMimeType = (filename: string, mime = mimes): string | undefined 
   return mimeType
 }
 
-export const getExtension = (mimeType: string, mime = mimes): string | undefined => {
-  return Object.keys(mime).find((ext) => mime[ext] === mimeType)
+export const getExtension = (mimeType: string): string | undefined => {
+  return Object.keys(mimes).find((ext) => mimes[ext] === mimeType)
 }
 
 const mimes: Record<string, string> = {


### PR DESCRIPTION
close #2067 

This option enables you to set your own mime to serveStatic().
This `mimes` overwrites default mime in Hono.
```ts
// e.g. HLS
const mimes = {
  m3u8: 'application/x-mpegURL',
  ts: 'video/mp2t'
}
app.use('/video/*', serveStatic({mimes}))
```


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
