### PR TITLE
feat(rpc): Add status code to response type

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -1,6 +1,7 @@
 import type { UpgradedWebSocketResponseInputJSONType } from '../helper/websocket/index.ts'
 import type { Hono } from '../hono.ts'
-import type { Schema } from '../types.ts'
+import type { Endpoint, Schema } from '../types.ts'
+import type { StatusCode, SuccessStatusCode } from '../utils/http-status.ts'
 import type { HasRequiredKeys } from '../utils/types.ts'
 
 type HonoRequest = (typeof Hono.prototype)['request']
@@ -18,11 +19,11 @@ export type ClientRequestOptions<T = unknown> = keyof T extends never
     }
 
 export type ClientRequest<S extends Schema> = {
-  [M in keyof S]: S[M] extends { input: infer R; output: infer O }
+  [M in keyof S]: S[M] extends Endpoint & { input: infer R }
     ? R extends object
       ? HasRequiredKeys<R> extends true
-        ? (args: R, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
-        : (args?: R, options?: ClientRequestOptions) => Promise<ClientResponse<O>>
+        ? (args: R, options?: ClientRequestOptions) => Promise<ClientResponseOfEndpoint<S[M]>>
+        : (args?: R, options?: ClientRequestOptions) => Promise<ClientResponseOfEndpoint<S[M]>>
       : never
     : never
 } & {
@@ -51,11 +52,22 @@ type BlankRecordToNever<T> = T extends any
     : T
   : never
 
-export interface ClientResponse<T> {
+type ClientResponseOfEndpoint<T extends Endpoint = Endpoint> = T extends {
+  output: infer O
+  status: infer S
+}
+  ? ClientResponse<O, S>
+  : never
+
+export interface ClientResponse<T, U = StatusCode> {
   readonly body: ReadableStream | null
   readonly bodyUsed: boolean
-  ok: boolean
-  status: number
+  ok: U extends SuccessStatusCode
+    ? true
+    : U extends Exclude<StatusCode, SuccessStatusCode>
+    ? false
+    : boolean
+  status: U
   statusText: string
   headers: Headers
   url: string
@@ -73,15 +85,32 @@ export interface Response extends ClientResponse<unknown> {}
 export type Fetch<T> = (
   args?: InferRequestType<T>,
   opt?: ClientRequestOptions
-) => Promise<ClientResponse<InferResponseType<T>>>
+) => Promise<ClientResponseOfEndpoint<InferEndpointType<T>>>
 
-export type InferResponseType<T> = T extends (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any | undefined,
+type InferEndpointType<T> = T extends (
+  args: infer R,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options: any | undefined
-) => Promise<ClientResponse<infer O>>
-  ? O
+) => Promise<infer U>
+  ? U extends ClientResponse<infer O, infer S>
+    ? { input: NonNullable<R>; output: O; status: S } extends Endpoint
+      ? { input: NonNullable<R>; output: O; status: S }
+      : never
+    : never
+  : never
+
+export type InferResponseType<T, U extends StatusCode = StatusCode> = InferResponseTypeFromEndpoint<
+  InferEndpointType<T>,
+  U
+>
+
+type InferResponseTypeFromEndpoint<T extends Endpoint, U extends StatusCode> = T extends {
+  output: infer O
+  status: infer S
+}
+  ? S extends U
+    ? O
+    : never
   : never
 
 export type InferRequestType<T> = T extends (

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -50,9 +50,9 @@ interface TextRespond {
 }
 
 interface JSONRespond {
-  <T>(
+  <T, U extends StatusCode>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    status?: StatusCode,
+    status?: U,
     headers?: HeaderRecord
   ): Response &
     TypedResponse<
@@ -60,15 +60,20 @@ interface JSONRespond {
         ? JSONValue extends InterfaceToType<T>
           ? never
           : JSONParsed<T>
-        : never
+        : never,
+      U
     >
-  <T>(object: InterfaceToType<T> extends JSONValue ? T : JSONValue, init?: ResponseInit): Response &
+  <T, U extends StatusCode>(
+    object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
+    init?: ResponseInit
+  ): Response &
     TypedResponse<
       InterfaceToType<T> extends JSONValue
         ? JSONValue extends InterfaceToType<T>
           ? never
           : JSONParsed<T>
-        : never
+        : never,
+      U
     >
 }
 
@@ -473,9 +478,9 @@ export class Context<
    * ```
    * @see https://hono.dev/api/context#json
    */
-  json: JSONRespond = <T>(
+  json: JSONRespond = <T, U extends StatusCode>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    arg?: StatusCode | ResponseInit,
+    arg?: U | ResponseInit,
     headers?: HeaderRecord
   ): Response &
     TypedResponse<
@@ -483,7 +488,8 @@ export class Context<
         ? JSONValue extends InterfaceToType<T>
           ? never
           : JSONParsed<T>
-        : never
+        : never,
+      U
     > => {
     const body = JSON.stringify(object)
     this.#preparedHeaders ??= {}

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context.ts'
 import type { Hono } from './hono.ts'
+import type { StatusCode } from './utils/http-status.ts'
 import type {
   IfAnyThenEmptyObject,
   Prettify,
@@ -102,7 +103,7 @@ export interface HandlerInterface<
     handler: H<E2, P, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -118,7 +119,7 @@ export interface HandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -134,7 +135,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -152,7 +153,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -170,7 +171,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -190,7 +191,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -210,7 +211,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -237,7 +238,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -259,7 +260,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -289,7 +290,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -320,7 +321,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, P, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -353,7 +354,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -387,7 +388,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -423,7 +424,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -460,7 +461,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, P, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -499,7 +500,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -539,7 +540,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I9['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -581,7 +582,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -624,7 +625,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, P, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I10['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -669,7 +670,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -680,18 +681,18 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any
   >(
     ...handlers: H<E, P, I, R>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.get(path)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
     E,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 }
@@ -924,7 +925,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -944,7 +945,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -966,7 +967,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -995,7 +996,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1027,7 +1028,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1062,7 +1063,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1100,7 +1101,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1141,7 +1142,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1185,7 +1186,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1231,8 +1232,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S &
-      ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponse<HandlerResponse<any>>>,
     BasePath
   >
 
@@ -1241,7 +1241,7 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.get(method[], path, handler)
   <
@@ -1257,7 +1257,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1277,7 +1277,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1299,7 +1299,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1328,7 +1328,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1360,7 +1360,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1395,7 +1395,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1433,7 +1433,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1474,7 +1474,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1522,7 +1522,7 @@ export interface OnHandlerInterface<
         Ms[number],
         MergePath<BasePath, P>,
         I9['in'],
-        MergeTypedResponseData<HandlerResponse<any>>
+        MergeTypedResponse<HandlerResponse<any>>
       >,
     BasePath
   >
@@ -1574,7 +1574,7 @@ export interface OnHandlerInterface<
         Ms[number],
         MergePath<BasePath, P>,
         I10['in'],
-        MergeTypedResponseData<HandlerResponse<any>>
+        MergeTypedResponse<HandlerResponse<any>>
       >,
     BasePath
   >
@@ -1584,18 +1584,14 @@ export interface OnHandlerInterface<
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<
-    E,
-    S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.on(method | method[], path[], ...handlers[])
   <I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     methods: string | string[],
     paths: string[],
     ...handlers: H<E, any, I, R>[]
-  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponse<R>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -1610,24 +1606,35 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = Prettify<{
+export type ToSchema<
+  M extends string,
+  P extends string,
+  I extends Input['in'],
+  R extends TypedResponse
+> = Prettify<{
   [K in P]: {
-    [K2 in M as AddDollar<K2>]: {
-      input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
-      output: unknown extends O ? {} : O
-    }
+    [K2 in M as AddDollar<K2>]: R extends TypedResponse<infer T, infer U>
+      ? {
+          input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
+          output: unknown extends T ? {} : T
+          status: U
+        }
+      : never
   }
 }>
 
 export type Schema = {
   [Path: string]: {
-    [Method: `$${Lowercase<string>}`]: {
-      input: Partial<ValidationTargets> & {
-        param?: Record<string, string>
-      }
-      output: any
-    }
+    [Method: `$${Lowercase<string>}`]: Endpoint
   }
+}
+
+export type Endpoint = {
+  input: Partial<ValidationTargets> & {
+    param?: Record<string, string>
+  }
+  output: any
+  status: StatusCode
 }
 
 type ExtractParams<Path extends string> = string extends Path
@@ -1645,6 +1652,7 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
     [M in keyof OrigSchema[P]]: OrigSchema[P][M] extends {
       input: infer Input
       output: infer Output
+      status: infer Status
     }
       ? {
           input: Input extends { param: infer _ }
@@ -1671,6 +1679,7 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
                 }
               }
           output: Output
+          status: Status
         }
       : never
   }
@@ -1706,18 +1715,19 @@ export type MergePath<A extends string, B extends string> = B extends ''
 //////                            //////
 ////////////////////////////////////////
 
-export type TypedResponse<T = unknown> = {
+export type TypedResponse<T = unknown, U extends StatusCode = StatusCode> = {
   data: T
+  status: U
   format: 'json' // Currently, support only `json` with `c.json()`
 }
 
-type MergeTypedResponseData<T> = T extends Promise<infer T2>
-  ? T2 extends TypedResponse<infer U>
-    ? U
-    : {}
-  : T extends TypedResponse<infer U>
-  ? U
-  : {}
+type MergeTypedResponse<T> = T extends Promise<infer T2>
+  ? T2 extends TypedResponse
+    ? T2
+    : TypedResponse
+  : T extends TypedResponse
+  ? T
+  : TypedResponse
 
 ////////////////////////////////////////
 //////                             /////

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -621,26 +621,42 @@ describe('Response with different status codes', () => {
 
   const client = hc<typeof app>('', { fetch: app.request })
 
-  it('Should be filtered by status code', async () => {
+  it('all', async () => {
+    const res = await client.index.$get()
+    const json = await res.json()
+    expectTypeOf(json).toEqualTypeOf<{ data: string } | { message: string } | null>()
+  })
+
+  it('status 200', async () => {
     const res = await client.index.$get()
     if (res.status === 200) {
       const json = await res.json()
       expectTypeOf(json).toEqualTypeOf<{ data: string } | null>()
     }
+  })
+
+  it('status 400', async () => {
+    const res = await client.index.$get()
     if (res.status === 400) {
       const json = await res.json()
       expectTypeOf(json).toEqualTypeOf<{ message: string } | null>()
     }
+  })
+
+  it('response is ok', async () => {
+    const res = await client.index.$get()
     if (res.ok) {
       const json = await res.json()
       expectTypeOf(json).toEqualTypeOf<{ data: string } | null>()
     }
+  })
+
+  it('response is not ok', async () => {
+    const res = await client.index.$get()
     if (!res.ok) {
       const json = await res.json()
       expectTypeOf(json).toEqualTypeOf<{ message: string } | null>()
     }
-    const json = await res.json()
-    expectTypeOf(json).toEqualTypeOf<{ data: string } | { message: string } | null>()
   })
 })
 

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -606,6 +606,85 @@ describe('ClientResponse<T>.json() returns a Union type correctly', () => {
   })
 })
 
+describe('Response with different status codes', () => {
+  const condition = () => true
+  const app = new Hono().get('/', async (c) => {
+    const ok = condition()
+    if (ok) {
+      return c.json({ data: 'foo' }, 200)
+    }
+    if (!ok) {
+      return c.json({ message: 'error' }, 400)
+    }
+    return c.json(null)
+  })
+
+  const client = hc<typeof app>('', { fetch: app.request })
+
+  it('Should be filtered by status code', async () => {
+    const res = await client.index.$get()
+    if (res.status === 200) {
+      const json = await res.json()
+      expectTypeOf(json).toEqualTypeOf<{ data: string } | null>()
+    }
+    if (res.status === 400) {
+      const json = await res.json()
+      expectTypeOf(json).toEqualTypeOf<{ message: string } | null>()
+    }
+    if (res.ok) {
+      const json = await res.json()
+      expectTypeOf(json).toEqualTypeOf<{ data: string } | null>()
+    }
+    if (!res.ok) {
+      const json = await res.json()
+      expectTypeOf(json).toEqualTypeOf<{ message: string } | null>()
+    }
+    const json = await res.json()
+    expectTypeOf(json).toEqualTypeOf<{ data: string } | { message: string } | null>()
+  })
+})
+
+describe('Infer the response type with different status codes', () => {
+  const condition = () => true
+  const app = new Hono().get('/', async (c) => {
+    const ok = condition()
+    if (ok) {
+      return c.json({ data: 'foo' }, 200)
+    }
+    if (!ok) {
+      return c.json({ message: 'error' }, 400)
+    }
+    return c.json(null)
+  })
+
+  const client = hc<typeof app>('', { fetch: app.request })
+
+  it('Should infer response type correctly', () => {
+    const req = client.index.$get
+
+    type Actual = InferResponseType<typeof req>
+    type Expected =
+      | {
+          data: string
+        }
+      | {
+          message: string
+        }
+      | null
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer response type of status 200 correctly', () => {
+    const req = client.index.$get
+
+    type Actual = InferResponseType<typeof req, 200>
+    type Expected = {
+      data: string
+    } | null
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+})
+
 describe('$url() with a param option', () => {
   const app = new Hono().get('/posts/:id/comments', (c) => c.json({ ok: true }))
   type AppType = typeof app

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -5,5 +5,5 @@ export type {
   Fetch,
   ClientRequestOptions,
   ClientRequest,
-  ClientResponse,
+  EndpointResponse as ClientResponse,
 } from './types'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -5,5 +5,5 @@ export type {
   Fetch,
   ClientRequestOptions,
   ClientRequest,
-  EndpointResponse as ClientResponse,
+  ClientResponse,
 } from './types'

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -99,15 +99,12 @@ type InferEndpointType<T> = T extends (
     : never
   : never
 
-export type InferResponseType<T, U extends StatusCode> = InferResponseTypeFromEndpoint<
+export type InferResponseType<T, U extends StatusCode = StatusCode> = InferResponseTypeFromEndpoint<
   InferEndpointType<T>,
   U
 >
 
-type InferResponseTypeFromEndpoint<
-  T extends Endpoint,
-  U extends StatusCode = StatusCode
-> = T extends {
+type InferResponseTypeFromEndpoint<T extends Endpoint, U extends StatusCode> = T extends {
   output: infer O
   status: infer S
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,12 +1,5 @@
 import type { HonoRequest } from './request'
-import type {
-  Env,
-  FetchEventLike,
-  NotFoundHandler,
-  Input,
-  TypedResponse,
-  TypedResponseInit,
-} from './types'
+import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types'
 import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
 import type { JSONValue, InterfaceToType, JSONParsed, IsAny } from './utils/types'
@@ -72,7 +65,7 @@ interface JSONRespond {
     >
   <T, U extends StatusCode>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    init?: ResponseInit & TypedResponseInit<U>
+    init?: ResponseInit
   ): Response &
     TypedResponse<
       InterfaceToType<T> extends JSONValue
@@ -487,7 +480,7 @@ export class Context<
    */
   json: JSONRespond = <T, U extends StatusCode>(
     object: InterfaceToType<T> extends JSONValue ? T : JSONValue,
-    arg?: U | (ResponseInit & TypedResponseInit<U>),
+    arg?: U | ResponseInit,
     headers?: HeaderRecord
   ): Response &
     TypedResponse<

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -2,7 +2,8 @@ import { expectTypeOf } from 'vitest'
 import { hc } from '../../client'
 import type { ClientRequest } from '../../client/types'
 import { Hono } from '../../index'
-import type { ToSchema } from '../../types'
+import type { ToSchema, TypedResponse } from '../../types'
+import type { StatusCode } from '../../utils/http-status'
 import { validator } from '../../validator'
 import { createMiddleware, createFactory } from './index'
 
@@ -77,6 +78,7 @@ describe('createHandler', () => {
           $get: {
             input: {}
             output: {}
+            status: StatusCode
           }
         }>
       }>()
@@ -113,10 +115,10 @@ describe('createHandler', () => {
             page: string
           }
         },
-        {
+        TypedResponse<{
           page: string
           foo: string
-        }
+        }>
       >,
       '/'
     >
@@ -179,12 +181,12 @@ describe('createHandler', () => {
             id: number
           }
         },
-        {
+        TypedResponse<{
           auth: string
           page: string
           foo: string
           id: number
-        }
+        }>
       >,
       '/'
     >

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2113,10 +2113,10 @@ describe('Parse Body', () => {
   const app = new Hono()
 
   app.post('/json', async (c) => {
-    return c.json<{}>(await c.req.parseBody(), 200)
+    return c.json<{}, 200>(await c.req.parseBody(), 200)
   })
   app.post('/form', async (c) => {
-    return c.json<{}>(await c.req.parseBody(), 200)
+    return c.json<{}, 200>(await c.req.parseBody(), 200)
   })
 
   it('POST with JSON', async () => {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -393,22 +393,19 @@ describe('Test types of Handler', () => {
 
 describe('`json()`', () => {
   const app = new Hono<{ Variables: { foo: string } }>()
-
   app.get('/post/:id', (c) => {
     c.req.param('id')
     const id = c.req.param('id')
     return c.text('foo')
   })
 
-  const route = app.get('/hello', (c) => {
-    return c.json({
-      message: 'Hello!',
-    })
-  })
-
   test('json', () => {
+    const route = app.get('/hello', (c) => {
+      return c.json({
+        message: 'Hello!',
+      })
+    })
     type Actual = ExtractSchema<typeof route>
-
     type Expected = {
       '/hello': {
         $get: {
@@ -420,7 +417,30 @@ describe('`json()`', () => {
         }
       }
     }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
 
+  test('json with specific status code', () => {
+    const route = app.get('/hello', (c) => {
+      return c.json(
+        {
+          message: 'Hello!',
+        },
+        200
+      )
+    })
+    type Actual = ExtractSchema<typeof route>
+    type Expected = {
+      '/hello': {
+        $get: {
+          input: {}
+          output: {
+            message: string
+          }
+          status: 200
+        }
+      }
+    }
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
@@ -738,6 +758,7 @@ describe('MergeSchemaPath', () => {
 describe('Different types using json()', () => {
   describe('no path pattern', () => {
     const app = new Hono()
+
     test('Three different types', () => {
       const route = app.get((c) => {
         const flag = false
@@ -784,10 +805,64 @@ describe('Different types using json()', () => {
       }
       type verify = Expect<Equal<Expected, Actual>>
     })
+
+    test('Three different types and status codes', () => {
+      const route = app.get((c) => {
+        const flag = false
+        if (flag) {
+          return c.json(
+            {
+              ng: true,
+            },
+            400
+          )
+        }
+        if (!flag) {
+          return c.json(
+            {
+              ok: true,
+            },
+            200
+          )
+        }
+        return c.json({
+          default: true,
+        })
+      })
+      type Actual = ExtractSchema<typeof route>
+      type Expected = {
+        '/': {
+          $get:
+            | {
+                input: {}
+                output: {
+                  ng: boolean
+                }
+                status: 400
+              }
+            | {
+                input: {}
+                output: {
+                  ok: boolean
+                }
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  default: boolean
+                }
+                status: StatusCode
+              }
+        }
+      }
+      type verify = Expect<Equal<Expected, Actual>>
+    })
   })
 
   describe('path pattern', () => {
     const app = new Hono()
+
     test('Three different types', () => {
       const route = app.get('/foo', (c) => {
         const flag = false
@@ -834,12 +909,66 @@ describe('Different types using json()', () => {
       }
       type verify = Expect<Equal<Expected, Actual>>
     })
+
+    test('Three different types and status codes', () => {
+      const route = app.get('/foo', (c) => {
+        const flag = false
+        if (flag) {
+          return c.json(
+            {
+              ng: true,
+            },
+            400
+          )
+        }
+        if (!flag) {
+          return c.json(
+            {
+              ok: true,
+            },
+            200
+          )
+        }
+        return c.json({
+          default: true,
+        })
+      })
+      type Actual = ExtractSchema<typeof route>
+      type Expected = {
+        '/foo': {
+          $get:
+            | {
+                input: {}
+                output: {
+                  ng: boolean
+                }
+                status: 400
+              }
+            | {
+                input: {}
+                output: {
+                  ok: boolean
+                }
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  default: boolean
+                }
+                status: StatusCode
+              }
+        }
+      }
+      type verify = Expect<Equal<Expected, Actual>>
+    })
   })
 })
 
 describe('json() in an async handler', () => {
   const app = new Hono()
-  test('Three different types', () => {
+
+  test('json', () => {
     const route = app.get(async (c) => {
       return c.json({
         ok: true,
@@ -854,6 +983,30 @@ describe('json() in an async handler', () => {
             ok: boolean
           }
           status: StatusCode
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  test('json with specific status code', () => {
+    const route = app.get(async (c) => {
+      return c.json(
+        {
+          ok: true,
+        },
+        200
+      )
+    })
+    type Actual = ExtractSchema<typeof route>
+    type Expected = {
+      '/': {
+        $get: {
+          input: {}
+          output: {
+            ok: boolean
+          }
+          status: 200
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1652,6 +1652,7 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
     [M in keyof OrigSchema[P]]: OrigSchema[P][M] extends {
       input: infer Input
       output: infer Output
+      status: infer Status
     }
       ? {
           input: Input extends { param: infer _ }
@@ -1678,6 +1679,7 @@ export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> =
                 }
               }
           output: Output
+          status: Status
         }
       : never
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Context } from './context'
 import type { Hono } from './hono'
+import type { StatusCode } from './utils/http-status'
 import type {
   IfAnyThenEmptyObject,
   Prettify,
@@ -102,7 +103,7 @@ export interface HandlerInterface<
     handler: H<E2, P, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -118,7 +119,7 @@ export interface HandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -134,7 +135,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -152,7 +153,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -170,7 +171,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -190,7 +191,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -210,7 +211,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -237,7 +238,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -259,7 +260,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -289,7 +290,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -320,7 +321,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, P, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -353,7 +354,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -387,7 +388,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -423,7 +424,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -460,7 +461,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, P, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -499,7 +500,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -539,7 +540,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I9['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -581,7 +582,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -624,7 +625,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, P, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I10['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -669,7 +670,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -680,18 +681,18 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any
   >(
     ...handlers: H<E, P, I, R>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.get(path)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
     E,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 }
@@ -924,7 +925,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -944,7 +945,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -966,7 +967,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -995,7 +996,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1027,7 +1028,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1062,7 +1063,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1100,7 +1101,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1141,7 +1142,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1185,7 +1186,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1231,8 +1232,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S &
-      ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponse<HandlerResponse<any>>>,
     BasePath
   >
 
@@ -1241,7 +1241,7 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.get(method[], path, handler)
   <
@@ -1257,7 +1257,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1277,7 +1277,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1299,7 +1299,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1328,7 +1328,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1360,7 +1360,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1395,7 +1395,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1433,7 +1433,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1474,7 +1474,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8['in'], MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1522,7 +1522,7 @@ export interface OnHandlerInterface<
         Ms[number],
         MergePath<BasePath, P>,
         I9['in'],
-        MergeTypedResponseData<HandlerResponse<any>>
+        MergeTypedResponse<HandlerResponse<any>>
       >,
     BasePath
   >
@@ -1574,7 +1574,7 @@ export interface OnHandlerInterface<
         Ms[number],
         MergePath<BasePath, P>,
         I10['in'],
-        MergeTypedResponseData<HandlerResponse<any>>
+        MergeTypedResponse<HandlerResponse<any>>
       >,
     BasePath
   >
@@ -1584,18 +1584,14 @@ export interface OnHandlerInterface<
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<
-    E,
-    S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponse<R>>, BasePath>
 
   // app.on(method | method[], path[], ...handlers[])
   <I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     methods: string | string[],
     paths: string[],
     ...handlers: H<E, any, I, R>[]
-  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponse<R>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -1610,24 +1606,35 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = Prettify<{
+export type ToSchema<
+  M extends string,
+  P extends string,
+  I extends Input['in'],
+  R extends TypedResponse
+> = Prettify<{
   [K in P]: {
-    [K2 in M as AddDollar<K2>]: {
-      input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
-      output: unknown extends O ? {} : O
-    }
+    [K2 in M as AddDollar<K2>]: R extends TypedResponse<infer T, infer U>
+      ? {
+          input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
+          output: unknown extends T ? {} : T
+          status: U
+        }
+      : never
   }
 }>
 
 export type Schema = {
   [Path: string]: {
-    [Method: `$${Lowercase<string>}`]: {
-      input: Partial<ValidationTargets> & {
-        param?: Record<string, string>
-      }
-      output: any
-    }
+    [Method: `$${Lowercase<string>}`]: Endpoint
   }
+}
+
+export type Endpoint = {
+  input: Partial<ValidationTargets> & {
+    param?: Record<string, string>
+  }
+  output: any
+  status: StatusCode
 }
 
 type ExtractParams<Path extends string> = string extends Path
@@ -1706,18 +1713,23 @@ export type MergePath<A extends string, B extends string> = B extends ''
 //////                            //////
 ////////////////////////////////////////
 
-export type TypedResponse<T = unknown> = {
+export type TypedResponseInit<T extends StatusCode> = {
+  status?: T
+}
+
+export type TypedResponse<T = unknown, U extends StatusCode = StatusCode> = {
   data: T
+  status: U
   format: 'json' // Currently, support only `json` with `c.json()`
 }
 
-type MergeTypedResponseData<T> = T extends Promise<infer T2>
-  ? T2 extends TypedResponse<infer U>
-    ? U
-    : {}
-  : T extends TypedResponse<infer U>
-  ? U
-  : {}
+type MergeTypedResponse<T> = T extends Promise<infer T2>
+  ? T2 extends TypedResponse
+    ? T2
+    : TypedResponse
+  : T extends TypedResponse
+  ? T
+  : TypedResponse
 
 ////////////////////////////////////////
 //////                             /////

--- a/src/types.ts
+++ b/src/types.ts
@@ -1715,10 +1715,6 @@ export type MergePath<A extends string, B extends string> = B extends ''
 //////                            //////
 ////////////////////////////////////////
 
-export type TypedResponseInit<T extends StatusCode> = {
-  status?: T
-}
-
 export type TypedResponse<T = unknown, U extends StatusCode = StatusCode> = {
   data: T
   status: U

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -935,6 +935,7 @@ describe('Validator with using Zod directly', () => {
           output: {
             message: string
           }
+          status: 201
         }
       }
     }>()

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { Hono } from '../hono'
 import { HTTPException } from '../http-exception'
 import type { ErrorHandler, ExtractSchema, MiddlewareHandler, ValidationTargets } from '../types'
+import type { StatusCode } from '../utils/http-status'
 import type { Equal, Expect } from '../utils/types'
 import type { ValidationFunction } from './validator'
 import { validator } from './validator'
@@ -57,6 +58,7 @@ describe('Validator middleware', () => {
           query: undefined
         }
         output: {}
+        status: StatusCode
       }
     }
   }
@@ -287,6 +289,7 @@ describe('Validator middleware with a custom validation function', () => {
             id: number
           }
         }
+        status: StatusCode
       }
     }
   }
@@ -348,6 +351,7 @@ describe('Validator middleware with Zod validates JSON', () => {
             title: string
           }
         }
+        status: StatusCode
       }
     }
   }
@@ -635,6 +639,7 @@ describe('Validator middleware with Zod multiple validators', () => {
           page: number
           title: string
         }
+        status: StatusCode
       }
     }
   }
@@ -692,6 +697,7 @@ it('With path parameters', () => {
           }
         }
         output: {}
+        status: StatusCode
       }
     }
   }
@@ -738,6 +744,7 @@ it('`on`', () => {
         output: {
           success: boolean
         }
+        status: StatusCode
       }
     }
   }
@@ -944,6 +951,7 @@ describe('Transform', () => {
           output: {
             page: number
           }
+          status: StatusCode
         }
       }
     }


### PR DESCRIPTION
This PR adds a status code to the response type and allows type filtering in RPC as below.

server.ts
```ts
const app = new Hono().get(
  "/posts/:id",
  zValidator(
    "param",
    z.object({
      id: z.string(),
    })
  ),
  async (c) => {
    const { id } = c.req.valid("param");

    try {
      const post: Post | undefined = await getPost(id);

      if (post !== undefined) {
        return c.json({ post }, 200);
      }

      return c.json({ error: "not found" }, 404);
    } catch (e) {
      return c.json({ error: "internal server error" }, 500);
    }
  }
);

export type AppType = typeof app;
```

client.ts
```ts
const client = hc<AppType>("/api");

const res = await client.posts[":id"].$get({
  param: { id: "1" },
});

if (res.status === 404) {
  const data: { error: string } = await res.json();
  console.log(data.error);
}

if (res.ok) {
  const data: { post: Post } = await res.json();
  console.log(data.post);
}

// { post: Post } | { error: string }
type ResponseType = InferResponseType<(typeof client.posts)[":id"]["$get"]>;

// { post: Post }
type ResponseType200 = InferResponseType<(typeof client.posts)[":id"]["$get"], 200>;
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
