### PR TITLE
chore: use official deno installer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:20
 
 # Install Deno
 ENV DENO_INSTALL=/usr/local
-RUN curl -fsSL https://gist.githubusercontent.com/LukeChannings/09d53f5c364391042186518c8598b85e/raw/ac8cd8c675b985edd4b3e16df63ffef14d1f0e24/deno_install.sh | sh
+RUN curl -fsSL https://deno.land/install.sh | sh
 
 # Install Bun
 ENV BUN_INSTALL=/usr/local


### PR DESCRIPTION
Deno installer support ARM64 builds from [v1.40.4](https://github.com/denoland/deno/releases/tag/v1.40.4).
The third party installer we are currently using has officially come to an end.
https://github.com/LukeChannings/deno-arm64

We can use the official installer.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno