### PR TITLE
feat: support for `vary` header in cache middleware

### DIFF
--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -5,7 +5,7 @@ export const cache = (options: {
   cacheName: string
   wait?: boolean
   cacheControl?: string
-  vary?: string[]
+  vary?: string | string[]
 }): MiddlewareHandler => {
   if (options.wait === undefined) {
     options.wait = false
@@ -14,6 +14,9 @@ export const cache = (options: {
   const cacheControlDirectives = options.cacheControl
     ?.split(',')
     .map((directive) => directive.toLowerCase())
+  const varyDirectives = Array.isArray(options.vary)
+    ? options.vary
+    : options.vary?.split(',').map((directive) => directive.trim())
   // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
   // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
   if (options.vary?.includes('*')) {
@@ -38,7 +41,7 @@ export const cache = (options: {
       }
     }
 
-    if (options.vary) {
+    if (varyDirectives) {
       const existingDirectives =
         c.res.headers
           .get('Vary')
@@ -47,7 +50,7 @@ export const cache = (options: {
 
       const vary = Array.from(
         new Set(
-          [...existingDirectives, ...options.vary].map((directive) => directive.toLowerCase())
+          [...existingDirectives, ...varyDirectives].map((directive) => directive.toLowerCase())
         )
       ).sort()
 

--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -5,7 +5,7 @@ export const cache = (options: {
   cacheName: string
   wait?: boolean
   cacheControl?: string
-  vary?: string
+  vary?: string[]
 }): MiddlewareHandler => {
   if (options.wait === undefined) {
     options.wait = false
@@ -14,10 +14,9 @@ export const cache = (options: {
   const cacheControlDirectives = options.cacheControl
     ?.split(',')
     .map((directive) => directive.toLowerCase())
-  const varyDirectives = options.vary?.split(',').map((directive) => directive.trim())
   // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
   // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
-  if (varyDirectives?.includes('*')) {
+  if (options.vary?.includes('*')) {
     throw new Error(
       'Middleware vary configuration cannot include "*", as it disallows effective caching.'
     )
@@ -39,19 +38,18 @@ export const cache = (options: {
       }
     }
 
-    if (varyDirectives) {
+    if (options.vary) {
       const existingDirectives =
         c.res.headers
           .get('Vary')
           ?.split(',')
           .map((d) => d.trim()) ?? []
+
       const vary = Array.from(
         new Set(
-          [...existingDirectives, ...varyDirectives].map((directive) =>
-            directive.toLocaleLowerCase()
-          )
+          [...existingDirectives, ...options.vary].map((directive) => directive.toLowerCase())
         )
-      ).sort((a, b) => a.localeCompare(b))
+      ).sort()
 
       if (vary.includes('*')) {
         c.header('Vary', '*')

--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -5,26 +5,58 @@ export const cache = (options: {
   cacheName: string
   wait?: boolean
   cacheControl?: string
+  vary?: string
 }): MiddlewareHandler => {
   if (options.wait === undefined) {
     options.wait = false
   }
 
-  const directives = options.cacheControl?.split(',').map((directive) => directive.toLowerCase())
+  const cacheControlDirectives = options.cacheControl
+    ?.split(',')
+    .map((directive) => directive.toLowerCase())
+  const varyDirectives = options.vary?.split(',').map((directive) => directive.trim())
+  // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
+  // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
+  if (varyDirectives?.includes('*')) {
+    throw new Error(
+      'Middleware vary configuration cannot include "*", as it disallows effective caching.'
+    )
+  }
 
   const addHeader = (c: Context) => {
-    if (directives) {
+    if (cacheControlDirectives) {
       const existingDirectives =
         c.res.headers
           .get('Cache-Control')
           ?.split(',')
           .map((d) => d.trim().split('=', 1)[0]) ?? []
-      for (const directive of directives) {
+      for (const directive of cacheControlDirectives) {
         let [name, value] = directive.trim().split('=', 2)
         name = name.toLowerCase()
         if (!existingDirectives.includes(name)) {
           c.header('Cache-Control', `${name}${value ? `=${value}` : ''}`, { append: true })
         }
+      }
+    }
+
+    if (varyDirectives) {
+      const existingDirectives =
+        c.res.headers
+          .get('Vary')
+          ?.split(',')
+          .map((d) => d.trim()) ?? []
+      const vary = Array.from(
+        new Set(
+          [...existingDirectives, ...varyDirectives].map((directive) =>
+            directive.toLocaleLowerCase()
+          )
+        )
+      ).sort((a, b) => a.localeCompare(b))
+
+      if (vary.includes('*')) {
+        c.header('Vary', '*')
+      } else {
+        c.header('Vary', vary.join(', '))
       }
     }
   }

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -51,12 +51,12 @@ describe('Cache Middleware', () => {
     return c.text('cached')
   })
 
-  app.use('/vary1/*', cache({ cacheName: 'my-app-v1', wait: true, vary: 'Accept' }))
+  app.use('/vary1/*', cache({ cacheName: 'my-app-v1', wait: true, vary: ['Accept'] }))
   app.get('/vary1/', (c) => {
     return c.text('cached')
   })
 
-  app.use('/vary2/*', cache({ cacheName: 'my-app-v1', wait: true, vary: 'Accept' }))
+  app.use('/vary2/*', cache({ cacheName: 'my-app-v1', wait: true, vary: ['Accept'] }))
   app.get('/vary2/', (c) => {
     c.header('Vary', 'Accept-Encoding')
     return c.text('cached')
@@ -64,7 +64,7 @@ describe('Cache Middleware', () => {
 
   app.use(
     '/vary3/*',
-    cache({ cacheName: 'my-app-v1', wait: true, vary: 'Accept, Accept-Encoding' })
+    cache({ cacheName: 'my-app-v1', wait: true, vary: ['Accept', 'Accept-Encoding'] })
   )
   app.get('/vary3/', (c) => {
     c.header('Vary', 'Accept-Language')
@@ -73,14 +73,14 @@ describe('Cache Middleware', () => {
 
   app.use(
     '/vary4/*',
-    cache({ cacheName: 'my-app-v1', wait: true, vary: 'Accept, Accept-Encoding' })
+    cache({ cacheName: 'my-app-v1', wait: true, vary: ['Accept', 'Accept-Encoding'] })
   )
   app.get('/vary4/', (c) => {
     c.header('Vary', 'Accept, Accept-Language')
     return c.text('cached')
   })
 
-  app.use('/vary5/*', cache({ cacheName: 'my-app-v1', wait: true, vary: 'Accept' }))
+  app.use('/vary5/*', cache({ cacheName: 'my-app-v1', wait: true, vary: ['Accept'] }))
   app.get('/vary5/', (c) => {
     c.header('Vary', '*')
     return c.text('cached')
@@ -88,7 +88,7 @@ describe('Cache Middleware', () => {
 
   app.use(
     '/not-found/*',
-    cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10', vary: 'Accept' })
+    cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10', vary: ['Accept'] })
   )
 
   const ctx = new Context()

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -131,38 +131,38 @@ describe('Cache Middleware', () => {
     expect(res.headers.get('cache-control')).toBe('private, max-age=10')
   })
 
-  it('Should set correct vary headers for route vary1', async () => {
+  it('Should correctly apply a single Vary header from middleware', async () => {
     const res = await app.request('http://localhost/vary1/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('vary')).toBe('accept')
   })
 
-  it('Should append Accept-Language to vary headers for route vary2', async () => {
+  it('Should merge Vary headers from middleware and handler without duplicating', async () => {
     const res = await app.request('http://localhost/vary2/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('vary')).toBe('accept, accept-encoding')
   })
 
-  it('Should merge and deduplicate vary headers without duplication', async () => {
+  it('Should deduplicate while merging multiple Vary headers from middleware and handler', async () => {
     const res = await app.request('http://localhost/vary3/')
     expect(res.headers.get('vary')).toBe('accept, accept-encoding, accept-language')
   })
 
-  it('Should not duplicate vary headers when set both in middleware and handler', async () => {
+  it('Should prevent duplication of Vary headers when identical ones are set by both middleware and handler', async () => {
     const res = await app.request('http://localhost/vary4/')
     expect(res.headers.get('vary')).toBe('accept, accept-encoding, accept-language')
   })
 
-  it('Should override vary headers with * when * is set by handler in route vary3', async () => {
+  it('Should prioritize the "*" Vary header from handler over any set by middleware', async () => {
     const res = await app.request('http://localhost/vary5/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('vary')).toBe('*')
   })
 
-  it('Should throw an error when * is set as vary header in middleware configuration', async () => {
+  it('Should not allow "*" as a Vary header in middleware configuration due to its impact on caching effectiveness', async () => {
     expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: '*' })).toThrow()
   })
 

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -169,14 +169,14 @@ describe('Cache Middleware', () => {
     expect(res.headers.get('vary')).toBe('accept, accept-encoding, accept-language')
   })
 
-  it('Should handle Vary header with Accept and Accept-Encoding specified as a string', async () => {
+  it('Should correctly apply and return a single Vary header with Accept specified by middleware', async () => {
     const res = await app.request('http://localhost/vary5/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('vary')).toBe('accept')
   })
 
-  it('Should handle Vary header with Accept and Accept-Encoding specified as an array', async () => {
+  it('Should merge Vary headers specified by middleware as a string with additional headers added by handler', async () => {
     const res = await app.request('http://localhost/vary6/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -86,7 +86,10 @@ describe('Cache Middleware', () => {
     return c.text('cached')
   })
 
-  app.use('/not-found/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.use(
+    '/not-found/*',
+    cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10', vary: 'Accept' })
+  )
 
   const ctx = new Context()
 
@@ -168,5 +171,6 @@ describe('Cache Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(404)
     expect(res.headers.get('cache-control')).toBeFalsy()
+    expect(res.headers.get('vary')).toBeFalsy()
   })
 })

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -192,6 +192,7 @@ describe('Cache Middleware', () => {
 
   it('Should not allow "*" as a Vary header in middleware configuration due to its impact on caching effectiveness', async () => {
     expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: ['*'] })).toThrow()
+    expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: '*' })).toThrow()
   })
 
   it('Should not cache if it is not found', async () => {

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -163,7 +163,7 @@ describe('Cache Middleware', () => {
   })
 
   it('Should not allow "*" as a Vary header in middleware configuration due to its impact on caching effectiveness', async () => {
-    expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: '*' })).toThrow()
+    expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: ['*'] })).toThrow()
   })
 
   it('Should not cache if it is not found', async () => {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -46,7 +46,7 @@ export const cache = (options: {
           .map((d) => d.trim()) ?? []
       const vary = Array.from(
         new Set(
-          [...existingDirectives, ...options.vary].map((directive) => directive.toLocaleLowerCase())
+          [...existingDirectives, ...options.vary].map((directive) => directive.toLowerCase())
         )
       ).sort((a, b) => a.localeCompare(b))
 

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -5,7 +5,7 @@ export const cache = (options: {
   cacheName: string
   wait?: boolean
   cacheControl?: string
-  vary?: string[]
+  vary?: string | string[]
 }): MiddlewareHandler => {
   if (options.wait === undefined) {
     options.wait = false
@@ -14,6 +14,9 @@ export const cache = (options: {
   const cacheControlDirectives = options.cacheControl
     ?.split(',')
     .map((directive) => directive.toLowerCase())
+  const varyDirectives = Array.isArray(options.vary)
+    ? options.vary
+    : options.vary?.split(',').map((directive) => directive.trim())
   // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
   // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
   if (options.vary?.includes('*')) {
@@ -38,7 +41,7 @@ export const cache = (options: {
       }
     }
 
-    if (options.vary) {
+    if (varyDirectives) {
       const existingDirectives =
         c.res.headers
           .get('Vary')
@@ -47,7 +50,7 @@ export const cache = (options: {
 
       const vary = Array.from(
         new Set(
-          [...existingDirectives, ...options.vary].map((directive) => directive.toLowerCase())
+          [...existingDirectives, ...varyDirectives].map((directive) => directive.toLowerCase())
         )
       ).sort()
 

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -5,7 +5,7 @@ export const cache = (options: {
   cacheName: string
   wait?: boolean
   cacheControl?: string
-  vary?: string
+  vary?: string[]
 }): MiddlewareHandler => {
   if (options.wait === undefined) {
     options.wait = false
@@ -14,10 +14,9 @@ export const cache = (options: {
   const cacheControlDirectives = options.cacheControl
     ?.split(',')
     .map((directive) => directive.toLowerCase())
-  const varyDirectives = options.vary?.split(',').map((directive) => directive.trim())
   // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
   // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
-  if (varyDirectives?.includes('*')) {
+  if (options.vary?.includes('*')) {
     throw new Error(
       'Middleware vary configuration cannot include "*", as it disallows effective caching.'
     )
@@ -39,7 +38,7 @@ export const cache = (options: {
       }
     }
 
-    if (varyDirectives) {
+    if (options.vary) {
       const existingDirectives =
         c.res.headers
           .get('Vary')
@@ -47,9 +46,7 @@ export const cache = (options: {
           .map((d) => d.trim()) ?? []
       const vary = Array.from(
         new Set(
-          [...existingDirectives, ...varyDirectives].map((directive) =>
-            directive.toLocaleLowerCase()
-          )
+          [...existingDirectives, ...options.vary].map((directive) => directive.toLocaleLowerCase())
         )
       ).sort((a, b) => a.localeCompare(b))
 

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -5,26 +5,58 @@ export const cache = (options: {
   cacheName: string
   wait?: boolean
   cacheControl?: string
+  vary?: string
 }): MiddlewareHandler => {
   if (options.wait === undefined) {
     options.wait = false
   }
 
-  const directives = options.cacheControl?.split(',').map((directive) => directive.toLowerCase())
+  const cacheControlDirectives = options.cacheControl
+    ?.split(',')
+    .map((directive) => directive.toLowerCase())
+  const varyDirectives = options.vary?.split(',').map((directive) => directive.trim())
+  // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
+  // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
+  if (varyDirectives?.includes('*')) {
+    throw new Error(
+      'Middleware vary configuration cannot include "*", as it disallows effective caching.'
+    )
+  }
 
   const addHeader = (c: Context) => {
-    if (directives) {
+    if (cacheControlDirectives) {
       const existingDirectives =
         c.res.headers
           .get('Cache-Control')
           ?.split(',')
           .map((d) => d.trim().split('=', 1)[0]) ?? []
-      for (const directive of directives) {
+      for (const directive of cacheControlDirectives) {
         let [name, value] = directive.trim().split('=', 2)
         name = name.toLowerCase()
         if (!existingDirectives.includes(name)) {
           c.header('Cache-Control', `${name}${value ? `=${value}` : ''}`, { append: true })
         }
+      }
+    }
+
+    if (varyDirectives) {
+      const existingDirectives =
+        c.res.headers
+          .get('Vary')
+          ?.split(',')
+          .map((d) => d.trim()) ?? []
+      const vary = Array.from(
+        new Set(
+          [...existingDirectives, ...varyDirectives].map((directive) =>
+            directive.toLocaleLowerCase()
+          )
+        )
+      ).sort((a, b) => a.localeCompare(b))
+
+      if (vary.includes('*')) {
+        c.header('Vary', '*')
+      } else {
+        c.header('Vary', vary.join(', '))
       }
     }
   }

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -44,11 +44,12 @@ export const cache = (options: {
           .get('Vary')
           ?.split(',')
           .map((d) => d.trim()) ?? []
+
       const vary = Array.from(
         new Set(
           [...existingDirectives, ...options.vary].map((directive) => directive.toLowerCase())
         )
-      ).sort((a, b) => a.localeCompare(b))
+      ).sort()
 
       if (vary.includes('*')) {
         c.header('Vary', '*')


### PR DESCRIPTION
This PR adds support for the `Vary` header in cache middleware, allowing developers to specify headers that should trigger separate cache entries. This feature is essential for applications serving content that varies based on client headers, such as Accept or Accept-Language, enhancing content negotiation and caching efficiency.

closed: https://github.com/honojs/hono/issues/2395

### Example Usage

```ts
app.use('/example/*', cache({ cacheName: 'my-app-cache', vary: 'Accept, Accept-Encoding' }));
app.get('/example/', (c) => {
  return c.text('This content is cached with Vary header.');
});
```

This simple addition enables the server to cache different versions of a resource based on the specified header(s), ensuring that clients receive content that's tailored to their needs, such as different image formats or languages.


**Author should do the following, if applicable:**
- [X] Add tests.
- [X] Run tests.
- [X] `yarn denoify` to generate files for Deno.