### PR TITLE
fix (jsx/dom): keep ref.current value during lifecycle.

### DIFF
--- a/deno_dist/jsx/hooks/index.ts
+++ b/deno_dist/jsx/hooks/index.ts
@@ -9,6 +9,7 @@ export const STASH_EFFECT = 1
 const STASH_CALLBACK = 2
 const STASH_USE = 3
 const STASH_MEMO = 4
+const STASH_REF = 5
 
 export type EffectData = [
   readonly unknown[] | undefined, // deps
@@ -263,7 +264,16 @@ export const useCallback = <T extends (...args: unknown[]) => unknown>(
 
 export type RefObject<T> = { current: T | null }
 export const useRef = <T>(initialValue: T | null): RefObject<T> => {
-  return { current: initialValue }
+  const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
+  if (!buildData) {
+    return { current: initialValue }
+  }
+  const [, node] = buildData
+
+  const refArray = (node[DOM_STASH][1][STASH_REF] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
+
+  return (refArray[hookIndex] ||= { current: initialValue })
 }
 
 export const use = <T>(promise: Promise<T>): T => {

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -919,52 +919,80 @@ describe('DOM', () => {
     expect(renderCount).toBe(2)
   })
 
-  it('useRef', async () => {
-    const Input = ({ label, ref }: { label: string; ref: RefObject<HTMLInputElement> }) => {
-      return (
-        <div>
-          <label>{label}</label>
-          <input ref={ref} />
-        </div>
+  describe('useRef', async () => {
+    it('simple', async () => {
+      const Input = ({ label, ref }: { label: string; ref: RefObject<HTMLInputElement> }) => {
+        return (
+          <div>
+            <label>{label}</label>
+            <input ref={ref} />
+          </div>
+        )
+      }
+      const Form = () => {
+        const [values, setValues] = useState<{ [key: string]: string }>({})
+        const nameRef = useRef<HTMLInputElement>(null)
+        const emailRef = useRef<HTMLInputElement>(null)
+        return (
+          <form>
+            <Input label='Name' ref={nameRef} />
+            <Input label='Email' ref={emailRef} />
+            <button
+              onClick={(ev: Event) => {
+                ev.preventDefault()
+                setValues({
+                  name: nameRef.current?.value || '',
+                  email: emailRef.current?.value || '',
+                })
+              }}
+            >
+              serialize
+            </button>
+            <span>{JSON.stringify(values)}</span>
+          </form>
+        )
+      }
+      const app = <Form />
+      render(app, root)
+      expect(root.innerHTML).toBe(
+        '<form><div><label>Name</label><input></div><div><label>Email</label><input></div><button>serialize</button><span>{}</span></form>'
       )
-    }
-    const Form = () => {
-      const [values, setValues] = useState<{ [key: string]: string }>({})
-      const nameRef = useRef<HTMLInputElement>(null)
-      const emailRef = useRef<HTMLInputElement>(null)
-      return (
-        <form>
-          <Input label='Name' ref={nameRef} />
-          <Input label='Email' ref={emailRef} />
-          <button
-            onClick={(ev: Event) => {
-              ev.preventDefault()
-              setValues({
-                name: nameRef.current?.value || '',
-                email: emailRef.current?.value || '',
-              })
-            }}
-          >
-            serialize
-          </button>
-          <span>{JSON.stringify(values)}</span>
-        </form>
+      const [nameInput, emailInput] = root.querySelectorAll('input')
+      nameInput.value = 'John'
+      emailInput.value = 'john@example.com'
+      const [button] = root.querySelectorAll('button')
+      button.click()
+      await Promise.resolve()
+      expect(root.innerHTML).toBe(
+        '<form><div><label>Name</label><input></div><div><label>Email</label><input></div><button>serialize</button><span>{"name":"John","email":"john@example.com"}</span></form>'
       )
-    }
-    const app = <Form />
-    render(app, root)
-    expect(root.innerHTML).toBe(
-      '<form><div><label>Name</label><input></div><div><label>Email</label><input></div><button>serialize</button><span>{}</span></form>'
-    )
-    const [nameInput, emailInput] = root.querySelectorAll('input')
-    nameInput.value = 'John'
-    emailInput.value = 'john@example.com'
-    const [button] = root.querySelectorAll('button')
-    button.click()
-    await Promise.resolve()
-    expect(root.innerHTML).toBe(
-      '<form><div><label>Name</label><input></div><div><label>Email</label><input></div><button>serialize</button><span>{"name":"John","email":"john@example.com"}</span></form>'
-    )
+    })
+
+    it('update current', async () => {
+      const App = () => {
+        const [, setState] = useState(0)
+        const ref = useRef<boolean>(false)
+        return (
+          <>
+            <button
+              onClick={() => {
+                setState((c) => c + 1)
+                ref.current = true
+              }}
+            >
+              update
+            </button>
+            <span>{String(ref.current)}</span>
+          </>
+        )
+      }
+      const app = <App />
+      render(app, root)
+      expect(root.innerHTML).toBe('<button>update</button><span>false</span>')
+      root.querySelector('button')?.click()
+      await Promise.resolve()
+      expect(root.innerHTML).toBe('<button>update</button><span>true</span>')
+    })
   })
 
   describe('useEffect', () => {

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -9,6 +9,7 @@ export const STASH_EFFECT = 1
 const STASH_CALLBACK = 2
 const STASH_USE = 3
 const STASH_MEMO = 4
+const STASH_REF = 5
 
 export type EffectData = [
   readonly unknown[] | undefined, // deps
@@ -263,7 +264,16 @@ export const useCallback = <T extends (...args: unknown[]) => unknown>(
 
 export type RefObject<T> = { current: T | null }
 export const useRef = <T>(initialValue: T | null): RefObject<T> => {
-  return { current: initialValue }
+  const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
+  if (!buildData) {
+    return { current: initialValue }
+  }
+  const [, node] = buildData
+
+  const refArray = (node[DOM_STASH][1][STASH_REF] ||= [])
+  const hookIndex = node[DOM_STASH][0]++
+
+  return (refArray[hookIndex] ||= { current: initialValue })
 }
 
 export const use = <T>(promise: Promise<T>): T => {


### PR DESCRIPTION
fixes #2303

We have had simple examples that worked, but the actual implementation was almost what we would call a mock😢  This PR will make sure that the values are properly stored within the lifecycle.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
