### PR TITLE
fix(trailing-slash): export types in `package.json` correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,6 +382,9 @@
       "etag": [
         "./dist/types/middleware/etag"
       ],
+      "trailing-slash": [
+        "./dist/types/middleware/trailing-slash"
+      ],
       "html": [
         "./dist/types/helper/html"
       ],


### PR DESCRIPTION
Fixes #2482

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
