### PR TITLE
chore(lint): set `curly` rule as `all`

### DIFF
--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -34,7 +34,9 @@ export const serveStatic = <E extends Env = Env>(
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
-    if (!path) return await next()
+    if (!path) {
+      return await next()
+    }
 
     path = `./${path}`
 

--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -8,7 +8,9 @@ import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './util
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
     get(_obj, key) {
-      if (typeof key !== 'string' || key === 'then') return undefined
+      if (typeof key !== 'string' || key === 'then') {
+        return undefined
+      }
       return createProxy(callback, [...path, key])
     },
     apply(_1, _2, args) {
@@ -100,7 +102,9 @@ class ClientRequestImpl {
       headerValues['Cookie'] = cookies.join(',')
     }
 
-    if (this.cType) headerValues['Content-Type'] = this.cType
+    if (this.cType) {
+      headerValues['Content-Type'] = this.cType
+    }
 
     const headers = new Headers(headerValues ?? undefined)
     let url = this.url

--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -43,13 +43,27 @@ export const getRuntimeKey = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 
-  if (global?.Deno !== undefined) return 'deno'
-  if (global?.Bun !== undefined) return 'bun'
-  if (typeof global?.WebSocketPair === 'function') return 'workerd'
-  if (typeof global?.EdgeRuntime === 'string') return 'edge-light'
-  if (global?.fastly !== undefined) return 'fastly'
-  if (global?.__lagon__ !== undefined) return 'lagon'
-  if (global?.process?.release?.name === 'node') return 'node'
+  if (global?.Deno !== undefined) {
+    return 'deno'
+  }
+  if (global?.Bun !== undefined) {
+    return 'bun'
+  }
+  if (typeof global?.WebSocketPair === 'function') {
+    return 'workerd'
+  }
+  if (typeof global?.EdgeRuntime === 'string') {
+    return 'edge-light'
+  }
+  if (global?.fastly !== undefined) {
+    return 'fastly'
+  }
+  if (global?.__lagon__ !== undefined) {
+    return 'lagon'
+  }
+  if (global?.process?.release?.name === 'node') {
+    return 'node'
+  }
 
   return 'other'
 }

--- a/deno_dist/helper/cookie/index.ts
+++ b/deno_dist/helper/cookie/index.ts
@@ -15,11 +15,15 @@ interface GetSignedCookie {
 export const getCookie: GetCookie = (c, key?) => {
   const cookie = c.req.raw.headers.get('Cookie')
   if (typeof key === 'string') {
-    if (!cookie) return undefined
+    if (!cookie) {
+      return undefined
+    }
     const obj = parse(cookie, key)
     return obj[key]
   }
-  if (!cookie) return {}
+  if (!cookie) {
+    return {}
+  }
   const obj = parse(cookie)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return obj as any
@@ -28,11 +32,15 @@ export const getCookie: GetCookie = (c, key?) => {
 export const getSignedCookie: GetSignedCookie = async (c, secret, key?) => {
   const cookie = c.req.raw.headers.get('Cookie')
   if (typeof key === 'string') {
-    if (!cookie) return undefined
+    if (!cookie) {
+      return undefined
+    }
     const obj = await parseSigned(cookie, secret, key)
     return obj[key]
   }
-  if (!cookie) return {}
+  if (!cookie) {
+    return {}
+  }
   const obj = await parseSigned(cookie, secret)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return obj as any

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -101,7 +101,9 @@ class Hono<
 
     // Implementation of app.on(method, path, ...handlers[])
     this.on = (method: string | string[], path: string, ...handlers: H[]) => {
-      if (!method) return this
+      if (!method) {
+        return this
+      }
       this.#path = path
       for (const m of [method].flat()) {
         handlers.map((handler) => {
@@ -236,7 +238,9 @@ class Hono<
         ...optionsArray
       )
 
-      if (res) return res
+      if (res) {
+        return res
+      }
 
       await next()
     }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -94,7 +94,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   header(name: string): string | undefined
   header(): Record<string, string>
   header(name?: string) {
-    if (name) return this.raw.headers.get(name.toLowerCase()) ?? undefined
+    if (name) {
+      return this.raw.headers.get(name.toLowerCase()) ?? undefined
+    }
 
     const headerData: Record<string, string | undefined> = {}
     this.raw.headers.forEach((value, key) => {
@@ -127,7 +129,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
 
   cookie(key?: string) {
     const cookie = this.raw.headers.get('Cookie')
-    if (!cookie) return
+    if (!cookie) {
+      return
+    }
     const obj = parse(cookie)
     if (key) {
       const value = obj[key]
@@ -138,7 +142,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   async parseBody<T extends BodyData = BodyData>(options?: ParseBodyOptions): Promise<T> {
-    if (this.bodyCache.parsedBody) return this.bodyCache.parsedBody as T
+    if (this.bodyCache.parsedBody) {
+      return this.bodyCache.parsedBody as T
+    }
     const parsedBody = await parseBody<T>(this, options)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
@@ -147,7 +153,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private cachedBody = (key: keyof Body) => {
     const { bodyCache, raw } = this
     const cachedBody = bodyCache[key]
-    if (cachedBody) return cachedBody
+    if (cachedBody) {
+      return cachedBody
+    }
     /**
      * If an arrayBuffer cache is exist,
      * use it for creating a text, json, and others.

--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -137,7 +137,9 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error(MESSAGE_MATCHER_IS_ALREADY_BUILT)
     }
 
-    if (methodNames.indexOf(method) === -1) methodNames.push(method)
+    if (methodNames.indexOf(method) === -1) {
+      methodNames.push(method)
+    }
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
         handlerMap[method] = {}

--- a/deno_dist/router/trie-router/node.ts
+++ b/deno_dist/router/trie-router/node.ts
@@ -53,7 +53,9 @@ export class Node<T> {
         parentPatterns.push(...curNode.patterns)
         curNode = curNode.children[p]
         const pattern = getPattern(p)
-        if (pattern) possibleKeys.push(pattern[1])
+        if (pattern) {
+          possibleKeys.push(pattern[1])
+        }
         continue
       }
 
@@ -160,7 +162,9 @@ export class Node<T> {
             continue
           }
 
-          if (part === '') continue
+          if (part === '') {
+            continue
+          }
 
           const [key, name, matcher] = pattern
 

--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -36,7 +36,9 @@ const verifySignature = async (
   try {
     const signatureBinStr = atob(base64Signature)
     const signature = new Uint8Array(signatureBinStr.length)
-    for (let i = 0; i < signatureBinStr.length; i++) signature[i] = signatureBinStr.charCodeAt(i)
+    for (let i = 0; i < signatureBinStr.length; i++) {
+      signature[i] = signatureBinStr.charCodeAt(i)
+    }
     return await crypto.subtle.verify(algorithm, secret, signature, new TextEncoder().encode(value))
   } catch (e) {
     return false
@@ -59,16 +61,22 @@ export const parse = (cookie: string, name?: string): Cookie => {
   return pairs.reduce((parsedCookie, pairStr) => {
     pairStr = pairStr.trim()
     const valueStartPos = pairStr.indexOf('=')
-    if (valueStartPos === -1) return parsedCookie
+    if (valueStartPos === -1) {
+      return parsedCookie
+    }
 
     const cookieName = pairStr.substring(0, valueStartPos).trim()
-    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) return parsedCookie
+    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
+      return parsedCookie
+    }
 
     let cookieValue = pairStr.substring(valueStartPos + 1).trim()
-    if (cookieValue.startsWith('"') && cookieValue.endsWith('"'))
+    if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
       cookieValue = cookieValue.slice(1, -1)
-    if (validCookieValueRegEx.test(cookieValue))
+    }
+    if (validCookieValueRegEx.test(cookieValue)) {
       parsedCookie[cookieName] = decodeURIComponent_(cookieValue)
+    }
 
     return parsedCookie
   }, {} as Cookie)
@@ -84,11 +92,15 @@ export const parseSigned = async (
 
   for (const [key, value] of Object.entries(parse(cookie, name))) {
     const signatureStartPos = value.lastIndexOf('.')
-    if (signatureStartPos < 1) continue
+    if (signatureStartPos < 1) {
+      continue
+    }
 
     const signedValue = value.substring(0, signatureStartPos)
     const signature = value.substring(signatureStartPos + 1)
-    if (signature.length !== 44 || !signature.endsWith('=')) continue
+    if (signature.length !== 44 || !signature.endsWith('=')) {
+      continue
+    }
 
     const isVerified = await verifySignature(signature, signedValue, secretKey)
     parsedCookie[key] = isVerified ? signedValue : false

--- a/deno_dist/utils/filepath.ts
+++ b/deno_dist/utils/filepath.ts
@@ -6,7 +6,9 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) return
+  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
+    return
+  }
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'

--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -1,7 +1,9 @@
 export const getMimeType = (filename: string): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
-  if (!match) return
+  if (!match) {
+    return
+  }
   let mimeType = mimes[match[1]]
   if ((mimeType && mimeType.startsWith('text')) || mimeType === 'application/json') {
     mimeType += '; charset=utf-8'

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -126,7 +126,9 @@ export const checkOptionalParameter = (path: string): string[] | null => {
    in other cases it will return null
   */
 
-  if (!path.match(/\:.+\?$/)) return null
+  if (!path.match(/\:.+\?$/)) {
+    return null
+  }
 
   const segments = path.split('/')
   const results: string[] = []

--- a/package.json
+++ b/package.json
@@ -472,7 +472,7 @@
   ],
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231121.0",
-    "@hono/eslint-config": "^0.0.3",
+    "@hono/eslint-config": "^0.0.4",
     "@hono/node-server": "^1.3.3",
     "@types/crypto-js": "^4.1.1",
     "@types/glob": "^8.0.0",

--- a/runtime_tests/lambda/index.test.ts
+++ b/runtime_tests/lambda/index.test.ts
@@ -133,7 +133,9 @@ describe('AWS Lambda Adapter for Hono', () => {
     const validCookies =
       getCookie(c, testCookie1.key) === testCookie1.value &&
       getCookie(c, testCookie2.key) === testCookie2.value
-    if (!validCookies) return c.text('Invalid Cookies')
+    if (!validCookies) {
+      return c.text('Invalid Cookies')
+    }
     return c.text('Valid Cookies')
   })
 

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -204,7 +204,9 @@ const createRequest = (event: LambdaEvent) => {
   const headers = new Headers()
   getCookies(event, headers)
   for (const [k, v] of Object.entries(event.headers)) {
-    if (v) headers.set(k, v)
+    if (v) {
+      headers.set(k, v)
+    }
   }
 
   const method = isProxyEventV2(event) ? event.requestContext.http.method : event.httpMethod

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -36,7 +36,9 @@ export const serveStatic = <E extends Env = Env>(
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
-    if (!path) return await next()
+    if (!path) {
+      return await next()
+    }
 
     path = `./${path}`
 

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -36,7 +36,9 @@ export const serveStatic = <E extends Env = Env>(
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
-    if (!path) return await next()
+    if (!path) {
+      return await next()
+    }
 
     const content = await getContentFromKVAsset(path, {
       manifest: options.manifest,

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -34,7 +34,9 @@ export const serveStatic = <E extends Env = Env>(
       defaultDocument: DEFAULT_DOCUMENT,
     })
 
-    if (!path) return await next()
+    if (!path) {
+      return await next()
+    }
 
     path = `./${path}`
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -8,7 +8,9 @@ import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './util
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
     get(_obj, key) {
-      if (typeof key !== 'string' || key === 'then') return undefined
+      if (typeof key !== 'string' || key === 'then') {
+        return undefined
+      }
       return createProxy(callback, [...path, key])
     },
     apply(_1, _2, args) {
@@ -100,7 +102,9 @@ class ClientRequestImpl {
       headerValues['Cookie'] = cookies.join(',')
     }
 
-    if (this.cType) headerValues['Content-Type'] = this.cType
+    if (this.cType) {
+      headerValues['Content-Type'] = this.cType
+    }
 
     const headers = new Headers(headerValues ?? undefined)
     let url = this.url

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -43,13 +43,27 @@ export const getRuntimeKey = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 
-  if (global?.Deno !== undefined) return 'deno'
-  if (global?.Bun !== undefined) return 'bun'
-  if (typeof global?.WebSocketPair === 'function') return 'workerd'
-  if (typeof global?.EdgeRuntime === 'string') return 'edge-light'
-  if (global?.fastly !== undefined) return 'fastly'
-  if (global?.__lagon__ !== undefined) return 'lagon'
-  if (global?.process?.release?.name === 'node') return 'node'
+  if (global?.Deno !== undefined) {
+    return 'deno'
+  }
+  if (global?.Bun !== undefined) {
+    return 'bun'
+  }
+  if (typeof global?.WebSocketPair === 'function') {
+    return 'workerd'
+  }
+  if (typeof global?.EdgeRuntime === 'string') {
+    return 'edge-light'
+  }
+  if (global?.fastly !== undefined) {
+    return 'fastly'
+  }
+  if (global?.__lagon__ !== undefined) {
+    return 'lagon'
+  }
+  if (global?.process?.release?.name === 'node') {
+    return 'node'
+  }
 
   return 'other'
 }

--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -122,7 +122,9 @@ describe('Cookie Middleware', () => {
       app.get('/cookie', (c) => {
         const yummyCookie = getCookie(c, 'yummy_cookie')
         const res = new Response('Good cookie')
-        if (yummyCookie) res.headers.set('Yummy-Cookie', yummyCookie)
+        if (yummyCookie) {
+          res.headers.set('Yummy-Cookie', yummyCookie)
+        }
         return res
       })
 

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -15,11 +15,15 @@ interface GetSignedCookie {
 export const getCookie: GetCookie = (c, key?) => {
   const cookie = c.req.raw.headers.get('Cookie')
   if (typeof key === 'string') {
-    if (!cookie) return undefined
+    if (!cookie) {
+      return undefined
+    }
     const obj = parse(cookie, key)
     return obj[key]
   }
-  if (!cookie) return {}
+  if (!cookie) {
+    return {}
+  }
   const obj = parse(cookie)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return obj as any
@@ -28,11 +32,15 @@ export const getCookie: GetCookie = (c, key?) => {
 export const getSignedCookie: GetSignedCookie = async (c, secret, key?) => {
   const cookie = c.req.raw.headers.get('Cookie')
   if (typeof key === 'string') {
-    if (!cookie) return undefined
+    if (!cookie) {
+      return undefined
+    }
     const obj = await parseSigned(cookie, secret, key)
     return obj[key]
   }
-  if (!cookie) return {}
+  if (!cookie) {
+    return {}
+  }
   const obj = await parseSigned(cookie, secret)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return obj as any

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -101,7 +101,9 @@ class Hono<
 
     // Implementation of app.on(method, path, ...handlers[])
     this.on = (method: string | string[], path: string, ...handlers: H[]) => {
-      if (!method) return this
+      if (!method) {
+        return this
+      }
       this.#path = path
       for (const m of [method].flat()) {
         handlers.map((handler) => {
@@ -236,7 +238,9 @@ class Hono<
         ...optionsArray
       )
 
-      if (res) return res
+      if (res) {
+        return res
+      }
 
       await next()
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -94,7 +94,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   header(name: string): string | undefined
   header(): Record<string, string>
   header(name?: string) {
-    if (name) return this.raw.headers.get(name.toLowerCase()) ?? undefined
+    if (name) {
+      return this.raw.headers.get(name.toLowerCase()) ?? undefined
+    }
 
     const headerData: Record<string, string | undefined> = {}
     this.raw.headers.forEach((value, key) => {
@@ -127,7 +129,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
 
   cookie(key?: string) {
     const cookie = this.raw.headers.get('Cookie')
-    if (!cookie) return
+    if (!cookie) {
+      return
+    }
     const obj = parse(cookie)
     if (key) {
       const value = obj[key]
@@ -138,7 +142,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   async parseBody<T extends BodyData = BodyData>(options?: ParseBodyOptions): Promise<T> {
-    if (this.bodyCache.parsedBody) return this.bodyCache.parsedBody as T
+    if (this.bodyCache.parsedBody) {
+      return this.bodyCache.parsedBody as T
+    }
     const parsedBody = await parseBody<T>(this, options)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
@@ -147,7 +153,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private cachedBody = (key: keyof Body) => {
     const { bodyCache, raw } = this
     const cachedBody = bodyCache[key]
-    if (cachedBody) return cachedBody
+    if (cachedBody) {
+      return cachedBody
+    }
     /**
      * If an arrayBuffer cache is exist,
      * use it for creating a text, json, and others.

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -137,7 +137,9 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error(MESSAGE_MATCHER_IS_ALREADY_BUILT)
     }
 
-    if (methodNames.indexOf(method) === -1) methodNames.push(method)
+    if (methodNames.indexOf(method) === -1) {
+      methodNames.push(method)
+    }
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
         handlerMap[method] = {}

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -53,7 +53,9 @@ export class Node<T> {
         parentPatterns.push(...curNode.patterns)
         curNode = curNode.children[p]
         const pattern = getPattern(p)
-        if (pattern) possibleKeys.push(pattern[1])
+        if (pattern) {
+          possibleKeys.push(pattern[1])
+        }
         continue
       }
 
@@ -160,7 +162,9 @@ export class Node<T> {
             continue
           }
 
-          if (part === '') continue
+          if (part === '') {
+            continue
+          }
 
           const [key, name, matcher] = pattern
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -36,7 +36,9 @@ const verifySignature = async (
   try {
     const signatureBinStr = atob(base64Signature)
     const signature = new Uint8Array(signatureBinStr.length)
-    for (let i = 0; i < signatureBinStr.length; i++) signature[i] = signatureBinStr.charCodeAt(i)
+    for (let i = 0; i < signatureBinStr.length; i++) {
+      signature[i] = signatureBinStr.charCodeAt(i)
+    }
     return await crypto.subtle.verify(algorithm, secret, signature, new TextEncoder().encode(value))
   } catch (e) {
     return false
@@ -59,16 +61,22 @@ export const parse = (cookie: string, name?: string): Cookie => {
   return pairs.reduce((parsedCookie, pairStr) => {
     pairStr = pairStr.trim()
     const valueStartPos = pairStr.indexOf('=')
-    if (valueStartPos === -1) return parsedCookie
+    if (valueStartPos === -1) {
+      return parsedCookie
+    }
 
     const cookieName = pairStr.substring(0, valueStartPos).trim()
-    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) return parsedCookie
+    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
+      return parsedCookie
+    }
 
     let cookieValue = pairStr.substring(valueStartPos + 1).trim()
-    if (cookieValue.startsWith('"') && cookieValue.endsWith('"'))
+    if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
       cookieValue = cookieValue.slice(1, -1)
-    if (validCookieValueRegEx.test(cookieValue))
+    }
+    if (validCookieValueRegEx.test(cookieValue)) {
       parsedCookie[cookieName] = decodeURIComponent_(cookieValue)
+    }
 
     return parsedCookie
   }, {} as Cookie)
@@ -84,11 +92,15 @@ export const parseSigned = async (
 
   for (const [key, value] of Object.entries(parse(cookie, name))) {
     const signatureStartPos = value.lastIndexOf('.')
-    if (signatureStartPos < 1) continue
+    if (signatureStartPos < 1) {
+      continue
+    }
 
     const signedValue = value.substring(0, signatureStartPos)
     const signature = value.substring(signatureStartPos + 1)
-    if (signature.length !== 44 || !signature.endsWith('=')) continue
+    if (signature.length !== 44 || !signature.endsWith('=')) {
+      continue
+    }
 
     const isVerified = await verifySignature(signature, signedValue, secretKey)
     parsedCookie[key] = isVerified ? signedValue : false

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -6,7 +6,9 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) return
+  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
+    return
+  }
 
   let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,7 +1,9 @@
 export const getMimeType = (filename: string): string | undefined => {
   const regexp = /\.([a-zA-Z0-9]+?)$/
   const match = filename.match(regexp)
-  if (!match) return
+  if (!match) {
+    return
+  }
   let mimeType = mimes[match[1]]
   if ((mimeType && mimeType.startsWith('text')) || mimeType === 'application/json') {
     mimeType += '; charset=utf-8'

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -126,7 +126,9 @@ export const checkOptionalParameter = (path: string): string[] | null => {
    in other cases it will return null
   */
 
-  if (!path.match(/\:.+\?$/)) return null
+  if (!path.match(/\:.+\?$/)) {
+    return null
+  }
 
   const segments = path.split('/')
   const results: string[] = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,10 +496,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hono/eslint-config@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@hono/eslint-config/-/eslint-config-0.0.3.tgz#15978d401c53c5497156f0a80dc2b261e94139c9"
-  integrity sha512-A4pbMilmx+HpY9TPZuC7+1eEhdTfTWKo7wJjWULOkJiH3pf580ZhaRZ+GvArCDPW6YkvTVvaGxr0wkt8VApzDg==
+"@hono/eslint-config@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@hono/eslint-config/-/eslint-config-0.0.4.tgz#11bf12fd606b63302b4c4f5880f6965cc33ddcd2"
+  integrity sha512-CaL3LBdI2tw7Luo4vGDhhrdntA02Nsts6P0FjAz3U5piy3UhWzgEvEN+L9M0fsG7Mm1cgd+kM3hF8CRJOH0aGA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^6.14.0"
     "@typescript-eslint/parser" "^6.14.0"


### PR DESCRIPTION
Related to https://github.com/orgs/honojs/discussions/2108

As mentioned above, the style of braces in if statements should be unified. It should not be changed by refactoring. Therefore, we add the eslint rule. The option `all` is the style preferred by me and @usualoma. We will go with that.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
