### PR TITLE
fix(context): Inherit current status if not specified

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -359,7 +359,7 @@ export class Context<
       const headers = setHeaders(new Headers(arg.headers), this.#preparedHeaders)
       return new Response(data, {
         headers,
-        status: arg.status,
+        status: arg.status ?? this.#status,
       })
     }
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -128,6 +128,20 @@ describe('Context', () => {
     expect(c.res.status).toBe(201)
   })
 
+  it('Inherit current status if not specified', async () => {
+    c.status(201)
+    const res = c.newResponse('this is body', {
+      headers: {
+        'x-custom3': 'Message3',
+        'x-custom2': 'Message2-Override',
+      },
+    })
+    expect(res.headers.get('x-Custom2')).toBe('Message2-Override')
+    expect(res.headers.get('x-Custom3')).toBe('Message3')
+    expect(res.status).toBe(201)
+    expect(await res.text()).toBe('this is body')
+  })
+
   it('Should append the previous headers to new Response', () => {
     c.res.headers.set('x-Custom1', 'Message1')
     const res2 = new Response('foo2', {

--- a/src/context.ts
+++ b/src/context.ts
@@ -359,7 +359,7 @@ export class Context<
       const headers = setHeaders(new Headers(arg.headers), this.#preparedHeaders)
       return new Response(data, {
         headers,
-        status: arg.status,
+        status: arg.status ?? this.#status,
       })
     }
 

--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -366,4 +366,53 @@ d.replaceWith(c.content)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('<!DOCTYPE html><div>Hi</div>')
   })
+
+  describe('keep context status', async () => {
+    it('Should keep context status', async () => {
+      const app = new Hono()
+      app.use(
+        '*',
+        jsxRenderer(({ children }) => {
+          return (
+            <html>
+              <body>{children}</body>
+            </html>
+          )
+        })
+      )
+      app.get('/', (c) => {
+        c.status(201)
+        return c.render(<h1>Hello</h1>, { title: 'Title' })
+      })
+      const res = await app.request('/')
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(201)
+      expect(await res.text()).toBe('<!DOCTYPE html><html><body><h1>Hello</h1></body></html>')
+    })
+
+    it('Should keep context status with stream option', async () => {
+      const app = new Hono()
+      app.use(
+        '*',
+        jsxRenderer(
+          ({ children }) => {
+            return (
+              <html>
+                <body>{children}</body>
+              </html>
+            )
+          },
+          { stream: true }
+        )
+      )
+      app.get('/', (c) => {
+        c.status(201)
+        return c.render(<h1>Hello</h1>, { title: 'Title' })
+      })
+      const res = await app.request('/')
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(201)
+      expect(await res.text()).toBe('<!DOCTYPE html><html><body><h1>Hello</h1></body></html>')
+    })
+  })
 })


### PR DESCRIPTION
There is a problem that the status code is not inherited when using `jsxRenderer` with `stream:true`.

```ts
      app.use(
        '*',
        jsxRenderer(
          ({ children }) => {
            return (
              <html>
                <body>{children}</body>
              </html>
            )
          },
          { stream: true }
        )
      )
```

Here we call `c.body()` with two arguments, but since status is not inherited in this call, it is always 200.

https://github.com/honojs/hono/blob/48c6ce9b6f630e215bd1142af2b52307c3f1ac52/src/middleware/jsx-renderer/index.ts#L54-L62

This issue has caused problems with 404s turning into 200s in uses such as honox.

https://github.com/honojs/honox/blob/main/src/server/server.ts#L179-L182

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
