### PR TITLE
fix(html): Remove circular dependencies in `hono/html`

### DIFF
--- a/deno_dist/helper/html/index.ts
+++ b/deno_dist/helper/html/index.ts
@@ -1,18 +1,11 @@
-import { escapeToBuffer, stringBufferToString } from '../../utils/html.ts'
+import { escapeToBuffer, stringBufferToString, raw } from '../../utils/html.ts'
 import type {
   StringBuffer,
   HtmlEscaped,
   HtmlEscapedString,
-  HtmlEscapedCallback,
 } from '../../utils/html.ts'
 
-export const raw = (value: unknown, callbacks?: HtmlEscapedCallback[]): HtmlEscapedString => {
-  const escapedString = new String(value) as HtmlEscapedString
-  escapedString.isEscaped = true
-  escapedString.callbacks = callbacks
-
-  return escapedString
-}
+export { raw }
 
 export const html = (
   strings: TemplateStringsArray,

--- a/deno_dist/helper/html/index.ts
+++ b/deno_dist/helper/html/index.ts
@@ -1,9 +1,5 @@
 import { escapeToBuffer, stringBufferToString, raw } from '../../utils/html.ts'
-import type {
-  StringBuffer,
-  HtmlEscaped,
-  HtmlEscapedString,
-} from '../../utils/html.ts'
+import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html.ts'
 
 export { raw }
 

--- a/deno_dist/utils/html.ts
+++ b/deno_dist/utils/html.ts
@@ -31,7 +31,13 @@ export type HtmlEscapedString = string & HtmlEscaped
  */
 export type StringBuffer = (string | Promise<string>)[]
 
-import { raw } from '../helper/html/index.ts'
+export const raw = (value: unknown, callbacks?: HtmlEscapedCallback[]): HtmlEscapedString => {
+  const escapedString = new String(value) as HtmlEscapedString
+  escapedString.isEscaped = true
+  escapedString.callbacks = callbacks
+
+  return escapedString
+}
 
 // The `escapeToBuffer` implementation is based on code from the MIT licensed `react-dom` package.
 // https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/server/escapeTextForBrowser.js

--- a/src/helper/html/index.ts
+++ b/src/helper/html/index.ts
@@ -1,9 +1,5 @@
 import { escapeToBuffer, stringBufferToString, raw } from '../../utils/html'
-import type {
-  StringBuffer,
-  HtmlEscaped,
-  HtmlEscapedString,
-} from '../../utils/html'
+import type { StringBuffer, HtmlEscaped, HtmlEscapedString } from '../../utils/html'
 
 export { raw }
 

--- a/src/helper/html/index.ts
+++ b/src/helper/html/index.ts
@@ -1,18 +1,11 @@
-import { escapeToBuffer, stringBufferToString } from '../../utils/html'
+import { escapeToBuffer, stringBufferToString, raw } from '../../utils/html'
 import type {
   StringBuffer,
   HtmlEscaped,
   HtmlEscapedString,
-  HtmlEscapedCallback,
 } from '../../utils/html'
 
-export const raw = (value: unknown, callbacks?: HtmlEscapedCallback[]): HtmlEscapedString => {
-  const escapedString = new String(value) as HtmlEscapedString
-  escapedString.isEscaped = true
-  escapedString.callbacks = callbacks
-
-  return escapedString
-}
+export { raw }
 
 export const html = (
   strings: TemplateStringsArray,

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -31,7 +31,13 @@ export type HtmlEscapedString = string & HtmlEscaped
  */
 export type StringBuffer = (string | Promise<string>)[]
 
-import { raw } from '../helper/html'
+export const raw = (value: unknown, callbacks?: HtmlEscapedCallback[]): HtmlEscapedString => {
+  const escapedString = new String(value) as HtmlEscapedString
+  escapedString.isEscaped = true
+  escapedString.callbacks = callbacks
+
+  return escapedString
+}
 
 // The `escapeToBuffer` implementation is based on code from the MIT licensed `react-dom` package.
 // https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/server/escapeTextForBrowser.js


### PR DESCRIPTION
# Why
There is a circular dependency between `src/helper/html/index.ts` and `src/utils/html.ts`. This PR removes this circular dependency by removing imports to helper files in utility files.

I found this circular dependency while running Hono in [Expo API Routes](https://blog.expo.dev/rfc-api-routes-cce5a3b9f25d). Displaying warnings for node_modules dependencies is [a bug](https://github.com/expo/expo/issues/26613) in Expo but I believe it's good to remove circular dependencies in the first place. 

<img width="704" alt="Screenshot 2024-02-03 at 18 31 40" src="https://github.com/honojs/hono/assets/13040/4fe07f2f-42ed-4d0e-9948-f9c43029cd00">

# How
Move the `raw` function to `src/utils/html.ts` and re-export `raw` in `src/helper/html/index.ts`

# Test Plan
- Run the following command to find circular dependencies warnings disappear after the change.
```
npx dpdm --transform --no-tree ./src/helper/html/index.ts
```
<img width="816" alt="Screenshot 2024-02-03 at 18 14 13" src="https://github.com/honojs/hono/assets/13040/818c1182-925b-4096-8817-6796a1dd14f2">

- Tests for the `raw` remain in the `src/helper/html/index.ts` file so that we continue to test all public API surfaces there. 

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
