### PR TITLE
fix(validator): Default use to `OutputTypeExcludeResponseType` when `InputType` is unknown

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -34,14 +34,18 @@ export const validator = <
   V extends {
     in: {
       [K in U]: K extends 'json'
-        ? InputType
+        ? unknown extends InputType
+          ? OutputTypeExcludeResponseType
+          : InputType
         : { [K2 in keyof OutputTypeExcludeResponseType]: ValidationTargets[K][K2] }
     }
     out: { [K in U]: OutputTypeExcludeResponseType }
   } = {
     in: {
       [K in U]: K extends 'json'
-        ? InputType
+        ? unknown extends InputType
+          ? OutputTypeExcludeResponseType
+          : InputType
         : { [K2 in keyof OutputTypeExcludeResponseType]: ValidationTargets[K][K2] }
     }
     out: { [K in U]: OutputTypeExcludeResponseType }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -894,7 +894,7 @@ describe('Validator with using Zod directly', () => {
     })
     const app = new Hono()
 
-    app.post(
+    const route = app.post(
       '/posts',
       validator('json', (value, c) => {
         const parsed = testSchema.safeParse(value)
@@ -914,6 +914,23 @@ describe('Validator with using Zod directly', () => {
         )
       }
     )
+
+    expectTypeOf<ExtractSchema<typeof route>>().toEqualTypeOf<{
+      '/posts': {
+        $post: {
+          input: {
+            json: {
+              type: 'a'
+              name: string
+              age: number
+            }
+          }
+          output: {
+            message: string
+          }
+        }
+      }
+    }>()
   })
 })
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -34,14 +34,18 @@ export const validator = <
   V extends {
     in: {
       [K in U]: K extends 'json'
-        ? InputType
+        ? unknown extends InputType
+          ? OutputTypeExcludeResponseType
+          : InputType
         : { [K2 in keyof OutputTypeExcludeResponseType]: ValidationTargets[K][K2] }
     }
     out: { [K in U]: OutputTypeExcludeResponseType }
   } = {
     in: {
       [K in U]: K extends 'json'
-        ? InputType
+        ? unknown extends InputType
+          ? OutputTypeExcludeResponseType
+          : InputType
         : { [K2 in keyof OutputTypeExcludeResponseType]: ValidationTargets[K][K2] }
     }
     out: { [K in U]: OutputTypeExcludeResponseType }


### PR DESCRIPTION
This PR fixed an issue where the type was not shared properly on the Hono Client side when `json` was specified for the `validator` function.

### Changes

- Default use to `OutputTypeExcludeResponseType` when `InputType` is unknown

### Example Scenario and Code Snippet

```ts
const app = new Hono()

const route = app.post(
  '/foo',
  validator('json', () => {
    return {} as {
      id: number
      title: string
    }
  }),
  (c) => {
    return c.json({})
  }
)

type AppType = typeof route
const client = hc<AppType>('http://localhost')

client.foo.$post({
  // Previously, this would result in `unknown` instead of `{ id: number; title: string; }`
  json: {
    id: 1,
    title: 'title'
  }
})
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
