### PR TITLE
fix(client): Update $url() Method to Remove /index with Future API Considerations

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -100,7 +100,6 @@ class ClientRequestImpl {
     const headers = new Headers(headerValues ?? undefined)
     let url = this.url
 
-    url = removeIndexString(url)
     url = replaceUrlParam(url, this.pathParams)
 
     if (this.queryParams) {
@@ -135,7 +134,9 @@ export const hc = <T extends Hono<any, any, any>>(
     }
 
     const path = parts.join('/')
-    const url = mergePath(baseUrl, path)
+    // TODO: The `/index` automatically added by Hono Client autocomplete should be removed, but explicitly added `/index` should not be removed.
+    // Due to the current implementation, this distinction is not made, necessitating future API changes to correctly handle both scenarios.
+    const url = removeIndexString(mergePath(baseUrl, path))
     if (method === 'url') {
       if (opts.args[0] && opts.args[0].param) {
         return new URL(replaceUrlParam(url, opts.args[0].param))

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -100,7 +100,6 @@ class ClientRequestImpl {
     const headers = new Headers(headerValues ?? undefined)
     let url = this.url
 
-    url = removeIndexString(url)
     url = replaceUrlParam(url, this.pathParams)
 
     if (this.queryParams) {
@@ -135,7 +134,9 @@ export const hc = <T extends Hono<any, any, any>>(
     }
 
     const path = parts.join('/')
-    const url = mergePath(baseUrl, path)
+    // TODO: The `/index` automatically added by Hono Client autocomplete should be removed, but explicitly added `/index` should not be removed.
+    // Due to the current implementation, this distinction is not made, necessitating future API changes to correctly handle both scenarios.
+    const url = removeIndexString(mergePath(baseUrl, path))
     if (method === 'url') {
       if (opts.args[0] && opts.args[0].param) {
         return new URL(replaceUrlParam(url, opts.args[0].param))


### PR DESCRIPTION
This PR is a follow-up to [#2344](https://github.com/honojs/hono/pull/2344), implementing changes to the `$url()` method to ensure that `/index` is removed from URLs. This aligns with the existing behavior in Hono Client, where automatically added `/index` segments are stripped to match the expected endpoint paths for routing.

**Changes:**
- Modified the `$url()` method to remove `/index` from generated URLs, ensuring consistency with the way Hono Client handles route matching.

**Concerns & Future Considerations:**
While this change improves consistency with existing behaviors, it introduces a concern regarding the handling of explicitly added `/index` segments by users. Currently, both automatically added and explicitly added `/index` segments are removed, which might not always align with user expectations for route definitions.

This behavior, although aligned with current implementations, signals the need for a potential API change in the future to distinguish between automatically added and user-defined `/index` segments more clearly. Such a change would allow for greater flexibility and accuracy in route matching and endpoint definition.

**Example Code:**
```typescript
const app = new Hono();

const route = app
  // The /index in this URL is automatically added by the routing system when the path is empty.
  .route(
    '/me',
    new Hono().route(
      '',
      new Hono().get('', async (c) => {
        return c.json({ name: 'hono' })
      })
    )
  )
  // The /index in this URL is explicitly added by the user in the route definition.
  .get('/index', (c) => c.json({ hello: 'world' }));

// Currently, the system does not differentiate between these two scenarios:
// - Automatically added /index when accessing `hc<AppType>("http://localhost:8787").api.v1.me.index.$url();`
// - Explicitly defined /index in `hc<AppType>("http://localhost:8787").api.v1.index.$url();`
// Future API changes should aim to preserve user-defined /index segments while removing automatically added ones.
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
