### PR TITLE
fix(client): fix websocket client protocol

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -3,7 +3,13 @@ import type { ValidationTargets } from '../types.ts'
 import { serialize } from '../utils/cookie.ts'
 import type { UnionToIntersection } from '../utils/types.ts'
 import type { Callback, Client, ClientRequestOptions } from './types.ts'
-import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './utils.ts'
+import {
+  deepMerge,
+  mergePath,
+  removeIndexString,
+  replaceUrlParam,
+  replaceUrlProtocol,
+} from './utils.ts'
 
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
@@ -147,8 +153,11 @@ export const hc = <T extends Hono<any, any, any>>(
       return new URL(url)
     }
     if (method === 'ws') {
-      const targetUrl =
-        opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url
+      const targetUrl = replaceUrlProtocol(
+        opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
+        'ws'
+      )
+
       return new WebSocket(targetUrl)
     }
 

--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -15,6 +15,15 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
   return urlString
 }
 
+export const replaceUrlProtocol = (urlString: string, protocol: 'ws' | 'http') => {
+  switch (protocol) {
+    case 'ws':
+      return urlString.replace(/^http/, 'ws')
+    case 'http':
+      return urlString.replace(/^ws/, 'http')
+  }
+}
+
 export const removeIndexString = (urlSting: string) => {
   return urlSting.replace(/\/index$/, '')
 }

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -731,4 +731,18 @@ describe('WebSocket Client Initialization and Connection Tests', () => {
 
     expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index')
   })
+
+  it('Establishes WebSocket connection over ws', async () => {
+    const client = hc<AppType>('ws://localhost')
+    client.index.$ws()
+
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index')
+  })
+
+  it('Establishes WebSocket connection over wss', async () => {
+    const client = hc<AppType>('wss://localhost')
+    client.index.$ws()
+
+    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index')
+  })
 })

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -688,7 +688,7 @@ describe('Dynamic headers', () => {
   })
 })
 
-describe('WebSocket Client Initialization and Connection Tests', () => {
+describe('WebSocket URL Protocol Translation', () => {
   const app = new Hono()
   const route = app.get(
     '/',
@@ -718,31 +718,27 @@ describe('WebSocket Client Initialization and Connection Tests', () => {
   })
   afterAll(() => server.close())
 
-  it('Establishes WebSocket connection over HTTP', async () => {
+  it('Translates HTTP to ws', async () => {
     const client = hc<AppType>('http://localhost')
     client.index.$ws()
-
     expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index')
   })
 
-  it('Establishes WebSocket connection over HTTPS', async () => {
+  it('Translates HTTPS to wss', async () => {
     const client = hc<AppType>('https://localhost')
     client.index.$ws()
-
     expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index')
   })
 
-  it('Establishes WebSocket connection over ws', async () => {
+  it('Keeps ws unchanged', async () => {
     const client = hc<AppType>('ws://localhost')
     client.index.$ws()
-
     expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index')
   })
 
-  it('Establishes WebSocket connection over wss', async () => {
+  it('Keeps wss unchanged', async () => {
     const client = hc<AppType>('wss://localhost')
     client.index.$ws()
-
     expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index')
   })
 })

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,7 +3,13 @@ import type { ValidationTargets } from '../types'
 import { serialize } from '../utils/cookie'
 import type { UnionToIntersection } from '../utils/types'
 import type { Callback, Client, ClientRequestOptions } from './types'
-import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './utils'
+import {
+  deepMerge,
+  mergePath,
+  removeIndexString,
+  replaceUrlParam,
+  replaceUrlProtocol,
+} from './utils'
 
 const createProxy = (callback: Callback, path: string[]) => {
   const proxy: unknown = new Proxy(() => {}, {
@@ -147,8 +153,11 @@ export const hc = <T extends Hono<any, any, any>>(
       return new URL(url)
     }
     if (method === 'ws') {
-      const targetUrl =
-        opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url
+      const targetUrl = replaceUrlProtocol(
+        opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
+        'ws'
+      )
+
       return new WebSocket(targetUrl)
     }
 

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -42,6 +42,32 @@ describe('replaceUrlParams', () => {
   })
 })
 
+describe('replaceUrlProtocol', () => {
+  it('Should replace http to ws', () => {
+    const url = 'http://localhost'
+    const newUrl = replaceUrlProtocol(url, 'ws')
+    expect(newUrl).toBe('ws://localhost')
+  })
+
+  it('Should replace ws to http', () => {
+    const url = 'ws://localhost'
+    const newUrl = replaceUrlProtocol(url, 'http')
+    expect(newUrl).toBe('http://localhost')
+  })
+
+  it('Should replace https to wss', () => {
+    const url = 'https://localhost'
+    const newUrl = replaceUrlProtocol(url, 'wss')
+    expect(newUrl).toBe('wss://localhost')
+  })
+
+  it('Should replace wss to https', () => {
+    const url = 'wss://localhost'
+    const newUrl = replaceUrlProtocol(url, 'https')
+    expect(newUrl).toBe('https://localhost')
+  })
+})
+
 describe('removeIndexString', () => {
   it('Should remove last `/index` string', () => {
     let url = 'http://localhost/index'

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,4 +1,10 @@
-import { deepMerge, mergePath, removeIndexString, replaceUrlParam } from './utils'
+import {
+  deepMerge,
+  mergePath,
+  removeIndexString,
+  replaceUrlParam,
+  replaceUrlProtocol,
+} from './utils'
 
 describe('mergePath', () => {
   it('Should merge paths correctly', () => {
@@ -53,18 +59,6 @@ describe('replaceUrlProtocol', () => {
     const url = 'ws://localhost'
     const newUrl = replaceUrlProtocol(url, 'http')
     expect(newUrl).toBe('http://localhost')
-  })
-
-  it('Should replace https to wss', () => {
-    const url = 'https://localhost'
-    const newUrl = replaceUrlProtocol(url, 'wss')
-    expect(newUrl).toBe('wss://localhost')
-  })
-
-  it('Should replace wss to https', () => {
-    const url = 'wss://localhost'
-    const newUrl = replaceUrlProtocol(url, 'https')
-    expect(newUrl).toBe('https://localhost')
   })
 })
 

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -55,10 +55,22 @@ describe('replaceUrlProtocol', () => {
     expect(newUrl).toBe('ws://localhost')
   })
 
+  it('Should replace https to wss', () => {
+    const url = 'https://localhost'
+    const newUrl = replaceUrlProtocol(url, 'ws')
+    expect(newUrl).toBe('wss://localhost')
+  })
+
   it('Should replace ws to http', () => {
     const url = 'ws://localhost'
     const newUrl = replaceUrlProtocol(url, 'http')
     expect(newUrl).toBe('http://localhost')
+  })
+
+  it('Should replace wss to https', () => {
+    const url = 'wss://localhost'
+    const newUrl = replaceUrlProtocol(url, 'http')
+    expect(newUrl).toBe('https://localhost')
   })
 })
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -15,6 +15,15 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
   return urlString
 }
 
+export const replaceUrlProtocol = (urlString: string, protocol: 'ws' | 'http') => {
+  switch (protocol) {
+    case 'ws':
+      return urlString.replace(/^http/, 'ws')
+    case 'http':
+      return urlString.replace(/^ws/, 'http')
+  }
+}
+
 export const removeIndexString = (urlSting: string) => {
   return urlSting.replace(/\/index$/, '')
 }


### PR DESCRIPTION
This PR fixes an issue in the Hono client where WebSocket connections could not be established due to the `hc` function's `baseUrl` containing `http` or `https` schemes. Given that the WebSocket API requires URLs to use the `ws` or `wss` schemes, our existing implementation led to errors when attempting WebSocket connections with `http` or `https` URLs.

To address this, we've introduced a utility function, `replaceUrlProtocol`, which converts `http` URLs to `ws` and `https` URLs to `wss` for WebSocket connections. This ensures compatibility with the WebSocket API and resolves the protocol mismatch issue.

This change allows for seamless WebSocket communication within Hono applications by correctly handling the URL schemes required for WebSocket connections.

### Author should do the followings, if applicable

- [X] Add tests
- [X] Run tests
- [X] `yarn denoify` to generate files for Deno