### PR TITLE
fix: fix comment

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1655,7 +1655,7 @@ export type MergePath<A extends string, B extends string> = A extends ''
 
 export type TypedResponse<T = unknown> = {
   data: T
-  format: 'json' // Currently, support only `json` with `c.jsonT()`
+  format: 'json' // Currently, support only `json` with `c.json()`
 }
 
 type ExtractResponseData<T> = T extends Promise<infer T2>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1655,7 +1655,7 @@ export type MergePath<A extends string, B extends string> = A extends ''
 
 export type TypedResponse<T = unknown> = {
   data: T
-  format: 'json' // Currently, support only `json` with `c.jsonT()`
+  format: 'json' // Currently, support only `json` with `c.json()`
 }
 
 type ExtractResponseData<T> = T extends Promise<infer T2>


### PR DESCRIPTION
`c.jsonT` is removed now, but there is a reference to it in the comment.
I found it when I was reading the code, it may cause confusion for contributors, so I fixed it.
### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
