### PR TITLE
fix(reg-exp-router): use matchers[METHOD_NAME_ALL] as fallback for unknown method

### DIFF
--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -682,9 +682,15 @@ describe('Capture Group', () => {
 describe('Unknown method', () => {
   const router = new RegExpRouter<string>()
   router.add('GET', '/', 'index')
+  router.add('ALL', '/all', 'all')
 
-  it('HONO /', () => {
-    const [res] = router.match('HONO', '/')
+  it('UNKNOWN_METHOD /', () => {
+    const [res] = router.match('UNKNOWN_METHOD', '/')
     expect(res.length).toBe(0)
+  })
+
+  it('UNKNOWN_METHOD /all', () => {
+    const [res] = router.match('UNKNOWN_METHOD', '/all')
+    expect(res.length).toBe(1)
   })
 })

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -692,5 +692,6 @@ describe('Unknown method', () => {
   it('UNKNOWN_METHOD /all', () => {
     const [res] = router.match('UNKNOWN_METHOD', '/all')
     expect(res.length).toBe(1)
+    expect(res[0][0]).toBe('all')
   })
 })

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -678,3 +678,13 @@ describe('Capture Group', () => {
     })
   })
 })
+
+describe('Unknown method', () => {
+  const router = new RegExpRouter<string>()
+  router.add('GET', '/', 'index')
+
+  it('HONO /', () => {
+    const [res] = router.match('HONO', '/')
+    expect(res.length).toBe(0)
+  })
+})

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -212,7 +212,7 @@ export class RegExpRouter<T> implements Router<T> {
     const matchers = this.buildAllMatchers()
 
     this.match = (method, path) => {
-      const matcher = matchers[method]
+      const matcher = (matchers[method] || matchers[METHOD_NAME_ALL]) as Matcher<T>
 
       const staticMatch = matcher[2][path]
       if (staticMatch) {

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -2,15 +2,12 @@
 import type { Router, Result, ParamIndexMap } from '../../router'
 import {
   METHOD_NAME_ALL,
-  METHODS,
   UnsupportedPathError,
   MESSAGE_MATCHER_IS_ALREADY_BUILT,
 } from '../../router'
 import { checkOptionalParameter } from '../../utils/url'
 import { PATH_ERROR, type ParamAssocArray } from './node'
 import { Trie } from './trie'
-
-const methodNames = [METHOD_NAME_ALL, ...METHODS].map((method) => method.toUpperCase())
 
 type HandlerData<T> = [T, ParamIndexMap][]
 type StaticMap<T> = Record<string, Result<T>>
@@ -137,9 +134,6 @@ export class RegExpRouter<T> implements Router<T> {
       throw new Error(MESSAGE_MATCHER_IS_ALREADY_BUILT)
     }
 
-    if (methodNames.indexOf(method) === -1) {
-      methodNames.push(method)
-    }
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
         handlerMap[method] = {}
@@ -231,11 +225,11 @@ export class RegExpRouter<T> implements Router<T> {
     return this.match(method, path)
   }
 
-  private buildAllMatchers(): Record<string, Matcher<T>> {
-    const matchers: Record<string, Matcher<T>> = {}
+  private buildAllMatchers(): Record<string, Matcher<T> | null> {
+    const matchers: Record<string, Matcher<T> | null> = {}
 
-    methodNames.forEach((method) => {
-      matchers[method] = this.buildMatcher(method) || matchers[METHOD_NAME_ALL]
+    ;[...Object.keys(this.routes!), ...Object.keys(this.middleware!)].forEach((method) => {
+      matchers[method] ||= this.buildMatcher(method)
     })
 
     // Release cache


### PR DESCRIPTION
fixes #2254

Fixed an error when accessed by an unknown method. I don't think there is a compatibility issue.

I will think about #1953 later.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
