### PR TITLE
refactor(ssg): create request from saved requestInit in order to avoid memory leak warnings

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -148,9 +148,13 @@ export const fetchRoutesContent = async <
       forGetInfoURLRequest.ssgParams = [{}]
     }
 
+    const requestInit = {
+      method: forGetInfoURLRequest.method,
+      headers: forGetInfoURLRequest.headers,
+    }
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
+      let response = await app.request(replacedUrlParam, requestInit)
       if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
         continue
       }

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -148,9 +148,13 @@ export const fetchRoutesContent = async <
       forGetInfoURLRequest.ssgParams = [{}]
     }
 
+    const requestInit = {
+      method: forGetInfoURLRequest.method,
+      headers: forGetInfoURLRequest.headers,
+    }
     for (const param of forGetInfoURLRequest.ssgParams) {
       const replacedUrlParam = replaceUrlParam(route.path, param)
-      let response = await app.request(replacedUrlParam, forGetInfoURLRequest)
+      let response = await app.request(replacedUrlParam, requestInit)
       if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
         continue
       }


### PR DESCRIPTION
Continued from #2177

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
