### PR TITLE
fix(types): `MergePath` merge blank paths correctly

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -500,6 +500,27 @@ describe('Merge path with `app.route()`', () => {
       expect(url.href).toBe('http://localhost/api/bar')
     })
   })
+
+  describe('With a blank path', () => {
+    const app = new Hono().basePath('/api/v1')
+    const routes = app.route(
+      '/me',
+      new Hono().route(
+        '',
+        new Hono().get('', async (c) => {
+          return c.json({ name: 'hono' })
+        })
+      )
+    )
+    const client = hc<typeof routes>('http://localhost')
+
+    it('Should infer paths correctly', async () => {
+      // Should not a throw type error
+      const url = client.api.v1.me.$url()
+      expectTypeOf<URL>(url)
+      expect(url.href).toBe('http://localhost/api/v1/me')
+    })
+  })
 })
 
 describe('Use custom fetch method', () => {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -535,6 +535,14 @@ describe('MergePath', () => {
     type verify3 = Expect<Equal<'/api/', path3>>
     type path4 = MergePath<'/api', '/'>
     type verify4 = Expect<Equal<'/api', path4>>
+    type path5 = MergePath<'/', ''>
+    type verify5 = Expect<Equal<'/', path5>>
+    type path6 = MergePath<'', '/'>
+    type verify6 = Expect<Equal<'/', path6>>
+    type path7 = MergePath<'/', '/'>
+    type verify7 = Expect<Equal<'/', path7>>
+    type path8 = MergePath<'', ''>
+    type verify8 = Expect<Equal<'/', path8>>
   })
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1649,7 +1649,9 @@ export type AddParam<I, P extends string> = ParamKeys<P> extends never
 
 type AddDollar<T extends string> = `$${Lowercase<T>}`
 
-export type MergePath<A extends string, B extends string> = A extends ''
+export type MergePath<A extends string, B extends string> = B extends ''
+  ? MergePath<A, '/'>
+  : A extends ''
   ? B
   : A extends '/'
   ? B


### PR DESCRIPTION
### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
