### PR TITLE
perf(utils/url): use `slice` + `indexOf` for `getPath()`

### DIFF
--- a/benchmarks/utils/.gitignore
+++ b/benchmarks/utils/.gitignore
@@ -1,0 +1,2 @@
+yarn.lock
+bun.lockb

--- a/benchmarks/utils/package.json
+++ b/benchmarks/utils/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "mitata": "^0.1.11"
+  }
+}

--- a/benchmarks/utils/src/get-path.ts
+++ b/benchmarks/utils/src/get-path.ts
@@ -1,0 +1,20 @@
+import { run, group, bench } from 'mitata'
+
+bench('noop', () => {})
+
+const request = new Request('http://localhost/about/me')
+
+group('getPath', () => {
+  bench('slice + indexOf', () => {
+    const url = request.url
+    const queryIndex = url.indexOf('?', 8)
+    url.slice(url.indexOf('/', 8), queryIndex === -1 ? undefined : queryIndex)
+  })
+
+  bench('regexp', () => {
+    const match = request.url.match(/^https?:\/\/[^/]+(\/[^?]*)/)
+    match ? match[1] : ''
+  })
+})
+
+run()

--- a/deno_dist/utils/url.ts
+++ b/deno_dist/utils/url.ts
@@ -70,9 +70,10 @@ export const getPattern = (label: string): Pattern | null => {
 }
 
 export const getPath = (request: Request): string => {
-  // Optimized: RegExp is faster than indexOf() + slice()
-  const match = request.url.match(/^https?:\/\/[^/]+(\/[^?]*)/)
-  return match ? match[1] : ''
+  // Optimized: indexOf() + slice() is faster than RegExp
+  const url = request.url
+  const queryIndex = url.indexOf('?', 8)
+  return url.slice(url.indexOf('/', 8), queryIndex === -1 ? undefined : queryIndex)
 }
 
 export const getQueryStrings = (url: string): string => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -70,9 +70,10 @@ export const getPattern = (label: string): Pattern | null => {
 }
 
 export const getPath = (request: Request): string => {
-  // Optimized: RegExp is faster than indexOf() + slice()
-  const match = request.url.match(/^https?:\/\/[^/]+(\/[^?]*)/)
-  return match ? match[1] : ''
+  // Optimized: indexOf() + slice() is faster than RegExp
+  const url = request.url
+  const queryIndex = url.indexOf('?', 8)
+  return url.slice(url.indexOf('/', 8), queryIndex === -1 ? undefined : queryIndex)
 }
 
 export const getQueryStrings = (url: string): string => {


### PR DESCRIPTION
For `getPath()`, the `slice` + `indexOf` is faster than RegExp.

Node.js:

```txt
cpu: Apple M1 Pro
runtime: node v20.10.0 (arm64-darwin)

benchmark            time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------- -----------------------------
noop                 61 ps/iter        (20 ps … 257 ns)     61 ps     81 ps    143 ps !

• getPath
------------------------------------------------------- -----------------------------
slice + indexOf   35.85 ns/iter     (21.28 ns … 162 ns)  36.11 ns  38.84 ns  47.32 ns
regexp            57.76 ns/iter     (45.29 ns … 215 ns)  55.81 ns    134 ns    185 ns

summary for getPath
  slice + indexOf
   1.61x faster than regexp
```

Bun:

```
cpu: Apple M1 Pro
runtime: bun 1.0.31 (arm64-darwin)

benchmark            time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------- -----------------------------
noop                 50 ps/iter       (0 ps … 66.08 ns)     61 ps     81 ps    264 ps !

• getPath
------------------------------------------------------- -----------------------------
slice + indexOf   31.45 ns/iter     (29.62 ns … 319 ns)   31.8 ns  38.78 ns    184 ns
regexp            40.87 ns/iter     (36.68 ns … 324 ns)  41.22 ns  59.59 ns    237 ns

summary for getPath
  slice + indexOf
   1.3x faster than regexp
```

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
