### PR TITLE
Fix(adaptor): Lambda@Edge GET/HEAD body error.

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -1,4 +1,4 @@
-import { isContentTypeBinary } from './handler'
+import { createBody, isContentTypeBinary } from './handler'
 
 describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
@@ -13,5 +13,24 @@ describe('isContentTypeBinary', () => {
     expect(isContentTypeBinary('application/json')).toBe(false)
     expect(isContentTypeBinary('application/ld+json')).toBe(false)
     expect(isContentTypeBinary('application/json; charset=UTF-8')).toBe(false)
+  })
+})
+
+describe('createBody', () => {
+  it('Should the request be a GET or HEAD, the Request must not include a Body', () => {
+    const data = Buffer.from('test')
+    const body = {
+      action: 'read-only',
+      data: data.toString('base64'),
+      encoding: 'base64',
+      inputTruncated: false,
+    }
+
+    expect(createBody('GET', body)).toEqual(undefined)
+    expect(createBody('GET', body)).not.toEqual(data)
+    expect(createBody('HEAD', body)).toEqual(undefined)
+    expect(createBody('HEAD', body)).not.toEqual(data)
+    expect(createBody('POST', body)).toEqual(data)
+    expect(createBody('POST', body)).not.toEqual(undefined)
   })
 })

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -155,16 +155,27 @@ const createRequest = (event: CloudFrontEdgeEvent) => {
   })
 
   const requestBody = event.Records[0].cf.request.body
-  const body =
-    requestBody?.encoding === 'base64' && requestBody?.data
-      ? Buffer.from(requestBody.data, 'base64')
-      : requestBody?.data
+  const method = event.Records[0].cf.request.method
+  const body = createBody(method, requestBody)
 
   return new Request(url, {
     headers,
-    method: event.Records[0].cf.request.method,
+    method,
     body,
   })
+}
+
+export function createBody(method: string, requestBody: CloudFrontRequest['body']) {
+  if (!requestBody || !requestBody.data) {
+    return undefined
+  }
+  if (method === 'GET' || method === 'HEAD') {
+    return undefined
+  }
+  if (requestBody.encoding === 'base64' && requestBody.data) {
+    return Buffer.from(requestBody.data, 'base64')
+  }
+  return requestBody.data
 }
 
 export const isContentTypeBinary = (contentType: string) => {


### PR DESCRIPTION
This PR addresses the issue where the exception Request with GET/HEAD method cannot have body. is raised when using the GET or HEAD method with Lambda@Edge.

```typescript
import { Hono } from "hono";
import { handle } from "hono/lambda-edge";
app.get("/", (c, next) => {
    return c.json({}, 200);
});
app.post("/", (c, next) => {
    return c.json({}, 200);
});

export const handler = handle(app);
```

While POST requests work without any issues, sending a GET request results in an error.


### Changes
Made sure that the request does not include a body when the method is GET or HEAD.


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
