### PR TITLE
fix(jsx/dom): Do not call insertBefore if the element position does not change

### DIFF
--- a/deno_dist/jsx/dom/render.ts
+++ b/deno_dist/jsx/dom/render.ts
@@ -256,6 +256,7 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
     }
   }
 
+  const childNodes = container.childNodes
   for (let i = 0, len = next.length; i < len; i++, offset++) {
     const child = next[i]
 
@@ -270,8 +271,8 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
       applyProps(el as HTMLElement, child.props, child.pP)
       applyNode(child, el as HTMLElement)
     }
-    if (container.childNodes[offset] !== el) {
-      container.insertBefore(el, container.childNodes[offset] || null)
+    if (childNodes[offset] !== el && childNodes[offset - 1] !== child.e) {
+      container.insertBefore(el, childNodes[offset] || null)
     }
   }
   remove.forEach(removeNode)

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -200,6 +200,30 @@ describe('DOM', () => {
       await Promise.resolve()
       expect(root.innerHTML).toBe('2')
     })
+
+    it('one child is updated', async () => {
+      let setCount: (count: number) => void = () => {}
+      const App = () => {
+        const [count, _setCount] = useState(0)
+        setCount = _setCount
+        return <div>{count}</div>
+      }
+      const app = (
+        <>
+          <App />
+          <div>Footer</div>
+        </>
+      )
+      render(app, root)
+      const container = getContainer(app) as HTMLElement
+      expect(root.innerHTML).toBe('<div>0</div><div>Footer</div>')
+
+      const insertBeforeSpy = vi.spyOn(container, 'insertBefore')
+      setCount(1)
+      await Promise.resolve()
+      expect(root.innerHTML).toBe('<div>1</div><div>Footer</div>')
+      expect(insertBeforeSpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('Event', () => {

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -256,6 +256,7 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
     }
   }
 
+  const childNodes = container.childNodes
   for (let i = 0, len = next.length; i < len; i++, offset++) {
     const child = next[i]
 
@@ -270,8 +271,8 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
       applyProps(el as HTMLElement, child.props, child.pP)
       applyNode(child, el as HTMLElement)
     }
-    if (container.childNodes[offset] !== el) {
-      container.insertBefore(el, container.childNodes[offset] || null)
+    if (childNodes[offset] !== el && childNodes[offset - 1] !== child.e) {
+      container.insertBefore(el, childNodes[offset] || null)
     }
   }
   remove.forEach(removeNode)


### PR DESCRIPTION
Fixed the same problem as #2016 when one child is updated in an element having multiple children.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
