### PR TITLE
fix(aws-lambda): handle response without body (#2401)

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -126,11 +126,13 @@ export const streamHandle = <
           headers: Object.fromEntries(res.headers.entries()),
         }
 
+        // Update response stream
+        responseStream = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata)
+
         if (res.body) {
-          await streamToNodeStream(
-            res.body.getReader(),
-            awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata)
-          )
+          await streamToNodeStream(res.body.getReader(), responseStream)
+        } else {
+          responseStream.write('')
         }
       } catch (error) {
         console.error('Error processing request:', error)


### PR DESCRIPTION
In case of a streaming lambda, the response should still contain metadata
like status and content type, even if no body is given.
This could be for example a redirect response.
