### PR TITLE
feat: introduce Body Limit Middleware using stream

### DIFF
--- a/deno_dist/middleware/body-limit/index.ts
+++ b/deno_dist/middleware/body-limit/index.ts
@@ -94,13 +94,3 @@ export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
     }
   }
 }
-
-/**
- * Unit any
- * @example
- * ```ts
- * const limit = 100 * Unit.kb // 100kb
- * const limit2 = 1 * Unit.gb // 1gb
- * ```
- */
-export const Unit = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4, pb: 1024 ** 5 }

--- a/deno_dist/middleware/body-limit/index.ts
+++ b/deno_dist/middleware/body-limit/index.ts
@@ -1,9 +1,20 @@
 import type { Context } from '../../context.ts'
+import { HTTPException } from '../../http-exception.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 
+const ERROR_MESSAGE = 'Payload Too Large'
+
+type OnError = (c: Context) => Response | Promise<Response>
 type BodyLimitOptions = {
   maxSize: number
-  onError?: (c: Context) => Response | Promise<Response>
+  onError?: OnError
+}
+
+class BodyLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BodyLimitError'
+  }
 }
 
 /**
@@ -16,7 +27,7 @@ type BodyLimitOptions = {
  *  bodyLimit({
  *    maxSize: 15 * Unit.b,
  *    onError: (c) => {
- *      return c.text('oveflow :(', 413)
+ *      return c.text('overflow :(', 413)
  *    }
  *  }),
  *  (c) => {
@@ -25,42 +36,64 @@ type BodyLimitOptions = {
  * )
  * ```
  */
-export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler =>
-  async function bodyLimit(c, next) {
-    if (!c.req.raw.body) return next()
+export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
+  const onError: OnError =
+    options.onError ||
+    (() => {
+      const res = new Response(ERROR_MESSAGE, {
+        status: 413,
+      })
+      throw new HTTPException(413, { res })
+    })
+  const maxSize = options.maxSize
 
-    const maxSize = options.maxSize
-    let size = 0
-
-    const reader = c.req.raw.body.getReader()
-    const chunks: Uint8Array[] = []
-
-    for (;;) {
-      const { done, value } = await reader.read()
-      if (done) break
-      if (value) {
-        size += value.length
-        if (size > maxSize) {
-          if (options?.onError) {
-            return options?.onError(c)
-          }
-          return c.text('413 Request Entity Too Large', 413)
-        }
-        chunks.push(value)
-      }
+  return async function bodyLimit(c, next) {
+    if (!c.req.raw.body) {
+      // maybe GET or HEAD request
+      return next()
     }
 
-    const bodyUint8Array = chunks.reduce((acc: Uint8Array, val: Uint8Array) => {
-      const temp = new Uint8Array(acc.length + val.length)
-      temp.set(acc, 0)
-      temp.set(val, acc.length)
-      return temp
-    }, new Uint8Array())
+    if (c.req.raw.headers.has('content-length')) {
+      // we can trust content-length header because it's already validated by server
+      const contentLength = parseInt(c.req.raw.headers.get('content-length') || '0', 10)
+      return contentLength > maxSize ? onError(c) : next()
+    }
 
-    c.req.bodyCache.arrayBuffer = bodyUint8Array
+    // maybe chunked transfer encoding
+
+    let size = 0
+    const rawReader = c.req.raw.body.getReader()
+    const reader = new ReadableStream({
+      async start(controller) {
+        try {
+          for (;;) {
+            const { done, value } = await rawReader.read()
+            if (done) {
+              break
+            }
+            size += value.length
+            if (size > maxSize) {
+              controller.error(new BodyLimitError(ERROR_MESSAGE))
+              break
+            }
+
+            controller.enqueue(value)
+          }
+        } finally {
+          controller.close()
+        }
+      },
+    })
+
+    c.req.raw = new Request(c.req.raw, { body: reader })
 
     await next()
+
+    if (c.error instanceof BodyLimitError) {
+      c.res = await onError(c)
+    }
   }
+}
 
 /**
  * Unit any

--- a/deno_dist/middleware/body-limit/index.ts
+++ b/deno_dist/middleware/body-limit/index.ts
@@ -25,7 +25,7 @@ class BodyLimitError extends Error {
  * app.post(
  *  '/hello',
  *  bodyLimit({
- *    maxSize: 15 * Unit.b,
+ *    maxSize: 100 * 1024, // 100kb
  *    onError: (c) => {
  *      return c.text('overflow :(', 413)
  *    }

--- a/deno_dist/middleware/body-limit/index.ts
+++ b/deno_dist/middleware/body-limit/index.ts
@@ -1,0 +1,73 @@
+import type { Context } from '../../context.ts'
+import type { MiddlewareHandler } from '../../types.ts'
+
+type BodyLimitOptions = {
+  maxSize: number
+  onError?: (c: Context) => Response | Promise<Response>
+}
+
+/**
+ * Body Limit Middleware
+ *
+ * @example
+ * ```ts
+ * app.post(
+ *  '/hello',
+ *  bodyLimit({
+ *    maxSize: 15 * Unit.b,
+ *    onError: (c) => {
+ *      return c.text('oveflow :(', 413)
+ *    }
+ *  }),
+ *  (c) => {
+ *    return c.text('pass :)')
+ *  }
+ * )
+ * ```
+ */
+export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler =>
+  async function bodyLimit(c, next) {
+    if (!c.req.raw.body) return next()
+
+    const maxSize = options.maxSize
+    let size = 0
+
+    const reader = c.req.raw.body.getReader()
+    const chunks: Uint8Array[] = []
+
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        size += value.length
+        if (size > maxSize) {
+          if (options?.onError) {
+            return options?.onError(c)
+          }
+          return c.text('413 Request Entity Too Large', 413)
+        }
+        chunks.push(value)
+      }
+    }
+
+    const bodyUint8Array = chunks.reduce((acc: Uint8Array, val: Uint8Array) => {
+      const temp = new Uint8Array(acc.length + val.length)
+      temp.set(acc, 0)
+      temp.set(val, acc.length)
+      return temp
+    }, new Uint8Array())
+
+    c.req.bodyCache.arrayBuffer = bodyUint8Array
+
+    await next()
+  }
+
+/**
+ * Unit any
+ * @example
+ * ```ts
+ * const limit = 100 * Unit.kb // 100kb
+ * const limit2 = 1 * Unit.gb // 1gb
+ * ```
+ */
+export const Unit = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4, pb: 1024 ** 5 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/middleware/bearer-auth/index.js",
       "require": "./dist/cjs/middleware/bearer-auth/index.js"
     },
+    "./body-limit": {
+      "types": "./dist/types/middleware/body-limit/index.d.ts",
+      "import": "./dist/middleware/body-limit/index.js",
+      "require": "./dist/cjs/middleware/body-limit/index.js"
+    },
     "./cache": {
       "types": "./dist/types/middleware/cache/index.d.ts",
       "import": "./dist/middleware/cache/index.js",
@@ -337,6 +342,9 @@
       ],
       "bearer-auth": [
         "./dist/types/middleware/bearer-auth"
+      ],
+      "body-limit": [
+        "./dist/types/middleware/body-limit"
       ],
       "cache": [
         "./dist/types/middleware/cache"

--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { Unit, bodyLimit } from '.'
+import { bodyLimit } from '.'
 
 const GlobalRequest = globalThis.Request
 globalThis.Request = class Request extends GlobalRequest {
@@ -35,7 +35,7 @@ describe('Body Limit Middleware', () => {
 
   beforeEach(() => {
     app = new Hono()
-    app.use('*', bodyLimit({ maxSize: 15 * Unit.b }))
+    app.use('*', bodyLimit({ maxSize: 15 }))
     app.get('/', (c) => c.text('index'))
     app.post('/body-limit-15byte', async (c) => {
       return c.text(await c.req.raw.text())
@@ -118,7 +118,7 @@ describe('Body Limit Middleware', () => {
       app.post(
         '/text-limit-15byte-custom',
         bodyLimit({
-          maxSize: 15 * Unit.b,
+          maxSize: 15,
           onError: (c) => {
             return c.text('no', 413)
           },
@@ -139,18 +139,5 @@ describe('Body Limit Middleware', () => {
       expect(res.status).toBe(413)
       expect(await res.text()).toBe('no')
     })
-  })
-})
-
-describe('Unit', () => {
-  it('should return the correct size', () => {
-    let beforeSize = 1 / 1024
-
-    for (let i = 0, keys = Object.keys(Unit), len = keys.length; i < len; i++) {
-      // @ts-expect-error: <safe access>
-      const size = Unit[keys[i]]
-      expect(size === beforeSize * 1024).toBeTruthy()
-      beforeSize = size
-    }
   })
 })

--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -1,66 +1,144 @@
 import { Hono } from '../../hono'
 import { Unit, bodyLimit } from '.'
 
+const GlobalRequest = globalThis.Request
+globalThis.Request = class Request extends GlobalRequest {
+  constructor(input: Request | string, init: RequestInit) {
+    if (init) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(init as any).duplex ??= 'half'
+    }
+    super(input, init)
+  }
+} as typeof GlobalRequest
+
+const buildRequestInit = (init: RequestInit = {}): RequestInit => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'text/plain',
+  }
+  if (typeof init.body === 'string') {
+    headers['Content-Length'] = init.body.length.toString()
+  }
+  return {
+    method: 'POST',
+    headers,
+    body: null,
+    ...init,
+  }
+}
+
 describe('Body Limit Middleware', () => {
-  const app = new Hono()
+  let app: Hono
 
-  const exampleText = 'hono is cool' // 12byte
-  const exampleText2 = 'hono is cool and cute' // 21byte
+  const exampleText = 'hono is so cool' // 15byte
+  const exampleText2 = 'hono is so cool and cute' // 24byte
 
-  app.post(
-    '/body-limit-15byte',
-    bodyLimit({
-      maxSize: 15 * Unit.b,
-    }),
-    (c) => {
-      return c.text('yes')
-    }
-  )
-
-  it('should return 200 response', async () => {
-    const res = await app.request('/body-limit-15byte', {
-      method: 'POST',
-      body: exampleText,
+  beforeEach(() => {
+    app = new Hono()
+    app.use('*', bodyLimit({ maxSize: 15 * Unit.b }))
+    app.get('/', (c) => c.text('index'))
+    app.post('/body-limit-15byte', async (c) => {
+      return c.text(await c.req.raw.text())
     })
-
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(await res.text()).toBe('yes')
   })
 
-  it('should return 413 response', async () => {
-    const res = await app.request('/body-limit-15byte', {
-      method: 'POST',
-      body: exampleText2,
+  describe('GET request', () => {
+    it('should return 200 response', async () => {
+      const res = await app.request('/')
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('index')
     })
-
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(413)
-    expect(await res.text()).toBe('413 Request Entity Too Large')
   })
 
-  app.post(
-    '/text-limit-15byte-custom',
-    bodyLimit({
-      maxSize: 15 * Unit.b,
-      onError: (c) => {
-        return c.text('no', 413)
-      },
-    }),
-    (c) => {
-      return c.text('yes')
-    }
-  )
+  describe('POST request', () => {
+    describe('string body', () => {
+      it('should return 200 response', async () => {
+        const res = await app.request('/body-limit-15byte', buildRequestInit({ body: exampleText }))
 
-  it('should return the custom error handler', async () => {
-    const res = await app.request('/text-limit-15byte-custom', {
-      method: 'POST',
-      body: exampleText2,
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe(exampleText)
+      })
+
+      it('should return 413 response', async () => {
+        const res = await app.request(
+          '/body-limit-15byte',
+          buildRequestInit({ body: exampleText2 })
+        )
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(413)
+        expect(await res.text()).toBe('Payload Too Large')
+      })
     })
 
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(413)
-    expect(await res.text()).toBe('no')
+    describe('ReadableStream body', () => {
+      it('should return 200 response', async () => {
+        const contents = ['a', 'b', 'c']
+        const stream = new ReadableStream({
+          start(controller) {
+            while (contents.length) {
+              controller.enqueue(new TextEncoder().encode(contents.shift() as string))
+            }
+            controller.close()
+          },
+        })
+        const res = await app.request('/body-limit-15byte', buildRequestInit({ body: stream }))
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe('abc')
+      })
+
+      it('should return 413 response', async () => {
+        const readSpy = vi.fn().mockImplementation(() => {
+          return {
+            done: false,
+            value: new TextEncoder().encode(exampleText),
+          }
+        })
+        const stream = new ReadableStream()
+        vi.spyOn(stream, 'getReader').mockReturnValue({
+          read: readSpy,
+        } as unknown as ReadableStreamDefaultReader)
+        const res = await app.request('/body-limit-15byte', buildRequestInit({ body: stream }))
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(413)
+        expect(readSpy).toHaveBeenCalledTimes(2)
+        expect(await res.text()).toBe('Payload Too Large')
+      })
+    })
+  })
+
+  describe('custom error handler', () => {
+    beforeEach(() => {
+      app = new Hono()
+      app.post(
+        '/text-limit-15byte-custom',
+        bodyLimit({
+          maxSize: 15 * Unit.b,
+          onError: (c) => {
+            return c.text('no', 413)
+          },
+        }),
+        (c) => {
+          return c.text('yes')
+        }
+      )
+    })
+
+    it('should return the custom error handler', async () => {
+      const res = await app.request(
+        '/text-limit-15byte-custom',
+        buildRequestInit({ body: exampleText2 })
+      )
+
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(413)
+      expect(await res.text()).toBe('no')
+    })
   })
 })
 

--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -1,0 +1,78 @@
+import { Hono } from '../../hono'
+import { Unit, bodyLimit } from '.'
+
+describe('Body Limit Middleware', () => {
+  const app = new Hono()
+
+  const exampleText = 'hono is cool' // 12byte
+  const exampleText2 = 'hono is cool and cute' // 21byte
+
+  app.post(
+    '/body-limit-15byte',
+    bodyLimit({
+      maxSize: 15 * Unit.b,
+    }),
+    (c) => {
+      return c.text('yes')
+    }
+  )
+
+  it('should return 200 response', async () => {
+    const res = await app.request('/body-limit-15byte', {
+      method: 'POST',
+      body: exampleText,
+    })
+
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('yes')
+  })
+
+  it('should return 413 response', async () => {
+    const res = await app.request('/body-limit-15byte', {
+      method: 'POST',
+      body: exampleText2,
+    })
+
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(413)
+    expect(await res.text()).toBe('413 Request Entity Too Large')
+  })
+
+  app.post(
+    '/text-limit-15byte-custom',
+    bodyLimit({
+      maxSize: 15 * Unit.b,
+      onError: (c) => {
+        return c.text('no', 413)
+      },
+    }),
+    (c) => {
+      return c.text('yes')
+    }
+  )
+
+  it('should return the custom error handler', async () => {
+    const res = await app.request('/text-limit-15byte-custom', {
+      method: 'POST',
+      body: exampleText2,
+    })
+
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(413)
+    expect(await res.text()).toBe('no')
+  })
+})
+
+describe('Unit', () => {
+  it('should return the correct size', () => {
+    let beforeSize = 1 / 1024
+
+    for (let i = 0, keys = Object.keys(Unit), len = keys.length; i < len; i++) {
+      // @ts-expect-error: <safe access>
+      const size = Unit[keys[i]]
+      expect(size === beforeSize * 1024).toBeTruthy()
+      beforeSize = size
+    }
+  })
+})

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -94,13 +94,3 @@ export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
     }
   }
 }
-
-/**
- * Unit any
- * @example
- * ```ts
- * const limit = 100 * Unit.kb // 100kb
- * const limit2 = 1 * Unit.gb // 1gb
- * ```
- */
-export const Unit = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4, pb: 1024 ** 5 }

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -1,0 +1,73 @@
+import type { Context } from '../../context'
+import type { MiddlewareHandler } from '../../types'
+
+type BodyLimitOptions = {
+  maxSize: number
+  onError?: (c: Context) => Response | Promise<Response>
+}
+
+/**
+ * Body Limit Middleware
+ *
+ * @example
+ * ```ts
+ * app.post(
+ *  '/hello',
+ *  bodyLimit({
+ *    maxSize: 15 * Unit.b,
+ *    onError: (c) => {
+ *      return c.text('oveflow :(', 413)
+ *    }
+ *  }),
+ *  (c) => {
+ *    return c.text('pass :)')
+ *  }
+ * )
+ * ```
+ */
+export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler =>
+  async function bodyLimit(c, next) {
+    if (!c.req.raw.body) return next()
+
+    const maxSize = options.maxSize
+    let size = 0
+
+    const reader = c.req.raw.body.getReader()
+    const chunks: Uint8Array[] = []
+
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        size += value.length
+        if (size > maxSize) {
+          if (options?.onError) {
+            return options?.onError(c)
+          }
+          return c.text('413 Request Entity Too Large', 413)
+        }
+        chunks.push(value)
+      }
+    }
+
+    const bodyUint8Array = chunks.reduce((acc: Uint8Array, val: Uint8Array) => {
+      const temp = new Uint8Array(acc.length + val.length)
+      temp.set(acc, 0)
+      temp.set(val, acc.length)
+      return temp
+    }, new Uint8Array())
+
+    c.req.bodyCache.arrayBuffer = bodyUint8Array
+
+    await next()
+  }
+
+/**
+ * Unit any
+ * @example
+ * ```ts
+ * const limit = 100 * Unit.kb // 100kb
+ * const limit2 = 1 * Unit.gb // 1gb
+ * ```
+ */
+export const Unit = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4, pb: 1024 ** 5 }

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -25,7 +25,7 @@ class BodyLimitError extends Error {
  * app.post(
  *  '/hello',
  *  bodyLimit({
- *    maxSize: 15 * Unit.b,
+ *    maxSize: 100 * 1024, // 100kb
  *    onError: (c) => {
  *      return c.text('overflow :(', 413)
  *    }


### PR DESCRIPTION
This is an implementation of the feature proposed in #2077 using stream.

### How to use

Simply specify the maximum size.

```ts
app.post(
  '/hello',
  bodyLimit({
    maxSize: 15 * Unit.b, // byte,
    onError: (c) => {
      return c.text('oveflow :(', 413)
    },
  }),
  (c) => {
    return c.text('pass :)')
  }
)
```

### Using stream

The problem discussed in #2077 that a body must be read at a time is solved by using stream.

### `c.req.bodyCache`

It uses `c.req.bodyCache` used by the Validator implementation. By setting the loaded ArrayBuffer to `c.req.bodyCache.arrayBuffer`, such as `c.req.json()` will use that cached body from then on.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
