### PR TITLE
fix(client): Remove trailing slash from /index for precise path matching

### DIFF
--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -16,7 +16,7 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
 }
 
 export const removeIndexString = (urlSting: string) => {
-  return urlSting.replace(/\/index$/, '/')
+  return urlSting.replace(/\/index$/, '')
 }
 
 function isObject(item: unknown): item is ObjectType {

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -43,18 +43,18 @@ describe('replaceUrlParams', () => {
 })
 
 describe('removeIndexString', () => {
-  it('Should remove last `index` string', () => {
+  it('Should remove last `/index` string', () => {
     let url = 'http://localhost/index'
     let newUrl = removeIndexString(url)
-    expect(newUrl).toBe('http://localhost/')
+    expect(newUrl).toBe('http://localhost')
 
     url = '/index'
     newUrl = removeIndexString(url)
-    expect(newUrl).toBe('/')
+    expect(newUrl).toBe('')
 
     url = '/sub/index'
     newUrl = removeIndexString(url)
-    expect(newUrl).toBe('/sub/')
+    expect(newUrl).toBe('/sub')
 
     url = '/subindex'
     newUrl = removeIndexString(url)

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -16,7 +16,7 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
 }
 
 export const removeIndexString = (urlSting: string) => {
-  return urlSting.replace(/\/index$/, '/')
+  return urlSting.replace(/\/index$/, '')
 }
 
 function isObject(item: unknown): item is ObjectType {


### PR DESCRIPTION
This PR addresses an issue where the `removeIndexString` function was leaving a trailing slash when removing `/index` from URLs, which conflicted with Hono's exact matching behavior for route definitions. This behavior was observed in Hono v4.1.0 running on Cloudflare Workers, where the presence of a trailing slash would cause an otherwise valid endpoint to return a 404 error.

### Changes
- Updated `removeIndexString` function within the Hono Client to ensure the trailing slash is removed along with `/index`, aligning URL formats with the expected endpoint paths for exact matching.

### Example Scenario and Code Snippet:
Below is an example highlighting the issue and demonstrating how the current implementation may lead to unexpected behavior:

```ts
const app = new Hono().basePath("/api/v1");
export const getMe = new Hono().get("", async (c) => {
  return c.json({ name: "hono" });
});

export const meRoute = new Hono().route("", getMe);

const route = app.route("/me", meRoute);
type AppType = typeof route;

// Previously, this would result in a request to http://localhost:8787/api/v1/me/ instead of http://localhost:8787/api/v1/me
hc<AppType>("http://localhost:8787").api.v1.me.index.$get();
```

### Additional Consideration

Additionally, when using the Hono Client's `$url` method, the `/index` segment is not removed as expected, resulting in URLs that could potentially cause fetch errors. For example, `hc<AppType>("http://localhost:8787").api.v1.me.index.$url().href` returns `http://localhost:8787/api/v1/me/index`, which is not ideal. I'm considering submitting a separate PR to address this issue by enhancing the $url method to remove the /index segment when generating URLs. Feedback on this proposal would be greatly appreciated.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
