### PR TITLE
fix(jws): Only import necessary helper (not all helpers)

### DIFF
--- a/deno_dist/utils/jwt/jws.ts
+++ b/deno_dist/utils/jwt/jws.ts
@@ -1,4 +1,4 @@
-import { getRuntimeKey } from '../../helper.ts'
+import { getRuntimeKey } from '../../helper/adapter/index.ts'
 import { decodeBase64 } from '../encode.ts'
 import type { SignatureAlgorithm } from './jwa.ts'
 import { JwtAlgorithmNotImplemented } from './types.ts'

--- a/src/utils/jwt/jws.ts
+++ b/src/utils/jwt/jws.ts
@@ -1,4 +1,4 @@
-import { getRuntimeKey } from '../../helper'
+import { getRuntimeKey } from '../../helper/adapter'
 import { decodeBase64 } from '../encode'
 import type { SignatureAlgorithm } from './jwa'
 import { JwtAlgorithmNotImplemented } from './types'


### PR DESCRIPTION
This change prevents bundlers from pulling in all helpers, including the "ssg" helper which is not compatible with Cloudflare workers as it creates a "Request" in the global scope, and only imports the required (adapter) helper.

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
