### PR TITLE
feat(jsx/dom): more react staff

### DIFF
--- a/deno_dist/helper/css/index.ts
+++ b/deno_dist/helper/css/index.ts
@@ -1,6 +1,6 @@
 import { raw } from '../../helper/html/index.ts'
+import { DOM_RENDERER } from '../../jsx/constants.ts'
 import { createCssJsxDomObjects } from '../../jsx/dom/css.ts'
-import { RENDER_TO_DOM } from '../../jsx/dom/render.ts'
 import type { HtmlEscapedCallback, HtmlEscapedString } from '../../utils/html.ts'
 import type { CssClassName as CssClassNameCommon, CssVariableType } from './common.ts'
 import {
@@ -138,7 +138,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
       ? raw(`<style id="${id}">${(children as unknown as CssClassName)[STYLE_STRING]}</style>`)
       : raw(`<style id="${id}"></style>`)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(Style as any)[RENDER_TO_DOM] = StyleRenderToDom
+  ;(Style as any)[DOM_RENDERER] = StyleRenderToDom
 
   return {
     css,

--- a/deno_dist/jsx/components.ts
+++ b/deno_dist/jsx/components.ts
@@ -1,9 +1,9 @@
 import { raw } from '../helper/html/index.ts'
 import type { HtmlEscapedString, HtmlEscapedCallback } from '../utils/html.ts'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../utils/html.ts'
+import { DOM_RENDERER } from './constants.ts'
 import { ErrorBoundary as ErrorBoundaryDomRenderer } from './dom/components.ts'
 import type { HasRenderToDom } from './dom/render.ts'
-import { RENDER_TO_DOM } from './dom/render.ts'
 import type { FC, Child } from './index.ts'
 
 let errorBoundaryCounter = 0
@@ -180,4 +180,4 @@ d.remove()
     return raw(resArray.join(''))
   }
 }
-;(ErrorBoundary as HasRenderToDom)[RENDER_TO_DOM] = ErrorBoundaryDomRenderer
+;(ErrorBoundary as HasRenderToDom)[DOM_RENDERER] = ErrorBoundaryDomRenderer

--- a/deno_dist/jsx/constants.ts
+++ b/deno_dist/jsx/constants.ts
@@ -1,0 +1,3 @@
+export const DOM_RENDERER = Symbol('RENDERER')
+export const DOM_ERROR_HANDLER = Symbol('ERROR_HANDLER')
+export const DOM_STASH = Symbol('STASH')

--- a/deno_dist/jsx/context.ts
+++ b/deno_dist/jsx/context.ts
@@ -1,7 +1,7 @@
 import { raw } from '../helper/html/index.ts'
 import type { HtmlEscapedString } from '../utils/html.ts'
+import { DOM_RENDERER } from './constants.ts'
 import { createContextProviderFunction } from './dom/context.ts'
-import { RENDER_TO_DOM } from './dom/render.ts'
 import { JSXFragmentNode } from './index.ts'
 import type { FC } from './index.ts'
 
@@ -10,35 +10,40 @@ export interface Context<T> {
   Provider: FC<{ value: T }>
 }
 
+export const globalContexts: Context<unknown>[] = []
+
 export const createContext = <T>(defaultValue: T): Context<T> => {
   const values = [defaultValue]
   const context: Context<T> = {
     values,
     Provider(props): HtmlEscapedString | Promise<HtmlEscapedString> {
       values.push(props.value)
-      const string = props.children
-        ? (Array.isArray(props.children)
-            ? new JSXFragmentNode('', {}, props.children)
-            : props.children
-          ).toString()
-        : ''
-      values.pop()
+      let string
+      try {
+        string = props.children
+          ? (Array.isArray(props.children)
+              ? new JSXFragmentNode('', {}, props.children)
+              : props.children
+            ).toString()
+          : ''
+      } finally {
+        values.pop()
+      }
 
       if (string instanceof Promise) {
-        return Promise.resolve().then<HtmlEscapedString>(async () => {
-          values.push(props.value)
-          const awaited = await string
-          const promiseRes = raw(awaited, (awaited as HtmlEscapedString).callbacks)
-          values.pop()
-          return promiseRes
-        })
+        return string.then((resString) =>
+          raw(resString, (resString as HtmlEscapedString).callbacks)
+        )
       } else {
         return raw(string)
       }
     },
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(context.Provider as any)[RENDER_TO_DOM] = createContextProviderFunction(values)
+  ;(context.Provider as any)[DOM_RENDERER] = createContextProviderFunction(values)
+
+  globalContexts.push(context as Context<unknown>)
+
   return context
 }
 

--- a/deno_dist/jsx/dom/components.ts
+++ b/deno_dist/jsx/dom/components.ts
@@ -1,7 +1,7 @@
 import type { FC, Child } from '../index.ts'
 import type { FallbackRender, ErrorHandler } from '../components.ts'
+import { DOM_ERROR_HANDLER } from '../constants.ts'
 import { Fragment } from './jsx-runtime.ts'
-import { ERROR_HANDLER } from './render.ts'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const ErrorBoundary: FC<{
@@ -10,7 +10,7 @@ export const ErrorBoundary: FC<{
   onError?: ErrorHandler
 }> = (({ children, fallback, fallbackRender, onError }: any) => {
   const res = Fragment({ children })
-  ;(res as any)[ERROR_HANDLER] = (err: any) => {
+  ;(res as any)[DOM_ERROR_HANDLER] = (err: any) => {
     if (err instanceof Promise) {
       throw err
     }
@@ -22,7 +22,7 @@ export const ErrorBoundary: FC<{
 
 export const Suspense: FC<{ fallback: any }> = (({ children, fallback }: any) => {
   const res = Fragment({ children })
-  ;(res as any)[ERROR_HANDLER] = (err: any, retry: () => void) => {
+  ;(res as any)[DOM_ERROR_HANDLER] = (err: any, retry: () => void) => {
     if (!(err instanceof Promise)) {
       throw err
     }

--- a/deno_dist/jsx/dom/context.ts
+++ b/deno_dist/jsx/dom/context.ts
@@ -1,7 +1,8 @@
 import type { Child } from '../index.ts'
+import { DOM_ERROR_HANDLER } from '../constants.ts'
 import type { Context } from '../context.ts'
+import { globalContexts } from '../context.ts'
 import { Fragment } from './jsx-runtime.ts'
-import { ERROR_HANDLER } from './render.ts'
 
 export const createContextProviderFunction =
   <T>(values: T[]) =>
@@ -22,7 +23,7 @@ export const createContextProviderFunction =
       ],
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(res as any)[ERROR_HANDLER] = (err: unknown) => {
+    ;(res as any)[DOM_ERROR_HANDLER] = (err: unknown) => {
       values.pop()
       throw err
     }
@@ -31,9 +32,11 @@ export const createContextProviderFunction =
 
 export const createContext = <T>(defaultValue: T): Context<T> => {
   const values = [defaultValue]
-  return {
+  const context = {
     values,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Provider: createContextProviderFunction(values) as any,
   }
+  globalContexts.push(context)
+  return context
 }

--- a/deno_dist/jsx/dom/index.ts
+++ b/deno_dist/jsx/dom/index.ts
@@ -1,5 +1,38 @@
+export {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  use,
+  startTransition,
+  useTransition,
+  useDeferredValue,
+  startViewTransition,
+  useViewTransition,
+  useMemo,
+  useLayoutEffect,
+} from '../hooks/index.ts'
 export { render } from './render.ts'
 export { Suspense, ErrorBoundary } from './components.ts'
 export { useContext } from '../context.ts'
 export type { Context } from '../context.ts'
 export { createContext } from './context.ts'
+export { memo, isValidElement } from '../index.ts'
+
+import type { Props, Child, JSXNode } from '../index.ts'
+import { jsx } from './jsx-runtime.ts'
+export const cloneElement = <T extends JSXNode | JSX.Element>(
+  element: T,
+  props: Props,
+  ...children: Child[]
+): T => {
+  return jsx(
+    (element as JSXNode).tag,
+    {
+      ...(element as JSXNode).props,
+      ...props,
+      children: children.length ? children : (element as JSXNode).children,
+    },
+    (element as JSXNode).key
+  ) as T
+}

--- a/deno_dist/jsx/dom/render.ts
+++ b/deno_dist/jsx/dom/render.ts
@@ -1,5 +1,8 @@
 import type { FC, Child, Props } from '../index.ts'
 import type { JSXNode } from '../index.ts'
+import { DOM_RENDERER, DOM_ERROR_HANDLER, DOM_STASH } from '../constants.ts'
+import type { Context as JSXContext } from '../context.ts'
+import { globalContexts as globalJSXContexts } from '../context.ts'
 import type { EffectData } from '../hooks/index.ts'
 import { STASH_EFFECT } from '../hooks/index.ts'
 
@@ -7,15 +10,13 @@ const eventAliasMap: Record<string, string> = {
   change: 'input',
 }
 
-export const RENDER_TO_DOM = Symbol()
-export const ERROR_HANDLER = Symbol()
-export const STASH = Symbol()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type HasRenderToDom = FC<any> & { [RENDER_TO_DOM]: FC<any> }
+export type HasRenderToDom = FC<any> & { [DOM_RENDERER]: FC<any> }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ErrorHandler = (error: any, retry: () => void) => Child | undefined
 
 type Container = HTMLElement | DocumentFragment
+type LocalJSXContexts = [JSXContext<unknown>, unknown][] | undefined
 
 export type NodeObject = {
   pP: Props | undefined // previous props
@@ -25,11 +26,18 @@ export type NodeObject = {
   s?: Node[] // shadow virtual dom children
   c: Container | undefined // container
   e: HTMLElement | Text | undefined // rendered element
-  [STASH]: [
-    number, // current hook index
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any[][] // stash for hooks
-  ]
+  [DOM_STASH]:
+    | [
+        number, // current hook index
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any[][], // stash for hooks
+        LocalJSXContexts // context
+      ]
+    | [
+        number,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any[][]
+      ]
 } & JSXNode
 type NodeString = [string] & {
   e?: Text
@@ -133,9 +141,9 @@ const invokeTag = (context: Context, node: NodeObject): Child[] => {
     return res
   }
 
-  node[STASH][0] = 0
+  node[DOM_STASH][0] = 0
   buildDataStack.push([context, node])
-  const func = (node.tag as HasRenderToDom)[RENDER_TO_DOM] || node.tag
+  const func = (node.tag as HasRenderToDom)[DOM_RENDERER] || node.tag
   try {
     return [
       func.call(null, {
@@ -157,7 +165,7 @@ const getNextChildren = (
 ) => {
   childrenToRemove.push(...node.vR)
   if (typeof node.tag === 'function') {
-    node[STASH][1][STASH_EFFECT]?.forEach((data: EffectData) => callbacks.push(data))
+    node[DOM_STASH][1][STASH_EFFECT]?.forEach((data: EffectData) => callbacks.push(data))
   }
   node.vC.forEach((child) => {
     if (isNodeString(child)) {
@@ -195,7 +203,7 @@ const findInsertBefore = (node: Node | undefined): ChildNode | null => {
 
 const removeNode = (node: Node) => {
   if (!isNodeString(node)) {
-    node[STASH]?.[1][STASH_EFFECT]?.forEach((data: EffectData) => data[2]?.())
+    node[DOM_STASH]?.[1][STASH_EFFECT]?.forEach((data: EffectData) => data[2]?.())
     node.vC?.forEach(removeNode)
   }
   node.e?.remove()
@@ -255,6 +263,9 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
   }
   remove.forEach(removeNode)
   callbacks.forEach(([, cb]) => cb?.())
+  requestAnimationFrame(() => {
+    callbacks.forEach(([, , , cb]) => cb?.())
+  })
 }
 
 export const build = (
@@ -271,7 +282,7 @@ export const build = (
   children ||= typeof node.tag == 'function' ? invokeTag(context, node) : node.children
   if ((children[0] as JSXNode)?.tag === '') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    errorHandler = (children[0] as any)[ERROR_HANDLER] as ErrorHandler
+    errorHandler = (children[0] as any)[DOM_ERROR_HANDLER] as ErrorHandler
     topLevelErrorHandlerNode ||= node
   }
   const oldVChildren: Node[] = node.vC ? [...node.vC] : []
@@ -286,6 +297,10 @@ export const build = (
           prevNode.nN = child
         }
         prevNode = child
+
+        if (typeof child.tag === 'function' && globalJSXContexts.length > 0) {
+          child[DOM_STASH][2] = globalJSXContexts.map((c) => [c, c.values.at(-1)])
+        }
 
         let oldChild: Node | undefined
         const i = oldVChildren.findIndex((c) => c.key === (child as Node).key)
@@ -346,7 +361,7 @@ const buildNode = (node: Child): Node | undefined => {
     return [node.toString()] as NodeString
   } else {
     if (typeof (node as JSXNode).tag === 'function') {
-      ;(node as NodeObject)[STASH] = [0, []]
+      ;(node as NodeObject)[DOM_STASH] = [0, []]
     }
     return node as NodeObject
   }
@@ -360,7 +375,13 @@ const replaceContainer = (node: NodeObject, from: DocumentFragment, to: Containe
 }
 
 const updateSync = (context: Context, node: NodeObject) => {
+  node[DOM_STASH][2]?.forEach(([c, v]) => {
+    c.values.push(v)
+  })
   build(context, node, undefined)
+  node[DOM_STASH][2]?.forEach(([c]) => {
+    c.values.pop()
+  })
   if (context[0] !== 1 || !context[1]) {
     apply(node, node.c as Container)
   }

--- a/deno_dist/jsx/hooks/index.ts
+++ b/deno_dist/jsx/hooks/index.ts
@@ -1,4 +1,5 @@
-import { buildDataStack, update, build, STASH } from '../dom/render.ts'
+import { DOM_STASH } from '../constants.ts'
+import { buildDataStack, update, build } from '../dom/render.ts'
 import type { Node, NodeObject, Context, PendingType, UpdateHook } from '../dom/render.ts'
 
 type UpdateStateFunction<T> = (newState: T | ((currentState: T) => T)) => void
@@ -7,14 +8,25 @@ const STASH_SATE = 0
 export const STASH_EFFECT = 1
 const STASH_CALLBACK = 2
 const STASH_USE = 3
+const STASH_MEMO = 4
 
 export type EffectData = [
   readonly unknown[] | undefined, // deps
-  (() => void | (() => void)) | undefined, // effect
-  (() => void) | undefined // cleanup
+  (() => void | (() => void)) | undefined, // layout effect
+  (() => void) | undefined, // cleanup
+  (() => void) | undefined // effect
 ]
 
 const resolvedPromiseValueMap = new WeakMap<Promise<unknown>, unknown>()
+
+const isDepsChanged = (
+  prevDeps: readonly unknown[] | undefined,
+  deps: readonly unknown[] | undefined
+): boolean =>
+  !prevDeps ||
+  !deps ||
+  prevDeps.length !== deps.length ||
+  deps.some((dep, i) => dep !== prevDeps[i])
 
 let viewTransitionState:
   | [
@@ -135,8 +147,8 @@ export const useState = <T>(initialState: T | (() => T)): [T, UpdateStateFunctio
   }
   const [, node] = buildData
 
-  const stateArray = (node[STASH][1][STASH_SATE] ||= [])
-  const hookIndex = node[STASH][0]++
+  const stateArray = (node[DOM_STASH][1][STASH_SATE] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   return (stateArray[hookIndex] ||= [
     resolveInitialState(),
@@ -192,32 +204,40 @@ export const useState = <T>(initialState: T | (() => T)): [T, UpdateStateFunctio
   ])
 }
 
-export const useEffect = (effect: () => void | (() => void), deps?: readonly unknown[]): void => {
+const useEffectCommon = (
+  index: number,
+  effect: () => void | (() => void),
+  deps?: readonly unknown[]
+): void => {
   const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
   if (!buildData) {
     return
   }
   const [, node] = buildData
 
-  const effectDepsArray = (node[STASH][1][STASH_EFFECT] ||= [])
-  const hookIndex = node[STASH][0]++
+  const effectDepsArray = (node[DOM_STASH][1][STASH_EFFECT] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   const [prevDeps, , prevCleanup] = (effectDepsArray[hookIndex] ||= [])
-  if (!deps || !prevDeps || deps.some((dep, i) => dep !== prevDeps[i])) {
+  if (isDepsChanged(prevDeps, deps)) {
     if (prevCleanup) {
       prevCleanup()
     }
-    const data: EffectData = [
-      deps,
-      () => {
-        data[1] = undefined // clear this effect in order to avoid calling effect twice
-        data[2] = effect() as (() => void) | undefined
-      },
-      undefined,
-    ]
+    const runner = () => {
+      data[index] = undefined // clear this effect in order to avoid calling effect twice
+      data[2] = effect() as (() => void) | undefined
+    }
+    const data: EffectData = [deps, undefined, undefined, undefined]
+    data[index] = runner
     effectDepsArray[hookIndex] = data
   }
 }
+export const useEffect = (effect: () => void | (() => void), deps?: readonly unknown[]): void =>
+  useEffectCommon(3, effect, deps)
+export const useLayoutEffect = (
+  effect: () => void | (() => void),
+  deps?: readonly unknown[]
+): void => useEffectCommon(1, effect, deps)
 
 export const useCallback = <T extends (...args: unknown[]) => unknown>(
   callback: T,
@@ -229,11 +249,11 @@ export const useCallback = <T extends (...args: unknown[]) => unknown>(
   }
   const [, node] = buildData
 
-  const callbackArray = (node[STASH][1][STASH_CALLBACK] ||= [])
-  const hookIndex = node[STASH][0]++
+  const callbackArray = (node[DOM_STASH][1][STASH_CALLBACK] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   const prevDeps = callbackArray[hookIndex]
-  if (!prevDeps || deps.some((dep, i) => dep !== prevDeps[1][i])) {
+  if (isDepsChanged(prevDeps?.[1], deps)) {
     callbackArray[hookIndex] = [callback, deps]
   } else {
     callback = callbackArray[hookIndex][0] as T
@@ -264,8 +284,8 @@ export const use = <T>(promise: Promise<T>): T => {
   }
   const [, node] = buildData
 
-  const promiseArray = (node[STASH][1][STASH_USE] ||= [])
-  const hookIndex = node[STASH][0]++
+  const promiseArray = (node[DOM_STASH][1][STASH_USE] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   promise
     .then((res) => {
@@ -284,4 +304,21 @@ export const use = <T>(promise: Promise<T>): T => {
   }
 
   throw promise
+}
+
+export const useMemo = <T>(factory: () => T, deps: readonly unknown[]): T => {
+  const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
+  if (!buildData) {
+    return factory()
+  }
+  const [, node] = buildData
+
+  const memoArray = (node[DOM_STASH][1][STASH_MEMO] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
+
+  const prevDeps = memoArray[hookIndex]
+  if (isDepsChanged(prevDeps?.[1], deps)) {
+    memoArray[hookIndex] = [factory(), deps]
+  }
+  return memoArray[hookIndex][0] as T
 }

--- a/deno_dist/jsx/index.ts
+++ b/deno_dist/jsx/index.ts
@@ -1,6 +1,8 @@
 import { raw } from '../helper/html/index.ts'
 import { escapeToBuffer, stringBufferToString } from '../utils/html.ts'
 import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../utils/html.ts'
+import type { Context } from './context.ts'
+import { globalContexts } from './context.ts'
 import type { IntrinsicElements as IntrinsicElementsDefined } from './intrinsic-elements.ts'
 
 export { ErrorBoundary } from './components.ts'
@@ -16,6 +18,8 @@ export {
   useDeferredValue,
   startViewTransition,
   useViewTransition,
+  useMemo,
+  useLayoutEffect,
 } from './hooks/index.ts'
 export type { RefObject } from './hooks/index.ts'
 export { createContext, useContext } from './context.ts'
@@ -108,6 +112,7 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBuffer): void
   }
 }
 
+type LocalContexts = [Context<unknown>, unknown][]
 export type Child = string | Promise<string> | number | JSXNode | Child[]
 export class JSXNode implements HtmlEscaped {
   tag: string | Function
@@ -115,6 +120,7 @@ export class JSXNode implements HtmlEscaped {
   key?: string
   children: Child[]
   isEscaped: true = true as const
+  localContexts?: LocalContexts
   constructor(tag: string | Function, props: Props, children: Child[]) {
     this.tag = tag
     this.props = props
@@ -123,7 +129,16 @@ export class JSXNode implements HtmlEscaped {
 
   toString(): string | Promise<string> {
     const buffer: StringBuffer = ['']
-    this.toStringToBuffer(buffer)
+    this.localContexts?.forEach(([context, value]) => {
+      context.values.push(value)
+    })
+    try {
+      this.toStringToBuffer(buffer)
+    } finally {
+      this.localContexts?.forEach(([context]) => {
+        context.values.pop()
+      })
+    }
     return buffer.length === 1 ? buffer[0] : stringBufferToString(buffer)
   }
 
@@ -224,7 +239,21 @@ class JSXFunctionNode extends JSXNode {
     }
 
     if (res instanceof Promise) {
-      buffer.unshift('', res)
+      if (globalContexts.length === 0) {
+        buffer.unshift('', res)
+      } else {
+        // save current contexts for resuming
+        const currentContexts: LocalContexts = globalContexts.map((c) => [c, c.values.at(-1)])
+        buffer.unshift(
+          '',
+          res.then((childRes) => {
+            if (childRes instanceof JSXNode) {
+              childRes.localContexts = currentContexts
+            }
+            return childRes
+          })
+        )
+      }
     } else if (res instanceof JSXNode) {
       res.toStringToBuffer(buffer)
     } else if (typeof res === 'number' || (res as HtmlEscaped).isEscaped) {
@@ -282,14 +311,21 @@ const shallowEqual = (a: Props, b: Props): boolean => {
     return true
   }
 
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
+  const aKeys = Object.keys(a).sort()
+  const bKeys = Object.keys(b).sort()
   if (aKeys.length !== bKeys.length) {
     return false
   }
 
   for (let i = 0, len = aKeys.length; i < len; i++) {
-    if (a[aKeys[i]] !== b[aKeys[i]]) {
+    if (
+      aKeys[i] === 'children' &&
+      bKeys[i] === 'children' &&
+      !a.children?.length &&
+      !b.children?.length
+    ) {
+      continue
+    } else if (a[aKeys[i]] !== b[aKeys[i]]) {
       return false
     }
   }
@@ -301,9 +337,9 @@ export const memo = <T>(
   component: FC<T>,
   propsAreEqual: (prevProps: Readonly<T>, nextProps: Readonly<T>) => boolean = shallowEqual
 ): FC<T> => {
-  let computed = undefined
+  let computed: HtmlEscapedString | Promise<HtmlEscapedString> | undefined = undefined
   let prevProps: T | undefined = undefined
-  return ((props: T & { children?: Child }): HtmlEscapedString => {
+  return ((props: T & { children?: Child }): HtmlEscapedString | Promise<HtmlEscapedString> => {
     if (prevProps && !propsAreEqual(prevProps, props)) {
       computed = undefined
     }
@@ -323,4 +359,27 @@ export const Fragment = ({
     {},
     Array.isArray(children) ? children : children ? [children] : []
   ) as never
+}
+
+export const isValidElement = (element: unknown): element is JSXNode => {
+  return !!(
+    element &&
+    typeof element === 'object' &&
+    'tag' in element &&
+    'props' in element &&
+    'children' in element
+  )
+}
+
+export const cloneElement = <T extends JSXNode | JSX.Element>(
+  element: T,
+  props: Partial<Props>,
+  ...children: Child[]
+): T => {
+  return jsxFn(
+    (element as JSXNode).tag,
+    { ...(element as JSXNode).props, ...props },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    children.length ? children : ((element as JSXNode).children as any) || []
+  ) as T
 }

--- a/deno_dist/jsx/streaming.ts
+++ b/deno_dist/jsx/streaming.ts
@@ -2,8 +2,9 @@ import { raw } from '../helper/html/index.ts'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../utils/html.ts'
 import type { HtmlEscapedString } from '../utils/html.ts'
 import { childrenToString } from './components.ts'
+import { DOM_RENDERER, DOM_STASH } from './constants.ts'
 import { Suspense as SuspenseDomRenderer } from './dom/components.ts'
-import { RENDER_TO_DOM, buildDataStack, STASH } from './dom/render.ts'
+import { buildDataStack } from './dom/render.ts'
 import type { HasRenderToDom, NodeObject } from './dom/render.ts'
 import type { FC, Child } from './index.ts'
 
@@ -26,21 +27,21 @@ export const Suspense: FC<{ fallback: any }> = async ({ children, fallback }) =>
   let resArray: HtmlEscapedString[] | Promise<HtmlEscapedString[]>[] = []
 
   // for use() hook
-  const stackNode = { [STASH]: [0, []] } as unknown as NodeObject
+  const stackNode = { [DOM_STASH]: [0, []] } as unknown as NodeObject
   const popNodeStack = (value?: unknown) => {
     buildDataStack.pop()
     return value
   }
 
   try {
-    stackNode[STASH][0] = 0
+    stackNode[DOM_STASH][0] = 0
     buildDataStack.push([[], stackNode])
     resArray = children.map((c) => c.toString()) as HtmlEscapedString[]
   } catch (e) {
     if (e instanceof Promise) {
       resArray = [
         e.then(() => {
-          stackNode[STASH][0] = 0
+          stackNode[DOM_STASH][0] = 0
           buildDataStack.push([[], stackNode])
           return childrenToString(children as Child[]).then(popNodeStack)
         }),
@@ -101,7 +102,7 @@ d.replaceWith(c.content)
     return raw(resArray.join(''))
   }
 }
-;(Suspense as HasRenderToDom)[RENDER_TO_DOM] = SuspenseDomRenderer
+;(Suspense as HasRenderToDom)[DOM_RENDERER] = SuspenseDomRenderer
 
 const textEncoder = new TextEncoder()
 /**

--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -1,6 +1,6 @@
 import { raw } from '../../helper/html'
+import { DOM_RENDERER } from '../../jsx/constants'
 import { createCssJsxDomObjects } from '../../jsx/dom/css'
-import { RENDER_TO_DOM } from '../../jsx/dom/render'
 import type { HtmlEscapedCallback, HtmlEscapedString } from '../../utils/html'
 import type { CssClassName as CssClassNameCommon, CssVariableType } from './common'
 import {
@@ -138,7 +138,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
       ? raw(`<style id="${id}">${(children as unknown as CssClassName)[STYLE_STRING]}</style>`)
       : raw(`<style id="${id}"></style>`)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(Style as any)[RENDER_TO_DOM] = StyleRenderToDom
+  ;(Style as any)[DOM_RENDERER] = StyleRenderToDom
 
   return {
     css,

--- a/src/jsx/components.ts
+++ b/src/jsx/components.ts
@@ -1,9 +1,9 @@
 import { raw } from '../helper/html'
 import type { HtmlEscapedString, HtmlEscapedCallback } from '../utils/html'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../utils/html'
+import { DOM_RENDERER } from './constants'
 import { ErrorBoundary as ErrorBoundaryDomRenderer } from './dom/components'
 import type { HasRenderToDom } from './dom/render'
-import { RENDER_TO_DOM } from './dom/render'
 import type { FC, Child } from '.'
 
 let errorBoundaryCounter = 0
@@ -180,4 +180,4 @@ d.remove()
     return raw(resArray.join(''))
   }
 }
-;(ErrorBoundary as HasRenderToDom)[RENDER_TO_DOM] = ErrorBoundaryDomRenderer
+;(ErrorBoundary as HasRenderToDom)[DOM_RENDERER] = ErrorBoundaryDomRenderer

--- a/src/jsx/constants.ts
+++ b/src/jsx/constants.ts
@@ -1,0 +1,3 @@
+export const DOM_RENDERER = Symbol('RENDERER')
+export const DOM_ERROR_HANDLER = Symbol('ERROR_HANDLER')
+export const DOM_STASH = Symbol('STASH')

--- a/src/jsx/context.ts
+++ b/src/jsx/context.ts
@@ -1,7 +1,7 @@
 import { raw } from '../helper/html'
 import type { HtmlEscapedString } from '../utils/html'
+import { DOM_RENDERER } from './constants'
 import { createContextProviderFunction } from './dom/context'
-import { RENDER_TO_DOM } from './dom/render'
 import { JSXFragmentNode } from '.'
 import type { FC } from '.'
 
@@ -40,7 +40,7 @@ export const createContext = <T>(defaultValue: T): Context<T> => {
     },
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(context.Provider as any)[RENDER_TO_DOM] = createContextProviderFunction(values)
+  ;(context.Provider as any)[DOM_RENDERER] = createContextProviderFunction(values)
 
   globalContexts.push(context as Context<unknown>)
 

--- a/src/jsx/dom/components.test.tsx
+++ b/src/jsx/dom/components.test.tsx
@@ -17,6 +17,10 @@ function runner(
   ErrorBoundary: typeof ErrorBoundaryDom
 ) {
   describe(name, () => {
+    beforeAll(() => {
+      global.requestAnimationFrame = (cb) => setTimeout(cb)
+    })
+
     describe('Suspense', () => {
       let dom: JSDOM
       let root: HTMLElement

--- a/src/jsx/dom/components.ts
+++ b/src/jsx/dom/components.ts
@@ -1,7 +1,7 @@
 import type { FC, Child } from '..'
 import type { FallbackRender, ErrorHandler } from '../components'
+import { DOM_ERROR_HANDLER } from '../constants'
 import { Fragment } from './jsx-runtime'
-import { ERROR_HANDLER } from './render'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const ErrorBoundary: FC<{
@@ -10,7 +10,7 @@ export const ErrorBoundary: FC<{
   onError?: ErrorHandler
 }> = (({ children, fallback, fallbackRender, onError }: any) => {
   const res = Fragment({ children })
-  ;(res as any)[ERROR_HANDLER] = (err: any) => {
+  ;(res as any)[DOM_ERROR_HANDLER] = (err: any) => {
     if (err instanceof Promise) {
       throw err
     }
@@ -22,7 +22,7 @@ export const ErrorBoundary: FC<{
 
 export const Suspense: FC<{ fallback: any }> = (({ children, fallback }: any) => {
   const res = Fragment({ children })
-  ;(res as any)[ERROR_HANDLER] = (err: any, retry: () => void) => {
+  ;(res as any)[DOM_ERROR_HANDLER] = (err: any, retry: () => void) => {
     if (!(err instanceof Promise)) {
       throw err
     }

--- a/src/jsx/dom/context.test.tsx
+++ b/src/jsx/dom/context.test.tsx
@@ -17,6 +17,10 @@ function runner(
   useContext: typeof useContextCommon
 ) {
   describe(name, () => {
+    beforeAll(() => {
+      global.requestAnimationFrame = (cb) => setTimeout(cb)
+    })
+
     describe('Context', () => {
       let dom: JSDOM
       let root: HTMLElement

--- a/src/jsx/dom/context.ts
+++ b/src/jsx/dom/context.ts
@@ -1,8 +1,8 @@
 import type { Child } from '..'
+import { DOM_ERROR_HANDLER } from '../constants'
 import type { Context } from '../context'
 import { globalContexts } from '../context'
 import { Fragment } from './jsx-runtime'
-import { ERROR_HANDLER } from './render'
 
 export const createContextProviderFunction =
   <T>(values: T[]) =>
@@ -23,7 +23,7 @@ export const createContextProviderFunction =
       ],
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(res as any)[ERROR_HANDLER] = (err: unknown) => {
+    ;(res as any)[DOM_ERROR_HANDLER] = (err: unknown) => {
       values.pop()
       throw err
     }

--- a/src/jsx/dom/context.ts
+++ b/src/jsx/dom/context.ts
@@ -1,5 +1,6 @@
 import type { Child } from '..'
 import type { Context } from '../context'
+import { globalContexts } from '../context'
 import { Fragment } from './jsx-runtime'
 import { ERROR_HANDLER } from './render'
 
@@ -31,9 +32,11 @@ export const createContextProviderFunction =
 
 export const createContext = <T>(defaultValue: T): Context<T> => {
   const values = [defaultValue]
-  return {
+  const context = {
     values,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Provider: createContextProviderFunction(values) as any,
   }
+  globalContexts.push(context)
+  return context
 }

--- a/src/jsx/dom/css.test.tsx
+++ b/src/jsx/dom/css.test.tsx
@@ -10,6 +10,10 @@ import type { JSXNode } from '../../jsx'
 import { render } from '.'
 
 describe('Style and css for jsx/dom', () => {
+  beforeAll(() => {
+    global.requestAnimationFrame = (cb) => setTimeout(cb)
+  })
+
   let dom: JSDOM
   let root: HTMLElement
   beforeEach(() => {

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -13,6 +13,10 @@ const getContainer = (element: JSX.Element): DocumentFragment | HTMLElement | un
 }
 
 describe('DOM', () => {
+  beforeAll(() => {
+    global.requestAnimationFrame = (cb) => setTimeout(cb)
+  })
+
   let dom: JSDOM
   let root: HTMLElement
   beforeEach(() => {
@@ -313,6 +317,7 @@ describe('DOM', () => {
     render(app, root)
     expect(root.innerHTML).toBe('<div><button>+</button>0 0</div>')
     expect(called).toBe(1)
+    await new Promise((resolve) => setTimeout(resolve))
     root.querySelector('button')?.click()
     expect(called).toBe(1)
     await Promise.resolve()
@@ -524,6 +529,7 @@ describe('DOM', () => {
       }
       const app = <Counter />
       render(app, root)
+      await new Promise((resolve) => setTimeout(resolve))
       await Promise.resolve()
       expect(root.innerHTML).toBe('<div>1</div>')
     })
@@ -541,6 +547,7 @@ describe('DOM', () => {
       }
       const app = <Counter />
       render(app, root)
+      await new Promise((resolve) => setTimeout(resolve))
       await Promise.resolve()
       expect(root.innerHTML).toBe('<div>2</div>')
     })
@@ -567,6 +574,7 @@ describe('DOM', () => {
       const app = <Parent />
       render(app, root)
       expect(root.innerHTML).toBe('<div><div>Child</div><button>hide</button></div>')
+      await new Promise((resolve) => setTimeout(resolve))
       const [button] = root.querySelectorAll('button')
       button.click()
       await Promise.resolve()
@@ -597,10 +605,12 @@ describe('DOM', () => {
       }
       const app = <App />
       render(app, root)
+      await new Promise((resolve) => setTimeout(resolve))
       expect(effectCount).toBe(1)
       expect(cleanupCount).toBe(0)
       root.querySelectorAll('button')[0].click() // count++
       await Promise.resolve()
+      await new Promise((resolve) => setTimeout(resolve))
       expect(effectCount).toBe(2)
       expect(cleanupCount).toBe(1)
       root.querySelectorAll('button')[1].click() // count2++

--- a/src/jsx/dom/index.ts
+++ b/src/jsx/dom/index.ts
@@ -1,5 +1,38 @@
+export {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  use,
+  startTransition,
+  useTransition,
+  useDeferredValue,
+  startViewTransition,
+  useViewTransition,
+  useMemo,
+  useLayoutEffect,
+} from '../hooks'
 export { render } from './render'
 export { Suspense, ErrorBoundary } from './components'
 export { useContext } from '../context'
 export type { Context } from '../context'
 export { createContext } from './context'
+export { memo, isValidElement } from '..'
+
+import type { Props, Child, JSXNode } from '..'
+import { jsx } from './jsx-runtime'
+export const cloneElement = <T extends JSXNode | JSX.Element>(
+  element: T,
+  props: Props,
+  ...children: Child[]
+): T => {
+  return jsx(
+    (element as JSXNode).tag,
+    {
+      ...(element as JSXNode).props,
+      ...props,
+      children: children.length ? children : (element as JSXNode).children,
+    },
+    (element as JSXNode).key
+  ) as T
+}

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -255,6 +255,9 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
   }
   remove.forEach(removeNode)
   callbacks.forEach(([, cb]) => cb?.())
+  requestAnimationFrame(() => {
+    callbacks.forEach(([, , , cb]) => cb?.())
+  })
 }
 
 export const build = (

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -16,6 +16,10 @@ import {
 } from '.'
 
 describe('startTransition()', () => {
+  beforeAll(() => {
+    global.requestAnimationFrame = (cb) => setTimeout(cb)
+  })
+
   let dom: JSDOM
   let root: HTMLElement
   beforeEach(() => {

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -1,4 +1,5 @@
-import { buildDataStack, update, build, STASH } from '../dom/render'
+import { DOM_STASH } from '../constants'
+import { buildDataStack, update, build } from '../dom/render'
 import type { Node, NodeObject, Context, PendingType, UpdateHook } from '../dom/render'
 
 type UpdateStateFunction<T> = (newState: T | ((currentState: T) => T)) => void
@@ -146,8 +147,8 @@ export const useState = <T>(initialState: T | (() => T)): [T, UpdateStateFunctio
   }
   const [, node] = buildData
 
-  const stateArray = (node[STASH][1][STASH_SATE] ||= [])
-  const hookIndex = node[STASH][0]++
+  const stateArray = (node[DOM_STASH][1][STASH_SATE] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   return (stateArray[hookIndex] ||= [
     resolveInitialState(),
@@ -214,8 +215,8 @@ const useEffectCommon = (
   }
   const [, node] = buildData
 
-  const effectDepsArray = (node[STASH][1][STASH_EFFECT] ||= [])
-  const hookIndex = node[STASH][0]++
+  const effectDepsArray = (node[DOM_STASH][1][STASH_EFFECT] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   const [prevDeps, , prevCleanup] = (effectDepsArray[hookIndex] ||= [])
   if (isDepsChanged(prevDeps, deps)) {
@@ -248,8 +249,8 @@ export const useCallback = <T extends (...args: unknown[]) => unknown>(
   }
   const [, node] = buildData
 
-  const callbackArray = (node[STASH][1][STASH_CALLBACK] ||= [])
-  const hookIndex = node[STASH][0]++
+  const callbackArray = (node[DOM_STASH][1][STASH_CALLBACK] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   const prevDeps = callbackArray[hookIndex]
   if (isDepsChanged(prevDeps?.[1], deps)) {
@@ -283,8 +284,8 @@ export const use = <T>(promise: Promise<T>): T => {
   }
   const [, node] = buildData
 
-  const promiseArray = (node[STASH][1][STASH_USE] ||= [])
-  const hookIndex = node[STASH][0]++
+  const promiseArray = (node[DOM_STASH][1][STASH_USE] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   promise
     .then((res) => {
@@ -312,8 +313,8 @@ export const useMemo = <T>(factory: () => T, deps: readonly unknown[]): T => {
   }
   const [, node] = buildData
 
-  const memoArray = (node[STASH][1][STASH_MEMO] ||= [])
-  const hookIndex = node[STASH][0]++
+  const memoArray = (node[DOM_STASH][1][STASH_MEMO] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
 
   const prevDeps = memoArray[hookIndex]
   if (isDepsChanged(prevDeps?.[1], deps)) {

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -356,3 +356,26 @@ export const Fragment = ({
     Array.isArray(children) ? children : children ? [children] : []
   ) as never
 }
+
+export const isValidElement = (element: unknown): element is JSXNode => {
+  return !!(
+    element &&
+    typeof element === 'object' &&
+    'tag' in element &&
+    'props' in element &&
+    'children' in element
+  )
+}
+
+export const cloneElement = <T extends JSXNode | JSX.Element>(
+  element: T,
+  props: Partial<Props>,
+  ...children: Child[]
+): T => {
+  return jsxFn(
+    (element as JSXNode).tag,
+    { ...(element as JSXNode).props, ...props },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    children.length ? children : ((element as JSXNode).children as any) || []
+  ) as T
+}

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -243,10 +243,7 @@ class JSXFunctionNode extends JSXNode {
         buffer.unshift('', res)
       } else {
         // save current contexts for resuming
-        const currentContexts: LocalContexts = globalContexts.map((c) => [
-          c,
-          c.values[c.values.length - 1],
-        ])
+        const currentContexts: LocalContexts = globalContexts.map((c) => [c, c.values.at(-1)])
         buffer.unshift(
           '',
           res.then((childRes) => {

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -18,6 +18,8 @@ export {
   useDeferredValue,
   startViewTransition,
   useViewTransition,
+  useMemo,
+  useLayoutEffect,
 } from './hooks'
 export type { RefObject } from './hooks'
 export { createContext, useContext } from './context'

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -311,14 +311,21 @@ const shallowEqual = (a: Props, b: Props): boolean => {
     return true
   }
 
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
+  const aKeys = Object.keys(a).sort()
+  const bKeys = Object.keys(b).sort()
   if (aKeys.length !== bKeys.length) {
     return false
   }
 
   for (let i = 0, len = aKeys.length; i < len; i++) {
-    if (a[aKeys[i]] !== b[aKeys[i]]) {
+    if (
+      aKeys[i] === 'children' &&
+      bKeys[i] === 'children' &&
+      !a.children?.length &&
+      !b.children?.length
+    ) {
+      continue
+    } else if (a[aKeys[i]] !== b[aKeys[i]]) {
       return false
     }
   }
@@ -330,9 +337,9 @@ export const memo = <T>(
   component: FC<T>,
   propsAreEqual: (prevProps: Readonly<T>, nextProps: Readonly<T>) => boolean = shallowEqual
 ): FC<T> => {
-  let computed = undefined
+  let computed: HtmlEscapedString | Promise<HtmlEscapedString> | undefined = undefined
   let prevProps: T | undefined = undefined
-  return ((props: T & { children?: Child }): HtmlEscapedString => {
+  return ((props: T & { children?: Child }): HtmlEscapedString | Promise<HtmlEscapedString> => {
     if (prevProps && !propsAreEqual(prevProps, props)) {
       computed = undefined
     }

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -2,8 +2,9 @@ import { raw } from '../helper/html'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../utils/html'
 import type { HtmlEscapedString } from '../utils/html'
 import { childrenToString } from './components'
+import { DOM_RENDERER, DOM_STASH } from './constants'
 import { Suspense as SuspenseDomRenderer } from './dom/components'
-import { RENDER_TO_DOM, buildDataStack, STASH } from './dom/render'
+import { buildDataStack } from './dom/render'
 import type { HasRenderToDom, NodeObject } from './dom/render'
 import type { FC, Child } from '.'
 
@@ -26,21 +27,21 @@ export const Suspense: FC<{ fallback: any }> = async ({ children, fallback }) =>
   let resArray: HtmlEscapedString[] | Promise<HtmlEscapedString[]>[] = []
 
   // for use() hook
-  const stackNode = { [STASH]: [0, []] } as unknown as NodeObject
+  const stackNode = { [DOM_STASH]: [0, []] } as unknown as NodeObject
   const popNodeStack = (value?: unknown) => {
     buildDataStack.pop()
     return value
   }
 
   try {
-    stackNode[STASH][0] = 0
+    stackNode[DOM_STASH][0] = 0
     buildDataStack.push([[], stackNode])
     resArray = children.map((c) => c.toString()) as HtmlEscapedString[]
   } catch (e) {
     if (e instanceof Promise) {
       resArray = [
         e.then(() => {
-          stackNode[STASH][0] = 0
+          stackNode[DOM_STASH][0] = 0
           buildDataStack.push([[], stackNode])
           return childrenToString(children as Child[]).then(popNodeStack)
         }),
@@ -101,7 +102,7 @@ d.replaceWith(c.content)
     return raw(resArray.join(''))
   }
 }
-;(Suspense as HasRenderToDom)[RENDER_TO_DOM] = SuspenseDomRenderer
+;(Suspense as HasRenderToDom)[DOM_RENDERER] = SuspenseDomRenderer
 
 const textEncoder = new TextEncoder()
 /**


### PR DESCRIPTION
Merging this PR will accomplish the purpose of #2131.

### New staff members

`useMemo`, `useLeyoutEffect`, `isValidElement`, `cloneElement`

### Fixed

#### `useContext`

Fixed the same problem with dom version as #2124

#### `useEffect`

As in the original React, useEffect is now executed asynchronously after the DOM is rendered, rather than synchronously.

### Enable to use 'hono/jsx/dom' for replacement of 'react'. 

You can use dom-specific version of hooks and utils by importing from 'hono/jsx/dom' by 09da043

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
