### PR TITLE
fix(router): LinearRouter and PatternRouter support regexp quantifiers

### DIFF
--- a/deno_dist/router/linear-router/router.ts
+++ b/deno_dist/router/linear-router/router.ts
@@ -6,7 +6,7 @@ type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number
 
 const emptyParams = {}
 
-const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
+const splitPathRe = /\/(:\w+(?:{(?:(?:{[\d,]+})|[^}])+})?)|\/[^\/\?]+|(\?)/g
 const splitByStarRe = /\*/
 export class LinearRouter<T> implements Router<T> {
   name: string = 'LinearRouter'

--- a/deno_dist/router/pattern-router/router.ts
+++ b/deno_dist/router/pattern-router/router.ts
@@ -13,7 +13,7 @@ export class PatternRouter<T> implements Router<T> {
       path = path.slice(0, -2)
     }
 
-    const parts = path.match(/\/?(:\w+(?:{[^}]+})?)|\/?[^\/\?]+|(\?)/g) || []
+    const parts = path.match(/\/?(:\w+(?:{(?:(?:{[\d,]+})|[^}])+})?)|\/?[^\/\?]+|(\?)/g) || []
     if (parts[parts.length - 1] === '?') {
       this.add(method, parts.slice(0, parts.length - 2).join(''), handler)
       parts.pop()

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -90,6 +90,15 @@ describe('Complex', () => {
     expect(res[1][0]).toEqual('posts')
     expect(res[2][0]).toEqual('fallback')
   })
+
+  it('Should support regexp quantifiers', async () => {
+    router.add('GET', '/year/:year{[0-9]{4}}/month/:month{[0-9]{1,2}}', 'handler')
+    const [res] = router.match('GET', '/year/2024/month/2')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toBe('handler')
+    expect(res[0][1]['year']).toBe('2024')
+    expect(res[0][1]['month']).toBe('2')
+  })
 })
 
 describe('Multi match', () => {

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -6,7 +6,7 @@ type RegExpMatchArrayWithIndices = RegExpMatchArray & { indices: [number, number
 
 const emptyParams = {}
 
-const splitPathRe = /\/(:\w+(?:{[^}]+})?)|\/[^\/\?]+|(\?)/g
+const splitPathRe = /\/(:\w+(?:{(?:(?:{[\d,]+})|[^}])+})?)|\/[^\/\?]+|(\?)/g
 const splitByStarRe = /\*/
 export class LinearRouter<T> implements Router<T> {
   name: string = 'LinearRouter'

--- a/src/router/pattern-router/router.test.ts
+++ b/src/router/pattern-router/router.test.ts
@@ -78,6 +78,15 @@ describe('Complex', () => {
     ;[res] = router.match('GET', '/post/123/123')
     expect(res.length).toBe(0)
   })
+
+  it('Should support regexp quantifiers', async () => {
+    router.add('GET', '/year/:year{[0-9]{4}}/month/:month{[0-9]{1,2}}', 'handler')
+    const [res] = router.match('GET', '/year/2024/month/2')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toBe('handler')
+    expect(res[0][1]['year']).toBe('2024')
+    expect(res[0][1]['month']).toBe('2')
+  })
 })
 
 describe('Multi match', () => {

--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -13,7 +13,7 @@ export class PatternRouter<T> implements Router<T> {
       path = path.slice(0, -2)
     }
 
-    const parts = path.match(/\/?(:\w+(?:{[^}]+})?)|\/?[^\/\?]+|(\?)/g) || []
+    const parts = path.match(/\/?(:\w+(?:{(?:(?:{[\d,]+})|[^}])+})?)|\/?[^\/\?]+|(\?)/g) || []
     if (parts[parts.length - 1] === '?') {
       this.add(method, parts.slice(0, parts.length - 2).join(''), handler)
       parts.pop()


### PR DESCRIPTION
Fixes #2203

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
