### PR TITLE
feat(helper): new helper toPunyCode

### DIFF
--- a/deno_dist/helper/punycode/index.ts
+++ b/deno_dist/helper/punycode/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Converts string to puny code
+ * @param string - string to be converted
+ * @param options - options
+ * @returns converted string (puny code)
+ * @example
+ * ```typescript
+ * const url = toPunyCode('https://🔥.com'); // https://xn--4v8h.com
+ * // usage
+ * c.redirect(url);
+ * ```
+ */
+
+const prefix = 'http://'
+
+export const toPunyCode = (
+  string: string,
+  options: {
+    strict?: boolean
+  } = {
+    strict: true,
+  }
+): string => {
+  const { strict } = options
+
+  let punyCode = ''
+  try {
+    punyCode = new URL(string).href
+  } catch {
+    if (strict) {
+      punyCode = string
+    } else {
+      const isEndSlash = string.endsWith('/')
+      punyCode = new URL(prefix + string).href.replace(prefix, '')
+      if (!isEndSlash) {
+        punyCode = punyCode.slice(0, -1)
+      }
+    }
+  }
+
+  return punyCode
+}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
       "import": "./dist/helper/html/index.js",
       "require": "./dist/cjs/helper/html/index.js"
     },
+    "./punycode": {
+      "types": "./dist/types/helper/punycode/index.d.ts",
+      "import": "./dist/helper/punycode/index.js",
+      "require": "./dist/cjs/helper/punycode/index.js"
+    },
     "./css": {
       "types": "./dist/types/helper/css/index.d.ts",
       "import": "./dist/helper/css/index.js",
@@ -361,6 +366,9 @@
       ],
       "html": [
         "./dist/types/helper/html"
+      ],
+      "punycode": [
+        "./dist/types/helper/punycode"
       ],
       "css": [
         "./dist/types/helper/css"

--- a/src/helper/punycode/index.test.ts
+++ b/src/helper/punycode/index.test.ts
@@ -1,0 +1,58 @@
+import { Hono } from '../../hono'
+import { toPunyCode } from '.'
+
+describe('PunyCode Helper', () => {
+  describe('Parse PunyCode', () => {
+    it('Parse PunyCode from string with no options', async () => {
+      const test1 = 'https://🔥.com'
+      const test2 = '🔥.com'
+      const test3 = 'http://🔥.com/hono?is=cool'
+
+      expect(toPunyCode(test1)).toBe('https://xn--4v8h.com/')
+      expect(toPunyCode(test2)).toBe('🔥.com')
+      expect(toPunyCode(test3)).toBe('http://xn--4v8h.com/hono?is=cool')
+    })
+
+    it('Parse PunyCode from string with options', async () => {
+      const test1 = 'https://🔥.com'
+      const test2 = '🔥.com'
+      const test3 = 'http://🔥.com/hono?is=cool'
+      const option1 = {
+        strict: true,
+      }
+      const option2 = {
+        strict: false,
+      }
+
+      expect(toPunyCode(test1, option1)).toBe('https://xn--4v8h.com/')
+      expect(toPunyCode(test2, option1)).toBe('🔥.com')
+      expect(toPunyCode(test3, option1)).toBe('http://xn--4v8h.com/hono?is=cool')
+
+      expect(toPunyCode(test1, option2)).toBe('https://xn--4v8h.com/')
+      expect(toPunyCode(test2, option2)).toBe('xn--4v8h.com')
+      expect(toPunyCode(test3, option2)).toBe('http://xn--4v8h.com/hono?is=cool')
+    })
+
+    it('Redirect with PunyCode', async () => {
+      const target = 'https://🔥.com'
+      const app = new Hono()
+
+      app.get('/pass', (c) => {
+        return c.redirect(toPunyCode(target))
+      })
+
+      app.get('/fail', (c) => {
+        return c.redirect(target)
+      })
+
+      const res1 = await app.request('/pass')
+      const res2 = await app.request('/fail')
+
+      expect(res1).not.toBeNull()
+      expect(res1.status).toBe(302)
+      expect(res1.headers.get('location')).toBe('https://xn--4v8h.com/')
+      expect(res2).not.toBeNull()
+      expect(res2.status).toBe(500)
+    })
+  })
+})

--- a/src/helper/punycode/index.ts
+++ b/src/helper/punycode/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Converts string to puny code
+ * @param string - string to be converted
+ * @param options - options
+ * @returns converted string (puny code)
+ * @example
+ * ```typescript
+ * const url = toPunyCode('https://🔥.com'); // https://xn--4v8h.com
+ * // usage
+ * c.redirect(url);
+ * ```
+ */
+
+const prefix = 'http://'
+
+export const toPunyCode = (
+  string: string,
+  options: {
+    strict?: boolean
+  } = {
+    strict: true,
+  }
+): string => {
+  const { strict } = options
+
+  let punyCode = ''
+  try {
+    punyCode = new URL(string).href
+  } catch {
+    if (strict) {
+      punyCode = string
+    } else {
+      const isEndSlash = string.endsWith('/')
+      punyCode = new URL(prefix + string).href.replace(prefix, '')
+      if (!isEndSlash) {
+        punyCode = punyCode.slice(0, -1)
+      }
+    }
+  }
+
+  return punyCode
+}


### PR DESCRIPTION
before
```ts
c.redirect("https://🔥.com") // throw Error
```

after
```ts
import { toPunyCode } from "hono/punycode"
...
c.redirect(toPunyCode("https://🔥.com")) // redirect to https://xn--4v8h.com
```

## Options
```ts
toPunyCode("🔥.com", {
    strict: true
}) // 🔥.com => 🔥.com (not URL)

toPunyCode("🔥.com", {
    strict: false
}) // 🔥.com => xn--4v8h.com (URL)

// default strict is true
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
