### PR TITLE
refactor(types): optimize inferring handler types

### DIFF
--- a/deno_dist/helper/testing/index.ts
+++ b/deno_dist/helper/testing/index.ts
@@ -1,4 +1,5 @@
 import { hc } from '../../client/index.ts'
+import type { ExecutionContext } from '../../context.ts'
 import type { Hono } from '../../hono.ts'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/deno_dist/jsx/hooks/index.ts
+++ b/deno_dist/jsx/hooks/index.ts
@@ -351,4 +351,4 @@ export const useMemo = <T>(factory: () => T, deps: readonly unknown[]): T => {
 
 // Define to avoid errors. This hook currently does nothing.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const useDebugValue = (value: unknown, formatter?: (value: unknown) => string): void => {}
+export const useDebugValue = (_value: unknown, _formatter?: (value: unknown) => string): void => {}

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -3,7 +3,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context.ts'
 import type { Hono } from './hono.ts'
-import type { IfAnyThenEmptyObject, RemoveBlankRecord, UnionToIntersection } from './utils/types.ts'
+import type {
+  IfAnyThenEmptyObject,
+  Prettify,
+  RemoveBlankRecord,
+  UnionToIntersection,
+} from './utils/types.ts'
 
 ////////////////////////////////////////
 //////                            //////
@@ -87,8 +92,6 @@ export interface HandlerInterface<
   S extends Schema = {},
   BasePath extends string = '/'
 > {
-  //// app.get(...handlers[])
-
   // app.get(handler)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -100,6 +103,22 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
     S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    E2 extends Env = E
+  >(
+    path: P,
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -119,6 +138,24 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x2)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    E2 extends Env = E,
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
+  >(
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 3)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -134,6 +171,26 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
     S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x3)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
+  >(
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -157,6 +214,33 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x4)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 5)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -176,6 +260,36 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x5)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -210,6 +324,39 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x6)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 7)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -241,6 +388,42 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x7)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -281,6 +464,45 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x8)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 9)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -318,6 +540,48 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
     S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x9)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -364,251 +628,6 @@ export interface HandlerInterface<
     BasePath
   >
 
-  // app.get(...handlers[])
-  <
-    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
-    I extends Input = BlankInput,
-    R extends HandlerResponse<any> = any
-  >(
-    ...handlers: H<E, P, I, R>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
-
-  ////  app.get(path)
-
-  // app.get(path)
-  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
-    E,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
-
-  ////  app.get(path, ...handlers[])
-
-  // app.get(path, handler)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    E2 extends Env = E
-  >(
-    path: P,
-    handler: H<E2, MergedPath, I, R>
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x2)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    E2 extends Env = E,
-    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
-  >(
-    path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x3)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
-  >(
-    path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x4)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x5)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x6)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x7)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = E,
-    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x8)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
-    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = E,
-    E8 extends Env = E,
-    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x9)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
-    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
-    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = E,
-    E8 extends Env = E,
-    E9 extends Env = E,
-    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
-      H<E10, MergedPath, I9, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>, BasePath>
-
   // app.get(path, handler x10)
   <
     P extends string,
@@ -649,16 +668,32 @@ export interface HandlerInterface<
       H<E11, MergedPath, I10, R>
     ]
   ): Hono<
-    E,
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
     S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
+
+  // app.get(...handlers[])
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    I extends Input = BlankInput,
+    R extends HandlerResponse<any> = any
+  >(
+    ...handlers: H<E, P, I, R>[]
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  // app.get(path)
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
+    E,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 }
 
 ////////////////////////////////////////
@@ -1575,14 +1610,14 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = {
+export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = Prettify<{
   [K in P]: {
     [K2 in M as AddDollar<K2>]: {
       input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
       output: unknown extends O ? {} : O
     }
   }
-}
+}>
 
 export type Schema = {
   [Path: string]: {
@@ -1597,15 +1632,15 @@ export type Schema = {
 
 type ExtractParams<Path extends string> = string extends Path
   ? Record<string, string>
-  : Path extends `${infer Start}:${infer Param}/${infer Rest}`
+  : Path extends `${infer _Start}:${infer Param}/${infer Rest}`
   ? { [K in Param | keyof ExtractParams<`/${Rest}`>]: string }
-  : Path extends `${infer Start}:${infer Param}`
+  : Path extends `${infer _Start}:${infer Param}`
   ? { [K in Param]: string }
   : never
 
 type FlattenIfIntersect<T> = T extends infer O ? { [K in keyof O]: O[K] } : never
 
-export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = {
+export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = Prettify<{
   [P in keyof OrigSchema as MergePath<SubPath, P & string>]: {
     [M in keyof OrigSchema[P]]: OrigSchema[P][M] extends {
       input: infer Input
@@ -1639,7 +1674,7 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
         }
       : never
   }
-}
+}>
 
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
@@ -1676,15 +1711,13 @@ export type TypedResponse<T = unknown> = {
   format: 'json' // Currently, support only `json` with `c.json()`
 }
 
-type ExtractResponseData<T> = T extends Promise<infer T2>
+type MergeTypedResponseData<T> = T extends Promise<infer T2>
   ? T2 extends TypedResponse<infer U>
     ? U
     : {}
   : T extends TypedResponse<infer U>
   ? U
   : {}
-
-type MergeTypedResponseData<T> = ExtractResponseData<T>
 
 ////////////////////////////////////////
 //////                             /////

--- a/deno_dist/utils/types.ts
+++ b/deno_dist/utils/types.ts
@@ -50,3 +50,7 @@ export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> 
   : true
 
 export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false
+
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -1,4 +1,5 @@
 import { hc } from '../../client'
+import type { ExecutionContext } from '../../context'
 import type { Hono } from '../../hono'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2839,7 +2839,7 @@ describe('c.var - with testing types', () => {
   })
 
   app.use('/no-path/10').get(
-    // @ts-expect-error
+    // @ts-expect-error The handlers are more than 10
     mw(),
     mw2(),
     mw3(),
@@ -2854,23 +2854,14 @@ describe('c.var - with testing types', () => {
       return c.text(
         // @ts-expect-error
         c.var.echo('hello') +
-          // @ts-expect-error
           c.var.echo2('hello2') +
-          // @ts-expect-error
           c.var.echo3('hello3') +
-          // @ts-expect-error
           c.var.echo4('hello4') +
-          // @ts-expect-error
           c.var.echo5('hello5') +
-          // @ts-expect-error
           c.var.echo6('hello6') +
-          // @ts-expect-error
           c.var.echo7('hello7') +
-          // @ts-expect-error
           c.var.echo8('hello8') +
-          // @ts-expect-error
           c.var.echo9('hello9') +
-          // @ts-expect-error
           c.var.echo10('hello10')
       )
     }

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -351,4 +351,4 @@ export const useMemo = <T>(factory: () => T, deps: readonly unknown[]): T => {
 
 // Define to avoid errors. This hook currently does nothing.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const useDebugValue = (value: unknown, formatter?: (value: unknown) => string): void => {}
+export const useDebugValue = (_value: unknown, _formatter?: (value: unknown) => string): void => {}

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1020,9 +1020,7 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
         return c.json(0)
       })
@@ -1040,13 +1038,9 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
         return c.json(0)
       })
@@ -1066,17 +1060,11 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
         return c.json(0)
       })
@@ -1098,21 +1086,13 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
-        // @ts-expect-error foo4 is not typed
         c.get('foo4')
-        // @ts-expect-error foo4 is not typed
         c.var.foo4
         return c.json(0)
       })
@@ -1136,25 +1116,15 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
-        // @ts-expect-error foo4 is not typed
         c.get('foo4')
-        // @ts-expect-error foo4 is not typed
         c.var.foo4
-        // @ts-expect-error foo5 is not typed
         c.get('foo5')
-        // @ts-expect-error foo5 is not typed
         c.var.foo5
         return c.json(0)
       })
@@ -1180,29 +1150,18 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
-        // @ts-expect-error foo4 is not typed
         c.get('foo4')
-        // @ts-expect-error foo4 is not typed
         c.var.foo4
-        // @ts-expect-error foo5 is not typed
         c.get('foo5')
-        // @ts-expect-error foo5 is not typed
         c.var.foo5
-        // @ts-expect-error foo6 is not typed
         c.get('foo6')
-        // @ts-expect-error foo6 is not typed
+
         c.var.foo6
         return c.json(0)
       })
@@ -1230,33 +1189,19 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
-        // @ts-expect-error foo4 is not typed
         c.get('foo4')
-        // @ts-expect-error foo4 is not typed
         c.var.foo4
-        // @ts-expect-error foo5 is not typed
         c.get('foo5')
-        // @ts-expect-error foo5 is not typed
         c.var.foo5
-        // @ts-expect-error foo6 is not typed
         c.get('foo6')
-        // @ts-expect-error foo6 is not typed
         c.var.foo6
-        // @ts-expect-error foo7 is not typed
         c.get('foo7')
-        // @ts-expect-error foo7 is not typed
         c.var.foo7
         return c.json(0)
       })
@@ -1286,37 +1231,21 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
-        // @ts-expect-error foo4 is not typed
         c.get('foo4')
-        // @ts-expect-error foo4 is not typed
         c.var.foo4
-        // @ts-expect-error foo5 is not typed
         c.get('foo5')
-        // @ts-expect-error foo5 is not typed
         c.var.foo5
-        // @ts-expect-error foo6 is not typed
         c.get('foo6')
-        // @ts-expect-error foo6 is not typed
         c.var.foo6
-        // @ts-expect-error foo7 is not typed
         c.get('foo7')
-        // @ts-expect-error foo7 is not typed
         c.var.foo7
-        // @ts-expect-error foo8 is not typed
         c.get('foo8')
-        // @ts-expect-error foo8 is not typed
         c.var.foo8
         return c.json(0)
       })
@@ -1348,41 +1277,23 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
-        // @ts-expect-error foo1 is not typed
         c.get('foo1')
-        // @ts-expect-error foo1 is not typed
         c.var.foo1
-        // @ts-expect-error foo2 is not typed
         c.get('foo2')
-        // @ts-expect-error foo2 is not typed
         c.var.foo2
-        // @ts-expect-error foo3 is not typed
         c.get('foo3')
-        // @ts-expect-error foo3 is not typed
         c.var.foo3
-        // @ts-expect-error foo4 is not typed
         c.get('foo4')
-        // @ts-expect-error foo4 is not typed
         c.var.foo4
-        // @ts-expect-error foo5 is not typed
         c.get('foo5')
-        // @ts-expect-error foo5 is not typed
         c.var.foo5
-        // @ts-expect-error foo6 is not typed
         c.get('foo6')
-        // @ts-expect-error foo6 is not typed
         c.var.foo6
-        // @ts-expect-error foo7 is not typed
         c.get('foo7')
-        // @ts-expect-error foo7 is not typed
         c.var.foo7
-        // @ts-expect-error foo8 is not typed
         c.get('foo8')
-        // @ts-expect-error foo8 is not typed
         c.var.foo8
-        // @ts-expect-error foo9 is not typed
         c.get('foo9')
-        // @ts-expect-error foo9 is not typed
         c.var.foo9
         return c.json(0)
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context'
 import type { Hono } from './hono'
-import type { IfAnyThenEmptyObject, RemoveBlankRecord, UnionToIntersection } from './utils/types'
+import type {
+  IfAnyThenEmptyObject,
+  Prettify,
+  RemoveBlankRecord,
+  UnionToIntersection,
+} from './utils/types'
 
 ////////////////////////////////////////
 //////                            //////
@@ -87,8 +92,6 @@ export interface HandlerInterface<
   S extends Schema = {},
   BasePath extends string = '/'
 > {
-  //// app.get(...handlers[])
-
   // app.get(handler)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -100,6 +103,22 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
     S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    E2 extends Env = E
+  >(
+    path: P,
+    handler: H<E2, MergedPath, I, R>
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -119,6 +138,24 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x2)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    E2 extends Env = E,
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
+  >(
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 3)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -134,6 +171,26 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
     S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x3)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
+  >(
+    path: P,
+    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -157,6 +214,33 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x4)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 5)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -176,6 +260,36 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x5)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -210,6 +324,39 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x6)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 7)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -241,6 +388,42 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x7)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -281,6 +464,45 @@ export interface HandlerInterface<
     BasePath
   >
 
+  // app.get(path, handler x8)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
   // app.get(handler x 9)
   <
     P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
@@ -318,6 +540,48 @@ export interface HandlerInterface<
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
     S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
+
+  // app.get(path, handler x9)
+  <
+    P extends string,
+    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    I3 extends Input = I & I2,
+    I4 extends Input = I & I2 & I3,
+    I5 extends Input = I & I2 & I3 & I4,
+    I6 extends Input = I & I2 & I3 & I4 & I5,
+    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
+    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
+    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
+    E2 extends Env = E,
+    E3 extends Env = E,
+    E4 extends Env = E,
+    E5 extends Env = E,
+    E6 extends Env = E,
+    E7 extends Env = E,
+    E8 extends Env = E,
+    E9 extends Env = E,
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+  >(
+    path: P,
+    ...handlers: [
+      H<E2, MergedPath, I>,
+      H<E3, MergedPath, I2>,
+      H<E4, MergedPath, I3>,
+      H<E5, MergedPath, I4>,
+      H<E6, MergedPath, I5>,
+      H<E7, MergedPath, I6>,
+      H<E8, MergedPath, I7>,
+      H<E9, MergedPath, I8>,
+      H<E10, MergedPath, I9, R>
+    ]
+  ): Hono<
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -364,251 +628,6 @@ export interface HandlerInterface<
     BasePath
   >
 
-  // app.get(...handlers[])
-  <
-    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
-    I extends Input = BlankInput,
-    R extends HandlerResponse<any> = any
-  >(
-    ...handlers: H<E, P, I, R>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
-
-  ////  app.get(path)
-
-  // app.get(path)
-  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
-    E,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
-
-  ////  app.get(path, ...handlers[])
-
-  // app.get(path, handler)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    E2 extends Env = E
-  >(
-    path: P,
-    handler: H<E2, MergedPath, I, R>
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x2)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    E2 extends Env = E,
-    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
-  >(
-    path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x3)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
-  >(
-    path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x4)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x5)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x6)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x7)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = E,
-    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x8)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
-    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = E,
-    E8 extends Env = E,
-    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>, BasePath>
-
-  // app.get(path, handler x9)
-  <
-    P extends string,
-    MergedPath extends MergePath<BasePath, P> = MergePath<BasePath, P>,
-    R extends HandlerResponse<any> = any,
-    I extends Input = BlankInput,
-    I2 extends Input = I,
-    I3 extends Input = I & I2,
-    I4 extends Input = I & I2 & I3,
-    I5 extends Input = I & I2 & I3 & I4,
-    I6 extends Input = I & I2 & I3 & I4 & I5,
-    I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
-    I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
-    I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
-    E2 extends Env = E,
-    E3 extends Env = E,
-    E4 extends Env = E,
-    E5 extends Env = E,
-    E6 extends Env = E,
-    E7 extends Env = E,
-    E8 extends Env = E,
-    E9 extends Env = E,
-    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
-  >(
-    path: P,
-    ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
-      H<E10, MergedPath, I9, R>
-    ]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>, BasePath>
-
   // app.get(path, handler x10)
   <
     P extends string,
@@ -649,16 +668,32 @@ export interface HandlerInterface<
       H<E11, MergedPath, I10, R>
     ]
   ): Hono<
-    E,
+    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
     S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
     BasePath
   >
+
+  // app.get(...handlers[])
+  <
+    P extends string = ExtractKey<S> extends never ? BasePath : ExtractKey<S>,
+    I extends Input = BlankInput,
+    R extends HandlerResponse<any> = any
+  >(
+    ...handlers: H<E, P, I, R>[]
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
   ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+
+  // app.get(path)
+  <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
+    E,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    BasePath
+  >
 }
 
 ////////////////////////////////////////
@@ -1575,14 +1610,14 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = {
+export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = Prettify<{
   [K in P]: {
     [K2 in M as AddDollar<K2>]: {
       input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
       output: unknown extends O ? {} : O
     }
   }
-}
+}>
 
 export type Schema = {
   [Path: string]: {
@@ -1597,15 +1632,15 @@ export type Schema = {
 
 type ExtractParams<Path extends string> = string extends Path
   ? Record<string, string>
-  : Path extends `${infer Start}:${infer Param}/${infer Rest}`
+  : Path extends `${infer _Start}:${infer Param}/${infer Rest}`
   ? { [K in Param | keyof ExtractParams<`/${Rest}`>]: string }
-  : Path extends `${infer Start}:${infer Param}`
+  : Path extends `${infer _Start}:${infer Param}`
   ? { [K in Param]: string }
   : never
 
 type FlattenIfIntersect<T> = T extends infer O ? { [K in keyof O]: O[K] } : never
 
-export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = {
+export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = Prettify<{
   [P in keyof OrigSchema as MergePath<SubPath, P & string>]: {
     [M in keyof OrigSchema[P]]: OrigSchema[P][M] extends {
       input: infer Input
@@ -1639,7 +1674,7 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
         }
       : never
   }
-}
+}>
 
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
@@ -1676,15 +1711,13 @@ export type TypedResponse<T = unknown> = {
   format: 'json' // Currently, support only `json` with `c.json()`
 }
 
-type ExtractResponseData<T> = T extends Promise<infer T2>
+type MergeTypedResponseData<T> = T extends Promise<infer T2>
   ? T2 extends TypedResponse<infer U>
     ? U
     : {}
   : T extends TypedResponse<infer U>
   ? U
   : {}
-
-type MergeTypedResponseData<T> = ExtractResponseData<T>
 
 ////////////////////////////////////////
 //////                             /////

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -50,3 +50,7 @@ export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> 
   : true
 
 export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false
+
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}


### PR DESCRIPTION
I've refactored the code for some types of matters.

* Fixed the handlers' overload order. This improves performance when inferring handler return types.
* Fixed some bugs for types.
* Apply `Prettify`.
* Fixed `tsc` errors.

Related to #2399

### Performance improvement

Getting faster inferring handler return types. Below are the results if it's a simple case that it has one handler.

Before:

<img width="1066" alt="Screenshot 2024-03-25 at 16 16 31" src="https://github.com/honojs/hono/assets/10682/fb00d72d-9b9e-4de7-9e4d-563026fad45b">

This PR:

<img width="564" alt="Screenshot 2024-03-25 at 16 15 59" src="https://github.com/honojs/hono/assets/10682/bfda368e-ee7c-42df-8b8a-de4cee04e9cd">

This improves RPC-mode performance but does not change much because the implementation of the `hc` function is not so good.

#### The scripts for measuring 

```ts
// create.ts
import { writeFileSync } from 'fs'

let code = `
import { Hono } from 'hono'

const app = new Hono()

const routes = app
`
for (let i = 1; i < 300; i++) {
  code += `.get('/route${i}', (c) => {
    return c.json({
      ok: true
    })
  })`
}

code += `

export type AppType = typeof routes
export default routes
`

writeFileSync(import.meta.dir + '/index.ts', code)
```

```ts
// client.ts
import { hc } from 'hono/client'
import { AppType } from '.'

const client = hc<AppType>('/')
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
