### PR TITLE
fix: add typesVersions of accepts helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,6 +344,9 @@
       "cookie": [
         "./dist/types/helper/cookie"
       ],
+      "accepts": [
+        "./dist/types/helper/accepts"
+      ],
       "compress": [
         "./dist/types/middleware/compress"
       ],


### PR DESCRIPTION
### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

Sorry, I forgot this!