### PR TITLE
refactor(ssg): check `c.env` variables to disable/enable SSG

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -153,15 +153,15 @@ export const fetchRoutesContent = async <
       let response = await app.request(replacedUrlParam, forGetInfoURLRequest, {
         [SSG_CONTEXT]: true,
       })
+      if (response === SSG_DISABLED_RESPONSE) {
+        continue
+      }
       if (afterResponseHook) {
         const maybeResponse = afterResponseHook(response)
         if (!maybeResponse) {
           continue
         }
         response = maybeResponse
-      }
-      if (response === SSG_DISABLED_RESPONSE) {
-        continue
       }
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -151,7 +151,6 @@ describe('toSSG function', () => {
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/index.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about/some.txt', expect.any(String))
-    expect(fsMock.writeFile).toHaveBeenCalledWith('static/about/some/thing.txt', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/bravo.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/Charlie.html', expect.any(String))
@@ -169,7 +168,7 @@ describe('toSSG function', () => {
       return false
     }
     const result = await toSSG(app, fsMock, { beforeRequestHook })
-    expect(result.files).toHaveLength(11)
+    expect(result.files).toHaveLength(10)
   })
 
   it('should skip the route if the request hook returns false', async () => {

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -4,6 +4,7 @@ import { Hono } from '../../hono'
 import { jsx } from '../../jsx'
 import { poweredBy } from '../../middleware/powered-by'
 import {
+  SSG_DISABLED_RESPONSE,
   fetchRoutesContent,
   saveContentToFiles,
   ssgParams,
@@ -351,6 +352,7 @@ describe('disableSSG/onlySSG middlewares', () => {
   const app = new Hono()
   app.get('/', (c) => c.html(<h1>Hello</h1>))
   app.get('/api', disableSSG(), (c) => c.text('an-api'))
+  app.get('/disable-by-response', () => SSG_DISABLED_RESPONSE)
   app.get('/static-page', onlySSG(), (c) => c.html(<h1>Welcome to my site</h1>))
 
   it('Should not generate the page if disableSSG is set', async () => {
@@ -358,6 +360,7 @@ describe('disableSSG/onlySSG middlewares', () => {
     expect(htmlMap.has('/')).toBe(true)
     expect(htmlMap.has('/static-page')).toBe(true)
     expect(htmlMap.has('/api')).toBe(false)
+    expect(htmlMap.has('/disable-by-response')).toBe(false)
   })
 
   it('Should return 404 response if onlySSG() is set', async () => {

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -8,6 +8,7 @@ import {
   saveContentToFiles,
   ssgParams,
   toSSG,
+  isSSGContext,
   disableSSG,
   onlySSG,
 } from './index'
@@ -325,6 +326,24 @@ describe('Dynamic route handling', () => {
   it('should not skip /foo:bar dynamic route', async () => {
     const htmlMap = await fetchRoutesContent(app)
     expect(htmlMap.has('/foo:bar')).toBeTruthy()
+  })
+})
+
+describe('isSSGContext()', () => {
+  const app = new Hono()
+  app.get('/', (c) => c.html(<h1>{isSSGContext(c) ? 'SSG' : 'noSSG'}</h1>))
+
+  it('Should not generate the page if disableSSG is set', async () => {
+    const htmlMap = await fetchRoutesContent(app)
+    expect(await htmlMap.get('/')).toEqual({
+      content: '<h1>SSG</h1>',
+      mimeType: 'text/html',
+    })
+  })
+
+  it('Should return 404 response if onlySSG() is set', async () => {
+    const res = await app.request('/')
+    expect(await res.text()).toBe('<h1>noSSG</h1>')
   })
 })
 

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -9,7 +9,7 @@ import { getExtension } from '../../utils/mime'
 import { joinPaths, dirname } from './utils'
 
 const SSG_CONTEXT = 'HONO_SSG_CONTEXT'
-export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'
+export const SSG_DISABLED_RESPONSE = new Response('SSG is disabled', { status: 404 })
 
 /**
  * @experimental
@@ -132,7 +132,6 @@ export const fetchRoutesContent = async <
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
 
     let forGetInfoURLRequest = new Request(thisRouteBaseURL) as AddedSSGDataRequest
-    forGetInfoURLRequest.headers.set(X_HONO_SSG_HEADER_KEY, 'true')
     if (beforeRequestHook) {
       const maybeRequest = beforeRequestHook(forGetInfoURLRequest)
       if (!maybeRequest) {
@@ -151,16 +150,18 @@ export const fetchRoutesContent = async <
 
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
-      if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
-        continue
-      }
+      let response = await app.request(replacedUrlParam, forGetInfoURLRequest, {
+        [SSG_CONTEXT]: true,
+      })
       if (afterResponseHook) {
         const maybeResponse = afterResponseHook(response)
         if (!maybeResponse) {
           continue
         }
         response = maybeResponse
+      }
+      if (response === SSG_DISABLED_RESPONSE) {
+        continue
       }
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)
@@ -272,11 +273,12 @@ export const isSSGContext = (c: Context): boolean => !!c.env?.[SSG_CONTEXT]
  * `disableSSG` is an experimental feature.
  * The API might be changed.
  */
-
 export const disableSSG = (): MiddlewareHandler =>
   async function disableSSG(c, next) {
+    if (isSSGContext(c)) {
+      return SSG_DISABLED_RESPONSE
+    }
     await next()
-    c.header(X_HONO_DISABLE_SSG_HEADER_KEY, 'true')
   }
 
 /**
@@ -286,9 +288,8 @@ export const disableSSG = (): MiddlewareHandler =>
  */
 export const onlySSG = (): MiddlewareHandler =>
   async function onlySSG(c, next) {
-    const headerValue = c.req.raw.headers.get(X_HONO_SSG_HEADER_KEY)
-    if (headerValue) {
-      await next()
+    if (!isSSGContext(c)) {
+      return c.notFound()
     }
-    return c.notFound()
+    await next()
   }

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -8,7 +8,7 @@ import { bufferToString } from '../../utils/buffer'
 import { getExtension } from '../../utils/mime'
 import { joinPaths, dirname } from './utils'
 
-export const X_HONO_SSG_HEADER_KEY = 'x-hono-ssg'
+const SSG_CONTEXT = 'HONO_SSG_CONTEXT'
 export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'
 
 /**
@@ -259,6 +259,13 @@ export const toSSG: ToSSGInterface = async (app, fs, options) => {
   await options?.afterGenerateHook?.(result)
   return result
 }
+
+/**
+ * @experimental
+ * `isSSGContext` is an experimental feature.
+ * The API might be changed.
+ */
+export const isSSGContext = (c: Context): boolean => !!c.env?.[SSG_CONTEXT]
 
 /**
  * @experimental

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -153,15 +153,15 @@ export const fetchRoutesContent = async <
       let response = await app.request(replacedUrlParam, forGetInfoURLRequest, {
         [SSG_CONTEXT]: true,
       })
+      if (response === SSG_DISABLED_RESPONSE) {
+        continue
+      }
       if (afterResponseHook) {
         const maybeResponse = afterResponseHook(response)
         if (!maybeResponse) {
           continue
         }
         response = maybeResponse
-      }
-      if (response === SSG_DISABLED_RESPONSE) {
-        continue
       }
       const mimeType = response.headers.get('Content-Type')?.split(';')[0] || 'text/plain'
       const content = await parseResponseContent(response)

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -2,6 +2,7 @@ import { replaceUrlParam } from '../../client/utils'
 import type { Context } from '../../context'
 import { inspectRoutes } from '../../helper/dev'
 import type { Hono } from '../../hono'
+import { METHOD_NAME_ALL } from '../../router'
 import type { Env, MiddlewareHandler, Schema } from '../../types'
 import { bufferToString } from '../../utils/buffer'
 import { getExtension } from '../../utils/mime'
@@ -123,7 +124,7 @@ export const fetchRoutesContent = async <
   const baseURL = 'http://localhost'
 
   for (const route of inspectRoutes(app)) {
-    if (route.isMiddleware) {
+    if (route.isMiddleware || (route.method !== 'GET' && route.method !== METHOD_NAME_ALL)) {
       continue
     }
 


### PR DESCRIPTION
Fixes #2176

### refactor(ssg): generate static files only for GET or ALL routes

Only GET and METHOD_NAME_ALL will be output. I don't think this will be disputed.

### Introduce `isSSGContext()`

Added a utility function to check that the context is an SSG context.

```
app.get('/', (c) => c.html(<h1>{isSSGContext(c) ? 'SSG' : 'noSSG'}</h1>))
```

### use environment variable and special response object to disable/enable SSG

The header-based approach is not a bad one, but should not be used because visitors may insert headers, or the headers may reveal more information than necessary. Instead, environment variables and objects can be used to determine whether they are enabled or disabled.

The following is excluded from this PR, as they appear to be issues currently handled by `afterResponseHook`.

<del>
### throw error when fetch failed

If the status code is not 200, it should be an error. There may be cases where it is better to continue without exiting, but I think it would be better to add that function in another PR.

</del>

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
