### PR TITLE
fix(jwt): Make JWT Header `typ` Field Optional to Enhance Compatibility

### DIFF
--- a/deno_dist/utils/jwt/jwt.ts
+++ b/deno_dist/utils/jwt/jwt.ts
@@ -22,7 +22,7 @@ const decodeJwtPart = (part: string): unknown =>
 
 export interface TokenHeader {
   alg: SignatureAlgorithm
-  typ: 'JWT'
+  typ?: 'JWT'
 }
 
 // eslint-disable-next-line
@@ -32,8 +32,7 @@ export function isTokenHeader(obj: any): obj is TokenHeader {
     obj !== null &&
     'alg' in obj &&
     Object.values(AlgorithmTypes).includes(obj.alg) &&
-    'typ' in obj &&
-    obj.typ === 'JWT'
+    (!('typ' in obj) || obj.typ === 'JWT')
   )
 }
 

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -30,6 +30,14 @@ describe('isTokenHeader', () => {
 
     expect(JWT.isTokenHeader(invalidTokenHeader)).toBe(false)
   })
+
+  it('should return true for valid TokenHeader without typ', () => {
+    const validTokenHeader: JWT.TokenHeader = {
+      alg: AlgorithmTypes.HS256,
+    }
+
+    expect(JWT.isTokenHeader(validTokenHeader)).toBe(true)
+  })
 })
 
 describe('JWT', () => {

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -31,12 +31,21 @@ describe('isTokenHeader', () => {
     expect(JWT.isTokenHeader(invalidTokenHeader)).toBe(false)
   })
 
-  it('should return true for valid TokenHeader without typ', () => {
+  it('returns true even if the typ field is absent in a TokenHeader', () => {
     const validTokenHeader: JWT.TokenHeader = {
       alg: AlgorithmTypes.HS256,
     }
 
     expect(JWT.isTokenHeader(validTokenHeader)).toBe(true)
+  })
+
+  it('returns false when the typ field is present but empty', () => {
+    const invalidTokenHeader = {
+      alg: AlgorithmTypes.HS256,
+      typ: '',
+    }
+
+    expect(JWT.isTokenHeader(invalidTokenHeader)).toBe(false)
   })
 })
 

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -22,7 +22,7 @@ const decodeJwtPart = (part: string): unknown =>
 
 export interface TokenHeader {
   alg: SignatureAlgorithm
-  typ: 'JWT'
+  typ?: 'JWT'
 }
 
 // eslint-disable-next-line
@@ -32,8 +32,7 @@ export function isTokenHeader(obj: any): obj is TokenHeader {
     obj !== null &&
     'alg' in obj &&
     Object.values(AlgorithmTypes).includes(obj.alg) &&
-    'typ' in obj &&
-    obj.typ === 'JWT'
+    (!('typ' in obj) || obj.typ === 'JWT')
   )
 }
 


### PR DESCRIPTION
This PR modifies the JWT header verification to make the `typ` field optional. This change is aligned with the JWT specifications as outlined in RFC 7519 Section 5.1, where the `typ` header parameter is optional. This adjustment was necessary to accommodate tokens, such as those decoded from Cloudflare Access's `CF_Authorization`, which do not include the `typ` field, thus previously preventing successful verification.

### Changes Made
- Made the `typ` field in the `TokenHeader` interface optional.
- Updated the `isTokenHeader` function to validate headers with or without the `typ` field.

Reference to the RFC: [JWT RFC 7519 Section 5.1](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1)

The necessity for this change arose during the verification of JWT tokens from Cloudflare Access, where the absence of the `typ` field led to verification issues. By accommodating tokens without the `typ` field, this PR ensures broader compatibility and adherence to the JWT standard.

### Author should do the followings, if applicable

- [X] Add tests
- [X] Run tests
- [X] `yarn denoify` to generate files for Deno