### PR TITLE
fix(types): use `{}` instead of Partial

### DIFF
--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -22,8 +22,8 @@ export type Env = {
 export type Next = () => Promise<void>
 
 export type Input = {
-  in?: Partial<ValidationTargets>
-  out?: Partial<{ [K in keyof ValidationTargets]: unknown }>
+  in?: {}
+  out?: {}
 }
 
 export type BlankSchema = {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export type Env = {
 export type Next = () => Promise<void>
 
 export type Input = {
-  in?: Partial<ValidationTargets>
-  out?: Partial<{ [K in keyof ValidationTargets]: unknown }>
+  in?: {}
+  out?: {}
 }
 
 export type BlankSchema = {}


### PR DESCRIPTION
If it uses `Partial`, the type will include `undefined`. It causes unexpected behavior in validators like Zod Validator.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
