### PR TITLE
fix(context): remove duplicate definition of render method

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -209,10 +209,10 @@ export class Context<
    * ```
    * @see https://hono.dev/api/context#render-setrenderer
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: Renderer = (...args: any[]) => this.renderer(...args)
+  render: Renderer = (...args) => this.renderer(...args)
+
+  setLayout = (layout: FC<PropsForRenderer & { Layout: FC }>) => (this.layout = layout)
+  getLayout = () => this.layout
 
   /**
    * `.setRenderer()` can set the layout in the custom middleware.
@@ -233,13 +233,6 @@ export class Context<
    * ```
    * @see https://hono.dev/api/context#render-setrenderer
    */
-  // @ts-expect-error It is unknown how many arguments the renderer will receive.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: Renderer = (...args: any[]) => this.renderer(...args)
-
-  setLayout = (layout: FC<PropsForRenderer & { Layout: FC }>) => (this.layout = layout)
-  getLayout = () => this.layout
-
   setRenderer = (renderer: Renderer) => {
     this.renderer = renderer
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -209,10 +209,10 @@ export class Context<
    * ```
    * @see https://hono.dev/api/context#render-setrenderer
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: Renderer = (...args: any[]) => this.renderer(...args)
+  render: Renderer = (...args) => this.renderer(...args)
+
+  setLayout = (layout: FC<PropsForRenderer & { Layout: FC }>) => (this.layout = layout)
+  getLayout = () => this.layout
 
   /**
    * `.setRenderer()` can set the layout in the custom middleware.
@@ -233,13 +233,6 @@ export class Context<
    * ```
    * @see https://hono.dev/api/context#render-setrenderer
    */
-  // @ts-expect-error It is unknown how many arguments the renderer will receive.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: Renderer = (...args: any[]) => this.renderer(...args)
-
-  setLayout = (layout: FC<PropsForRenderer & { Layout: FC }>) => (this.layout = layout)
-  getLayout = () => this.layout
-
   setRenderer = (renderer: Renderer) => {
     this.renderer = renderer
   }


### PR DESCRIPTION
The `render` method was defined twice in the `Context` class. This duplicate definition was causing a TypeScript error below if `tsc` is used to compile the project:

```
node_modules/hono/dist/types/context.d.ts(134,5): error TS2300: Duplicate identifier 'render'.
```

### Author should do the followings, if applicable

- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
