### PR TITLE
fix(jsx): The third argument of jsx(), key, is optional

### DIFF
--- a/deno_dist/jsx/dom/jsx-dev-runtime.ts
+++ b/deno_dist/jsx/dom/jsx-dev-runtime.ts
@@ -1,7 +1,7 @@
 import type { Props } from '../base.ts'
 import { normalizeIntrinsicElementProps } from '../utils.ts'
 
-export const jsxDEV = (tag: string | Function, props: Props, key: string | undefined) => {
+export const jsxDEV = (tag: string | Function, props: Props, key?: string) => {
   if (typeof tag === 'string') {
     normalizeIntrinsicElementProps(props)
   }

--- a/deno_dist/jsx/jsx-dev-runtime.ts
+++ b/deno_dist/jsx/jsx-dev-runtime.ts
@@ -6,7 +6,7 @@ export { Fragment } from './base.ts'
 export function jsxDEV(
   tag: string | Function,
   props: Record<string, unknown>,
-  key: string | undefined
+  key?: string
 ): JSXNode {
   let node: JSXNode
   if (!props || !('children' in props)) {

--- a/src/jsx/dom/jsx-dev-runtime.ts
+++ b/src/jsx/dom/jsx-dev-runtime.ts
@@ -1,7 +1,7 @@
 import type { Props } from '../base'
 import { normalizeIntrinsicElementProps } from '../utils'
 
-export const jsxDEV = (tag: string | Function, props: Props, key: string | undefined) => {
+export const jsxDEV = (tag: string | Function, props: Props, key?: string) => {
   if (typeof tag === 'string') {
     normalizeIntrinsicElementProps(props)
   }

--- a/src/jsx/jsx-dev-runtime.ts
+++ b/src/jsx/jsx-dev-runtime.ts
@@ -6,7 +6,7 @@ export { Fragment } from './base'
 export function jsxDEV(
   tag: string | Function,
   props: Record<string, unknown>,
-  key: string | undefined
+  key?: string
 ): JSXNode {
   let node: JSXNode
   if (!props || !('children' in props)) {


### PR DESCRIPTION
As shown in the following example, if key is unspecified, the third argument is not passed, so it is correct that it is optional.

![image](https://github.com/honojs/hono/assets/30598/7186880e-3143-475a-9cb1-a7589d3523ca)
https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

### Author should do the followings, if applicable

- [x] `yarn denoify` to generate files for Deno
