### PR TITLE
fix(jsx): allow null, undefined, and boolean as children

### DIFF
--- a/deno_dist/jsx/base.ts
+++ b/deno_dist/jsx/base.ts
@@ -92,7 +92,15 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBuffer): void
 }
 
 type LocalContexts = [Context<unknown>, unknown][]
-export type Child = string | Promise<string> | number | JSXNode | Child[]
+export type Child =
+  | string
+  | Promise<string>
+  | number
+  | JSXNode
+  | null
+  | undefined
+  | boolean
+  | Child[]
 export class JSXNode implements HtmlEscaped {
   tag: string | Function
   props: Props

--- a/deno_dist/jsx/components.ts
+++ b/deno_dist/jsx/components.ts
@@ -10,7 +10,9 @@ let errorBoundaryCounter = 0
 
 export const childrenToString = async (children: Child[]): Promise<HtmlEscapedString[]> => {
   try {
-    return children.map((c) => c.toString()) as HtmlEscapedString[]
+    return children
+      .flat()
+      .map((c) => (c == null || typeof c === 'boolean' ? '' : c.toString())) as HtmlEscapedString[]
   } catch (e) {
     if (e instanceof Promise) {
       await e
@@ -51,7 +53,9 @@ export const ErrorBoundary: FC<
   }
   let resArray: HtmlEscapedString[] | Promise<HtmlEscapedString[]>[] = []
   try {
-    resArray = children.map((c) => c.toString()) as HtmlEscapedString[]
+    resArray = children.map((c) =>
+      c == null || typeof c === 'boolean' ? '' : c.toString()
+    ) as HtmlEscapedString[]
   } catch (e) {
     fallbackStr = await fallback?.toString()
     if (e instanceof Promise) {

--- a/deno_dist/jsx/streaming.ts
+++ b/deno_dist/jsx/streaming.ts
@@ -39,7 +39,9 @@ export const Suspense: FC<PropsWithChildren<{ fallback: any }>> = async ({
   try {
     stackNode[DOM_STASH][0] = 0
     buildDataStack.push([[], stackNode])
-    resArray = children.map((c) => c.toString()) as HtmlEscapedString[]
+    resArray = children.map((c) =>
+      c == null || typeof c === 'boolean' ? '' : c.toString()
+    ) as HtmlEscapedString[]
   } catch (e) {
     if (e instanceof Promise) {
       resArray = [

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -92,7 +92,15 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBuffer): void
 }
 
 type LocalContexts = [Context<unknown>, unknown][]
-export type Child = string | Promise<string> | number | JSXNode | Child[]
+export type Child =
+  | string
+  | Promise<string>
+  | number
+  | JSXNode
+  | null
+  | undefined
+  | boolean
+  | Child[]
 export class JSXNode implements HtmlEscaped {
   tag: string | Function
   props: Props

--- a/src/jsx/components.test.tsx
+++ b/src/jsx/components.test.tsx
@@ -61,6 +61,32 @@ describe('ErrorBoundary', () => {
 
       suspenseCounter--
     })
+
+    it('nullish', async () => {
+      const html = (
+        <div>
+          <ErrorBoundary fallback={<Fallback />}>{[null, undefined]}</ErrorBoundary>
+        </div>
+      )
+
+      expect((await resolveCallback(await html.toString())).toString()).toEqual('<div></div>')
+
+      errorBoundaryCounter--
+      suspenseCounter--
+    })
+
+    it('boolean', async () => {
+      const html = (
+        <div>
+          <ErrorBoundary fallback={<Fallback />}>{[true, false]}</ErrorBoundary>
+        </div>
+      )
+
+      expect((await resolveCallback(await html.toString())).toString()).toEqual('<div></div>')
+
+      errorBoundaryCounter--
+      suspenseCounter--
+    })
   })
 
   describe('async', async () => {

--- a/src/jsx/components.ts
+++ b/src/jsx/components.ts
@@ -10,7 +10,9 @@ let errorBoundaryCounter = 0
 
 export const childrenToString = async (children: Child[]): Promise<HtmlEscapedString[]> => {
   try {
-    return children.map((c) => c.toString()) as HtmlEscapedString[]
+    return children
+      .flat()
+      .map((c) => (c == null || typeof c === 'boolean' ? '' : c.toString())) as HtmlEscapedString[]
   } catch (e) {
     if (e instanceof Promise) {
       await e
@@ -51,7 +53,9 @@ export const ErrorBoundary: FC<
   }
   let resArray: HtmlEscapedString[] | Promise<HtmlEscapedString[]>[] = []
   try {
-    resArray = children.map((c) => c.toString()) as HtmlEscapedString[]
+    resArray = children.map((c) =>
+      c == null || typeof c === 'boolean' ? '' : c.toString()
+    ) as HtmlEscapedString[]
   } catch (e) {
     fallbackStr = await fallback?.toString()
     if (e instanceof Promise) {

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -132,6 +132,134 @@ d.replaceWith(c.content)
     suspenseCounter -= 1 // fallback is not rendered
   })
 
+  it('nullish children', async () => {
+    const stream = renderToReadableStream(
+      <div>
+        <Suspense fallback={<p>Loading...</p>}>{[null, undefined]}</Suspense>
+      </div>
+    )
+
+    const chunks = []
+    const textDecoder = new TextDecoder()
+    for await (const chunk of stream as any) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+
+    expect(chunks).toEqual(['<div></div>'])
+
+    suspenseCounter -= 1 // fallback is not rendered
+  })
+
+  it('async nullish children', async () => {
+    let resolved = false
+    const Content = () => {
+      if (!resolved) {
+        resolved = true
+        throw new Promise<void>((r) =>
+          setTimeout(() => {
+            resolved = true
+            r()
+          }, 10)
+        )
+      }
+      return <h1>Hello</h1>
+    }
+
+    const stream = renderToReadableStream(
+      <Suspense fallback={<p>Loading...</p>}>
+        <Content />
+        {[null, undefined]}
+      </Suspense>
+    )
+
+    const chunks = []
+    const textDecoder = new TextDecoder()
+    for await (const chunk of stream as any) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+
+    expect(chunks).toEqual([
+      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1></template><script>
+((d,c,n) => {
+c=d.currentScript.previousSibling
+d=d.getElementById('H:${suspenseCounter}')
+if(!d)return
+do{n=d.nextSibling;n.remove()}while(n.nodeType!=8||n.nodeValue!='/$')
+d.replaceWith(c.content)
+})(document)
+</script>`,
+    ])
+
+    expect(replacementResult(`<html><body>${chunks.join('')}</body></html>`)).toEqual(
+      '<h1>Hello</h1>'
+    )
+  })
+
+  it('boolean children', async () => {
+    const stream = renderToReadableStream(
+      <div>
+        <Suspense fallback={<p>Loading...</p>}>{[true, false]}</Suspense>
+      </div>
+    )
+
+    const chunks = []
+    const textDecoder = new TextDecoder()
+    for await (const chunk of stream as any) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+
+    expect(chunks).toEqual(['<div></div>'])
+
+    suspenseCounter -= 1 // fallback is not rendered
+  })
+
+  it('async boolean children', async () => {
+    let resolved = false
+    const Content = () => {
+      if (!resolved) {
+        resolved = true
+        throw new Promise<void>((r) =>
+          setTimeout(() => {
+            resolved = true
+            r()
+          }, 10)
+        )
+      }
+      return <h1>Hello</h1>
+    }
+
+    const stream = renderToReadableStream(
+      <Suspense fallback={<p>Loading...</p>}>
+        <Content />
+        {[true, false]}
+      </Suspense>
+    )
+
+    const chunks = []
+    const textDecoder = new TextDecoder()
+    for await (const chunk of stream as any) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+
+    expect(chunks).toEqual([
+      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1></template><script>
+((d,c,n) => {
+c=d.currentScript.previousSibling
+d=d.getElementById('H:${suspenseCounter}')
+if(!d)return
+do{n=d.nextSibling;n.remove()}while(n.nodeType!=8||n.nodeValue!='/$')
+d.replaceWith(c.content)
+})(document)
+</script>`,
+    ])
+
+    expect(replacementResult(`<html><body>${chunks.join('')}</body></html>`)).toEqual(
+      '<h1>Hello</h1>'
+    )
+  })
+
   it('children Suspense', async () => {
     const Content1 = () =>
       new Promise<HtmlEscapedString>((resolve) => setTimeout(() => resolve(<h1>Hello</h1>), 10))

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -39,7 +39,9 @@ export const Suspense: FC<PropsWithChildren<{ fallback: any }>> = async ({
   try {
     stackNode[DOM_STASH][0] = 0
     buildDataStack.push([[], stackNode])
-    resArray = children.map((c) => c.toString()) as HtmlEscapedString[]
+    resArray = children.map((c) =>
+      c == null || typeof c === 'boolean' ? '' : c.toString()
+    ) as HtmlEscapedString[]
   } catch (e) {
     if (e instanceof Promise) {
       resArray = [


### PR DESCRIPTION
fixes #2391

### Insufficient type definitions

`null` and `undefined` should also be allowed for JSX child elements, and even hono was implemented with this assumption in the following places, but it was omitted from the type definition. This will be fixed in c16c6c0e839188742f24eec6f86266ead02ec707

https://github.com/usualoma/hono/blob/b5ad5f4418a6ed50ac61bdb07b8f016693bfd533/src/jsx/base.ts#L76-L77

### Insufficient null/undefined/boolean handling

There were some child elements of `Suspense` and `ErrorBoundary` that had insufficient handling of `null` and `undefined`, which were fixed with e151c792cf40751cacd988fc2745ef5e08ae56e9.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
