### PR TITLE
perf: don't use `#`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -102,7 +102,7 @@ class Hono<
   readonly getPath: GetPath<E>
   // Cannot use `#` because it requires visibility at JavaScript runtime.
   private _basePath: string = '/'
-  #path: string = '/'
+  _path: string = '/'
 
   routes: RouterRoute[] = []
 
@@ -114,13 +114,13 @@ class Hono<
     allMethods.map((method) => {
       this[method] = (args1: string | H, ...args: H[]) => {
         if (typeof args1 === 'string') {
-          this.#path = args1
+          this._path = args1
         } else {
-          this.addRoute(method, this.#path, args1)
+          this.addRoute(method, this._path, args1)
         }
         args.map((handler) => {
           if (typeof handler !== 'string') {
-            this.addRoute(method, this.#path, handler)
+            this.addRoute(method, this._path, handler)
           }
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -134,10 +134,10 @@ class Hono<
         return this
       }
       for (const p of [path].flat()) {
-        this.#path = p
+        this._path = p
         for (const m of [method].flat()) {
           handlers.map((handler) => {
-            this.addRoute(m.toUpperCase(), this.#path, handler)
+            this.addRoute(m.toUpperCase(), this._path, handler)
           })
         }
       }
@@ -149,13 +149,13 @@ class Hono<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.use = (arg1: string | MiddlewareHandler<any>, ...handlers: MiddlewareHandler<any>[]) => {
       if (typeof arg1 === 'string') {
-        this.#path = arg1
+        this._path = arg1
       } else {
-        this.#path = '*'
+        this._path = '*'
         handlers.unshift(arg1)
       }
       handlers.map((handler) => {
-        this.addRoute(METHOD_NAME_ALL, this.#path, handler)
+        this.addRoute(METHOD_NAME_ALL, this._path, handler)
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return this as any

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -39,8 +39,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   raw: Request
 
-  #validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
-  #matchResult: Result<[unknown, RouterRoute]>
+  _validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
+  _matchResult: Result<[unknown, RouterRoute]>
   routeIndex: number = 0
   /**
    * `.path` can get the pathname of the request.
@@ -62,8 +62,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   ) {
     this.raw = request
     this.path = path
-    this.#matchResult = matchResult
-    this.#validatedData = {}
+    this._matchResult = matchResult
+    this._validatedData = {}
   }
 
   /**
@@ -85,7 +85,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   private getDecodedParam(key: string): string | undefined {
-    const paramKey = this.#matchResult[0][this.routeIndex][1][key]
+    const paramKey = this._matchResult[0][this.routeIndex][1][key]
     const param = this.getParamValue(paramKey)
 
     return param ? (/\%/.test(param) ? decodeURIComponent_(param) : param) : undefined
@@ -94,9 +94,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private getAllDecodedParams(): Record<string, string> {
     const decoded: Record<string, string> = {}
 
-    const keys = Object.keys(this.#matchResult[0][this.routeIndex][1])
+    const keys = Object.keys(this._matchResult[0][this.routeIndex][1])
     for (const key of keys) {
-      const value = this.getParamValue(this.#matchResult[0][this.routeIndex][1][key])
+      const value = this.getParamValue(this._matchResult[0][this.routeIndex][1][key])
       if (value && typeof value === 'string') {
         decoded[key] = /\%/.test(value) ? decodeURIComponent_(value) : value
       }
@@ -106,7 +106,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   private getParamValue(paramKey: any): string | undefined {
-    return this.#matchResult[1] ? this.#matchResult[1][paramKey as any] : paramKey
+    return this._matchResult[1] ? this._matchResult[1][paramKey as any] : paramKey
   }
 
   /**
@@ -260,12 +260,12 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   addValidatedData(target: keyof ValidationTargets, data: {}) {
-    this.#validatedData[target] = data
+    this._validatedData[target] = data
   }
 
   valid<T extends keyof I & keyof ValidationTargets>(target: T): InputToDataByTarget<I, T>
   valid(target: keyof ValidationTargets) {
-    return this.#validatedData[target] as unknown
+    return this._validatedData[target] as unknown
   }
 
   /**
@@ -319,7 +319,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#matchedroutes
    */
   get matchedRoutes(): RouterRoute[] {
-    return this.#matchResult[0].map(([[, route]]) => route)
+    return this._matchResult[0].map(([[, route]]) => route)
   }
 
   /**
@@ -333,6 +333,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#routepath
    */
   get routePath(): string {
-    return this.#matchResult[0].map(([[, route]]) => route)[this.routeIndex].path
+    return this._matchResult[0].map(([[, route]]) => route)[this.routeIndex].path
   }
 }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -102,7 +102,7 @@ class Hono<
   readonly getPath: GetPath<E>
   // Cannot use `#` because it requires visibility at JavaScript runtime.
   private _basePath: string = '/'
-  #path: string = '/'
+  _path: string = '/'
 
   routes: RouterRoute[] = []
 
@@ -114,13 +114,13 @@ class Hono<
     allMethods.map((method) => {
       this[method] = (args1: string | H, ...args: H[]) => {
         if (typeof args1 === 'string') {
-          this.#path = args1
+          this._path = args1
         } else {
-          this.addRoute(method, this.#path, args1)
+          this.addRoute(method, this._path, args1)
         }
         args.map((handler) => {
           if (typeof handler !== 'string') {
-            this.addRoute(method, this.#path, handler)
+            this.addRoute(method, this._path, handler)
           }
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -134,10 +134,10 @@ class Hono<
         return this
       }
       for (const p of [path].flat()) {
-        this.#path = p
+        this._path = p
         for (const m of [method].flat()) {
           handlers.map((handler) => {
-            this.addRoute(m.toUpperCase(), this.#path, handler)
+            this.addRoute(m.toUpperCase(), this._path, handler)
           })
         }
       }
@@ -149,13 +149,13 @@ class Hono<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.use = (arg1: string | MiddlewareHandler<any>, ...handlers: MiddlewareHandler<any>[]) => {
       if (typeof arg1 === 'string') {
-        this.#path = arg1
+        this._path = arg1
       } else {
-        this.#path = '*'
+        this._path = '*'
         handlers.unshift(arg1)
       }
       handlers.map((handler) => {
-        this.addRoute(METHOD_NAME_ALL, this.#path, handler)
+        this.addRoute(METHOD_NAME_ALL, this._path, handler)
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return this as any

--- a/src/request.ts
+++ b/src/request.ts
@@ -39,8 +39,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   raw: Request
 
-  #validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
-  #matchResult: Result<[unknown, RouterRoute]>
+  _validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
+  _matchResult: Result<[unknown, RouterRoute]>
   routeIndex: number = 0
   /**
    * `.path` can get the pathname of the request.
@@ -62,8 +62,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   ) {
     this.raw = request
     this.path = path
-    this.#matchResult = matchResult
-    this.#validatedData = {}
+    this._matchResult = matchResult
+    this._validatedData = {}
   }
 
   /**
@@ -85,7 +85,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   private getDecodedParam(key: string): string | undefined {
-    const paramKey = this.#matchResult[0][this.routeIndex][1][key]
+    const paramKey = this._matchResult[0][this.routeIndex][1][key]
     const param = this.getParamValue(paramKey)
 
     return param ? (/\%/.test(param) ? decodeURIComponent_(param) : param) : undefined
@@ -94,9 +94,9 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private getAllDecodedParams(): Record<string, string> {
     const decoded: Record<string, string> = {}
 
-    const keys = Object.keys(this.#matchResult[0][this.routeIndex][1])
+    const keys = Object.keys(this._matchResult[0][this.routeIndex][1])
     for (const key of keys) {
-      const value = this.getParamValue(this.#matchResult[0][this.routeIndex][1][key])
+      const value = this.getParamValue(this._matchResult[0][this.routeIndex][1][key])
       if (value && typeof value === 'string') {
         decoded[key] = /\%/.test(value) ? decodeURIComponent_(value) : value
       }
@@ -106,7 +106,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   private getParamValue(paramKey: any): string | undefined {
-    return this.#matchResult[1] ? this.#matchResult[1][paramKey as any] : paramKey
+    return this._matchResult[1] ? this._matchResult[1][paramKey as any] : paramKey
   }
 
   /**
@@ -260,12 +260,12 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   addValidatedData(target: keyof ValidationTargets, data: {}) {
-    this.#validatedData[target] = data
+    this._validatedData[target] = data
   }
 
   valid<T extends keyof I & keyof ValidationTargets>(target: T): InputToDataByTarget<I, T>
   valid(target: keyof ValidationTargets) {
-    return this.#validatedData[target] as unknown
+    return this._validatedData[target] as unknown
   }
 
   /**
@@ -319,7 +319,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#matchedroutes
    */
   get matchedRoutes(): RouterRoute[] {
-    return this.#matchResult[0].map(([[, route]]) => route)
+    return this._matchResult[0].map(([[, route]]) => route)
   }
 
   /**
@@ -333,6 +333,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/api/request#routepath
    */
   get routePath(): string {
-    return this.#matchResult[0].map(([[, route]]) => route)[this.routeIndex].path
+    return this._matchResult[0].map(([[, route]]) => route)[this.routeIndex].path
   }
 }


### PR DESCRIPTION
I haven't found a source that says it explicitly, but adding `#` to private properties will significantly degrade performance. "Hello World" was slower than `fetch` and itty-router, so I thought it was strange, investigated, and found it.

The benchmark results:

Node.js:

```
cpu: Apple M1 Pro
runtime: node v20.10.0 (arm64-darwin)

benchmark                time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------- -----------------------------
noop                 325.93 ps/iter     (300 ps … 11.16 ns)    325 ps  345.8 ps  354.2 ps

• Get /hello
----------------------------------------------------------- -----------------------------
fetch                  4.43 µs/iter     (3.58 µs … 1.04 ms)      4 µs   8.96 µs  11.38 µs
Hono                   5.48 µs/iter     (5.29 µs … 6.22 µs)   5.52 µs   6.22 µs   6.22 µs
Hono without sharps    4.17 µs/iter     (4.03 µs … 4.45 µs)   4.25 µs   4.45 µs   4.45 µs
itty-router            4.73 µs/iter      (4.6 µs … 4.92 µs)   4.76 µs   4.92 µs   4.92 µs

summary for Get /hello
  Hono without sharps
   1.06x faster than fetch
   1.13x faster than itty-router
   1.31x faster than Hono
```

Bun:
```
cpu: Apple M1 Pro
runtime: bun 1.0.25 (arm64-darwin)

benchmark                time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------------- -----------------------------
noop                 327.07 ps/iter   (304.1 ps … 12.31 ns)    325 ps    350 ps  358.4 ps

• Get /hello
----------------------------------------------------------- -----------------------------
fetch                573.14 ns/iter (522.54 ns … 747.17 ns) 580.23 ns 747.17 ns 747.17 ns
Hono                   1.06 µs/iter   (680.44 ns … 1.68 µs)   1.32 µs   1.68 µs   1.68 µs
Hono without sharps  492.24 ns/iter (430.88 ns … 600.82 ns) 518.88 ns 569.58 ns 600.82 ns
itty-router            1.17 µs/iter     (1.05 µs … 1.41 µs)   1.21 µs   1.41 µs   1.41 µs

summary for Get /hello
  Hono without sharps
   1.16x faster than fetch
   2.15x faster than Hono
   2.37x faster than itty-router
```

The benchmark script: https://github.com/yusukebe/cloudflare-workshop-examples/tree/main/projects/benchmarks

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
