### PR TITLE
fix(jsx): Add catch to async function's promise

### DIFF
--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -148,10 +148,7 @@ export const renderToReadableStream = (
                 .forEach(then)
               resolvedCount++
               controller.enqueue(textEncoder.encode(res))
-            }).catch((err) => {
-            console.trace(err);
-            return "";
-          })
+            })
         )
       }
       ;(resolved as HtmlEscapedString).callbacks

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -148,7 +148,10 @@ export const renderToReadableStream = (
                 .forEach(then)
               resolvedCount++
               controller.enqueue(textEncoder.encode(res))
-            })
+            }).catch((err) => {
+            console.trace(err);
+            return "";
+          })
         )
       }
       ;(resolved as HtmlEscapedString).callbacks


### PR DESCRIPTION
The `.then(async function())` returns a new promise, that the above .catch() does not catch, resulting in rapid refreshing of the page to cause a fatal uncatchable error. Adding this second .catch fixes that.


## The problem: 

If you're streaming a response, via renderToReadableStream from hono/jsx/streaming, and you rapidly refresh your page, you can trigger an error:

```sh
TypeError: Invalid state: Controller is already closed
    at new NodeError (node:internal/errors:405:5)
    at ReadableStreamDefaultController.enqueue (node:internal/webstreams/readablestream:1038:13)
    at /Users/markwilkins/projects/wilkins-software-nx-v2/node_modules/hono/dist/cjs/jsx/streaming.js:137:24
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

which is uncatchable as far as I can tell. 

![Apr-05-2024 21-53-51](https://github.com/honojs/hono/assets/21322162/3c21e83b-0771-47ce-9278-388300916bd2)

## The fix:

Since the [catch block](https://github.com/honojs/hono/blob/e428a053161e6c7f29d7e9776675fa1f7e7cceec/src/jsx/streaming.ts#L138) above is applied to the `promise` variable, but not to the promise returned by [the async function in the .then()](https://github.com/honojs/hono/blob/e428a053161e6c7f29d7e9776675fa1f7e7cceec/src/jsx/streaming.ts#L142), the call to enqueue on [line 150](https://github.com/honojs/hono/blob/e428a053161e6c7f29d7e9776675fa1f7e7cceec/src/jsx/streaming.ts#L150) can fail due to a closed connection. 


Fixing it is as simple as adding another .catch, as funny as it looks at first glance. 

![Apr-05-2024 21-56-58](https://github.com/honojs/hono/assets/21322162/de63af22-09e8-45c0-b97a-e72373e2fc6e)


