### PR TITLE
refactor(ssg): filter SSG Route

### DIFF
--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -1,5 +1,6 @@
 import type { Hono } from '../../hono.ts'
 import { COMPOSED_HANDLER } from '../../hono-base.ts'
+import { METHOD_NAME_ALL } from '../../router.ts'
 import type { Env, RouterRoute } from '../../types.ts'
 
 interface ShowRoutesOptions {
@@ -12,6 +13,10 @@ interface RouteData {
   method: string
   name: string
   isMiddleware: boolean
+}
+
+interface FilterStaticGenerateRouteData {
+  path: string
 }
 
 const isMiddleware = (handler: Function) => handler.length > 1
@@ -36,6 +41,21 @@ export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {
       isMiddleware: isMiddleware(targetHandler),
     }
   })
+}
+
+export const filterStaticGenerateRoutes = <E extends Env>(
+  hono: Hono<E>
+): FilterStaticGenerateRouteData[] => {
+  return hono.routes
+    .filter(({ method, handler }: RouterRoute) => {
+      const targetHandler = findTargetHandler(handler)
+      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
+    })
+    .map(({ path }: RouterRoute) => {
+      return {
+        path,
+      }
+    })
 }
 
 export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOptions) => {

--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -1,6 +1,5 @@
 import type { Hono } from '../../hono.ts'
 import { COMPOSED_HANDLER } from '../../hono-base.ts'
-import { METHOD_NAME_ALL } from '../../router.ts'
 import type { Env, RouterRoute } from '../../types.ts'
 
 interface ShowRoutesOptions {
@@ -15,15 +14,11 @@ interface RouteData {
   isMiddleware: boolean
 }
 
-interface FilterStaticGenerateRouteData {
-  path: string
-}
-
-const isMiddleware = (handler: Function) => handler.length > 1
+export const isMiddleware = (handler: Function) => handler.length > 1
 const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
-const findTargetHandler = (handler: Function): Function => {
+export const findTargetHandler = (handler: Function): Function => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (handler as any)[COMPOSED_HANDLER]
     ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,21 +36,6 @@ export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {
       isMiddleware: isMiddleware(targetHandler),
     }
   })
-}
-
-export const filterStaticGenerateRoutes = <E extends Env>(
-  hono: Hono<E>
-): FilterStaticGenerateRouteData[] => {
-  return hono.routes
-    .filter(({ method, handler }: RouterRoute) => {
-      const targetHandler = findTargetHandler(handler)
-      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
-    })
-    .map(({ path }: RouterRoute) => {
-      return {
-        path,
-      }
-    })
 }
 
 export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOptions) => {

--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -1,6 +1,6 @@
 import type { Hono } from '../../hono.ts'
-import { COMPOSED_HANDLER } from '../../hono-base.ts'
 import type { Env, RouterRoute } from '../../types.ts'
+import { findTargetHandler, isMiddleware } from '../../utils/handler.ts'
 
 interface ShowRoutesOptions {
   verbose?: boolean
@@ -14,16 +14,8 @@ interface RouteData {
   isMiddleware: boolean
 }
 
-export const isMiddleware = (handler: Function) => handler.length > 1
 const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
-}
-export const findTargetHandler = (handler: Function): Function => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (handler as any)[COMPOSED_HANDLER]
-    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      findTargetHandler((handler as any)[COMPOSED_HANDLER])
-    : handler
 }
 
 export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {

--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -1,6 +1,6 @@
 import { replaceUrlParam } from '../../client/utils.ts'
 import type { Context } from '../../context.ts'
-import { inspectRoutes } from '../../helper/dev/index.ts'
+import { filterStaticGenerateRoutes } from '../../helper/dev/index.ts'
 import type { Hono } from '../../hono.ts'
 import type { Env, MiddlewareHandler, Schema } from '../../types.ts'
 import { bufferToString } from '../../utils/buffer.ts'
@@ -122,11 +122,7 @@ export const fetchRoutesContent = async <
   const htmlMap = new Map<string, { content: string | ArrayBuffer; mimeType: string }>()
   const baseURL = 'http://localhost'
 
-  for (const route of inspectRoutes(app)) {
-    if (route.isMiddleware) {
-      continue
-    }
-
+  for (const route of filterStaticGenerateRoutes(app)) {
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
 

--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -1,11 +1,10 @@
 import { replaceUrlParam } from '../../client/utils.ts'
 import type { Context } from '../../context.ts'
-import { filterStaticGenerateRoutes } from '../../helper/dev/index.ts'
 import type { Hono } from '../../hono.ts'
 import type { Env, MiddlewareHandler, Schema } from '../../types.ts'
 import { bufferToString } from '../../utils/buffer.ts'
 import { getExtension } from '../../utils/mime.ts'
-import { joinPaths, dirname } from './utils.ts'
+import { joinPaths, dirname, filterStaticGenerateRoutes } from './utils.ts'
 
 export const X_HONO_SSG_HEADER_KEY = 'x-hono-ssg'
 export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'

--- a/deno_dist/helper/ssg/utils.ts
+++ b/deno_dist/helper/ssg/utils.ts
@@ -1,7 +1,7 @@
-import { findTargetHandler, isMiddleware } from '../../helper/dev/index.ts'
 import type { Hono } from '../../hono.ts'
 import { METHOD_NAME_ALL } from '../../router.ts'
 import type { Env, RouterRoute } from '../../types.ts'
+import { findTargetHandler, isMiddleware } from '../../utils/handler.ts'
 
 /**
  * Get dirname

--- a/deno_dist/helper/ssg/utils.ts
+++ b/deno_dist/helper/ssg/utils.ts
@@ -1,3 +1,8 @@
+import { findTargetHandler, isMiddleware } from '../../helper/dev/index.ts'
+import type { Hono } from '../../hono.ts'
+import { METHOD_NAME_ALL } from '../../router.ts'
+import type { Env, RouterRoute } from '../../types.ts'
+
 /**
  * Get dirname
  * @param path File Path
@@ -44,4 +49,23 @@ export const joinPaths = (...paths: string[]) => {
   const resultPaths: string[] = []
   handleSegments(paths.join('/').split('/'), resultPaths)
   return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
+}
+
+interface FilterStaticGenerateRouteData {
+  path: string
+}
+
+export const filterStaticGenerateRoutes = <E extends Env>(
+  hono: Hono<E>
+): FilterStaticGenerateRouteData[] => {
+  return hono.routes
+    .filter(({ method, handler }: RouterRoute) => {
+      const targetHandler = findTargetHandler(handler)
+      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
+    })
+    .map(({ path }: RouterRoute) => {
+      return {
+        path,
+      }
+    })
 }

--- a/deno_dist/helper/ssg/utils.ts
+++ b/deno_dist/helper/ssg/utils.ts
@@ -58,14 +58,11 @@ interface FilterStaticGenerateRouteData {
 export const filterStaticGenerateRoutes = <E extends Env>(
   hono: Hono<E>
 ): FilterStaticGenerateRouteData[] => {
-  return hono.routes
-    .filter(({ method, handler }: RouterRoute) => {
-      const targetHandler = findTargetHandler(handler)
-      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
-    })
-    .map(({ path }: RouterRoute) => {
-      return {
-        path,
-      }
-    })
+  return hono.routes.reduce((acc, { method, handler, path }: RouterRoute) => {
+    const targetHandler = findTargetHandler(handler)
+    if (['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)) {
+      acc.push({ path })
+    }
+    return acc
+  }, [] as FilterStaticGenerateRouteData[])
 }

--- a/deno_dist/utils/handler.ts
+++ b/deno_dist/utils/handler.ts
@@ -1,0 +1,10 @@
+import { COMPOSED_HANDLER } from '../hono-base.ts'
+
+export const isMiddleware = (handler: Function) => handler.length > 1
+export const findTargetHandler = (handler: Function): Function => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (handler as any)[COMPOSED_HANDLER]
+    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findTargetHandler((handler as any)[COMPOSED_HANDLER])
+    : handler
+}

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -1,6 +1,5 @@
 import type { Hono } from '../../hono'
 import { COMPOSED_HANDLER } from '../../hono-base'
-import { METHOD_NAME_ALL } from '../../router'
 import type { Env, RouterRoute } from '../../types'
 
 interface ShowRoutesOptions {
@@ -15,15 +14,11 @@ interface RouteData {
   isMiddleware: boolean
 }
 
-interface FilterStaticGenerateRouteData {
-  path: string
-}
-
-const isMiddleware = (handler: Function) => handler.length > 1
+export const isMiddleware = (handler: Function) => handler.length > 1
 const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
-const findTargetHandler = (handler: Function): Function => {
+export const findTargetHandler = (handler: Function): Function => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (handler as any)[COMPOSED_HANDLER]
     ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,21 +36,6 @@ export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {
       isMiddleware: isMiddleware(targetHandler),
     }
   })
-}
-
-export const filterStaticGenerateRoutes = <E extends Env>(
-  hono: Hono<E>
-): FilterStaticGenerateRouteData[] => {
-  return hono.routes
-    .filter(({ method, handler }: RouterRoute) => {
-      const targetHandler = findTargetHandler(handler)
-      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
-    })
-    .map(({ path }: RouterRoute) => {
-      return {
-        path,
-      }
-    })
 }
 
 export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOptions) => {

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -1,6 +1,6 @@
 import type { Hono } from '../../hono'
-import { COMPOSED_HANDLER } from '../../hono-base'
 import type { Env, RouterRoute } from '../../types'
+import { findTargetHandler, isMiddleware } from '../../utils/handler'
 
 interface ShowRoutesOptions {
   verbose?: boolean
@@ -14,16 +14,8 @@ interface RouteData {
   isMiddleware: boolean
 }
 
-export const isMiddleware = (handler: Function) => handler.length > 1
 const handlerName = (handler: Function) => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
-}
-export const findTargetHandler = (handler: Function): Function => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (handler as any)[COMPOSED_HANDLER]
-    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      findTargetHandler((handler as any)[COMPOSED_HANDLER])
-    : handler
 }
 
 export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -1,5 +1,6 @@
 import type { Hono } from '../../hono'
 import { COMPOSED_HANDLER } from '../../hono-base'
+import { METHOD_NAME_ALL } from '../../router'
 import type { Env, RouterRoute } from '../../types'
 
 interface ShowRoutesOptions {
@@ -12,6 +13,10 @@ interface RouteData {
   method: string
   name: string
   isMiddleware: boolean
+}
+
+interface FilterStaticGenerateRouteData {
+  path: string
 }
 
 const isMiddleware = (handler: Function) => handler.length > 1
@@ -36,6 +41,21 @@ export const inspectRoutes = <E extends Env>(hono: Hono<E>): RouteData[] => {
       isMiddleware: isMiddleware(targetHandler),
     }
   })
+}
+
+export const filterStaticGenerateRoutes = <E extends Env>(
+  hono: Hono<E>
+): FilterStaticGenerateRouteData[] => {
+  return hono.routes
+    .filter(({ method, handler }: RouterRoute) => {
+      const targetHandler = findTargetHandler(handler)
+      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
+    })
+    .map(({ path }: RouterRoute) => {
+      return {
+        path,
+      }
+    })
 }
 
 export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOptions) => {

--- a/src/helper/ssg/index.test.tsx
+++ b/src/helper/ssg/index.test.tsx
@@ -151,7 +151,10 @@ describe('toSSG function', () => {
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/index.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about/some.txt', expect.any(String))
-    expect(fsMock.writeFile).toHaveBeenCalledWith('static/about/some/thing.txt', expect.any(String))
+    expect(fsMock.writeFile).not.toHaveBeenCalledWith(
+      'static/about/some/thing.txt',
+      expect.any(String)
+    )
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/about.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/bravo.html', expect.any(String))
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/Charlie.html', expect.any(String))
@@ -169,7 +172,7 @@ describe('toSSG function', () => {
       return false
     }
     const result = await toSSG(app, fsMock, { beforeRequestHook })
-    expect(result.files).toHaveLength(11)
+    expect(result.files).toHaveLength(10)
   })
 
   it('should skip the route if the request hook returns false', async () => {

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -1,6 +1,6 @@
 import { replaceUrlParam } from '../../client/utils'
 import type { Context } from '../../context'
-import { inspectRoutes } from '../../helper/dev'
+import { filterStaticGenerateRoutes } from '../../helper/dev'
 import type { Hono } from '../../hono'
 import type { Env, MiddlewareHandler, Schema } from '../../types'
 import { bufferToString } from '../../utils/buffer'
@@ -122,11 +122,7 @@ export const fetchRoutesContent = async <
   const htmlMap = new Map<string, { content: string | ArrayBuffer; mimeType: string }>()
   const baseURL = 'http://localhost'
 
-  for (const route of inspectRoutes(app)) {
-    if (route.isMiddleware) {
-      continue
-    }
-
+  for (const route of filterStaticGenerateRoutes(app)) {
     // GET Route Info
     const thisRouteBaseURL = new URL(route.path, baseURL).toString()
 

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -1,11 +1,10 @@
 import { replaceUrlParam } from '../../client/utils'
 import type { Context } from '../../context'
-import { filterStaticGenerateRoutes } from '../../helper/dev'
 import type { Hono } from '../../hono'
 import type { Env, MiddlewareHandler, Schema } from '../../types'
 import { bufferToString } from '../../utils/buffer'
 import { getExtension } from '../../utils/mime'
-import { joinPaths, dirname } from './utils'
+import { joinPaths, dirname, filterStaticGenerateRoutes } from './utils'
 
 export const X_HONO_SSG_HEADER_KEY = 'x-hono-ssg'
 export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -1,7 +1,7 @@
-import { findTargetHandler, isMiddleware } from '../../helper/dev'
 import type { Hono } from '../../hono'
 import { METHOD_NAME_ALL } from '../../router'
 import type { Env, RouterRoute } from '../../types'
+import { findTargetHandler, isMiddleware } from '../../utils/handler'
 
 /**
  * Get dirname

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -58,14 +58,11 @@ interface FilterStaticGenerateRouteData {
 export const filterStaticGenerateRoutes = <E extends Env>(
   hono: Hono<E>
 ): FilterStaticGenerateRouteData[] => {
-  return hono.routes
-    .filter(({ method, handler }: RouterRoute) => {
-      const targetHandler = findTargetHandler(handler)
-      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
-    })
-    .map(({ path }: RouterRoute) => {
-      return {
-        path,
-      }
-    })
+  return hono.routes.reduce((acc, { method, handler, path }: RouterRoute) => {
+    const targetHandler = findTargetHandler(handler)
+    if (['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)) {
+      acc.push({ path })
+    }
+    return acc
+  }, [] as FilterStaticGenerateRouteData[])
 }

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -1,3 +1,8 @@
+import { findTargetHandler, isMiddleware } from '../../helper/dev'
+import type { Hono } from '../../hono'
+import { METHOD_NAME_ALL } from '../../router'
+import type { Env, RouterRoute } from '../../types'
+
 /**
  * Get dirname
  * @param path File Path
@@ -44,4 +49,23 @@ export const joinPaths = (...paths: string[]) => {
   const resultPaths: string[] = []
   handleSegments(paths.join('/').split('/'), resultPaths)
   return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
+}
+
+interface FilterStaticGenerateRouteData {
+  path: string
+}
+
+export const filterStaticGenerateRoutes = <E extends Env>(
+  hono: Hono<E>
+): FilterStaticGenerateRouteData[] => {
+  return hono.routes
+    .filter(({ method, handler }: RouterRoute) => {
+      const targetHandler = findTargetHandler(handler)
+      return ['GET', METHOD_NAME_ALL].includes(method) && !isMiddleware(targetHandler)
+    })
+    .map(({ path }: RouterRoute) => {
+      return {
+        path,
+      }
+    })
 }

--- a/src/utils/handler.ts
+++ b/src/utils/handler.ts
@@ -1,0 +1,10 @@
+import { COMPOSED_HANDLER } from '../hono-base'
+
+export const isMiddleware = (handler: Function) => handler.length > 1
+export const findTargetHandler = (handler: Function): Function => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (handler as any)[COMPOSED_HANDLER]
+    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findTargetHandler((handler as any)[COMPOSED_HANDLER])
+    : handler
+}


### PR DESCRIPTION
Note: This overlaps with some aspects of the issue discussed here: https://github.com/honojs/hono/pull/2179.

We have ceased relying on inspectRoute and instead are filtering using a custom method for the following reasons.

1. Unnecessary information: Information such as Middleware and HandlerName is not needed. 
2. Avoiding bloat in fetchContentRoutes: If we are to apply filters for isMiddleware as well as for GET and ALL methods, it is more efficient to filter right from the start.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
