### PR TITLE
Fix/function for attribute

### DIFF
--- a/deno_dist/jsx/base.ts
+++ b/deno_dist/jsx/base.ts
@@ -163,6 +163,11 @@ export class JSXNode implements HtmlEscaped {
       } else if (v instanceof Promise) {
         buffer[0] += ` ${key}="`
         buffer.unshift('"', v)
+      } else if (typeof v === 'function') {
+        if (!key.startsWith('on')) {
+          throw `Invalid prop '${key}' of type 'function' supplied to '${tag}'.`
+        }
+        // maybe event handler for client components, just ignore in server components
       } else {
         buffer[0] += ` ${key}="`
         escapeToBuffer(v.toString(), buffer)

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -163,6 +163,11 @@ export class JSXNode implements HtmlEscaped {
       } else if (v instanceof Promise) {
         buffer[0] += ` ${key}="`
         buffer.unshift('"', v)
+      } else if (typeof v === 'function') {
+        if (!key.startsWith('on')) {
+          throw `Invalid prop '${key}' of type 'function' supplied to '${tag}'.`
+        }
+        // maybe event handler for client components, just ignore in server components
       } else {
         buffer[0] += ` ${key}="`
         escapeToBuffer(v.toString(), buffer)

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -293,6 +293,20 @@ describe('render to string', () => {
     })
   })
 
+  describe('Function', () => {
+    it('should be ignored used in on* props', () => {
+      const onClick = () => {}
+      const template = <button onClick={onClick}>Click</button>
+      expect(template.toString()).toBe('<button>Click</button>')
+    })
+
+    it('should raise an error if used in other props', () => {
+      const onClick = () => {}
+      const template = <button data-handler={onClick}>Click</button>
+      expect(() => template.toString()).toThrow()
+    })
+  })
+
   // https://en.reactjs.org/docs/jsx-in-depth.html#functions-as-children
   describe('Functions as Children', () => {
     it('Function', () => {

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -3,9 +3,9 @@ import { JSDOM } from 'jsdom'
 import { raw } from '../helper/html'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../utils/html'
 import type { HtmlEscapedString } from '../utils/html'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, Fragment } from './base'
 import { use } from './hooks'
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Suspense, renderToReadableStream } from './streaming'
 
 function replacementResult(html: string) {


### PR DESCRIPTION
Like React's `renderToString()`, the value should be ignored if the key starts with "on" and an error should occur if the key does not.

https://github.com/honojs/hono/compare/v4...usualoma:hono:fix/function-for-attribute?expand=1#diff-bbb085cf2da64bb28cf34775197b5fb966c1f425b9d12087a4f6e892a7324557R296-R308

Depending on the configuration of the application, users may want to pass functions as strings. However, it is not a good behavior for hono to automatically convert functions to strings, since the stringified function may unintentionally contain server-side code. If an application needs to stringify functions, it should explicitly stringify them using `toString()`.

```tsx
<button data-handler={((ev) => { clientSideCode(ev) }).toString()}>Click</button>
```


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
