### PR TITLE
feat(jsx-renderer): pass the context as 2nd arg

### DIFF
--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -5,6 +5,7 @@ import { jsx, createContext, useContext, Fragment } from '../../jsx/index.ts'
 import type { FC, PropsWithChildren, JSXNode } from '../../jsx/index.ts'
 import { renderToReadableStream } from '../../jsx/streaming.ts'
 import type { Env, Input, MiddlewareHandler } from '../../types.ts'
+import type { HtmlEscapedString } from '../../utils/html.ts'
 
 export const RequestContext = createContext<Context | null>(null)
 
@@ -13,13 +14,18 @@ type RendererOptions = {
   stream?: boolean | Record<string, string>
 }
 
+type Component = (
+  props: PropsForRenderer & { Layout: FC },
+  c: Context
+) => HtmlEscapedString | Promise<HtmlEscapedString>
+
+type ComponentWithChildren = (
+  props: PropsWithChildren<PropsForRenderer & { Layout: FC }>,
+  c: Context
+) => HtmlEscapedString | Promise<HtmlEscapedString>
+
 const createRenderer =
-  (
-    c: Context,
-    Layout: FC,
-    component?: FC<PropsForRenderer & { Layout: FC }>,
-    options?: RendererOptions
-  ) =>
+  (c: Context, Layout: FC, component?: Component, options?: RendererOptions) =>
   (children: JSXNode, props: PropsForRenderer) => {
     const docType =
       typeof options?.docType === 'string'
@@ -30,7 +36,7 @@ const createRenderer =
 
     const currentLayout = component
       ? jsx(
-          component,
+          (props: any) => component(props, c),
           {
             ...{ Layout, ...(props as any) },
           },
@@ -60,14 +66,14 @@ const createRenderer =
   }
 
 export const jsxRenderer = (
-  component?: FC<PropsWithChildren<PropsForRenderer & { Layout: FC }>>,
+  component?: ComponentWithChildren,
   options?: RendererOptions
 ): MiddlewareHandler =>
   function jsxRenderer(c, next) {
     const Layout = (c.getLayout() ?? Fragment) as FC
     if (component) {
       c.setLayout((props) => {
-        return component({ ...props, Layout })
+        return component({ ...props, Layout }, c)
       })
     }
     c.setRenderer(createRenderer(c, Layout, component, options) as any)

--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -56,6 +56,29 @@ describe('JSX renderer', () => {
     )
   })
 
+  it('Should get the context object as a 2nd arg', async () => {
+    const app = new Hono()
+    app.use(
+      jsxRenderer(
+        ({ children }, c) => {
+          return (
+            <div>
+              {children} at {c.req.path}
+            </div>
+          )
+        },
+        { docType: false }
+      )
+    )
+    app.get('/hi', (c) => {
+      return c.render('hi', { title: 'hi' })
+    })
+
+    const res = await app.request('/hi')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('<div>hi at /hi</div>')
+  })
+
   it('nested layout with Layout', async () => {
     const app = new Hono()
     app.use(

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -5,6 +5,7 @@ import { jsx, createContext, useContext, Fragment } from '../../jsx'
 import type { FC, PropsWithChildren, JSXNode } from '../../jsx'
 import { renderToReadableStream } from '../../jsx/streaming'
 import type { Env, Input, MiddlewareHandler } from '../../types'
+import type { HtmlEscapedString } from '../../utils/html'
 
 export const RequestContext = createContext<Context | null>(null)
 
@@ -13,13 +14,18 @@ type RendererOptions = {
   stream?: boolean | Record<string, string>
 }
 
+type Component = (
+  props: PropsForRenderer & { Layout: FC },
+  c: Context
+) => HtmlEscapedString | Promise<HtmlEscapedString>
+
+type ComponentWithChildren = (
+  props: PropsWithChildren<PropsForRenderer & { Layout: FC }>,
+  c: Context
+) => HtmlEscapedString | Promise<HtmlEscapedString>
+
 const createRenderer =
-  (
-    c: Context,
-    Layout: FC,
-    component?: FC<PropsForRenderer & { Layout: FC }>,
-    options?: RendererOptions
-  ) =>
+  (c: Context, Layout: FC, component?: Component, options?: RendererOptions) =>
   (children: JSXNode, props: PropsForRenderer) => {
     const docType =
       typeof options?.docType === 'string'
@@ -30,7 +36,7 @@ const createRenderer =
 
     const currentLayout = component
       ? jsx(
-          component,
+          (props: any) => component(props, c),
           {
             ...{ Layout, ...(props as any) },
           },
@@ -60,14 +66,14 @@ const createRenderer =
   }
 
 export const jsxRenderer = (
-  component?: FC<PropsWithChildren<PropsForRenderer & { Layout: FC }>>,
+  component?: ComponentWithChildren,
   options?: RendererOptions
 ): MiddlewareHandler =>
   function jsxRenderer(c, next) {
     const Layout = (c.getLayout() ?? Fragment) as FC
     if (component) {
       c.setLayout((props) => {
-        return component({ ...props, Layout })
+        return component({ ...props, Layout }, c)
       })
     }
     c.setRenderer(createRenderer(c, Layout, component, options) as any)


### PR DESCRIPTION
Fixes https://github.com/honojs/honox/issues/132

With this PR, you can get the context object in the component:

```ts
app.use(
  jsxRenderer(
    ({ children }, c) => {
      return (
        <div>
          {children} at {c.req.path}
        </div>
      )
    },
    { docType: false }
  )
)
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
