### PR TITLE
fix(ssg): allow `app: Hono<any, any, any>` for `toSSG`

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -215,13 +215,10 @@ export const saveContentToFiles = async (
  * `ToSSGInterface` is an experimental feature.
  * The API might be changed.
  */
-export interface ToSSGInterface<
-  E extends Env = Env,
-  S extends Schema = {},
-  BasePath extends string = '/'
-> {
+export interface ToSSGInterface {
   (
-    app: Hono<E, S, BasePath>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app: Hono<any, any, any>,
     fsModule: FileSystemModule,
     options?: ToSSGOptions
   ): Promise<ToSSGResult>

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -215,13 +215,10 @@ export const saveContentToFiles = async (
  * `ToSSGInterface` is an experimental feature.
  * The API might be changed.
  */
-export interface ToSSGInterface<
-  E extends Env = Env,
-  S extends Schema = {},
-  BasePath extends string = '/'
-> {
+export interface ToSSGInterface {
   (
-    app: Hono<E, S, BasePath>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app: Hono<any, any, any>,
     fsModule: FileSystemModule,
     options?: ToSSGOptions
   ): Promise<ToSSGResult>


### PR DESCRIPTION
Fixing the type error. The type here is never used, so it can be loose.

<img width="376" alt="Screenshot 2024-02-26 at 0 39 40" src="https://github.com/honojs/hono/assets/10682/3da9ef09-1b2e-4095-83be-49ee5fdb4589">


### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
