### PR TITLE
fix(adapter): handle multi value headers in AWS Lambda

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { isContentTypeBinary, isContentEncodingBinary,  handle } from './handler'
+import { isContentTypeBinary, isContentEncodingBinary, handle } from './handler'
 import type { ALBProxyEvent } from './handler'
 
 describe('isContentTypeBinary', () => {
@@ -42,7 +42,7 @@ describe('handle', () => {
     memoryLimitInMB: '',
     getRemainingTimeInMillis(): number {
       return 0
-    }
+    },
   }
 
   describe('ALB', () => {
@@ -67,8 +67,8 @@ describe('handle', () => {
         requestContext: {
           elb: {
             targetGroupArn: '',
-          }
-        }
+          },
+        },
       }
       const response = await handler(event, dummyLambdaContext)
       expect(response?.['statusCode']).toEqual(200)
@@ -87,8 +87,8 @@ describe('handle', () => {
         requestContext: {
           elb: {
             targetGroupArn: '',
-          }
-        }
+          },
+        },
       }
       const response = await handler(event, dummyLambdaContext)
       expect(response?.['statusCode']).toEqual(200)

--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -47,7 +47,10 @@ describe('handle', () => {
 
   describe('ALB', () => {
     const app = new Hono().post('/', (c) => {
-      return c.json({ message: 'ok' })
+      if (c.req.header('foo')?.includes('bar')) {
+        return c.json({ message: 'ok' })
+      }
+      return c.json({ message: 'fail' }, 400)
     })
     const handler = handle(app)
 
@@ -59,6 +62,7 @@ describe('handle', () => {
         path: '/',
         headers: {
           host: 'localhost',
+          foo: 'bar',
         },
         requestContext: {
           elb: {
@@ -78,6 +82,7 @@ describe('handle', () => {
         path: '/',
         multiValueHeaders: {
           host: ['localhost'],
+          foo: ['bar', 'buz'],
         },
         requestContext: {
           elb: {

--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,6 +1,4 @@
-import { Hono } from '../../hono'
-import { isContentTypeBinary, isContentEncodingBinary, handle } from './handler'
-import type { ALBProxyEvent } from './handler'
+import { isContentTypeBinary, isContentEncodingBinary } from './handler'
 
 describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
@@ -27,71 +25,5 @@ describe('isContentEncodingBinary', () => {
     expect(isContentEncodingBinary('deflate, gzip')).toBe(true)
     expect(isContentEncodingBinary('')).toBe(false)
     expect(isContentEncodingBinary('unknown')).toBe(false)
-  })
-})
-
-describe('handle', () => {
-  const dummyLambdaContext = {
-    awsRequestId: '',
-    callbackWaitsForEmptyEventLoop: false,
-    functionName: '',
-    functionVersion: '',
-    invokedFunctionArn: '',
-    logGroupName: '',
-    logStreamName: '',
-    memoryLimitInMB: '',
-    getRemainingTimeInMillis(): number {
-      return 0
-    },
-  }
-
-  describe('ALB', () => {
-    const app = new Hono().post('/', (c) => {
-      if (c.req.header('foo')?.includes('bar')) {
-        return c.json({ message: 'ok' })
-      }
-      return c.json({ message: 'fail' }, 400)
-    })
-    const handler = handle(app)
-
-    it('Should accept single value headers', async () => {
-      const event: ALBProxyEvent = {
-        body: '{}',
-        httpMethod: 'POST',
-        isBase64Encoded: false,
-        path: '/',
-        headers: {
-          host: 'localhost',
-          foo: 'bar',
-        },
-        requestContext: {
-          elb: {
-            targetGroupArn: '',
-          },
-        },
-      }
-      const response = await handler(event, dummyLambdaContext)
-      expect(response?.['statusCode']).toEqual(200)
-    })
-
-    it('Should accept multi value headers', async () => {
-      const event: ALBProxyEvent = {
-        body: '{}',
-        httpMethod: 'POST',
-        isBase64Encoded: false,
-        path: '/',
-        multiValueHeaders: {
-          host: ['localhost'],
-          foo: ['bar', 'buz'],
-        },
-        requestContext: {
-          elb: {
-            targetGroupArn: '',
-          },
-        },
-      }
-      const response = await handler(event, dummyLambdaContext)
-      expect(response?.['statusCode']).toEqual(200)
-    })
   })
 })

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -22,6 +22,7 @@ export interface APIGatewayProxyEventV2 {
   version: string
   routeKey: string
   headers: Record<string, string | undefined>
+  multiValueHeaders: undefined
   cookies?: string[]
   rawPath: string
   rawQueryString: string
@@ -63,7 +64,8 @@ export interface APIGatewayProxyEvent {
 // When calling Lambda through an Application Load Balancer
 export interface ALBProxyEvent {
   httpMethod: string
-  headers: Record<string, string | undefined>
+  headers?: Record<string, string | undefined>
+  multiValueHeaders?: Record<string, string[] | undefined>
   path: string
   body: string | null
   isBase64Encoded: boolean
@@ -198,14 +200,15 @@ const createRequest = (event: LambdaEvent) => {
   const domainName =
     event.requestContext && 'domainName' in event.requestContext
       ? event.requestContext.domainName
-      : event.headers['host']
+      : event.headers?.['host']
+      ?? event.multiValueHeaders?.['host']?.[0]
   const path = isProxyEventV2(event) ? event.rawPath : event.path
   const urlPath = `https://${domainName}${path}`
   const url = queryString ? `${urlPath}?${queryString}` : urlPath
 
   const headers = new Headers()
   getCookies(event, headers)
-  for (const [k, v] of Object.entries(event.headers)) {
+  for (const [k, v] of Object.entries(event.headers || {})) {
     if (v) {
       headers.set(k, v)
     }

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -22,7 +22,7 @@ export interface APIGatewayProxyEventV2 {
   version: string
   routeKey: string
   headers: Record<string, string | undefined>
-  multiValueHeaders: undefined
+  multiValueHeaders?: undefined
   cookies?: string[]
   rawPath: string
   rawQueryString: string

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -200,8 +200,7 @@ const createRequest = (event: LambdaEvent) => {
   const domainName =
     event.requestContext && 'domainName' in event.requestContext
       ? event.requestContext.domainName
-      : event.headers?.['host']
-      ?? event.multiValueHeaders?.['host']?.[0]
+      : event.headers?.['host'] ?? event.multiValueHeaders?.['host']?.[0]
   const path = isProxyEventV2(event) ? event.rawPath : event.path
   const urlPath = `https://${domainName}${path}`
   const url = queryString ? `${urlPath}?${queryString}` : urlPath

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -213,6 +213,11 @@ const createRequest = (event: LambdaEvent) => {
       headers.set(k, v)
     }
   }
+  for (const [k, values] of Object.entries(event.multiValueHeaders || {})) {
+    if (values) {
+      values.forEach((v) => headers.append(k, v))
+    }
+  }
 
   const method = isProxyEventV2(event) ? event.requestContext.http.method : event.httpMethod
   const requestInit: RequestInit = {

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -207,14 +207,17 @@ const createRequest = (event: LambdaEvent) => {
 
   const headers = new Headers()
   getCookies(event, headers)
-  for (const [k, v] of Object.entries(event.headers || {})) {
-    if (v) {
-      headers.set(k, v)
+  if (event.headers) {
+    for (const [k, v] of Object.entries(event.headers)) {
+      if (v) {
+        headers.set(k, v)
+      }
     }
-  }
-  for (const [k, values] of Object.entries(event.multiValueHeaders || {})) {
-    if (values) {
-      values.forEach((v) => headers.append(k, v))
+  } else if (event.multiValueHeaders) {
+    for (const [k, values] of Object.entries(event.multiValueHeaders)) {
+      if (values) {
+        values.forEach((v) => headers.append(k, v))
+      }
     }
   }
 

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -213,7 +213,8 @@ const createRequest = (event: LambdaEvent) => {
         headers.set(k, v)
       }
     }
-  } else if (event.multiValueHeaders) {
+  }
+  if (event.multiValueHeaders) {
     for (const [k, values] of Object.entries(event.multiValueHeaders)) {
       if (values) {
         values.forEach((v) => headers.append(k, v))


### PR DESCRIPTION
Fixes https://github.com/honojs/hono/issues/2493
Fixes https://github.com/honojs/hono/issues/2495

## Fixes for #2493
The current implementation assumes `headers` are always defined, which is incorrect 
`headers` can be `undefined` if `multiValueHeaders` exists,, and vice-versa, since`headers` and `multiValueHeaders` are mutually exclusive.

[`aws-lambda` type definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/46eab7d3077fa7939a1b11efc24358c06838df71/types/aws-lambda/trigger/alb.d.ts#L29-L39) in DefinitelyTyped also does so:
 ```typescript
export interface ALBEvent {
    requestContext: ALBEventRequestContext;
    httpMethod: string;
    path: string;
    queryStringParameters?: ALBEventQueryStringParameters | undefined; // URL encoded
    headers?: ALBEventHeaders | undefined;
    multiValueQueryStringParameters?: ALBEventMultiValueQueryStringParameters | undefined; // URL encoded
    multiValueHeaders?: ALBEventMultiValueHeaders | undefined;
    body: string | null;
    isBase64Encoded: boolean;
}
```

## Fixes for #2495

This PR also fixes a conversion from Lambda Event to Request for all event types (ALB, API GW V1/V2).
The current implementation does not extract values from multi-value headers.  
The new impl. extract values and delegates those to Request objects, using [Header#append](https://developer.mozilla.org/en-US/docs/Web/API/Headers/append).

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
