### PR TITLE
feat(middleware/cors): pass context to options.origin function

### DIFF
--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -1,7 +1,8 @@
+import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 
 type CORSOptions = {
-  origin: string | string[] | ((origin: string) => string | undefined | null)
+  origin: string | string[] | ((origin: string, c: Context) => string | undefined | null)
   allowMethods?: string[]
   allowHeaders?: string[]
   maxAge?: number
@@ -36,7 +37,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       c.res.headers.set(key, value)
     }
 
-    const allowOrigin = findAllowOrigin(c.req.header('origin') || '')
+    const allowOrigin = findAllowOrigin(c.req.header('origin') || '', c)
     if (allowOrigin) {
       set('Access-Control-Allow-Origin', allowOrigin)
     }

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -1,7 +1,8 @@
+import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
 type CORSOptions = {
-  origin: string | string[] | ((origin: string) => string | undefined | null)
+  origin: string | string[] | ((origin: string, c: Context) => string | undefined | null)
   allowMethods?: string[]
   allowHeaders?: string[]
   maxAge?: number
@@ -36,7 +37,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       c.res.headers.set(key, value)
     }
 
-    const allowOrigin = findAllowOrigin(c.req.header('origin') || '')
+    const allowOrigin = findAllowOrigin(c.req.header('origin') || '', c)
     if (allowOrigin) {
       set('Access-Control-Allow-Origin', allowOrigin)
     }


### PR DESCRIPTION
Hello!
I opened this PR because I wanted to use a context in the options.origin function as follows:
```
app.use(
  '/api/*',
  cors({
    origin: (origin, c) => {
      return c.env.MY_ALLOW_ORIGIN
    },
  })
)
```

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
