### PR TITLE
feat(request): cache body for reusing

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -68,26 +68,8 @@ export const validator = <
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }
-
-        if (c.req.bodyCache.json) {
-          value = c.req.bodyCache.json
-          break
-        }
-
         try {
-          let arrayBuffer: ArrayBuffer | undefined = undefined
-          for (const type of bodyTypes) {
-            // @ts-expect-error bodyCache[type] is not typed
-            const body = c.req.bodyCache[type]
-            if (body) {
-              arrayBuffer = await new Response(await body).arrayBuffer()
-              break
-            }
-          }
-          arrayBuffer ??= await c.req.raw.arrayBuffer()
-          value = await new Response(arrayBuffer).json()
-          c.req.bodyCache.json = value
-          c.req.bodyCache.arrayBuffer = arrayBuffer
+          value = await c.req.json()
         } catch {
           const message = 'Malformed JSON in request body'
           throw new HTTPException(400, { message })
@@ -104,16 +86,7 @@ export const validator = <
         }
 
         try {
-          let arrayBuffer: ArrayBuffer | undefined = undefined
-          for (const type of bodyTypes) {
-            // @ts-expect-error bodyCache[type] is not typed
-            const body = c.req.bodyCache[type]
-            if (body) {
-              arrayBuffer = await new Response(await body).arrayBuffer()
-              break
-            }
-          }
-          arrayBuffer ??= await c.req.arrayBuffer()
+          const arrayBuffer = await c.req.arrayBuffer()
           const formData = await bufferToFormData(arrayBuffer, contentType)
           const form: BodyData = {}
           formData.forEach((value, key) => {
@@ -121,7 +94,6 @@ export const validator = <
           })
           value = form
           c.req.bodyCache.formData = formData
-          c.req.bodyCache.arrayBuffer = arrayBuffer
         } catch (e) {
           let message = 'Malformed FormData request.'
           message += e instanceof Error ? ` ${e.message}` : ` ${String(e)}`

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -68,26 +68,8 @@ export const validator = <
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }
-
-        if (c.req.bodyCache.json) {
-          value = c.req.bodyCache.json
-          break
-        }
-
         try {
-          let arrayBuffer: ArrayBuffer | undefined = undefined
-          for (const type of bodyTypes) {
-            // @ts-expect-error bodyCache[type] is not typed
-            const body = c.req.bodyCache[type]
-            if (body) {
-              arrayBuffer = await new Response(await body).arrayBuffer()
-              break
-            }
-          }
-          arrayBuffer ??= await c.req.raw.arrayBuffer()
-          value = await new Response(arrayBuffer).json()
-          c.req.bodyCache.json = value
-          c.req.bodyCache.arrayBuffer = arrayBuffer
+          value = await c.req.json()
         } catch {
           const message = 'Malformed JSON in request body'
           throw new HTTPException(400, { message })
@@ -104,16 +86,7 @@ export const validator = <
         }
 
         try {
-          let arrayBuffer: ArrayBuffer | undefined = undefined
-          for (const type of bodyTypes) {
-            // @ts-expect-error bodyCache[type] is not typed
-            const body = c.req.bodyCache[type]
-            if (body) {
-              arrayBuffer = await new Response(await body).arrayBuffer()
-              break
-            }
-          }
-          arrayBuffer ??= await c.req.arrayBuffer()
+          const arrayBuffer = await c.req.arrayBuffer()
           const formData = await bufferToFormData(arrayBuffer, contentType)
           const form: BodyData = {}
           formData.forEach((value, key) => {
@@ -121,7 +94,6 @@ export const validator = <
           })
           value = form
           c.req.bodyCache.formData = formData
-          c.req.bodyCache.arrayBuffer = arrayBuffer
         } catch (e) {
           let message = 'Malformed FormData request.'
           message += e instanceof Error ? ` ${e.message}` : ` ${String(e)}`


### PR DESCRIPTION
Closes #1499 

As mentioned in #1499,`c.req.json()` throws an error if `c.req.text()` is called before it. With this PR, the body content created by `c.req.text()`, `c.req.arrayBuffer()`, and others will be cached correctly and reused so the error will not be thrown.

A concern is that there will be more code in `request.ts`, but this change is important for DX, so we will introduce it

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
