### PR TITLE
Fix regex pattern with length limit at replaceUrlParam

### DIFF
--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '(\\{([^{}]*?(\\{[^{}]*?\\})?)+?\\})?')
+    const reg = new RegExp('/:' + k + '(?:{[^/]+})?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString

--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '({[^}]*})?')
+    const reg = new RegExp('/:' + k + '({[^}]*}+)?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString

--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '({[^}]*}+)?')
+    const reg = new RegExp('/:' + k + '(\\{([^{}]*?(\\{[^{}]*?\\})?)+?\\})?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -30,6 +30,16 @@ describe('replaceUrlParams', () => {
     const replacedUrl = replaceUrlParam(url, params)
     expect(replacedUrl).toBe('http://localhost/posts/abc/comments/456')
   })
+
+  it('Should replace correctly when there is regex pattern with length limit', () => {
+    const url = 'http://localhost/year/:year{[0-9]{4}}/month/:month{[0-9]{2}}'
+    const params = {
+      year: '2024',
+      month: '2',
+    }
+    const replacedUrl = replaceUrlParam(url, params)
+    expect(replacedUrl).toBe('http://localhost/year/2024/month/2')
+  })
 })
 
 describe('removeIndexString', () => {

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -32,7 +32,7 @@ describe('replaceUrlParams', () => {
   })
 
   it('Should replace correctly when there is regex pattern with length limit', () => {
-    const url = 'http://localhost/year/:year{[0-9]{4}}/month/:month{[0-9]{2}}'
+    const url = 'http://localhost/year/:year{[1-9]{1}[0-9]{3}}/month/:month{[0-9]{2}}'
     const params = {
       year: '2024',
       month: '2',

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '(\\{([^{}]*?(\\{[^{}]*?\\})?)+?\\})?')
+    const reg = new RegExp('/:' + k + '(?:{[^/]+})?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '({[^}]*})?')
+    const reg = new RegExp('/:' + k + '({[^}]*}+)?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -9,7 +9,7 @@ export const mergePath = (base: string, path: string) => {
 
 export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '({[^}]*}+)?')
+    const reg = new RegExp('/:' + k + '(\\{([^{}]*?(\\{[^{}]*?\\})?)+?\\})?')
     urlString = urlString.replace(reg, `/${v}`)
   }
   return urlString


### PR DESCRIPTION

### Summary

There seems to be an issue with the function `replaceUrlParam` that replaces regular expressions in the path within the Client. Specifically, the problem arises when there's a length specification (`{}`) within the regular expression, and it appears at the end of the regex section.

```
/year/:year{[0-9]{4}}/month/:month{[0-9]{1,2}}
```

In this case, when the Client is given the params:

```
 param: {
   year: "2024",
   month: "2",
 }
```

it parses them as:

```
/year/2024}/month/2}
```

### Proposed Changes

The regular expression that "detects the regex section" within the path was only matching a single `}`. I propose to modify this to match one or more times (`+`), ensuring correct detection even when the length specification (`{}`) is at the end of the section.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
