### PR TITLE
refactor(context): skip jsx type import

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,5 +1,3 @@
-import type { FC } from './jsx/index.ts'
-import type { PropsForRenderer } from './middleware/jsx-renderer/index.ts'
 import type { HonoRequest } from './request.ts'
 import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types.ts'
 import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html.ts'
@@ -22,6 +20,12 @@ interface DefaultRenderer {
 }
 
 export type Renderer = ContextRenderer extends Function ? ContextRenderer : DefaultRenderer
+export type PropsForRenderer = [...Required<Parameters<Renderer>>] extends [unknown, infer Props]
+  ? Props
+  : unknown
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Layout<T = Record<string, any>> = (props: T) => any
 
 interface Get<E extends Env> {
   <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
@@ -134,7 +138,7 @@ export class Context<
   #preparedHeaders: Record<string, string> | undefined = undefined
   #res: Response | undefined
   #isFresh = true
-  private layout: FC<PropsForRenderer & { Layout: FC }> | undefined = undefined
+  private layout: Layout<PropsForRenderer & { Layout: Layout }> | undefined = undefined
   private renderer: Renderer = (content: string | Promise<string>) => this.html(content)
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
@@ -211,7 +215,7 @@ export class Context<
    */
   render: Renderer = (...args) => this.renderer(...args)
 
-  setLayout = (layout: FC<PropsForRenderer & { Layout: FC }>) => (this.layout = layout)
+  setLayout = (layout: Layout<PropsForRenderer & { Layout: Layout }>) => (this.layout = layout)
   getLayout = () => this.layout
 
   /**

--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Context, Renderer } from '../../context.ts'
+import type { Context, PropsForRenderer } from '../../context.ts'
 import { html, raw } from '../../helper/html/index.ts'
 import { jsx, createContext, useContext, Fragment } from '../../jsx/index.ts'
 import type { FC, PropsWithChildren, JSXNode } from '../../jsx/index.ts'
@@ -7,10 +7,6 @@ import { renderToReadableStream } from '../../jsx/streaming.ts'
 import type { Env, Input, MiddlewareHandler } from '../../types.ts'
 
 export const RequestContext = createContext<Context | null>(null)
-
-export type PropsForRenderer = [...Required<Parameters<Renderer>>] extends [unknown, infer Props]
-  ? Props
-  : unknown
 
 type RendererOptions = {
   docType?: boolean | string

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,3 @@
-import type { FC } from './jsx'
-import type { PropsForRenderer } from './middleware/jsx-renderer'
 import type { HonoRequest } from './request'
 import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types'
 import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html'
@@ -22,6 +20,12 @@ interface DefaultRenderer {
 }
 
 export type Renderer = ContextRenderer extends Function ? ContextRenderer : DefaultRenderer
+export type PropsForRenderer = [...Required<Parameters<Renderer>>] extends [unknown, infer Props]
+  ? Props
+  : unknown
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Layout<T = Record<string, any>> = (props: T) => any
 
 interface Get<E extends Env> {
   <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
@@ -134,7 +138,7 @@ export class Context<
   #preparedHeaders: Record<string, string> | undefined = undefined
   #res: Response | undefined
   #isFresh = true
-  private layout: FC<PropsForRenderer & { Layout: FC }> | undefined = undefined
+  private layout: Layout<PropsForRenderer & { Layout: Layout }> | undefined = undefined
   private renderer: Renderer = (content: string | Promise<string>) => this.html(content)
   private notFoundHandler: NotFoundHandler<E> = () => new Response()
 
@@ -211,7 +215,7 @@ export class Context<
    */
   render: Renderer = (...args) => this.renderer(...args)
 
-  setLayout = (layout: FC<PropsForRenderer & { Layout: FC }>) => (this.layout = layout)
+  setLayout = (layout: Layout<PropsForRenderer & { Layout: Layout }>) => (this.layout = layout)
   getLayout = () => this.layout
 
   /**

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Context, Renderer } from '../../context'
+import type { Context, PropsForRenderer } from '../../context'
 import { html, raw } from '../../helper/html'
 import { jsx, createContext, useContext, Fragment } from '../../jsx'
 import type { FC, PropsWithChildren, JSXNode } from '../../jsx'
@@ -7,10 +7,6 @@ import { renderToReadableStream } from '../../jsx/streaming'
 import type { Env, Input, MiddlewareHandler } from '../../types'
 
 export const RequestContext = createContext<Context | null>(null)
-
-export type PropsForRenderer = [...Required<Parameters<Renderer>>] extends [unknown, infer Props]
-  ? Props
-  : unknown
 
 type RendererOptions = {
   docType?: boolean | string


### PR DESCRIPTION
Maybe fixes #2190

### #2190 What is at stake here?

Importing "hono/client" is causing problems because hono's JSX types are being read.

```ts
import { hc } from "hono/client";
```

This is because "context.ts" imports "hono/jsx" and "hono/middleware/jsx-renderer". This PR eliminates this.


### Where are the conflicts?

However, even after resolving this, if I try to use `React.ElementType` and "hono/jsx" at the same time (I am not aware if there is such a case or not), we still have problems. 

The following part cannot avoid conflict with the `React.ElementType` definition in any way.
https://github.com/usualoma/hono/blob/33f2d484f651ea55913ebe7022ed028e8ac7743f/src/jsx/base.ts#L20-L22

If a workaround is needed, I think the only way is to remove `[tagName: string]: Props`.

### Author should do the followings, if applicable

- [x] `yarn denoify` to generate files for Deno
