### PR TITLE
fix(context): export `ExecutionContext` from `hono`

### DIFF
--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -20,7 +20,7 @@ export type {
   ToSchema,
   TypedResponse,
 } from './types.ts'
-export type { Context, ContextVariableMap, ContextRenderer } from './context.ts'
+export type { Context, ContextVariableMap, ContextRenderer, ExecutionContext } from './context.ts'
 export type { HonoRequest } from './request.ts'
 export { Hono }
 export { HTTPException } from './http-exception.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type {
   ToSchema,
   TypedResponse,
 } from './types'
-export type { Context, ContextVariableMap, ContextRenderer } from './context'
+export type { Context, ContextVariableMap, ContextRenderer, ExecutionContext } from './context'
 export type { HonoRequest } from './request'
 export type { InferRequestType, InferResponseType, ClientRequestOptions } from './client'
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,7 +20,7 @@ export type {
   ToSchema,
   TypedResponse,
 } from './types'
-export type { Context, ContextVariableMap, ContextRenderer } from './context'
+export type { Context, ContextVariableMap, ContextRenderer, ExecutionContext } from './context'
 export type { HonoRequest } from './request'
 export { Hono }
 export { HTTPException } from './http-exception'


### PR DESCRIPTION
With this change, you can re-define `ExecutionContext` types in your app:

```ts
declare module 'hono' {
  interface ExecutionContext {
    waitUntil(promise: Promise<any>): void
    passThroughOnException(): void
    abort(reason?: any): void
  }
}
```

Fixes #2341

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `yarn denoify` to generate files for Deno
