### PR TITLE
feat(jsx/dom): support namespace for svg and mathml elements

### DIFF
--- a/deno_dist/jsx/dom/render.ts
+++ b/deno_dist/jsx/dom/render.ts
@@ -5,11 +5,17 @@ import type { Context as JSXContext } from '../context.ts'
 import { globalContexts as globalJSXContexts } from '../context.ts'
 import type { EffectData } from '../hooks/index.ts'
 import { STASH_EFFECT } from '../hooks/index.ts'
+import { useContext, createContext } from './index.ts'
 
 const eventAliasMap: Record<string, string> = {
   Change: 'Input',
   DoubleClick: 'DblClick',
-}
+} as const
+
+const nameSpaceMap: Record<string, string> = {
+  svg: 'http://www.w3.org/2000/svg',
+  math: 'http://www.w3.org/1998/Math/MathML',
+} as const
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type HasRenderToDom = FC<any> & { [DOM_RENDERER]: FC<any> }
@@ -18,6 +24,7 @@ export type ErrorHandler = (error: any, retry: () => void) => Child | undefined
 
 type Container = HTMLElement | DocumentFragment
 type LocalJSXContexts = [JSXContext<unknown>, unknown][] | undefined
+type SupportedElement = HTMLElement | SVGElement | MathMLElement
 
 export type NodeObject = {
   pP: Props | undefined // previous props
@@ -25,8 +32,9 @@ export type NodeObject = {
   vC: Node[] // virtual dom children
   vR: Node[] // virtual dom children to remove
   s?: Node[] // shadow virtual dom children
+  n?: string // namespace
   c: Container | undefined // container
-  e: HTMLElement | Text | undefined // rendered element
+  e: SupportedElement | Text | undefined // rendered element
   [DOM_STASH]:
     | [
         number, // current hook index
@@ -74,6 +82,8 @@ export type Context =
 
 export const buildDataStack: [Context, Node][] = []
 
+let nameSpaceContext: JSXContext<string> | undefined = undefined
+
 const isNodeString = (node: Node): node is NodeString => Array.isArray(node)
 
 const getEventSpec = (key: string): [string, boolean] | undefined => {
@@ -85,7 +95,7 @@ const getEventSpec = (key: string): [string, boolean] | undefined => {
   return undefined
 }
 
-const applyProps = (container: HTMLElement, attributes: Props, oldAttributes?: Props) => {
+const applyProps = (container: SupportedElement, attributes: Props, oldAttributes?: Props) => {
   attributes ||= {}
   for (const [key, value] of Object.entries(attributes)) {
     if (!oldAttributes || oldAttributes[key] !== value) {
@@ -260,14 +270,16 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
   for (let i = 0, len = next.length; i < len; i++, offset++) {
     const child = next[i]
 
-    let el: HTMLElement | Text
+    let el: SupportedElement | Text
     if (isNodeString(child)) {
       if (child.e) {
         child.e.textContent = child[0]
       }
       el = child.e ||= document.createTextNode(child[0])
     } else {
-      el = child.e ||= document.createElement(child.tag as string)
+      el = child.e ||= child.n
+        ? (document.createElementNS(child.n, child.tag as string) as SVGElement | MathMLElement)
+        : document.createElement(child.tag as string)
       applyProps(el as HTMLElement, child.props, child.pP)
       applyNode(child, el as HTMLElement)
     }
@@ -339,6 +351,11 @@ export const build = (
             oldChild.children = child.children
             child = oldChild
           }
+        } else if (!isNodeString(child) && nameSpaceContext) {
+          const ns = useContext(nameSpaceContext)
+          if (ns) {
+            child.n = ns
+          }
         }
 
         if (!isNodeString(child)) {
@@ -376,6 +393,22 @@ const buildNode = (node: Child): Node | undefined => {
   } else {
     if (typeof (node as JSXNode).tag === 'function') {
       ;(node as NodeObject)[DOM_STASH] = [0, []]
+    } else {
+      const ns = nameSpaceMap[(node as JSXNode).tag as string]
+      if (ns) {
+        ;(node as NodeObject).n = ns
+        nameSpaceContext ||= createContext('')
+        ;(node as JSXNode).children = [
+          {
+            tag: nameSpaceContext.Provider,
+            props: {
+              value: ns,
+            },
+            children: (node as JSXNode).children,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any
+      }
     }
     return node as NodeObject
   }

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -1044,4 +1044,65 @@ describe('DOM', () => {
       expect(root.innerHTML).toBe('<div><p>1</p></div>')
     })
   })
+
+  describe('SVG', () => {
+    it('simple', () => {
+      const createElementSpy = vi.spyOn(dom.window.document, 'createElement')
+      const createElementNSSpy = vi.spyOn(dom.window.document, 'createElementNS')
+
+      const App = () => {
+        return (
+          <svg>
+            <circle cx='50' cy='50' r='40' stroke='black' stroke-width='3' fill='red' />
+          </svg>
+        )
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe(
+        '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>'
+      )
+    })
+
+    it('title element', () => {
+      const App = () => {
+        return (
+          <>
+            <title>Document Title</title>
+            <svg>
+              <title>SVG Title</title>
+            </svg>
+          </>
+        )
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe(
+        '<title>Document Title</title><svg><title>SVG Title</title></svg>'
+      )
+      expect(document.querySelector('title')).toBeInstanceOf(dom.window.HTMLTitleElement)
+      expect(document.querySelector('svg title')).toBeInstanceOf(dom.window.SVGTitleElement)
+    })
+  })
+
+  describe('MathML', () => {
+    it('simple', () => {
+      const createElementSpy = vi.spyOn(dom.window.document, 'createElement')
+      const createElementNSSpy = vi.spyOn(dom.window.document, 'createElementNS')
+
+      const App = () => {
+        return (
+          <math>
+            <mrow>
+              <mn>1</mn>
+            </mrow>
+          </math>
+        )
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<math><mrow><mn>1</mn></mrow></math>')
+
+      expect(createElementSpy).not.toHaveBeenCalled()
+      expect(createElementNSSpy).toHaveBeenCalledWith('http://www.w3.org/1998/Math/MathML', 'math')
+      expect(createElementNSSpy).toHaveBeenCalledWith('http://www.w3.org/1998/Math/MathML', 'mrow')
+    })
+  })
 })

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -5,11 +5,17 @@ import type { Context as JSXContext } from '../context'
 import { globalContexts as globalJSXContexts } from '../context'
 import type { EffectData } from '../hooks'
 import { STASH_EFFECT } from '../hooks'
+import { useContext, createContext } from '.'
 
 const eventAliasMap: Record<string, string> = {
   Change: 'Input',
   DoubleClick: 'DblClick',
 }
+
+const nameSpaceMap: Record<string, string> = {
+  svg: 'http://www.w3.org/2000/svg',
+  math: 'http://www.w3.org/1998/Math/MathML',
+} as const
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type HasRenderToDom = FC<any> & { [DOM_RENDERER]: FC<any> }
@@ -18,6 +24,7 @@ export type ErrorHandler = (error: any, retry: () => void) => Child | undefined
 
 type Container = HTMLElement | DocumentFragment
 type LocalJSXContexts = [JSXContext<unknown>, unknown][] | undefined
+type SupportedElement = HTMLElement | SVGElement | MathMLElement
 
 export type NodeObject = {
   pP: Props | undefined // previous props
@@ -25,8 +32,9 @@ export type NodeObject = {
   vC: Node[] // virtual dom children
   vR: Node[] // virtual dom children to remove
   s?: Node[] // shadow virtual dom children
+  n?: string // namespace
   c: Container | undefined // container
-  e: HTMLElement | Text | undefined // rendered element
+  e: SupportedElement | Text | undefined // rendered element
   [DOM_STASH]:
     | [
         number, // current hook index
@@ -74,6 +82,8 @@ export type Context =
 
 export const buildDataStack: [Context, Node][] = []
 
+let nameSpaceContext: JSXContext<string> | undefined = undefined
+
 const isNodeString = (node: Node): node is NodeString => Array.isArray(node)
 
 const getEventSpec = (key: string): [string, boolean] | undefined => {
@@ -85,7 +95,7 @@ const getEventSpec = (key: string): [string, boolean] | undefined => {
   return undefined
 }
 
-const applyProps = (container: HTMLElement, attributes: Props, oldAttributes?: Props) => {
+const applyProps = (container: SupportedElement, attributes: Props, oldAttributes?: Props) => {
   attributes ||= {}
   for (const [key, value] of Object.entries(attributes)) {
     if (!oldAttributes || oldAttributes[key] !== value) {
@@ -260,14 +270,16 @@ const applyNodeObject = (node: NodeObject, container: Container) => {
   for (let i = 0, len = next.length; i < len; i++, offset++) {
     const child = next[i]
 
-    let el: HTMLElement | Text
+    let el: SupportedElement | Text
     if (isNodeString(child)) {
       if (child.e) {
         child.e.textContent = child[0]
       }
       el = child.e ||= document.createTextNode(child[0])
     } else {
-      el = child.e ||= document.createElement(child.tag as string)
+      el = child.e ||= child.n
+        ? (document.createElementNS(child.n, child.tag as string) as SVGElement | MathMLElement)
+        : document.createElement(child.tag as string)
       applyProps(el as HTMLElement, child.props, child.pP)
       applyNode(child, el as HTMLElement)
     }
@@ -339,6 +351,11 @@ export const build = (
             oldChild.children = child.children
             child = oldChild
           }
+        } else if (!isNodeString(child) && nameSpaceContext) {
+          const ns = useContext(nameSpaceContext)
+          if (ns) {
+            child.n = ns
+          }
         }
 
         if (!isNodeString(child)) {
@@ -376,6 +393,22 @@ const buildNode = (node: Child): Node | undefined => {
   } else {
     if (typeof (node as JSXNode).tag === 'function') {
       ;(node as NodeObject)[DOM_STASH] = [0, []]
+    } else {
+      const ns = nameSpaceMap[(node as JSXNode).tag as string]
+      if (ns) {
+        ;(node as NodeObject).n = ns
+        nameSpaceContext ||= createContext('')
+        ;(node as JSXNode).children = [
+          {
+            tag: nameSpaceContext.Provider,
+            props: {
+              value: ns,
+            },
+            children: (node as JSXNode).children,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any
+      }
     }
     return node as NodeObject
   }

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -10,7 +10,7 @@ import { useContext, createContext } from '.'
 const eventAliasMap: Record<string, string> = {
   Change: 'Input',
   DoubleClick: 'DblClick',
-}
+} as const
 
 const nameSpaceMap: Record<string, string> = {
   svg: 'http://www.w3.org/2000/svg',


### PR DESCRIPTION
fixes https://github.com/honojs/honox/issues/71

In the case of SVG and MathML elements, it is necessary to use createElementNS instead of createElement to support them.

### Differences from React

In React, it is necessary to specify in lower camel case, and I think the output will be converted to kebab case. This PR does not do that conversion, but I think it is OK to have hono specify kebab case from the beginning. If there are many requests, we will consider adding a conversion process.

```tsx
   // in React 
   <circle
     cx="40"
     cy="40"
     r="35"
     stroke="black"
     strokeWidth="4"
     fill="lightgrey"
   /> // => <circle cx="40" cy="40" r="35" stroke="black" stroke-width="4" fill="lightgrey" />
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
