### PR TITLE
feat(types): better `c.var` type

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -4,7 +4,7 @@ import type { HonoRequest } from './request.ts'
 import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types.ts'
 import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html.ts'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status.ts'
-import type { JSONValue, InterfaceToType, JSONParsed } from './utils/types.ts'
+import type { JSONValue, InterfaceToType, JSONParsed, IsAny } from './utils/types.ts'
 
 type HeaderRecord = Record<string, string | string[]>
 type Data = string | ArrayBuffer | ReadableStream
@@ -343,7 +343,8 @@ export class Context<
    * @see https://hono.dev/api/context#var
    */
   // c.var.propName is a read-only
-  get var(): Readonly<E['Variables'] & ContextVariableMap> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get var(): Readonly<ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])> {
     return { ...this._var } as never
   }
 

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -343,8 +343,10 @@ export class Context<
    * @see https://hono.dev/api/context#var
    */
   // c.var.propName is a read-only
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get var(): Readonly<ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])> {
+  get var(): Readonly<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])
+  > {
     return { ...this._var } as never
   }
 

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -49,4 +49,4 @@ export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> 
   ? false
   : true
 
-export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
+export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -48,3 +48,5 @@ export type RequiredKeysOf<BaseType extends object> = Exclude<
 export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> extends never
   ? false
   : true
+
+export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;

--- a/src/context.ts
+++ b/src/context.ts
@@ -343,8 +343,10 @@ export class Context<
    * @see https://hono.dev/api/context#var
    */
   // c.var.propName is a read-only
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get var(): Readonly<ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])> {
+  get var(): Readonly<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])
+  > {
     return { ...this._var } as never
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import type { HonoRequest } from './request'
 import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types'
 import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
-import type { JSONValue, InterfaceToType, JSONParsed } from './utils/types'
+import type { JSONValue, InterfaceToType, JSONParsed, IsAny } from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
 type Data = string | ArrayBuffer | ReadableStream
@@ -343,7 +343,8 @@ export class Context<
    * @see https://hono.dev/api/context#var
    */
   // c.var.propName is a read-only
-  get var(): Readonly<E['Variables'] & ContextVariableMap> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get var(): Readonly<ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])> {
     return { ...this._var } as never
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -49,4 +49,4 @@ export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> 
   ? false
   : true
 
-export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
+export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -48,3 +48,5 @@ export type RequiredKeysOf<BaseType extends object> = Exclude<
 export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> extends never
   ? false
   : true
+
+export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;


### PR DESCRIPTION
I noticed `ContextVariableMap` is pretty much useless for `c.var` if `Env` in `Context` is `any` (the default), so I decided to make it respect it without breaking much code.

## Before

```ts
declare module 'hono' {
  export interface ContextVariableMap {
    x: string;
  }
}

const c = new Context(...);

c.var.x; // any
c.var.y; // any
```

## Now

```ts
declare module 'hono' {
  export interface ContextVariableMap {
    x: string;
  }
}

const c = new Context(...);

c.var.x; // string
c.var.y; // still any, as to not break any code
```