### PR TITLE
perf: Don't use `Arrap.prototype.map` if it is not needed return value

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -111,14 +111,14 @@ class Hono<
 
     // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
-    allMethods.map((method) => {
+    allMethods.forEach((method) => {
       this[method] = (args1: string | H, ...args: H[]) => {
         if (typeof args1 === 'string') {
           this.#path = args1
         } else {
           this.addRoute(method, this.#path, args1)
         }
-        args.map((handler) => {
+        args.forEach((handler) => {
           if (typeof handler !== 'string') {
             this.addRoute(method, this.#path, handler)
           }
@@ -154,7 +154,7 @@ class Hono<
         this.#path = '*'
         handlers.unshift(arg1)
       }
-      handlers.map((handler) => {
+      handlers.forEach((handler) => {
         this.addRoute(METHOD_NAME_ALL, this.#path, handler)
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -111,14 +111,14 @@ class Hono<
 
     // Implementation of app.get(...handlers[]) or app.get(path, ...handlers[])
     const allMethods = [...METHODS, METHOD_NAME_ALL_LOWERCASE]
-    allMethods.map((method) => {
+    allMethods.forEach((method) => {
       this[method] = (args1: string | H, ...args: H[]) => {
         if (typeof args1 === 'string') {
           this.#path = args1
         } else {
           this.addRoute(method, this.#path, args1)
         }
-        args.map((handler) => {
+        args.forEach((handler) => {
           if (typeof handler !== 'string') {
             this.addRoute(method, this.#path, handler)
           }
@@ -154,7 +154,7 @@ class Hono<
         this.#path = '*'
         handlers.unshift(arg1)
       }
-      handlers.map((handler) => {
+      handlers.forEach((handler) => {
         this.addRoute(METHOD_NAME_ALL, this.#path, handler)
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
I replaced some `Arrap.prototype.map` to `Arrap.prototype.forEach` to up performance a little.
`forEach` doesn't make result value, so It's faster than `map` a little.

[perf.link](https://perf.link/#eyJpZCI6InM1MHQwMWhhODZmIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGFyciA9IG5ldyBBcnJheSgxMDAwKS5maWxsKE1hdGgucmFuZG9tKCkpIiwidGVzdHMiOlt7Im5hbWUiOiJVc2luZyBgbWFwYCIsImNvZGUiOiJjb25zdCBuZXdBcnIgPSBbXVxuYXJyLm1hcCgoZSkgPT4ge1xuXHRuZXdBcnIucHVzaChlKVxufSkiLCJydW5zIjpbODMzMywzMzMzLDIwMDAwLDEwNjY2LDEwNjY2LDEwNjY2LDIzMzMzLDExNjY2LDc2NjYsMTA2NjYsMzMzMywyMzMzMywxMDY2NiwxMDY2NiwxMDY2NiwxMDY2NiwxMDMzMywxMDY2NiwxMDY2NiwxMTAwMCw5MzMzLDI2NjYsMjMzMzMsOTY2NiwxNDAwMCw2MDAwLDI0NjY2LDIwMzMzLDE1MzMzLDEwNjY2LDIzMzMzLDEwNjY2LDI5MDAwLDEzMDAwLDkzMzMsMTA2NjYsNzMzMywxMDY2NiwxMDY2NiwxMDY2NiwzMzMzLDk2NjYsMjY2NiwyNDMzMywxMDY2Niw3MzMzLDk2NjYsMzMzMzMsMTA2NjYsMTg2NjYsNDAwMCwyNjMzMywxMDY2NiwxMDY2Niw0MzMzLDE2MzMzLDEwNjY2LDEyMzMzLDYzMzMsMjM2NjYsMTA2NjYsMTA2NjYsMTAzMzMsMTA2NjYsNzMzMywxMDY2NiwxMDY2NiwxNzMzMywxMDY2NiwxMTAwMCwxMjY2NiwxNTMzMywxMTY2NiwyMzMzMywyMTMzMywyNTAwMCwxMjMzMywxMDY2NiwxOTMzMywxMDY2NiwxMDY2NiwyNTAwMCwxNjAwMCwxMDY2NiwyMjMzMyw3MzMzLDIyMzMzLDEwNjY2LDEwNjY2LDMzMzMsNDMzMywyMzMzMyw1NjY2LDEwNjY2LDI2MzMzLDEyMzMzLDE5NjY2LDEwNjY2LDEwMzMzLDUzMzNdLCJvcHMiOjEyOTU5fSx7Im5hbWUiOiJVc2luZyBgZm9yRWFjaGAiLCJjb2RlIjoiY29uc3QgbmV3QXJyID0gW11cbmFyci5mb3JFYWNoKChlKSA9PiB7XG5cdG5ld0Fyci5wdXNoKGUpXG59KSIsInJ1bnMiOlsxNDAwMCwxNjY2LDE0MzMzLDEwMDAwLDIyNjY2LDI0NjY2LDE1MDAwLDE1MDAwLDE1MDAwLDE2NjY2LDE1MDAwLDE1MDAwLDE1MDAwLDE1MDAwLDEzMDAwLDE1MDAwLDE1MDAwLDMyNjY2LDE5MDAwLDE1MDAwLDMwMDAwLDMyNjY2LDE1MDAwLDE1MDAwLDMwNjY2LDE1MDAwLDE1MDAwLDMyNjY2LDE1MDAwLDE1MDAwLDEzNjY2LDMyNjY2LDE1MDAwLDE1MDAwLDE1MDAwLDMxMDAwLDE1MDAwLDk2NjYsMTUwMDAsMzI2NjYsMTUwMDAsMzEzMzMsMTI2NjYsMTUwMDAsMzY2Niw0MTAwMCwxNTAwMCwxNTAwMCw5MzMzLDM2NjY2LDE1MDAwLDE1MDAwLDE1MDAwLDE1MDAwLDE5MDAwLDMyNjY2LDE1MDAwLDMyNjY2LDE1MDAwLDE1MDAwLDE1MDAwLDMyNjY2LDE0NjY2LDQ3NjY2LDEyNjY2LDMyNjY2LDExNjY2LDExMzMzLDkzMzMsMzI2NjYsMTI2NjYsMTUwMDAsNjY2NiwxOTAwMCwxNTAwMCwxNTAwMCwxNTAwMCwxNTAwMCwxMTMzMywzMjY2Niw5NjY2LDE1MDAwLDE1MDAwLDQwMDAsMTEwMDAsMTUwMDAsMTUwMDAsMTUwMDAsMzI2NjYsMTUwMDAsNzY2Niw5NjY2LDE1MDAwLDE1MDAwLDE1MDAwLDI2NjY2LDEzMzMzLDE1MDAwLDE1MDAwLDMyNjY2XSwib3BzIjoxODAzM31dLCJ1cGRhdGVkIjoiMjAyNC0wMy0yNlQwMDozOTozNS42MTlaIn0%3D)
### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
