### PR TITLE
fix(serve-static): support extensionless files and refactor

### DIFF
--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -1,65 +1,32 @@
-import type { Context } from '../../context.ts'
+import type { ServeStaticOptions } from '../../middleware/serve-static/index.ts'
+import { serveStatic as baseServeStatic } from '../../middleware/serve-static/index.ts'
 import type { Env, MiddlewareHandler } from '../../types.ts'
-import { getFilePath } from '../../utils/filepath.ts'
-import { getMimeType } from '../../utils/mime.ts'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const { open } = Deno
 
-export type ServeStaticOptions<E extends Env = Env> = {
-  root?: string
-  path?: string
-  mimes?: Record<string, string>
-  rewriteRequestPath?: (path: string) => string
-  onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
-}
-
-const DEFAULT_DOCUMENT = 'index.html'
-
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E> = { root: '' }
+  options: ServeStaticOptions<E>
 ): MiddlewareHandler => {
-  return async (c, next) => {
-    // Do nothing if Response is already set
-    if (c.finalized) {
-      await next()
-      return
-    }
-
-    const url = new URL(c.req.url)
-    const filename = options.path ?? decodeURI(url.pathname)
-    let path = getFilePath({
-      filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,
-      root: options.root,
-      defaultDocument: DEFAULT_DOCUMENT,
-    })
-
-    if (!path) {
-      return await next()
-    }
-
-    path = `./${path}`
-
-    let file
-
-    try {
-      file = await open(path)
-    } catch (e) {
-      console.warn(`${e}`)
-    }
-
-    if (file) {
-      const mimeType = getMimeType(path)
-      if (mimeType) {
-        c.header('Content-Type', mimeType)
+  return async function serveStatic(c, next) {
+    const getContent = async (path: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let file: any
+      try {
+        file = await open(path)
+      } catch (e) {
+        console.warn(`${e}`)
       }
-      // Return Response object with stream
-      return c.body(file.readable)
+      return file ? file.readable : undefined
     }
-
-    await options.onNotFound?.(path, c)
-    await next()
-    return
+    const pathResolve = (path: string) => {
+      return `./${path}`
+    }
+    return baseServeStatic({
+      ...options,
+      getContent,
+      pathResolve,
+    })(c, next)
   }
 }

--- a/deno_dist/middleware/serve-static/index.ts
+++ b/deno_dist/middleware/serve-static/index.ts
@@ -1,0 +1,87 @@
+import type { Context } from '../../context.ts'
+import type { Env, MiddlewareHandler } from '../../types.ts'
+import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath.ts'
+import { getMimeType } from '../../utils/mime.ts'
+
+export type ServeStaticOptions<E extends Env = Env> = {
+  root?: string
+  path?: string
+  mimes?: Record<string, string>
+  rewriteRequestPath?: (path: string) => string
+  onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+}
+
+const DEFAULT_DOCUMENT = 'index.html'
+const defaultPathResolve = (path: string) => path
+
+/**
+ * This middleware is not directly used by the user. Create a wrapper specifying `getContent()` by the environment such as Deno or Bun.
+ */
+export const serveStatic = <E extends Env = Env>(
+  options: ServeStaticOptions<E> & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getContent: (path: string) => any
+    pathResolve?: (path: string) => string
+  }
+): MiddlewareHandler => {
+  return async (c, next) => {
+    // Do nothing if Response is already set
+    if (c.finalized) {
+      await next()
+      return
+    }
+    const url = new URL(c.req.url)
+
+    let filename = options.path ?? decodeURI(url.pathname)
+    filename = options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename
+    const root = options.root
+
+    let path = getFilePath({
+      filename,
+      root,
+      defaultDocument: DEFAULT_DOCUMENT,
+    })
+
+    if (!path) {
+      return await next()
+    }
+
+    const getContent = options.getContent
+    const pathResolve = options.pathResolve ?? defaultPathResolve
+
+    path = pathResolve(path)
+    let content = await getContent(path)
+
+    if (!content) {
+      let pathWithOutDefaultDocument = getFilePathWithoutDefaultDocument({
+        filename,
+        root,
+      })
+      if (!pathWithOutDefaultDocument) {
+        return await next()
+      }
+      pathWithOutDefaultDocument = pathResolve(pathWithOutDefaultDocument)
+      content = await getContent(pathWithOutDefaultDocument)
+      if (content) {
+        path = pathWithOutDefaultDocument
+      }
+    }
+
+    if (content) {
+      let mimeType: string | undefined = undefined
+      if (options.mimes) {
+        mimeType = getMimeType(path, options.mimes) ?? getMimeType(path)
+      } else {
+        mimeType = getMimeType(path)
+      }
+      if (mimeType) {
+        c.header('Content-Type', mimeType)
+      }
+      return c.body(content)
+    }
+
+    await options.onNotFound?.(path, c)
+    await next()
+    return
+  }
+}

--- a/deno_dist/utils/filepath.ts
+++ b/deno_dist/utils/filepath.ts
@@ -6,11 +6,6 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
-    return
-  }
-
-  let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'
 
   if (filename.endsWith('/')) {
@@ -19,6 +14,24 @@ export const getFilePath = (options: FilePathOptions): string | undefined => {
   } else if (!filename.match(/\.[a-zA-Z0-9]+$/)) {
     // /top => /top/index.html
     filename = filename.concat('/' + defaultDocument)
+  }
+
+  const path = getFilePathWithoutDefaultDocument({
+    root: options.root,
+    filename,
+  })
+
+  return path
+}
+
+export const getFilePathWithoutDefaultDocument = (
+  options: Omit<FilePathOptions, 'defaultDocument'>
+) => {
+  let root = options.root || ''
+  let filename = options.filename
+
+  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
+    return
   }
 
   // /foo.html => foo.html

--- a/runtime_tests/bun/index.test.tsx
+++ b/runtime_tests/bun/index.test.tsx
@@ -129,6 +129,13 @@ describe('Serve Static Middleware', () => {
     expect(onNotFound).not.toHaveBeenCalled()
   })
 
+  it('Should return 200 response - /static/download', async () => {
+    const res = await app.request(new Request('http://localhost/static/download'))
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('download')
+    expect(onNotFound).not.toHaveBeenCalled()
+  })
+
   it('Should return 200 response - /dot-static/plain.txt', async () => {
     const res = await app.request(new Request('http://localhost/dot-static/plain.txt'))
     expect(res.status).toBe(200)

--- a/runtime_tests/bun/static/download
+++ b/runtime_tests/bun/static/download
@@ -1,0 +1,1 @@
+download

--- a/runtime_tests/deno/middleware.test.tsx
+++ b/runtime_tests/deno/middleware.test.tsx
@@ -109,6 +109,10 @@ Deno.test('Serve Static middleware', async () => {
   assertEquals(res.status, 200)
   assertEquals(await res.text(), 'Deno!')
 
+  res = await app.request('http://localhost/static/download')
+  assertEquals(res.status, 200)
+  assertEquals(await res.text(), 'download')
+
   res = await app.request('http://localhost/dot-static/plain.txt')
   assertEquals(res.status, 200)
   assertEquals(await res.text(), 'Deno!!')

--- a/runtime_tests/deno/static/download
+++ b/runtime_tests/deno/static/download
@@ -1,0 +1,1 @@
+download

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -1,63 +1,26 @@
 // @denoify-ignore
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import type { Context } from '../../context'
+import { serveStatic as baseServeStatic } from '../../middleware/serve-static'
+import type { ServeStaticOptions } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
-import { getFilePath } from '../../utils/filepath'
-import { getMimeType } from '../../utils/mime'
-
-export type ServeStaticOptions<E extends Env = Env> = {
-  root?: string
-  path?: string
-  mimes?: Record<string, string>
-  rewriteRequestPath?: (path: string) => string
-  onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
-}
-
-const DEFAULT_DOCUMENT = 'index.html'
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E> = { root: '' }
+  options: ServeStaticOptions<E>
 ): MiddlewareHandler => {
-  return async (c, next) => {
-    // Do nothing if Response is already set
-    if (c.finalized) {
-      await next()
-      return
+  return async function serveStatic(c, next) {
+    const getContent = async (path: string) => {
+      path = `./${path}`
+      // @ts-ignore
+      const file = Bun.file(path)
+      return (await file.exists()) ? file : null
     }
-    const url = new URL(c.req.url)
-
-    const filename = options.path ?? decodeURI(url.pathname)
-    let path = getFilePath({
-      filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,
-      root: options.root,
-      defaultDocument: DEFAULT_DOCUMENT,
-    })
-
-    if (!path) {
-      return await next()
+    const pathResolve = (path: string) => {
+      return `./${path}`
     }
-
-    path = `./${path}`
-
-    // @ts-ignore
-    const file = Bun.file(path)
-    const isExists = await file.exists()
-    if (isExists) {
-      let mimeType: string | undefined = undefined
-      if (options.mimes) {
-        mimeType = getMimeType(path, options.mimes) ?? getMimeType(path)
-      } else {
-        mimeType = getMimeType(path)
-      }
-      if (mimeType) {
-        c.header('Content-Type', mimeType)
-      }
-      // Return Response object
-      return c.body(file)
-    }
-
-    await options.onNotFound?.(path, c)
-    await next()
-    return
+    return baseServeStatic({
+      ...options,
+      getContent,
+      pathResolve,
+    })(c, next)
   }
 }

--- a/src/adapter/cloudflare-workers/serve-static.test.ts
+++ b/src/adapter/cloudflare-workers/serve-static.test.ts
@@ -14,6 +14,7 @@ const store: Record<string, string> = {
   'assets/static/video/morning-routine.abcdef.m3u8': 'Good morning',
   'assets/static/video/morning-routine1.abcdef.ts': 'Good',
   'assets/static/video/introduction.abcdef.mp4': 'Let me introduce myself',
+  'assets/static/download': 'download',
 }
 const manifest = JSON.stringify({
   'assets/static/plain.txt': 'assets/static/plain.abcdef.txt',
@@ -21,6 +22,7 @@ const manifest = JSON.stringify({
   'assets/static/top/index.html': 'assets/static/top/index.abcdef.html',
   'static-no-root/plain.txt': 'static-no-root/plain.abcdef.txt',
   'assets/.static/plain.txt': 'assets/.static/plain.abcdef.txt',
+  'assets/static/download': 'assets/static/download',
 })
 
 Object.assign(global, { __STATIC_CONTENT_MANIFEST: manifest })
@@ -188,6 +190,11 @@ describe('With middleware', () => {
     const res = await app.request('http://localhost/static/foo')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('bar')
+  })
+
+  it('Should handle a file without an extension', async () => {
+    const res = await app.request('http://localhost/static/download')
+    expect(res.status).toBe(200)
   })
 })
 

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -1,69 +1,35 @@
 // @denoify-ignore
 import type { KVNamespace } from '@cloudflare/workers-types'
-import type { Context } from '../../context'
+import { serveStatic as baseServeStatic } from '../../middleware/serve-static'
+import type { ServeStaticOptions as BaseServeStaticOptions } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
-import { getFilePath } from '../../utils/filepath'
-import { getMimeType } from '../../utils/mime'
 import { getContentFromKVAsset } from './utils'
 
-export type ServeStaticOptions<E extends Env = Env> = {
-  root?: string
-  path?: string
-  mimes?: Record<string, string>
-  manifest: object | string
+export type ServeStaticOptions<E extends Env = Env> = BaseServeStaticOptions<E> & {
   namespace?: KVNamespace
-  rewriteRequestPath?: (path: string) => string
-  onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+  manifest: object | string
 }
-
-const DEFAULT_DOCUMENT = 'index.html'
 
 // This middleware is available only on Cloudflare Workers.
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E>
 ): MiddlewareHandler => {
-  return async (c, next) => {
-    // Do nothing if Response is already set
-    if (c.finalized) {
-      await next()
-      return
+  return async function serveStatic(c, next) {
+    const getContent = async (path: string) => {
+      return getContentFromKVAsset(path, {
+        manifest: options.manifest,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        namespace: options.namespace
+          ? options.namespace
+          : c.env
+          ? c.env.__STATIC_CONTENT
+          : undefined,
+      })
     }
-
-    const url = new URL(c.req.url)
-    const filename = options.path ?? decodeURI(url.pathname)
-    const path = getFilePath({
-      filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,
-      root: options.root,
-      defaultDocument: DEFAULT_DOCUMENT,
-    })
-
-    if (!path) {
-      return await next()
-    }
-
-    const content = await getContentFromKVAsset(path, {
-      manifest: options.manifest,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      namespace: options.namespace ? options.namespace : c.env ? c.env.__STATIC_CONTENT : undefined,
-    })
-
-    if (content) {
-      let mimeType: string | undefined = undefined
-      if (options.mimes) {
-        mimeType = getMimeType(path, options.mimes) ?? getMimeType(path)
-      } else {
-        mimeType = getMimeType(path)
-      }
-      if (mimeType) {
-        c.header('Content-Type', mimeType)
-      }
-      // Return Response object
-      return c.body(content)
-    }
-
-    await options.onNotFound?.(path, c)
-    await next()
-    return
+    return baseServeStatic({
+      ...options,
+      getContent,
+    })(c, next)
   }
 }

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -1,65 +1,32 @@
-import type { Context } from '../../context'
+import type { ServeStaticOptions } from '../../middleware/serve-static'
+import { serveStatic as baseServeStatic } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
-import { getFilePath } from '../../utils/filepath'
-import { getMimeType } from '../../utils/mime'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const { open } = Deno
 
-export type ServeStaticOptions<E extends Env = Env> = {
-  root?: string
-  path?: string
-  mimes?: Record<string, string>
-  rewriteRequestPath?: (path: string) => string
-  onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
-}
-
-const DEFAULT_DOCUMENT = 'index.html'
-
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E> = { root: '' }
+  options: ServeStaticOptions<E>
 ): MiddlewareHandler => {
-  return async (c, next) => {
-    // Do nothing if Response is already set
-    if (c.finalized) {
-      await next()
-      return
-    }
-
-    const url = new URL(c.req.url)
-    const filename = options.path ?? decodeURI(url.pathname)
-    let path = getFilePath({
-      filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,
-      root: options.root,
-      defaultDocument: DEFAULT_DOCUMENT,
-    })
-
-    if (!path) {
-      return await next()
-    }
-
-    path = `./${path}`
-
-    let file
-
-    try {
-      file = await open(path)
-    } catch (e) {
-      console.warn(`${e}`)
-    }
-
-    if (file) {
-      const mimeType = getMimeType(path)
-      if (mimeType) {
-        c.header('Content-Type', mimeType)
+  return async function serveStatic(c, next) {
+    const getContent = async (path: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let file: any
+      try {
+        file = await open(path)
+      } catch (e) {
+        console.warn(`${e}`)
       }
-      // Return Response object with stream
-      return c.body(file.readable)
+      return file ? file.readable : undefined
     }
-
-    await options.onNotFound?.(path, c)
-    await next()
-    return
+    const pathResolve = (path: string) => {
+      return `./${path}`
+    }
+    return baseServeStatic({
+      ...options,
+      getContent,
+      pathResolve,
+    })(c, next)
   }
 }

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -1,0 +1,87 @@
+import type { Context } from '../../context'
+import type { Env, MiddlewareHandler } from '../../types'
+import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath'
+import { getMimeType } from '../../utils/mime'
+
+export type ServeStaticOptions<E extends Env = Env> = {
+  root?: string
+  path?: string
+  mimes?: Record<string, string>
+  rewriteRequestPath?: (path: string) => string
+  onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
+}
+
+const DEFAULT_DOCUMENT = 'index.html'
+const defaultPathResolve = (path: string) => path
+
+/**
+ * This middleware is not directly used by the user. Create a wrapper specifying `getContent()` by the environment such as Deno or Bun.
+ */
+export const serveStatic = <E extends Env = Env>(
+  options: ServeStaticOptions<E> & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getContent: (path: string) => any
+    pathResolve?: (path: string) => string
+  }
+): MiddlewareHandler => {
+  return async (c, next) => {
+    // Do nothing if Response is already set
+    if (c.finalized) {
+      await next()
+      return
+    }
+    const url = new URL(c.req.url)
+
+    let filename = options.path ?? decodeURI(url.pathname)
+    filename = options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename
+    const root = options.root
+
+    let path = getFilePath({
+      filename,
+      root,
+      defaultDocument: DEFAULT_DOCUMENT,
+    })
+
+    if (!path) {
+      return await next()
+    }
+
+    const getContent = options.getContent
+    const pathResolve = options.pathResolve ?? defaultPathResolve
+
+    path = pathResolve(path)
+    let content = await getContent(path)
+
+    if (!content) {
+      let pathWithOutDefaultDocument = getFilePathWithoutDefaultDocument({
+        filename,
+        root,
+      })
+      if (!pathWithOutDefaultDocument) {
+        return await next()
+      }
+      pathWithOutDefaultDocument = pathResolve(pathWithOutDefaultDocument)
+      content = await getContent(pathWithOutDefaultDocument)
+      if (content) {
+        path = pathWithOutDefaultDocument
+      }
+    }
+
+    if (content) {
+      let mimeType: string | undefined = undefined
+      if (options.mimes) {
+        mimeType = getMimeType(path, options.mimes) ?? getMimeType(path)
+      } else {
+        mimeType = getMimeType(path)
+      }
+      if (mimeType) {
+        c.header('Content-Type', mimeType)
+      }
+      return c.body(content)
+    }
+
+    await options.onNotFound?.(path, c)
+    await next()
+    return
+  }
+}

--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -1,39 +1,61 @@
-import { getFilePath } from './filepath'
+import { getFilePath, getFilePathWithoutDefaultDocument } from './filepath'
+
+describe('getFilePathWithoutDefaultDocument', () => {
+  it('Should return file path correctly', async () => {
+    expect(getFilePathWithoutDefaultDocument({ filename: 'foo.txt' })).toBe('foo.txt')
+    expect(getFilePathWithoutDefaultDocument({ filename: 'foo.txt', root: 'bar' })).toBe(
+      'bar/foo.txt'
+    )
+
+    expect(getFilePathWithoutDefaultDocument({ filename: '../foo' })).toBeUndefined()
+    expect(getFilePathWithoutDefaultDocument({ filename: '/../foo' })).toBeUndefined()
+    expect(getFilePathWithoutDefaultDocument({ filename: './../foo' })).toBeUndefined()
+    expect(getFilePathWithoutDefaultDocument({ filename: 'foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePathWithoutDefaultDocument({ filename: '/foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePathWithoutDefaultDocument({ filename: './foo..bar.txt' })).toBe('foo..bar.txt')
+    expect(getFilePathWithoutDefaultDocument({ filename: './..foo/bar.txt' })).toBe('..foo/bar.txt')
+    expect(getFilePathWithoutDefaultDocument({ filename: './foo../bar.txt' })).toBe('foo../bar.txt')
+    expect(getFilePathWithoutDefaultDocument({ filename: './..foo../bar.txt' })).toBe(
+      '..foo../bar.txt'
+    )
+
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('/../foo') })
+    ).toBeUndefined()
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./../foo') })
+    ).toBeUndefined()
+    expect(getFilePathWithoutDefaultDocument({ filename: slashToBackslash('foo..bar.txt') })).toBe(
+      'foo..bar.txt'
+    )
+    expect(getFilePathWithoutDefaultDocument({ filename: slashToBackslash('/foo..bar.txt') })).toBe(
+      'foo..bar.txt'
+    )
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./foo..bar.txt') })
+    ).toBe('foo..bar.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./..foo/bar.txt') })
+    ).toBe('..foo/bar.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./foo../bar.txt') })
+    ).toBe('foo../bar.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./..foo../bar.txt') })
+    ).toBe('..foo../bar.txt')
+  })
+})
 
 describe('getFilePath', () => {
   it('Should return file path correctly', async () => {
     expect(getFilePath({ filename: 'foo' })).toBe('foo/index.html')
-    expect(getFilePath({ filename: 'foo.txt' })).toBe('foo.txt')
 
     expect(getFilePath({ filename: 'foo', root: 'bar' })).toBe('bar/foo/index.html')
-    expect(getFilePath({ filename: 'foo.txt', root: 'bar' })).toBe('bar/foo.txt')
 
     expect(getFilePath({ filename: 'foo', defaultDocument: 'index.txt' })).toBe('foo/index.txt')
     expect(getFilePath({ filename: 'foo', root: 'bar', defaultDocument: 'index.txt' })).toBe(
       'bar/foo/index.txt'
     )
-
-    expect(getFilePath({ filename: './foo' })).toBe('foo/index.html')
-    expect(getFilePath({ filename: 'foo', root: './bar' })).toBe('bar/foo/index.html')
-
-    expect(getFilePath({ filename: '../foo' })).toBeUndefined()
-    expect(getFilePath({ filename: '/../foo' })).toBeUndefined()
-    expect(getFilePath({ filename: './../foo' })).toBeUndefined()
-    expect(getFilePath({ filename: 'foo..bar.txt' })).toBe('foo..bar.txt')
-    expect(getFilePath({ filename: '/foo..bar.txt' })).toBe('foo..bar.txt')
-    expect(getFilePath({ filename: './foo..bar.txt' })).toBe('foo..bar.txt')
-    expect(getFilePath({ filename: './..foo/bar.txt' })).toBe('..foo/bar.txt')
-    expect(getFilePath({ filename: './foo../bar.txt' })).toBe('foo../bar.txt')
-    expect(getFilePath({ filename: './..foo../bar.txt' })).toBe('..foo../bar.txt')
-
-    expect(getFilePath({ filename: slashToBackslash('/../foo') })).toBeUndefined()
-    expect(getFilePath({ filename: slashToBackslash('./../foo') })).toBeUndefined()
-    expect(getFilePath({ filename: slashToBackslash('foo..bar.txt') })).toBe('foo..bar.txt')
-    expect(getFilePath({ filename: slashToBackslash('/foo..bar.txt') })).toBe('foo..bar.txt')
-    expect(getFilePath({ filename: slashToBackslash('./foo..bar.txt') })).toBe('foo..bar.txt')
-    expect(getFilePath({ filename: slashToBackslash('./..foo/bar.txt') })).toBe('..foo/bar.txt')
-    expect(getFilePath({ filename: slashToBackslash('./foo../bar.txt') })).toBe('foo../bar.txt')
-    expect(getFilePath({ filename: slashToBackslash('./..foo../bar.txt') })).toBe('..foo../bar.txt')
   })
 })
 

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -6,11 +6,6 @@ type FilePathOptions = {
 
 export const getFilePath = (options: FilePathOptions): string | undefined => {
   let filename = options.filename
-  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
-    return
-  }
-
-  let root = options.root || ''
   const defaultDocument = options.defaultDocument || 'index.html'
 
   if (filename.endsWith('/')) {
@@ -19,6 +14,24 @@ export const getFilePath = (options: FilePathOptions): string | undefined => {
   } else if (!filename.match(/\.[a-zA-Z0-9]+$/)) {
     // /top => /top/index.html
     filename = filename.concat('/' + defaultDocument)
+  }
+
+  const path = getFilePathWithoutDefaultDocument({
+    root: options.root,
+    filename,
+  })
+
+  return path
+}
+
+export const getFilePathWithoutDefaultDocument = (
+  options: Omit<FilePathOptions, 'defaultDocument'>
+) => {
+  let root = options.root || ''
+  let filename = options.filename
+
+  if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
+    return
   }
 
   // /foo.html => foo.html


### PR DESCRIPTION
Fixes #2251 and refactored.

Refactoring methods:

* Created `middleware/serve-static`, which is not used by users directly.
* Wrap the middleware by the environment, such as Deno, Bun, and Cloudflare Workers.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
