### PR TITLE
fix(types): `MergeSchemePath` infers param types correctly

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1627,7 +1627,7 @@ type ExtractParams<Path extends string> = string extends Path
   ? { [K in Param | keyof ExtractParams<`/${Rest}`>]: string }
   : Path extends `${infer Start}:${infer Param}`
   ? { [K in Param]: string }
-  : never
+  : {}
 
 export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = {
   [P in keyof OrigSchema as MergePath<SubPath, P & string>]: {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -537,6 +537,37 @@ describe('merge path', () => {
     type verify = Expect<Equal<Expected, Actual>>
   })
 
+  test('MergeSchemePath - with params and the subpath does not have params', () => {
+    type Actual = MergeSchemaPath<
+      {
+        '/': {
+          $get: {
+            input: {
+              param: {
+                id: string
+              }
+            }
+            output: {}
+          }
+        }
+      },
+      '/something'
+    >
+    type Expected = {
+      '/something': {
+        $get: {
+          input: {
+            param: {
+              id: string
+            }
+          }
+          output: {}
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
   type GetKey<T> = T extends Record<infer K, unknown> ? K : never
 
   it('Should remove a slash - `/` + `/`', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1627,7 +1627,7 @@ type ExtractParams<Path extends string> = string extends Path
   ? { [K in Param | keyof ExtractParams<`/${Rest}`>]: string }
   : Path extends `${infer Start}:${infer Param}`
   ? { [K in Param]: string }
-  : never
+  : {}
 
 export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = {
   [P in keyof OrigSchema as MergePath<SubPath, P & string>]: {


### PR DESCRIPTION
Fixes #2148

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
