### PR TITLE
fix(reg-exp-router): escape meta characters for find middleware

### DIFF
--- a/deno_dist/router/reg-exp-router/router.ts
+++ b/deno_dist/router/reg-exp-router/router.ts
@@ -21,7 +21,11 @@ const nullMatcher: Matcher<any> = [/^$/, [], Object.create(null)]
 let wildcardRegExpCache: Record<string, RegExp> = Object.create(null)
 function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
-    path === '*' ? '' : `^${path.replace(/\/\*/, '(?:|/.*)')}$`
+    path === '*'
+      ? ''
+      : `^${path.replace(/\/\*$|([.\\+*[^\]$()])/g, (_, metaChar) =>
+          metaChar ? `\\${metaChar}` : '(?:|/.*)'
+        )}$`
   ))
 }
 

--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -499,22 +499,28 @@ export const runTest = ({
 
     describe('non ascii characters', () => {
       beforeEach(() => {
+        router.add('ALL', '/$/*', 'middleware $')
         router.add('GET', '/$/:name', 'get $ name')
+        router.add('ALL', '/()/*', 'middleware ()')
         router.add('GET', '/()/:name', 'get () name')
       })
 
       it('GET /$/hono', () => {
         const res = match('GET', '/$/hono')
-        expect(res.length).toBe(1)
-        expect(res[0].handler).toEqual('get $ name')
-        expect(res[0].params['name']).toEqual('hono')
+        expect(res.length).toBe(2)
+        expect(res[0].handler).toEqual('middleware $')
+        expect(res[0].params).toEqual({})
+        expect(res[1].handler).toEqual('get $ name')
+        expect(res[1].params['name']).toEqual('hono')
       })
 
       it('GET /()/hono', () => {
         const res = match('GET', '/()/hono')
-        expect(res.length).toBe(1)
-        expect(res[0].handler).toEqual('get () name')
-        expect(res[0].params['name']).toEqual('hono')
+        expect(res.length).toBe(2)
+        expect(res[0].handler).toEqual('middleware ()')
+        expect(res[0].params).toEqual({})
+        expect(res[1].handler).toEqual('get () name')
+        expect(res[1].params['name']).toEqual('hono')
       })
     })
 

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -21,7 +21,11 @@ const nullMatcher: Matcher<any> = [/^$/, [], Object.create(null)]
 let wildcardRegExpCache: Record<string, RegExp> = Object.create(null)
 function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
-    path === '*' ? '' : `^${path.replace(/\/\*/, '(?:|/.*)')}$`
+    path === '*'
+      ? ''
+      : `^${path.replace(/\/\*$|([.\\+*[^\]$()])/g, (_, metaChar) =>
+          metaChar ? `\\${metaChar}` : '(?:|/.*)'
+        )}$`
   ))
 }
 


### PR DESCRIPTION
fixes #2345

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
