### PR TITLE
refactor: jsx streaming

### DIFF
--- a/deno_dist/jsx/components.ts
+++ b/deno_dist/jsx/components.ts
@@ -79,7 +79,7 @@ export const ErrorBoundary: FC<
       }
       return buffer
         ? ''
-        : `<template>${fallbackResString}</template><script>
+        : `<template data-hono-target="E:${index}">${fallbackResString}</template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('E:${index}')
@@ -100,7 +100,7 @@ d.replaceWith(c.content)
             const content = htmlArray.join('')
             let html = buffer
               ? ''
-              : `<template>${content}</template><script>
+              : `<template data-hono-target="E:${index}">${content}</template><script>
 ((d,c) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('E:${index}')
@@ -161,7 +161,7 @@ d.parentElement.insertBefore(c.content,d.nextSibling)
 d=d.getElementById('E:${index}')
 if(!d)return
 n=d.nextSibling
-do{n=n.nextSibling}while(n.nodeType!=8||n.nodeValue!='E:${index}')
+while(n.nodeType!=8||n.nodeValue!='E:${index}'){n=n.nextSibling}
 n.remove()
 d.remove()
 })(document)

--- a/deno_dist/jsx/streaming.ts
+++ b/deno_dist/jsx/streaming.ts
@@ -76,7 +76,7 @@ export const Suspense: FC<PropsWithChildren<{ fallback: any }>> = async ({
           }
           let html = buffer
             ? ''
-            : `<template>${content}</template><script>
+            : `<template data-hono-target="H:${index}">${content}</template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${index}')

--- a/runtime_tests/deno-jsx/jsx.test.tsx
+++ b/runtime_tests/deno-jsx/jsx.test.tsx
@@ -68,7 +68,7 @@ Deno.test('JSX: Suspense', async () => {
 
   assertEquals(chunks, [
     '<template id="H:0"></template><p>Loading...</p><!--/$-->',
-    `<template><h1>Hello</h1></template><script>
+    `<template data-hono-target="H:0"><h1>Hello</h1></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:0')

--- a/src/helper/css/index.test.tsx
+++ b/src/helper/css/index.test.tsx
@@ -240,7 +240,7 @@ describe('CSS Helper', () => {
       const res = await app.request('http://localhost/stream')
       expect(res).not.toBeNull()
       expect(await res.text()).toBe(
-        `<style id="hono-css"></style><template id="H:0"></template><p>Loading...</p><!--/$--><script>document.querySelector('#hono-css').textContent+=".css-2458908649{background-color:blue}"</script><template><h1 class="css-2458908649">Hello!</h1></template><script>
+        `<style id="hono-css"></style><template id="H:0"></template><p>Loading...</p><!--/$--><script>document.querySelector('#hono-css').textContent+=".css-2458908649{background-color:blue}"</script><template data-hono-target="H:0"><h1 class="css-2458908649">Hello!</h1></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:0')

--- a/src/jsx/components.test.tsx
+++ b/src/jsx/components.test.tsx
@@ -212,7 +212,7 @@ d.replaceWith(c.content)
 d=d.getElementById('E:${errorBoundaryCounter}')
 if(!d)return
 n=d.nextSibling
-do{n=n.nextSibling}while(n.nodeType!=8||n.nodeValue!='E:${errorBoundaryCounter}')
+while(n.nodeType!=8||n.nodeValue!='E:${errorBoundaryCounter}'){n=n.nextSibling}
 n.remove()
 d.remove()
 })(document)

--- a/src/jsx/components.test.tsx
+++ b/src/jsx/components.test.tsx
@@ -191,7 +191,7 @@ describe('ErrorBoundary', () => {
 
       expect(chunks).toEqual([
         `<template id="E:${errorBoundaryCounter}"></template><!--E:${errorBoundaryCounter}-->`,
-        `<template><template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$--></template><script>
+        `<template data-hono-target="E:${errorBoundaryCounter}"><template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$--></template><script>
 ((d,c) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('E:${errorBoundaryCounter}')
@@ -199,7 +199,7 @@ if(!d)return
 d.parentElement.insertBefore(c.content,d.nextSibling)
 })(document)
 </script>`,
-        `<template><div>Hello</div></template><script>
+        `<template data-hono-target="H:${suspenseCounter}"><div>Hello</div></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')

--- a/src/jsx/components.ts
+++ b/src/jsx/components.ts
@@ -79,7 +79,7 @@ export const ErrorBoundary: FC<
       }
       return buffer
         ? ''
-        : `<template>${fallbackResString}</template><script>
+        : `<template data-hono-target="E:${index}">${fallbackResString}</template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('E:${index}')
@@ -100,7 +100,7 @@ d.replaceWith(c.content)
             const content = htmlArray.join('')
             let html = buffer
               ? ''
-              : `<template>${content}</template><script>
+              : `<template data-hono-target="E:${index}">${content}</template><script>
 ((d,c) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('E:${index}')

--- a/src/jsx/components.ts
+++ b/src/jsx/components.ts
@@ -161,7 +161,7 @@ d.parentElement.insertBefore(c.content,d.nextSibling)
 d=d.getElementById('E:${index}')
 if(!d)return
 n=d.nextSibling
-do{n=n.nextSibling}while(n.nodeType!=8||n.nodeValue!='E:${index}')
+while(n.nodeType!=8||n.nodeValue!='E:${index}'){n=n.nextSibling}
 n.remove()
 d.remove()
 })(document)

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -653,7 +653,7 @@ describe('Context', () => {
 
       expect(chunks).toEqual([
         '<template id="H:0"></template><span>red</span><!--/$-->',
-        `<template><span>dark</span><span>black</span></template><script>
+        `<template data-hono-target="H:0"><span>dark</span><span>black</span></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:0')

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -44,7 +44,7 @@ describe('Streaming', () => {
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template><h1>Hello</h1></template><script>
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')
@@ -92,7 +92,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template><p>thrown a promise then resolved</p></template><script>
+      `<template data-hono-target="H:${suspenseCounter}"><p>thrown a promise then resolved</p></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')
@@ -208,7 +208,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template><p></p></template><script>
+      `<template data-hono-target="H:${suspenseCounter}"><p></p></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')
@@ -242,7 +242,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template><p></p></template><script>
+      `<template data-hono-target="H:${suspenseCounter}"><p></p></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')
@@ -316,7 +316,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template><h1>Hello</h1><h2>World</h2></template><script>
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><h2>World</h2></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')
@@ -362,7 +362,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template>Loading<span>...</span><!--/$-->`,
-      `<template><h1>Hello</h1></template><script>
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')
@@ -418,7 +418,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template><h1>Hello</h1><template id=\"H:${
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><template id=\"H:${
         suspenseCounter + 1
       }\"></template><p>Loading sub content...</p><!--/$--></template><script>
 ((d,c,n) => {
@@ -429,7 +429,7 @@ do{n=d.nextSibling;n.remove()}while(n.nodeType!=8||n.nodeValue!='/$')
 d.replaceWith(c.content)
 })(document)
 </script>`,
-      `<template><h2>World</h2></template><script>
+      `<template data-hono-target="H:${suspenseCounter + 1}"><h2>World</h2></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter + 1}')
@@ -605,7 +605,7 @@ d.replaceWith(c.content)
 
       expect(chunks).toEqual([
         `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-        `<template><h1>Hello from use()</h1></template><script>
+        `<template data-hono-target="H:${suspenseCounter}"><h1>Hello from use()</h1></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${suspenseCounter}')

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -76,7 +76,7 @@ export const Suspense: FC<PropsWithChildren<{ fallback: any }>> = async ({
           }
           let html = buffer
             ? ''
-            : `<template>${content}</template><script>
+            : `<template data-hono-target="H:${index}">${content}</template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${index}')

--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -233,7 +233,7 @@ describe('JSX renderer', () => {
     }
     expect(chunk).toEqual([
       '<!DOCTYPE html><html><body><template id="H:0"></template><p>Loading...</p><!--/$--></body></html>',
-      `<template><p>Hello Hono!</p></template><script>
+      `<template data-hono-target="H:0"><p>Hello Hono!</p></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:0')
@@ -302,7 +302,7 @@ d.replaceWith(c.content)
     }
     expect(chunk).toEqual([
       '<!DOCTYPE html><html><body><template id="H:1"></template><p>Loading...</p><!--/$--></body></html>',
-      `<template><p>Hello Hono again!</p></template><script>
+      `<template data-hono-target="H:1"><p>Hello Hono again!</p></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:1')


### PR DESCRIPTION
There is no change in behavior, but it is not a useful refactoring for existing applications, so it is a question of whether to include it in a patch version. A minor version might be fine.

* 867f85722b33038606a8f3d7b826742d490a0134 : Depending on the content, it may look like the following, and in this case a JS error occurs.
    * `<template id="E:0"></template><! -E:0->`
* 71c8ec52bbcedf1149420a81bb9fd0b53ce791ec : When handling https://github.com/honojs/honox/issues/47, it is useful to be able to retrieve the resolved value later, so the data attribute was added. The data will be slightly larger, but I don't think it will be a problem.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
