### PR TITLE
feat(bearer-auth): add `verifyToken` option

### DIFF
--- a/deno_dist/middleware/bearer-auth/index.ts
+++ b/deno_dist/middleware/bearer-auth/index.ts
@@ -16,7 +16,7 @@ type BearerAuthOptions =
   | {
       realm?: string
       prefix?: string
-      verifyToken: (token: string, c: Context) => Promise<boolean>
+      verifyToken: (token: string, c: Context) => boolean | Promise<boolean>
       hashFunction?: Function
     }
 

--- a/deno_dist/middleware/bearer-auth/index.ts
+++ b/deno_dist/middleware/bearer-auth/index.ts
@@ -1,3 +1,4 @@
+import type { Context } from '../../context.ts'
 import { HTTPException } from '../../http-exception.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 import { timingSafeEqual } from '../../utils/buffer.ts'
@@ -5,13 +6,22 @@ import { timingSafeEqual } from '../../utils/buffer.ts'
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
 
-export const bearerAuth = (options: {
-  token: string | string[]
-  realm?: string
-  prefix?: string
-  hashFunction?: Function
-}): MiddlewareHandler => {
-  if (!options.token) {
+type BearerAuthOptions =
+  | {
+      token: string | string[]
+      realm?: string
+      prefix?: string
+      hashFunction?: Function
+    }
+  | {
+      realm?: string
+      prefix?: string
+      verifyToken: (token: string, c: Context) => Promise<boolean>
+      hashFunction?: Function
+    }
+
+export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
+  if (!('token' in options || 'verifyToken' in options)) {
     throw new Error('bearer auth middleware requires options for "token"')
   }
   if (!options.realm) {
@@ -49,7 +59,9 @@ export const bearerAuth = (options: {
         throw new HTTPException(400, { res })
       } else {
         let equal = false
-        if (typeof options.token === 'string') {
+        if ('verifyToken' in options) {
+          equal = await options.verifyToken(match[1], c)
+        } else if (typeof options.token === 'string') {
           equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
         } else if (Array.isArray(options.token) && options.token.length > 0) {
           for (const token of options.token) {

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -16,7 +16,7 @@ type BearerAuthOptions =
   | {
       realm?: string
       prefix?: string
-      verifyToken: (token: string, c: Context) => Promise<boolean>
+      verifyToken: (token: string, c: Context) => boolean | Promise<boolean>
       hashFunction?: Function
     }
 

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -1,3 +1,4 @@
+import type { Context } from '../../context'
 import { HTTPException } from '../../http-exception'
 import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
@@ -5,13 +6,22 @@ import { timingSafeEqual } from '../../utils/buffer'
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
 
-export const bearerAuth = (options: {
-  token: string | string[]
-  realm?: string
-  prefix?: string
-  hashFunction?: Function
-}): MiddlewareHandler => {
-  if (!options.token) {
+type BearerAuthOptions =
+  | {
+      token: string | string[]
+      realm?: string
+      prefix?: string
+      hashFunction?: Function
+    }
+  | {
+      realm?: string
+      prefix?: string
+      verifyToken: (token: string, c: Context) => Promise<boolean>
+      hashFunction?: Function
+    }
+
+export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
+  if (!('token' in options || 'verifyToken' in options)) {
     throw new Error('bearer auth middleware requires options for "token"')
   }
   if (!options.realm) {
@@ -49,7 +59,9 @@ export const bearerAuth = (options: {
         throw new HTTPException(400, { res })
       } else {
         let equal = false
-        if (typeof options.token === 'string') {
+        if ('verifyToken' in options) {
+          equal = await options.verifyToken(match[1], c)
+        } else if (typeof options.token === 'string') {
           equal = await timingSafeEqual(options.token, match[1], options.hashFunction)
         } else if (Array.isArray(options.token) && options.token.length > 0) {
           for (const token of options.token) {


### PR DESCRIPTION
This PR will fix #2316 and #2410.

With this PR, it enables passing the function to verify the token in Bearer Middleware.

```ts
app.use(
  '/auth-verify-token/*',
  bearerAuth({
    verifyToken: async (token) => {
      return token === 'dynamic-token'
    },
  })
)
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
