### PR TITLE
Handler stuck when awaiting aborted SSE stream

### DIFF
--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -12,6 +12,13 @@ export class StreamingApi {
 
     const reader = _readable.getReader()
 
+    // in case the user disconnects, let the reader know to cancel
+    // this in-turn results in responseReadable being closed
+    // and writeSSE method no longer blocks indefinitely
+    this.abortSubscribers.push(async () => {
+      await reader.cancel()
+    })
+
     this.responseReadable = new ReadableStream({
       async pull(controller) {
         const { done, value } = await reader.read()

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -12,6 +12,13 @@ export class StreamingApi {
 
     const reader = _readable.getReader()
 
+    // in case the user disconnects, let the reader know to cancel
+    // this in-turn results in responseReadable being closed
+    // and writeSSE method no longer blocks indefinitely
+    this.abortSubscribers.push(async () => {
+      await reader.cancel()
+    })
+
     this.responseReadable = new ReadableStream({
       async pull(controller) {
         const { done, value } = await reader.read()


### PR DESCRIPTION
Fixes: #2068
In the current version of Hono, the `stream.writeSSE` method was getting blocked indefinitely when the user disconnects from the SSE stream prematurely. Consider this example (taken from #2068):

```typescript
import { serve } from "@hono/node-server";
import { Hono } from "hono";
import { streamSSE } from "hono/streaming";

const app = new Hono();

let testId = 0;

app.get("/sse", (c) =>
  streamSSE(c, async (stream) => {
    try {
      const currentTestId = ++testId;
      let aborted = false;
      stream.onAbort(() => {
        aborted = true;
      });

      for (let i = 0; i < 10; i++) {
        console.log(currentTestId, "Iteration", i, aborted ? "(aborted)" : "");
        // If I await the writeSSE like this, it sometimes never returns when the stream is aborted
        await stream.writeSSE({ data: JSON.stringify({ iteration: i }) });
        await stream.sleep(1000);
      }
      console.log("Done");
    } catch (error) {
      console.error("Error", error);
    }
  })
);

const port = 8000;
console.log(`Server is running on port ${port}`);

serve({
  fetch: app.fetch,
  port,
});
```

When the client disconnects from the stream while the loop is still going on, the following things happen:
In the file `src/utils/stream.ts`:
```typescript
this.responseReadable = new ReadableStream({
  async pull(controller) {
    const { done, value } = await reader.read()
    done ? controller.close() : controller.enqueue(value)
  },
  cancel: () => {
    this.abortSubscribers.forEach((subscriber) => subscriber())
  },
})
```

`cancel` function runs, thereby running all the abort subscribers, but due to the loop in the test code provided above, the `pull` function still receives `done` as `false` and some value from the `reader`, and gets blocked indefinitely because the `controller` enqueued it.

It is difficult to reproduce this behaviour in the test suites, because aborting the request from code works fine. This is not the case when using a client such as `curl` or postman.