### PR TITLE
refactor(jsx): shorten use hook a bit

### DIFF
--- a/deno_dist/jsx/hooks/index.ts
+++ b/deno_dist/jsx/hooks/index.ts
@@ -274,9 +274,10 @@ export const use = <T>(promise: Promise<T>): T => {
     }
     return cachedRes[0] as T
   }
-  promise
-    .then((res) => resolvedPromiseValueMap.set(promise, [res]))
-    .catch((e) => resolvedPromiseValueMap.set(promise, [undefined, e]))
+  promise.then(
+    (res) => resolvedPromiseValueMap.set(promise, [res]),
+    (e) => resolvedPromiseValueMap.set(promise, [undefined, e])
+  )
 
   const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
   if (!buildData) {
@@ -287,13 +288,14 @@ export const use = <T>(promise: Promise<T>): T => {
   const promiseArray = (node[DOM_STASH][1][STASH_USE] ||= [])
   const hookIndex = node[DOM_STASH][0]++
 
-  promise
-    .then((res) => {
+  promise.then(
+    (res) => {
       promiseArray[hookIndex] = [res]
-    })
-    .catch((e) => {
+    },
+    (e) => {
       promiseArray[hookIndex] = [undefined, e]
-    })
+    }
+  )
 
   const res = promiseArray[hookIndex]
   if (res) {

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -274,9 +274,10 @@ export const use = <T>(promise: Promise<T>): T => {
     }
     return cachedRes[0] as T
   }
-  promise
-    .then((res) => resolvedPromiseValueMap.set(promise, [res]))
-    .catch((e) => resolvedPromiseValueMap.set(promise, [undefined, e]))
+  promise.then(
+    (res) => resolvedPromiseValueMap.set(promise, [res]),
+    (e) => resolvedPromiseValueMap.set(promise, [undefined, e])
+  )
 
   const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
   if (!buildData) {
@@ -287,13 +288,14 @@ export const use = <T>(promise: Promise<T>): T => {
   const promiseArray = (node[DOM_STASH][1][STASH_USE] ||= [])
   const hookIndex = node[DOM_STASH][0]++
 
-  promise
-    .then((res) => {
+  promise.then(
+    (res) => {
       promiseArray[hookIndex] = [res]
-    })
-    .catch((e) => {
+    },
+    (e) => {
       promiseArray[hookIndex] = [undefined, e]
-    })
+    }
+  )
 
   const res = promiseArray[hookIndex]
   if (res) {


### PR DESCRIPTION
This is a very small refactoring and changes nothing in the specifications.

When processing the result of an "if/else" type of promise, it is shorter and clearer to pass two functions to `.then()` than to use `.catch()`.

### Author should do the followings, if applicable

- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
