### PR TITLE
feat(cookie): Add Cookie bis condition check

### DIFF
--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -112,7 +112,34 @@ export const parseSigned = async (
 const _serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
   let cookie = `${name}=${value}`
 
+  if (name.startsWith('__Secure-') && !opt.secure) {
+    // FIXME: replace link to RFC
+    // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.3.1
+    throw new Error('__Secure- Cookie must have Secure attributes')
+  }
+
+  if (name.startsWith('__Host-')) {
+    // FIXME: replace link to RFC
+    // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.3.2
+    if (!opt.secure) {
+      throw new Error('__Host- Cookie must have Secure attributes')
+    }
+
+    if (opt.path !== '/') {
+      throw new Error('__Host- Cookie must have Path attributes with "/"')
+    }
+
+    if (opt.domain) {
+      throw new Error('__Host- Cookie must not have Domain attributes')
+    }
+  }
+
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
+    if (opt.maxAge > 34560000) {
+      // FIXME: replace link to RFC
+      // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2
+      throw new Error('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
+    }
     cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
   }
 
@@ -125,6 +152,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.expires) {
+    if (opt.expires.getTime() - Date.now() > 34560000_000) {
+      // FIXME: replace link to RFC
+      // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.1
+      throw new Error('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
+    }
     cookie += `; Expires=${opt.expires.toUTCString()}`
   }
 
@@ -141,6 +173,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.partitioned) {
+    // FIXME: replace link to RFC
+    // https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-01.html#section-2.3
+    if (!opt.secure) {
+      throw new Error('Partitioned Cookie must have Secure attributes')
+    }
     cookie += '; Partitioned'
   }
 

--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -138,7 +138,9 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
     if (opt.maxAge > 34560000) {
       // FIXME: replace link to RFC
       // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2
-      throw new Error('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
+      throw new Error(
+        'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
+      )
     }
     cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
   }
@@ -155,7 +157,9 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
     if (opt.expires.getTime() - Date.now() > 34560000_000) {
       // FIXME: replace link to RFC
       // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.1
-      throw new Error('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
+      throw new Error(
+        'Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.'
+      )
     }
     cookie += `; Expires=${opt.expires.toUTCString()}`
   }

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -215,4 +215,14 @@ describe('Set cookie', () => {
       })
     }).toThrowError('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
   })
+
+  it('Should throw Error cookie with expires grater than 400days', () => {
+    const now = Date.now()
+    const day401 = new Date(now + 1000*3600*24*401)
+    expect(() => {
+      serialize('great_cookie', 'banana', {
+        expires: day401
+      })
+    }).toThrowError('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
+  })
 })

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -274,4 +274,12 @@ describe('Set cookie', () => {
       })
     }).toThrowError('__Host- Cookie must not have Domain attributes')
   })
+
+  it('Should throw Error Partitioned cookie without Secure attributes', () => {
+    expect(() => {
+      serialize('great_cookie', 'banana', {
+        partitioned: true
+      })
+    }).toThrowError('Partitioned Cookie must have Secure attributes')
+  })
 })

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -207,4 +207,12 @@ describe('Set cookie', () => {
     })
     expect(serialized).toBe('great_cookie=banana')
   })
+
+  it('Should throw Error cookie with maxAge grater than 400days', () => {
+    expect(() => {
+      serialize('great_cookie', 'banana', {
+        maxAge: 3600*24*401,
+      })
+    }).toThrowError('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
+  })
 })

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -225,4 +225,10 @@ describe('Set cookie', () => {
       })
     }).toThrowError('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
   })
+
+  it('Should throw Error __Secure- cookie without Secure attributes', () => {
+    expect(() => {
+      serialize('__Secure-great_cookie', 'banana', {})
+    }).toThrowError('__Secure- Cookie must have Secure attributes')
+  })
 })

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -154,7 +154,7 @@ describe('Set cookie', () => {
   })
 
   it('Should serialize cookie with all options', () => {
-    const serialized = serialize('great_cookie', 'banana', {
+    const serialized = serialize('__Secure-great_cookie', 'banana', {
       path: '/',
       secure: true,
       domain: 'example.com',
@@ -165,7 +165,22 @@ describe('Set cookie', () => {
       partitioned: true,
     })
     expect(serialized).toBe(
-      'great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Partitioned'
+      '__Secure-great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Partitioned'
+    )
+  })
+
+  it('Should serialize __Host- cookie with all valid options', () => {
+    const serialized = serialize('__Host-great_cookie', 'banana', {
+      path: '/',
+      secure: true,
+      httpOnly: true,
+      maxAge: 1000,
+      expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
+      sameSite: 'Strict',
+      partitioned: true,
+    })
+    expect(serialized).toBe(
+      '__Host-great_cookie=banana; Max-Age=1000; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Partitioned'
     )
   })
 
@@ -230,5 +245,33 @@ describe('Set cookie', () => {
     expect(() => {
       serialize('__Secure-great_cookie', 'banana', {})
     }).toThrowError('__Secure- Cookie must have Secure attributes')
+  })
+
+  it('Should throw Error __Host- cookie without Secure attributes', () => {
+    expect(() => {
+      serialize('__Host-great_cookie', 'banana', {
+        secure: false,
+        path: '/'
+      })
+    }).toThrowError('__Host- Cookie must have Secure attributes')
+  })
+
+  it('Should throw Error __Host- cookie without Path attributes with "/"', () => {
+    expect(() => {
+      serialize('__Host-great_cookie', 'banana', {
+        secure: true,
+        path: '/admin'
+      })
+    }).toThrowError('__Host- Cookie must have Path attributes with "/"')
+  })
+
+  it('Should throw Error __Host- cookie with Domain attributes', () => {
+    expect(() => {
+      serialize('__Host-great_cookie', 'banana', {
+        secure: true,
+        path: '/',
+        domain: 'site.example'
+      })
+    }).toThrowError('__Host- Cookie must not have Domain attributes')
   })
 })

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -226,19 +226,23 @@ describe('Set cookie', () => {
   it('Should throw Error cookie with maxAge grater than 400days', () => {
     expect(() => {
       serialize('great_cookie', 'banana', {
-        maxAge: 3600*24*401,
+        maxAge: 3600 * 24 * 401,
       })
-    }).toThrowError('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
+    }).toThrowError(
+      'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
+    )
   })
 
   it('Should throw Error cookie with expires grater than 400days', () => {
     const now = Date.now()
-    const day401 = new Date(now + 1000*3600*24*401)
+    const day401 = new Date(now + 1000 * 3600 * 24 * 401)
     expect(() => {
       serialize('great_cookie', 'banana', {
-        expires: day401
+        expires: day401,
       })
-    }).toThrowError('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
+    }).toThrowError(
+      'Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.'
+    )
   })
 
   it('Should throw Error __Secure- cookie without Secure attributes', () => {
@@ -251,7 +255,7 @@ describe('Set cookie', () => {
     expect(() => {
       serialize('__Host-great_cookie', 'banana', {
         secure: false,
-        path: '/'
+        path: '/',
       })
     }).toThrowError('__Host- Cookie must have Secure attributes')
   })
@@ -260,7 +264,7 @@ describe('Set cookie', () => {
     expect(() => {
       serialize('__Host-great_cookie', 'banana', {
         secure: true,
-        path: '/admin'
+        path: '/admin',
       })
     }).toThrowError('__Host- Cookie must have Path attributes with "/"')
   })
@@ -270,7 +274,7 @@ describe('Set cookie', () => {
       serialize('__Host-great_cookie', 'banana', {
         secure: true,
         path: '/',
-        domain: 'site.example'
+        domain: 'site.example',
       })
     }).toThrowError('__Host- Cookie must not have Domain attributes')
   })
@@ -278,7 +282,7 @@ describe('Set cookie', () => {
   it('Should throw Error Partitioned cookie without Secure attributes', () => {
     expect(() => {
       serialize('great_cookie', 'banana', {
-        partitioned: true
+        partitioned: true,
       })
     }).toThrowError('Partitioned Cookie must have Secure attributes')
   })

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -130,6 +130,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.expires) {
+    if (opt.expires.getTime() - Date.now() > 34560000_000) {
+      // FIXME: replace link to RFC
+      // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.1
+      throw new Error('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
+    }
     cookie += `; Expires=${opt.expires.toUTCString()}`
   }
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -173,6 +173,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.partitioned) {
+    // FIXME: replace link to RFC
+    // https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-01.html#section-2.3
+    if (!opt.secure) {
+      throw new Error('Partitioned Cookie must have Secure attributes')
+    }
     cookie += '; Partitioned'
   }
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -113,7 +113,25 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   let cookie = `${name}=${value}`
 
   if (name.startsWith('__Secure-') && !opt.secure) {
+    // FIXME: replace link to RFC
+    // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.3.1
     throw new Error('__Secure- Cookie must have Secure attributes')
+  }
+
+  if (name.startsWith('__Host-')) {
+    // FIXME: replace link to RFC
+    // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.3.2
+    if (!opt.secure) {
+      throw new Error('__Host- Cookie must have Secure attributes')
+    }
+
+    if (opt.path !== '/') {
+      throw new Error('__Host- Cookie must have Path attributes with "/"')
+    }
+
+    if (opt.domain) {
+      throw new Error('__Host- Cookie must not have Domain attributes')
+    }
   }
 
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -112,6 +112,10 @@ export const parseSigned = async (
 const _serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
   let cookie = `${name}=${value}`
 
+  if (name.startsWith('__Secure-') && !opt.secure) {
+    throw new Error('__Secure- Cookie must have Secure attributes')
+  }
+
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
     if (opt.maxAge > 34560000) {
       // FIXME: replace link to RFC

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -113,6 +113,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   let cookie = `${name}=${value}`
 
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
+    if (opt.maxAge > 34560000) {
+      // FIXME: replace link to RFC
+      // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2
+      throw new Error('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
+    }
     cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
   }
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -138,7 +138,9 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
     if (opt.maxAge > 34560000) {
       // FIXME: replace link to RFC
       // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2
-      throw new Error('Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.')
+      throw new Error(
+        'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
+      )
     }
     cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
   }
@@ -155,7 +157,9 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
     if (opt.expires.getTime() - Date.now() > 34560000_000) {
       // FIXME: replace link to RFC
       // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.1
-      throw new Error('Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.')
+      throw new Error(
+        'Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.'
+      )
     }
     cookie += `; Expires=${opt.expires.toUTCString()}`
   }


### PR DESCRIPTION
New Cookie RFC (a.k.a cookie-bis) and CHIPS includes some best practices for Cookie settings which developers should follow.

This PR adding some condition check for Cookie handling especially.

- [RFC6265bis-13](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13)
  - `Max-Age`/`Expires` limitation
  - `--Host-`/`--Secure_` prefix limitation 
- [CHIPS-01](https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-01.html)
  - `Partitioned` limitation

Note: I'm adding link to latest draft in each comment, but should be updated to RFC link.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno