### PR TITLE
PoC: feat(ssg): generate files concurrently

### DIFF
--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -177,7 +177,10 @@ export const fetchRoutesContent = function* <
                 try {
                   const replacedUrlParam = replaceUrlParam(route.path, param)
                   let response = await pool.run(() =>
-                    app.request(replacedUrlParam, forGetInfoURLRequest)
+                    app.request(replacedUrlParam, {
+                      method: forGetInfoURLRequest.method,
+                      headers: forGetInfoURLRequest.headers,
+                    })
                   )
                   if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
                     resolveReq(undefined)

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -91,7 +91,10 @@ type AddedSSGDataRequest = Request & {
  * Define SSG Route
  */
 export const ssgParams: SSGParamsMiddleware = (params) => async (c, next) => {
-  ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
+  if (c.req.raw.headers.get(X_HONO_SSG_HEADER_KEY)) {
+    ;(c.req.raw as AddedSSGDataRequest).ssgParams = Array.isArray(params) ? params : await params(c)
+    return c.text('')
+  }
   await next()
 }
 
@@ -162,6 +165,9 @@ export const fetchRoutesContent = function* <
           }
           forGetInfoURLRequest.ssgParams = [{}]
         }
+
+        // FIXME: I want to skip ssgParams somehow.
+        forGetInfoURLRequest.headers.delete(X_HONO_SSG_HEADER_KEY)
 
         resolveGetInfo(
           (function* () {

--- a/src/utils/concurrent.ts
+++ b/src/utils/concurrent.ts
@@ -1,0 +1,50 @@
+const DEFAULT_CONCURRENCY = 1024
+
+export interface Pool {
+  run<T>(fn: () => T): Promise<T>
+}
+
+export const createPool = ({
+  concurrency,
+  interval,
+}: {
+  concurrency?: number
+  interval?: number
+} = {}): Pool => {
+  concurrency ||= DEFAULT_CONCURRENCY
+
+  if (concurrency === Infinity) {
+    // unlimited
+    return {
+      run: async (fn) => fn(),
+    }
+  }
+
+  const pool: Set<{}> = new Set()
+  const run = async <T>(
+    fn: () => T,
+    promise?: Promise<T>,
+    resolve?: (result: T) => void
+  ): Promise<T> => {
+    if (pool.size >= (concurrency as number)) {
+      promise ||= new Promise<T>((r) => (resolve = r))
+      setTimeout(() => run(fn, promise, resolve))
+      return promise
+    }
+    const marker = {}
+    pool.add(marker)
+    const result = await fn()
+    if (interval) {
+      setTimeout(() => pool.delete(marker), interval)
+    } else {
+      pool.delete(marker)
+    }
+    if (resolve) {
+      resolve(result)
+      return promise as Promise<T>
+    } else {
+      return result
+    }
+  }
+  return { run }
+}


### PR DESCRIPTION
This PR refers to v4, but I believe the merge to v4 can be done at a later date.

### Overview

#2013 is great. However, in SSG, as well as requests to external APIs, writing to the file system is also a heavy process, so I think it would be better to parallelize everything, including writing to the file system. Also in v4, the SSG feature reads all pages into memory before writing them out, but it would be preferable to be able to parallelize the generation and writing so that not all pages are read.

In this PR, the following number of requests are processed in parallel at the same time.
https://github.com/honojs/hono/compare/v4...usualoma:hono:feat/ssg-generator?expand=1#diff-5bc74b06798a0aee17368e4fb5a84c845e66631cab1e30a35342a8b5a4f7d545R1

### Usage

```ts
toSSG(app, fs) // Default number of parallelism
```

```ts
toSSG(app, fs, {
  concurrency: 2,
}) // Change the number of parallels to 2
```


### Throttling of external API calls

When it comes to external API calls, I don't think limiting the number of concurrent executions is inherently the job of the SSG. I think we should use something like `createPool()` added in this PR to limit it when calling the fetch API. 

```ts
const fetchPoolMap: Record<string, Pool> = {}
// maximum 2 fetches per host at the same time
const throttledFetch = async (url: string, init?: RequestInit) => {
  const host = new URL(url).host
  const pool = fetchPoolMap[host] ||= createPool({ concurrency: 2 })
  return pool.run(() => fetch(url, init))
}
```

Nevertheless, well, it may be useful to be able to limit the SSG when it is a hassle to set up the `fetch` yourself.

### Benchmark - slow external API

<details>
<summary>code</summary>

```ts
/** @jsxRuntime automatic @jsxImportSource ./src/jsx */
import fs from 'fs/promises'
import { Hono } from './src'
import { toSSG, ssgParams } from './src/helper/ssg'
import { jsxRenderer } from './src/middleware/jsx-renderer'

const app = new Hono()

app.get(
  '*',
  jsxRenderer(
    ({ children }) => {
      return (
        <html>
          <body>{children}</body>
        </html>
      )
    },
    {
      docType: true,
    }
  )
)

const getShops = async () => {
  await new Promise((resolve) => setTimeout(resolve, 1000))
  return [
    { id: '1', name: 'Shop 1' },
    { id: '2', name: 'Shop 2' },
    { id: '3', name: 'Shop 3' },
    { id: '4', name: 'Shop 4' },
    { id: '5', name: 'Shop 5' },
    { id: '6', name: 'Shop 6' },
    { id: '7', name: 'Shop 7' },
    { id: '8', name: 'Shop 8' },
    { id: '9', name: 'Shop 9' },
    { id: '10', name: 'Shop 10' },
  ]
}

const getShop = async (id: string) => {
  await new Promise((resolve) => setTimeout(resolve, 1000))
  return (await getShops()).find((shop) => shop.id === id)
}

app.get(
  '/shops/:id',
  ssgParams(async () => {
    const shops = await getShops()
    return shops.map((shop) => ({ id: shop.id }))
  }),
  async (c) => {
    const shop = await getShop(c.req.param('id'))
    if (!shop) {
      return c.notFound()
    }
    return c.render(
      <div>
        <h1>{shop.name}</h1>
      </div>
    )
  }
)

toSSG(app, fs)
```
</details>

```
$ npx esbuild --platform=node --bundle ssg-app.tsx | time node # with this PR
node  0.06s user 0.04s system 2% cpu 3.765 total
$ npx esbuild --platform=node --bundle ssg-app.tsx | time node # v4
node  0.12s user 0.05s system 0% cpu 33.748 total
```


### Benchmark - large site

<details>
<summary>code</summary>

```ts
/** @jsxRuntime automatic @jsxImportSource ./src/jsx */
import fs from 'fs/promises'
import { Hono } from './src'
import { toSSG, ssgParams } from './src/helper/ssg'
import { jsxRenderer } from './src/middleware/jsx-renderer'

const app = new Hono()

app.get(
  '*',
  jsxRenderer(
    ({ children }) => {
      return (
        <html>
          <body>{children}</body>
        </html>
      )
    },
    {
      docType: true,
    }
  )
)

const shops = new Array(10000).fill(0).map((_, i) => ({ id: String(i + 1), name: `Shop ${i + 1}` }))
const getShops = async () => {
  return shops
}

const getShop = async (id: string) => {
  return (await getShops()).find((shop) => shop.id === id)
}

app.get(
  '/shops/:id',
  ssgParams(async () => {
    const shops = await getShops()
    return shops.map((shop) => ({ id: shop.id }))
  }),
  async (c) => {
    const shop = await getShop(c.req.param('id'))
    if (!shop) {
      return c.notFound()
    }
    return c.render(
      <div>
        <h1>{shop.name}</h1>
      </div>
    )
  }
)

toSSG(app, fs)
```
</details>

```
$ npx esbuild --platform=node --bundle ssg-app.tsx | time node # with this PR
node  1.44s user 2.37s system 139% cpu 2.733 total
$ npx esbuild --platform=node --bundle ssg-app.tsx | time node # v4
node  19.70s user 5.25s system 218% cpu 11.410 total
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
