### PR TITLE
fix(context): fix queries and headers types

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -126,7 +126,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#query
    */
   query(key: string): string | undefined
-  query(): Record<string, string>
+  query(): Record<string, string | undefined>
   query(key?: string) {
     return getQueryParam(this.url, key)
   }
@@ -143,7 +143,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#queries
    */
   queries(key: string): string[] | undefined
-  queries(): Record<string, string[]>
+  queries(): Record<string, string[] | undefined>
   queries(key?: string) {
     return getQueryParams(this.url, key)
   }
@@ -159,7 +159,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#header
    */
   header(name: string): string | undefined
-  header(): Record<string, string>
+  header(): Record<string, string | undefined>
   header(name?: string) {
     if (name) {
       return this.raw.headers.get(name.toLowerCase()) ?? undefined

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -171,7 +171,12 @@ const _getQueryParam = (
   url: string,
   key?: string,
   multiple?: boolean
-): string | undefined | Record<string, string> | string[] | Record<string, string[]> => {
+):
+  | string
+  | undefined
+  | Record<string, string | undefined>
+  | string[]
+  | Record<string, string[] | undefined> => {
   let encoded
 
   if (!multiple && key && !/[%+]/.test(key)) {
@@ -250,16 +255,19 @@ const _getQueryParam = (
 export const getQueryParam: (
   url: string,
   key?: string
-) => string | undefined | Record<string, string> = _getQueryParam as (
+) => string | undefined | Record<string, string | undefined> = _getQueryParam as (
   url: string,
   key?: string
-) => string | undefined | Record<string, string>
+) => string | undefined | Record<string, string | undefined>
 
 export const getQueryParams = (
   url: string,
   key?: string
-): string[] | undefined | Record<string, string[]> => {
-  return _getQueryParam(url, key, true) as string[] | undefined | Record<string, string[]>
+): string[] | undefined | Record<string, string[] | undefined> => {
+  return _getQueryParam(url, key, true) as
+    | string[]
+    | undefined
+    | Record<string, string[] | undefined>
 }
 
 // `decodeURIComponent` is a long name.

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -111,9 +111,13 @@ export const validator = <
       }
       case 'query':
         value = Object.fromEntries(
-          Object.entries(c.req.queries()).map(([k, v]) => {
-            return v.length === 1 ? [k, v[0]] : [k, v]
-          })
+          Object.entries(c.req.queries())
+            .filter((query): query is [string, string[]] => {
+              return typeof query[1] !== 'undefined'
+            })
+            .map(([k, v]) => {
+              return v.length === 1 ? [k, v[0]] : [k, v]
+            })
         )
         break
       case 'param':

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -760,6 +760,11 @@ describe('param and query', () => {
       return c.text(`q is ${queries[0]} and ${queries[1]}, limit is ${limit[0]}`)
     })
 
+    app.get('/optional-values', (c) => {
+      const { q } = c.req.queries()
+      return c.text(`q is ${typeof q === 'undefined' ? 'not ' : ''}present`)
+    })
+
     app.get('/add-header', (c) => {
       const bar = c.req.header('X-Foo')
       return c.text(`foo is ${bar}`)
@@ -788,7 +793,12 @@ describe('param and query', () => {
 
     app.get('/multiple-values', (c) => {
       const { q, limit } = c.req.queries()
-      return c.text(`q is ${q[0]} and ${q[1]}, limit is ${limit[0]}`)
+      return c.text(`q is ${q?.[0]} and ${q?.[1]}, limit is ${limit?.[0]}`)
+    })
+
+    app.get('/optional-values', (c) => {
+      const { q } = c.req.queries()
+      return c.text(`q is ${typeof q === 'undefined' ? 'not ' : ''}present`)
     })
 
     app.get('/add-header', (c) => {
@@ -842,6 +852,18 @@ describe('param and query', () => {
       const res = await app.request('http://localhost/multiple-values?q=foo&q=bar&limit=10')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('q is foo and bar, limit is 10')
+    })
+
+    it('query of /optional-values?q=foo is found', async () => {
+      const res = await app.request('http://localhost/optional-values?q=foo')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('q is present')
+    })
+
+    it('query of /optional-values is not found', async () => {
+      const res = await app.request('http://localhost/optional-values')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('q is not present')
     })
 
     it('/add-header header - X-Foo is Bar', async () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -126,7 +126,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#query
    */
   query(key: string): string | undefined
-  query(): Record<string, string>
+  query(): Record<string, string | undefined>
   query(key?: string) {
     return getQueryParam(this.url, key)
   }
@@ -143,7 +143,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#queries
    */
   queries(key: string): string[] | undefined
-  queries(): Record<string, string[]>
+  queries(): Record<string, string[] | undefined>
   queries(key?: string) {
     return getQueryParams(this.url, key)
   }
@@ -159,7 +159,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#header
    */
   header(name: string): string | undefined
-  header(): Record<string, string>
+  header(): Record<string, string | undefined>
   header(name?: string) {
     if (name) {
       return this.raw.headers.get(name.toLowerCase()) ?? undefined

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -171,7 +171,12 @@ const _getQueryParam = (
   url: string,
   key?: string,
   multiple?: boolean
-): string | undefined | Record<string, string> | string[] | Record<string, string[]> => {
+):
+  | string
+  | undefined
+  | Record<string, string | undefined>
+  | string[]
+  | Record<string, string[] | undefined> => {
   let encoded
 
   if (!multiple && key && !/[%+]/.test(key)) {
@@ -250,16 +255,19 @@ const _getQueryParam = (
 export const getQueryParam: (
   url: string,
   key?: string
-) => string | undefined | Record<string, string> = _getQueryParam as (
+) => string | undefined | Record<string, string | undefined> = _getQueryParam as (
   url: string,
   key?: string
-) => string | undefined | Record<string, string>
+) => string | undefined | Record<string, string | undefined>
 
 export const getQueryParams = (
   url: string,
   key?: string
-): string[] | undefined | Record<string, string[]> => {
-  return _getQueryParam(url, key, true) as string[] | undefined | Record<string, string[]>
+): string[] | undefined | Record<string, string[] | undefined> => {
+  return _getQueryParam(url, key, true) as
+    | string[]
+    | undefined
+    | Record<string, string[] | undefined>
 }
 
 // `decodeURIComponent` is a long name.

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -111,9 +111,13 @@ export const validator = <
       }
       case 'query':
         value = Object.fromEntries(
-          Object.entries(c.req.queries()).map(([k, v]) => {
-            return v.length === 1 ? [k, v[0]] : [k, v]
-          })
+          Object.entries(c.req.queries())
+            .filter((query): query is [string, string[]] => {
+              return typeof query[1] !== 'undefined'
+            })
+            .map(([k, v]) => {
+              return v.length === 1 ? [k, v[0]] : [k, v]
+            })
         )
         break
       case 'param':


### PR DESCRIPTION
### Importance of Implementation

The current routing system lacks enforcement of query parameters and headers, allowing them to be `undefined` if middleware fails to validate them. This behavior can lead to errors caused by type mismatches. To address this issue and align with the framework's behavior, the `undefined` type has been introduced. It is currently applicable for calls with keys like `Context.req.query('name')`, but not for those without keys such as `Context.req.query()`.

### Practical Example

Consider the following code snippet, which will not exhibit type issues but is prone to runtime failures:

```ts
app.get('/capitalized-name', (c) => {
  // At this point, 'name' is assumed to be a string
  const { name } = c.req.query();
  // This line is at risk of failure if the API is invoked without the 'name' query parameter
  return c.text(name.toUpperCase());
})
```

With this pull request, an error will be triggered on the last line, indicating that `name` could potentially be of type `undefined`.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno

### Related

- https://github.com/honojs/hono/issues/1632
This PR does not add generics as requested in the issue. However, if they are ever implemented, the `undefined` should be present and serve as the foundation for all generics, unless a router can filter query parameters.