### PR TITLE
fix(jsx-renderer): correct nested layouts

### DIFF
--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Context, Renderer } from '../../context.ts'
 import { html, raw } from '../../helper/html/index.ts'
 import { jsx, createContext, useContext, Fragment } from '../../jsx/index.ts'
@@ -17,7 +18,12 @@ type RendererOptions = {
 }
 
 const createRenderer =
-  (c: Context, component?: FC<PropsForRenderer & { Layout: FC }>, options?: RendererOptions) =>
+  (
+    c: Context,
+    Layout: FC,
+    component?: FC<PropsForRenderer & { Layout: FC }>,
+    options?: RendererOptions
+  ) =>
   (children: JSXNode, props: PropsForRenderer) => {
     const docType =
       typeof options?.docType === 'string'
@@ -25,11 +31,6 @@ const createRenderer =
         : options?.docType === false
         ? ''
         : '<!DOCTYPE html>'
-
-    const Layout: FC = (props) => {
-      const parentLayout = c.getLayout() as FC
-      return parentLayout({ ...props, Layout: Fragment })
-    }
 
     const currentLayout = component
       ? component({
@@ -66,13 +67,13 @@ export const jsxRenderer = (
   options?: RendererOptions
 ): MiddlewareHandler =>
   function jsxRenderer(c, next) {
-    const parentLayout = c.getLayout()
-    if (!parentLayout && component) {
-      c.setLayout(component)
+    const Layout = (c.getLayout() ?? Fragment) as FC
+    if (component) {
+      c.setLayout((props) => {
+        return component({ ...props, Layout })
+      })
     }
-
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    c.setRenderer(createRenderer(c, component, options) as any)
+    c.setRenderer(createRenderer(c, Layout, component, options) as any)
     return next()
   }
 

--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -81,13 +81,32 @@ describe('JSX renderer', () => {
     )
     app2.get('/', (c) => c.render(<h1>http://localhost/nested</h1>, { title: 'Nested' }))
 
+    const app3 = new Hono()
+    app3.use(
+      '*',
+      jsxRenderer(({ children, Layout, title }) => (
+        <Layout title={title}>
+          <div class='nested2'>{children}</div>
+        </Layout>
+      ))
+    )
+    app3.get('/', (c) => c.render(<h1>http://localhost/nested</h1>, { title: 'Nested2' }))
+    app2.route('/nested2', app3)
+
     app.route('/nested', app2)
 
-    const res = await app.request('http://localhost/nested')
+    let res = await app.request('http://localhost/nested')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(await res.text()).toBe(
       '<!DOCTYPE html><html><head>Nested</head><body><div class="nested"><h1>http://localhost/nested</h1></div></body></html>'
+    )
+
+    res = await app.request('http://localhost/nested/nested2')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe(
+      '<!DOCTYPE html><html><head>Nested2</head><body><div class="nested"><div class="nested2"><h1>http://localhost/nested</h1></div></div></body></html>'
     )
   })
 

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Context, Renderer } from '../../context'
 import { html, raw } from '../../helper/html'
 import { jsx, createContext, useContext, Fragment } from '../../jsx'
@@ -17,7 +18,12 @@ type RendererOptions = {
 }
 
 const createRenderer =
-  (c: Context, component?: FC<PropsForRenderer & { Layout: FC }>, options?: RendererOptions) =>
+  (
+    c: Context,
+    Layout: FC,
+    component?: FC<PropsForRenderer & { Layout: FC }>,
+    options?: RendererOptions
+  ) =>
   (children: JSXNode, props: PropsForRenderer) => {
     const docType =
       typeof options?.docType === 'string'
@@ -25,11 +31,6 @@ const createRenderer =
         : options?.docType === false
         ? ''
         : '<!DOCTYPE html>'
-
-    const Layout: FC = (props) => {
-      const parentLayout = c.getLayout() as FC
-      return parentLayout({ ...props, Layout: Fragment })
-    }
 
     const currentLayout = component
       ? component({
@@ -66,13 +67,13 @@ export const jsxRenderer = (
   options?: RendererOptions
 ): MiddlewareHandler =>
   function jsxRenderer(c, next) {
-    const parentLayout = c.getLayout()
-    if (!parentLayout && component) {
-      c.setLayout(component)
+    const Layout = (c.getLayout() ?? Fragment) as FC
+    if (component) {
+      c.setLayout((props) => {
+        return component({ ...props, Layout })
+      })
     }
-
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    c.setRenderer(createRenderer(c, component, options) as any)
+    c.setRenderer(createRenderer(c, Layout, component, options) as any)
     return next()
   }
 


### PR DESCRIPTION
Fixed not working correctly when there are more than 2 nested layouts.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
