### PR TITLE
test: stub `crypto` if not exist

### DIFF
--- a/src/test-utils/setup-vitest.ts
+++ b/src/test-utils/setup-vitest.ts
@@ -1,12 +1,14 @@
 // @denoify-ignore
-import crypto from 'node:crypto'
+import * as nodeCrypto from 'node:crypto'
 import { vi } from 'vitest'
 
 /**
  * crypto
  */
-vi.stubGlobal('crypto', crypto)
-vi.stubGlobal('CryptoKey', crypto.webcrypto.CryptoKey)
+if (!globalThis.crypto) {
+  vi.stubGlobal('crypto', nodeCrypto)
+  vi.stubGlobal('CryptoKey', nodeCrypto.webcrypto.CryptoKey)
+}
 
 /**
  * Cache API


### PR DESCRIPTION
Stub only when there is no `crypto` in global.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
