### PR TITLE
feat(jwt): Pass Cookie Options from jwt Middleware to getCookie/getSignedCookie 

### DIFF
--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -214,4 +214,54 @@ describe('JWT', () => {
       expect(handlerExecuted).toBeFalsy()
     })
   })
+  describe('Credentials in signed cookie', () => {
+    let handlerExecuted: boolean
+  
+    beforeEach(() => {
+      handlerExecuted = false
+    })
+  
+    const app = new Hono()
+  
+    app.use(
+      '/auth/*',
+      jwt({
+        secret: 'a-secret',
+        cookie: {
+          key: 'cookie_name',
+          secret: 'cookie_secret',
+        },
+      })
+    )
+  
+    app.get('/auth/*', async (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
+    })
+  
+    it('Should not authorize', async () => {
+      const req = new Request('http://localhost/auth/a')
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(await res.text()).toBe('Unauthorized')
+      expect(handlerExecuted).toBeFalsy()
+    })
+  
+    it('Should authorize', async () => {
+      const url = 'http://localhost/auth/a'
+      const req = new Request(url, {
+        headers: new Headers({
+          Cookie:
+            'cookie_name=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE.i2NSvtJOXOPS9NDL1u8dqTYmMrzcD4mNSws6P6qmeV0%3D; Path=/',
+        }),
+      })
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello world' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+  })
 })

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -47,7 +47,7 @@ export const jwt = (options: {
       if (typeof options.cookie == 'string') {
         token = getCookie(ctx, options.cookie)
       } else if (options.cookie.secret) {
-        token = getSignedCookie(ctx, options.cookie.secret, options.cookie.key, options.cookie.prefixOptions)
+        token = await getSignedCookie(ctx, options.cookie.secret, options.cookie.key, options.cookie.prefixOptions)
       } else {
         token = getCookie(ctx, options.cookie.key, options.cookie.prefixOptions)
       }


### PR DESCRIPTION
Fixes #2398. Adds support for getSignedCookie while also allowing for all options to getCookie/getSignedCookie to be set. Sets the cookie option to have the type:

```ts
cookie: string | { key: string, secret?: string | BufferSource, prefixOptions?: CookiePrefixOptions }
```

The key names reflect the parameter names from getCookie and getSignedCookie. Tests still need to be added and ran for this.

### Author should do the followings, if applicable

- [x] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
