### PR TITLE
feat: Add a "cause" option to HTTPException

### DIFF
--- a/deno_dist/http-exception.ts
+++ b/deno_dist/http-exception.ts
@@ -3,6 +3,7 @@ import type { StatusCode } from './utils/http-status.ts'
 type HTTPExceptionOptions = {
   res?: Response
   message?: string
+  cause?: unknown
 }
 
 /**
@@ -26,11 +27,13 @@ type HTTPExceptionOptions = {
 export class HTTPException extends Error {
   readonly res?: Response
   readonly status: StatusCode
+
   constructor(status: StatusCode = 500, options?: HTTPExceptionOptions) {
-    super(options?.message)
+    super(options?.message, { cause: options?.cause })
     this.res = options?.res
     this.status = status
   }
+
   getResponse(): Response {
     if (this.res) {
       return this.res

--- a/src/http-exception.test.ts
+++ b/src/http-exception.test.ts
@@ -1,15 +1,34 @@
 import { HTTPException } from './http-exception'
 
-describe('HTTPFatalError', () => {
-  it('Should be 401 HTTP exception object', () => {
+describe('HTTPException', () => {
+  it('Should be 401 HTTP exception object', async () => {
     // We should throw an exception if is not authorized
     // because next handlers should not be fired.
     const exception = new HTTPException(401, {
       message: 'Unauthorized',
     })
+    const res = exception.getResponse()
+
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Unauthorized')
     expect(exception.status).toBe(401)
     expect(exception.message).toBe('Unauthorized')
+  })
+
+  it('Should be accessible to the object causing the exception', async () => {
+    // We should pass the cause of the error to the cause option
+    // because it makes debugging easier.
+    const error = new Error('Server Error')
+    const exception = new HTTPException(500, {
+      message: 'Internal Server Error',
+      cause: error,
+    })
     const res = exception.getResponse()
-    expect(res.status).toBe(401)
+
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('Internal Server Error')
+    expect(exception.status).toBe(500)
+    expect(exception.message).toBe('Internal Server Error')
+    expect(exception.cause).toBe(error)
   })
 })

--- a/src/http-exception.ts
+++ b/src/http-exception.ts
@@ -3,6 +3,7 @@ import type { StatusCode } from './utils/http-status'
 type HTTPExceptionOptions = {
   res?: Response
   message?: string
+  cause?: unknown
 }
 
 /**
@@ -26,11 +27,13 @@ type HTTPExceptionOptions = {
 export class HTTPException extends Error {
   readonly res?: Response
   readonly status: StatusCode
+
   constructor(status: StatusCode = 500, options?: HTTPExceptionOptions) {
-    super(options?.message)
+    super(options?.message, { cause: options?.cause })
     this.res = options?.res
     this.status = status
   }
+
   getResponse(): Response {
     if (this.res) {
       return this.res

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "declaration": true,
     "moduleResolution": "Bundler",
     "outDir": "./dist",


### PR DESCRIPTION
Add a "cause" option to HTTPException for easier debugging.
close #2170 

### How to use

```ts
app.get('/users', (c) => {
  try {
    const result = await db.select().from(users);
    return c.json(result);
  } catch (error) {
    throw new HTTPException(500, {
      message: 'Internal Server Error',
      cause: error,
    })
  }
})
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
