### PR TITLE
fix(ssg): use response header to mark as disabled routes for SSG

### DIFF
--- a/deno_dist/helper/ssg/index.ts
+++ b/deno_dist/helper/ssg/index.ts
@@ -1,2 +1,8 @@
 export * from './ssg.ts'
-export { SSG_DISABLED_RESPONSE, ssgParams, isSSGContext, disableSSG, onlySSG } from './middleware.ts'
+export {
+  X_HONO_DISABLE_SSG_HEADER_KEY,
+  ssgParams,
+  isSSGContext,
+  disableSSG,
+  onlySSG,
+} from './middleware.ts'

--- a/deno_dist/helper/ssg/middleware.ts
+++ b/deno_dist/helper/ssg/middleware.ts
@@ -2,7 +2,23 @@ import type { Context } from '../../context.ts'
 import type { Env, MiddlewareHandler } from '../../types.ts'
 
 export const SSG_CONTEXT = 'HONO_SSG_CONTEXT'
-export const SSG_DISABLED_RESPONSE = new Response('SSG is disabled', { status: 404 })
+export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'
+
+/**
+ * @deprecated
+ * Use `X_HONO_DISABLE_SSG_HEADER_KEY` instead.
+ * This constant will be removed in the next minor version.
+ */
+export const SSG_DISABLED_RESPONSE = (() => {
+  try {
+    return new Response('SSG is disabled', {
+      status: 404,
+      headers: { [X_HONO_DISABLE_SSG_HEADER_KEY]: 'true' },
+    })
+  } catch (e) {
+    return null
+  }
+})() as Response
 
 interface SSGParam {
   [key: string]: string
@@ -43,7 +59,8 @@ export const isSSGContext = (c: Context): boolean => !!c.env?.[SSG_CONTEXT]
 export const disableSSG = (): MiddlewareHandler =>
   async function disableSSG(c, next) {
     if (isSSGContext(c)) {
-      return SSG_DISABLED_RESPONSE
+      c.header(X_HONO_DISABLE_SSG_HEADER_KEY, 'true')
+      return c.notFound()
     }
     await next()
   }

--- a/deno_dist/helper/ssg/ssg.ts
+++ b/deno_dist/helper/ssg/ssg.ts
@@ -4,7 +4,7 @@ import type { Env, Schema } from '../../types.ts'
 import { createPool } from '../../utils/concurrent.ts'
 import { getExtension } from '../../utils/mime.ts'
 import type { AddedSSGDataRequest, SSGParams } from './middleware.ts'
-import { SSG_DISABLED_RESPONSE, SSG_CONTEXT } from './middleware.ts'
+import { X_HONO_DISABLE_SSG_HEADER_KEY, SSG_CONTEXT } from './middleware.ts'
 import { joinPaths, dirname, filterStaticGenerateRoutes } from './utils.ts'
 
 const DEFAULT_CONCURRENCY = 2 // default concurrency for ssg
@@ -168,7 +168,7 @@ export const fetchRoutesContent = function* <
                       [SSG_CONTEXT]: true,
                     })
                   )
-                  if (response === SSG_DISABLED_RESPONSE) {
+                  if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
                     resolveReq(undefined)
                     return
                   }

--- a/src/helper/ssg/index.ts
+++ b/src/helper/ssg/index.ts
@@ -1,2 +1,8 @@
 export * from './ssg'
-export { SSG_DISABLED_RESPONSE, ssgParams, isSSGContext, disableSSG, onlySSG } from './middleware'
+export {
+  X_HONO_DISABLE_SSG_HEADER_KEY,
+  ssgParams,
+  isSSGContext,
+  disableSSG,
+  onlySSG,
+} from './middleware'

--- a/src/helper/ssg/middleware.ts
+++ b/src/helper/ssg/middleware.ts
@@ -2,7 +2,11 @@ import type { Context } from '../../context'
 import type { Env, MiddlewareHandler } from '../../types'
 
 export const SSG_CONTEXT = 'HONO_SSG_CONTEXT'
-export const SSG_DISABLED_RESPONSE = new Response('SSG is disabled', { status: 404 })
+export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'
+export const SSG_DISABLED_RESPONSE = new Response('SSG is disabled', {
+  status: 404,
+  headers: { [X_HONO_DISABLE_SSG_HEADER_KEY]: 'true' },
+})
 
 interface SSGParam {
   [key: string]: string
@@ -43,7 +47,8 @@ export const isSSGContext = (c: Context): boolean => !!c.env?.[SSG_CONTEXT]
 export const disableSSG = (): MiddlewareHandler =>
   async function disableSSG(c, next) {
     if (isSSGContext(c)) {
-      return SSG_DISABLED_RESPONSE
+      c.header(X_HONO_DISABLE_SSG_HEADER_KEY, 'true')
+      return c.notFound()
     }
     await next()
   }

--- a/src/helper/ssg/middleware.ts
+++ b/src/helper/ssg/middleware.ts
@@ -3,10 +3,22 @@ import type { Env, MiddlewareHandler } from '../../types'
 
 export const SSG_CONTEXT = 'HONO_SSG_CONTEXT'
 export const X_HONO_DISABLE_SSG_HEADER_KEY = 'x-hono-disable-ssg'
-export const SSG_DISABLED_RESPONSE = new Response('SSG is disabled', {
-  status: 404,
-  headers: { [X_HONO_DISABLE_SSG_HEADER_KEY]: 'true' },
-})
+
+/**
+ * @deprecated
+ * Use `X_HONO_DISABLE_SSG_HEADER_KEY` instead.
+ * This constant will be removed in the next minor version.
+ */
+export const SSG_DISABLED_RESPONSE = (() => {
+  try {
+    return new Response('SSG is disabled', {
+      status: 404,
+      headers: { [X_HONO_DISABLE_SSG_HEADER_KEY]: 'true' },
+    })
+  } catch (e) {
+    return null
+  }
+})() as Response
 
 interface SSGParam {
   [key: string]: string

--- a/src/helper/ssg/ssg.test.tsx
+++ b/src/helper/ssg/ssg.test.tsx
@@ -3,7 +3,13 @@ import { Hono } from '../../hono'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx } from '../../jsx'
 import { poweredBy } from '../../middleware/powered-by'
-import { SSG_DISABLED_RESPONSE, ssgParams, isSSGContext, disableSSG, onlySSG } from './middleware'
+import {
+  X_HONO_DISABLE_SSG_HEADER_KEY,
+  ssgParams,
+  isSSGContext,
+  disableSSG,
+  onlySSG,
+} from './middleware'
 import { fetchRoutesContent, saveContentToFile, toSSG, defaultExtensionMap } from './ssg'
 import type {
   BeforeRequestHook,
@@ -594,7 +600,9 @@ describe('disableSSG/onlySSG middlewares', () => {
   const app = new Hono()
   app.get('/', (c) => c.html(<h1>Hello</h1>))
   app.get('/api', disableSSG(), (c) => c.text('an-api'))
-  app.get('/disable-by-response', () => SSG_DISABLED_RESPONSE)
+  app.get('/disable-by-response', (c) =>
+    c.text('', 404, { [X_HONO_DISABLE_SSG_HEADER_KEY]: 'true' })
+  )
   app.get('/static-page', onlySSG(), (c) => c.html(<h1>Welcome to my site</h1>))
 
   const fsMock: FileSystemModule = {

--- a/src/helper/ssg/ssg.ts
+++ b/src/helper/ssg/ssg.ts
@@ -4,7 +4,7 @@ import type { Env, Schema } from '../../types'
 import { createPool } from '../../utils/concurrent'
 import { getExtension } from '../../utils/mime'
 import type { AddedSSGDataRequest, SSGParams } from './middleware'
-import { SSG_DISABLED_RESPONSE, SSG_CONTEXT } from './middleware'
+import { X_HONO_DISABLE_SSG_HEADER_KEY, SSG_CONTEXT } from './middleware'
 import { joinPaths, dirname, filterStaticGenerateRoutes } from './utils'
 
 const DEFAULT_CONCURRENCY = 2 // default concurrency for ssg
@@ -168,7 +168,7 @@ export const fetchRoutesContent = function* <
                       [SSG_CONTEXT]: true,
                     })
                   )
-                  if (response === SSG_DISABLED_RESPONSE) {
+                  if (response.headers.get(X_HONO_DISABLE_SSG_HEADER_KEY)) {
                     resolveReq(undefined)
                     return
                   }


### PR DESCRIPTION
Fixes #2476, https://github.com/honojs/honox/issues/58

As for #2179, using `c.env` to make the decision was a good change, but the decision in the response header should have been left as is. The response header is used again in this PR.

Since we use response headers in this PR, we can also remove the `new Response` before the request that causes an error in Cloudflare worker, but since it should not be changed in the patch version, we leave it marked as deprecated.

Also, if we can make it so that the response headers are used, the following issue will be fixed.
https://github.com/honojs/honox/issues/58


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
