### PR TITLE
feat(utils/cookie): Typesafe cookie options

### DIFF
--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -2,6 +2,13 @@ import { decodeURIComponent_ } from './url.ts'
 
 export type Cookie = Record<string, string>
 export type SignedCookie = Record<string, string | false>
+
+type PartitionCookieConstraint =
+  | { partition: true; secure: true }
+  | { partition?: boolean; secure?: boolean } // reset to default
+type SecureCookieConstraint = { secure: true }
+type HostCookieConstraint = { secure: true; path: '/'; domain?: undefined }
+
 export type CookieOptions = {
   domain?: string
   expires?: Date
@@ -13,8 +20,14 @@ export type CookieOptions = {
   sameSite?: 'Strict' | 'Lax' | 'None'
   partitioned?: boolean
   prefix?: CookiePrefixOptions
-}
+} & PartitionCookieConstraint
 export type CookiePrefixOptions = 'host' | 'secure'
+
+export type CookieConstraint<Name> = Name extends `__Secure-${string}`
+  ? CookieOptions & SecureCookieConstraint
+  : Name extends `__Host-${string}`
+  ? CookieOptions & HostCookieConstraint
+  : CookieOptions
 
 const algorithm = { name: 'HMAC', hash: 'SHA-256' }
 
@@ -190,7 +203,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   return cookie
 }
 
-export const serialize = (name: string, value: string, opt: CookieOptions = {}): string => {
+export const serialize = <Name extends string>(
+  name: Name,
+  value: string,
+  opt?: CookieConstraint<Name>
+): string => {
   value = encodeURIComponent(value)
   return _serialize(name, value, opt)
 }

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -245,40 +245,6 @@ describe('Set cookie', () => {
     )
   })
 
-  it('Should throw Error __Secure- cookie without Secure attributes', () => {
-    expect(() => {
-      serialize('__Secure-great_cookie', 'banana', {})
-    }).toThrowError('__Secure- Cookie must have Secure attributes')
-  })
-
-  it('Should throw Error __Host- cookie without Secure attributes', () => {
-    expect(() => {
-      serialize('__Host-great_cookie', 'banana', {
-        secure: false,
-        path: '/',
-      })
-    }).toThrowError('__Host- Cookie must have Secure attributes')
-  })
-
-  it('Should throw Error __Host- cookie without Path attributes with "/"', () => {
-    expect(() => {
-      serialize('__Host-great_cookie', 'banana', {
-        secure: true,
-        path: '/admin',
-      })
-    }).toThrowError('__Host- Cookie must have Path attributes with "/"')
-  })
-
-  it('Should throw Error __Host- cookie with Domain attributes', () => {
-    expect(() => {
-      serialize('__Host-great_cookie', 'banana', {
-        secure: true,
-        path: '/',
-        domain: 'site.example',
-      })
-    }).toThrowError('__Host- Cookie must not have Domain attributes')
-  })
-
   it('Should throw Error Partitioned cookie without Secure attributes', () => {
     expect(() => {
       serialize('great_cookie', 'banana', {


### PR DESCRIPTION
add Types for settings cookie options and make below operations typesafe

- `--Secure_` prefix
- `--Host_` prefix
- `Partitoned` option

as discussed in https://github.com/honojs/hono/pull/2314#issuecomment-1980809011

### Author should do the followings, if applicable

- [N/A] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
