### PR TITLE
refactor(ssh): create request from saved requestInit in order to avoid memory leak warnings

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -148,9 +148,13 @@ export const fetchRoutesContent = async <
       forGetInfoURLRequest.ssgParams = [{}]
     }
 
+    const requestInit = {
+      method: forGetInfoURLRequest.method,
+      headers: forGetInfoURLRequest.headers,
+    }
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
+      let response = await app.request(replacedUrlParam, requestInit)
       if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
         continue
       }

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -148,9 +148,13 @@ export const fetchRoutesContent = async <
       forGetInfoURLRequest.ssgParams = [{}]
     }
 
+    const requestInit = {
+      method: forGetInfoURLRequest.method,
+      headers: forGetInfoURLRequest.headers,
+    }
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
+      let response = await app.request(replacedUrlParam, requestInit)
       if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
         continue
       }


### PR DESCRIPTION
Unfortunately, in nodejs, when a Request object is passed to requestInit, `req.signal.addEventlistener()` is called and events are added. Something similar happens with `req.clone()`.

https://github.com/nodejs/undici/blob/0a069ab1f2d111b8e74f2d444d7f5678e302f39d/lib/fetch/request.js#L113
https://github.com/nodejs/undici/blob/0a069ab1f2d111b8e74f2d444d7f5678e302f39d/lib/fetch/request.js#L759

This would result in the following warning output if there were about 1,000 pages in a single routing. To avoid this problem, we would prefer to copy only the "headers" and "method".

```
...
(node:33127) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 996 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
(node:33127) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 997 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
(node:33127) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 998 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
(node:33127) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 999 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
(node:33127) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 1000 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
