### PR TITLE
fix(types): `MergeSchemaPath` supports regexp path params

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1615,10 +1615,26 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
           input: Input extends { param: infer _ }
             ? ExtractParams<SubPath> extends never
               ? Input
-              : FlattenIfIntersect<Input & { param: ExtractParams<SubPath> }>
+              : FlattenIfIntersect<
+                  Input & {
+                    param: {
+                      // Maps extracted keys, stripping braces, to a string-typed record.
+                      [K in keyof ExtractParams<SubPath> as K extends `${infer Prefix}{${infer _}}`
+                        ? Prefix
+                        : K]: string
+                    }
+                  }
+                >
             : RemoveBlankRecord<ExtractParams<SubPath>> extends never
             ? Input
-            : Input & { param: ExtractParams<SubPath> }
+            : Input & {
+                // Maps extracted keys, stripping braces, to a string-typed record.
+                param: {
+                  [K in keyof ExtractParams<SubPath> as K extends `${infer Prefix}{${infer _}}`
+                    ? Prefix
+                    : K]: string
+                }
+              }
           output: Output
         }
       : never

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -681,6 +681,25 @@ describe('MergeSchemaPath', () => {
     }
     type verify = Expect<Equal<Expected, Actual>>
   })
+
+  test('MergeSchemaPath - Path and SubPath have regexp path params', () => {
+    type Actual = MergeSchemaPath<ToSchema<'get', '/c/:d{.+}', {}, {}>, '/a/:b{.+}'>
+    type Expected = {
+      '/a/:b{.+}/c/:d{.+}': {
+        $get: {
+          input: {
+            param: {
+              d: string
+            } & {
+              b: string
+            }
+          }
+          output: {}
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
 })
 
 describe('Different types using json()', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1615,10 +1615,26 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
           input: Input extends { param: infer _ }
             ? ExtractParams<SubPath> extends never
               ? Input
-              : FlattenIfIntersect<Input & { param: ExtractParams<SubPath> }>
+              : FlattenIfIntersect<
+                  Input & {
+                    param: {
+                      // Maps extracted keys, stripping braces, to a string-typed record.
+                      [K in keyof ExtractParams<SubPath> as K extends `${infer Prefix}{${infer _}}`
+                        ? Prefix
+                        : K]: string
+                    }
+                  }
+                >
             : RemoveBlankRecord<ExtractParams<SubPath>> extends never
             ? Input
-            : Input & { param: ExtractParams<SubPath> }
+            : Input & {
+                // Maps extracted keys, stripping braces, to a string-typed record.
+                param: {
+                  [K in keyof ExtractParams<SubPath> as K extends `${infer Prefix}{${infer _}}`
+                    ? Prefix
+                    : K]: string
+                }
+              }
           output: Output
         }
       : never


### PR DESCRIPTION
Fixes #2253

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
