### PR TITLE
fix(hono-base): custom not found with middleware like compress

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -332,10 +332,9 @@ class Hono<
     if (matchResult[0].length === 1) {
       let res: ReturnType<H>
       try {
-        res = matchResult[0][0][0][0](c, async () => {})
-        if (!res) {
-          return this.notFoundHandler(c)
-        }
+        res = matchResult[0][0][0][0](c, async () => {
+          c.res = await this.notFoundHandler(c)
+        })
       } catch (err) {
         return this.handleError(err, c)
       }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -332,10 +332,9 @@ class Hono<
     if (matchResult[0].length === 1) {
       let res: ReturnType<H>
       try {
-        res = matchResult[0][0][0][0](c, async () => {})
-        if (!res) {
-          return this.notFoundHandler(c)
-        }
+        res = matchResult[0][0][0][0](c, async () => {
+          c.res = await this.notFoundHandler(c)
+        })
       } catch (err) {
         return this.handleError(err, c)
       }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1258,6 +1258,26 @@ describe('Not Found', () => {
       expect(await res.text()).toBe('404 Not Found')
     })
   })
+
+  describe('Custom 404 Not Found with a middleware like Compress Middleware', () => {
+    const app = new Hono()
+
+    // Custom Middleware which creates a new Response object after `next()`.
+    app.use('*', async (c, next) => {
+      await next()
+      c.res = new Response(await c.res.text(), c.res)
+    })
+
+    app.notFound((c) => {
+      return c.text('Custom NotFound', 404)
+    })
+
+    it('Custom 404 Not Found', async () => {
+      const res = await app.request('http://localhost/')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe('Custom NotFound')
+    })
+  })
 })
 
 describe('Redirect', () => {

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -9,6 +9,9 @@ describe('Parse Compress Middleware', () => {
     ctx.header('Content-Length', '5')
     return ctx.text('hello')
   })
+  app.notFound((c) => {
+    return c.text('Custom NotFound', 404)
+  })
 
   it('gzip', async () => {
     const req = new Request('http://localhost/hello', {
@@ -55,5 +58,35 @@ describe('Parse Compress Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toBeNull()
     expect(res.headers.get('Content-Length')).toBe('5')
+  })
+
+  it('Should handle Custom 404 Not Found', async () => {
+    const req = new Request('http://localhost/not-found', {
+      method: 'GET',
+      headers: new Headers({ 'Accept-Encoding': 'gzip' }),
+    })
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(404)
+    expect(res.headers.get('Content-Encoding')).toEqual('gzip')
+
+    // decompress response body
+    const decompressionStream = new DecompressionStream('gzip')
+    const decompressedStream = res.body!.pipeThrough(decompressionStream)
+
+    const textDecoder = new TextDecoder()
+    const reader = decompressedStream.getReader()
+    let text = ''
+
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      text += textDecoder.decode(value, { stream: true })
+    }
+
+    text += textDecoder.decode()
+    expect(text).toBe('Custom NotFound')
   })
 })


### PR DESCRIPTION
Fixed Custom NotFound not working with middleware that creates a new Response object after `next()` such as Compress Middleware. And added proper tests.

This was fixed by #2080, but it may not be merged to the main branch well. And there is no test to handle it, so we can't notice it has the bug.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
