### PR TITLE
perf(mime): make `getExtension()` fast

### DIFF
--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -12,7 +12,11 @@ export const getMimeType = (filename: string, mimes = baseMimes): string | undef
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(baseMimes).find((ext) => baseMimes[ext] === mimeType)
+  for (const ext in baseMimes) {
+    if (baseMimes[ext] === mimeType) {
+      return ext
+    }
+  }
 }
 
 const baseMimes: Record<string, string> = {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -12,7 +12,11 @@ export const getMimeType = (filename: string, mimes = baseMimes): string | undef
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
-  return Object.keys(baseMimes).find((ext) => baseMimes[ext] === mimeType)
+  for (const ext in baseMimes) {
+    if (baseMimes[ext] === mimeType) {
+      return ext
+    }
+  }
 }
 
 const baseMimes: Record<string, string> = {


### PR DESCRIPTION
`find` method is generally slower than for loop.
This PR replace it with for loop. More than 10x faster.
## Benchmark on Deno
<details>

<summary>Source code</summary>


```ts
// Run `deno bench`

export const getExtension1 = (mimeType: string): string | undefined => {
  return Object.keys(baseMimes).find((ext) => baseMimes[ext] === mimeType);
};
export const getExtension2 = (mimeType: string): string | undefined => {
  for (const ext in baseMimes) {
    if (baseMimes[ext] === mimeType) {
      return ext;
    }
  }
};
const baseMimes: Record<string, string> = {
  aac: "audio/aac",
  avi: "video/x-msvideo",
  avif: "image/avif",
  av1: "video/av1",
  bin: "application/octet-stream",
  bmp: "image/bmp",
  css: "text/css",
  csv: "text/csv",
  eot: "application/vnd.ms-fontobject",
  epub: "application/epub+zip",
  gif: "image/gif",
  gz: "application/gzip",
  htm: "text/html",
  html: "text/html",
  ico: "image/x-icon",
  ics: "text/calendar",
  jpeg: "image/jpeg",
  jpg: "image/jpeg",
  js: "text/javascript",
  json: "application/json",
  jsonld: "application/ld+json",
  map: "application/json",
  mid: "audio/x-midi",
  midi: "audio/x-midi",
  mjs: "text/javascript",
  mp3: "audio/mpeg",
  mp4: "video/mp4",
  mpeg: "video/mpeg",
  oga: "audio/ogg",
  ogv: "video/ogg",
  ogx: "application/ogg",
  opus: "audio/opus",
  otf: "font/otf",
  pdf: "application/pdf",
  png: "image/png",
  rtf: "application/rtf",
  svg: "image/svg+xml",
  tif: "image/tiff",
  tiff: "image/tiff",
  ts: "video/mp2t",
  ttf: "font/ttf",
  txt: "text/plain",
  wasm: "application/wasm",
  webm: "video/webm",
  weba: "audio/webm",
  webp: "image/webp",
  woff: "font/woff",
  woff2: "font/woff2",
  xhtml: "application/xhtml+xml",
  xml: "application/xml",
  zip: "application/zip",
  "3gp": "video/3gpp",
  "3g2": "video/3gpp2",
  gltf: "model/gltf+json",
  glb: "model/gltf-binary",
};

Deno.bench("Old: getExtension() find `text/html`", () => {
  getExtension1("text/html");
});
Deno.bench("New: getExtension() find `text/html`", () => {
  getExtension2("text/html");
});
Deno.bench("Old: getExtension() find default non-existent extensions", () => {
  getExtension1("hono/hono");
});
Deno.bench("New: getExtension() find default non-existent extensions", () => {
  getExtension2("hono/hono");
});
```

</details>

```
benchmark                                                     time (avg)        iter/s             (min … max)       p75       p99      p995
-------------------------------------------------------------------------------------------------------------- -----------------------------
Old: getExtension() find `text/html`                         317.18 ns/iter   3,152,772.1  (287.25 ns … 456.3 ns)  328.2 ns 436.62 ns  456.3 ns
New: getExtension() find `text/html`                          26.67 ns/iter  37,496,954.0   (24.54 ns … 69.92 ns)   25.6 ns  59.25 ns  62.88 ns
Old: getExtension() find default non-existent extensions       1.15 µs/iter     871,974.7     (1.07 µs … 2.56 µs)   1.13 µs   2.56 µs   2.56 µs
New: getExtension() find default non-existent extensions      96.86 ns/iter  10,323,689.8  (91.29 ns … 172.49 ns)  95.53 ns 160.97 ns 169.22 ns
```

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno