### PR TITLE
refactor(trie-router): parentPatterns is updated but never queried

### DIFF
--- a/deno_dist/router/trie-router/node.ts
+++ b/deno_dist/router/trie-router/node.ts
@@ -44,13 +44,11 @@ export class Node<T> {
     const parts = splitRoutingPath(path)
 
     const possibleKeys: string[] = []
-    const parentPatterns: Pattern[] = []
 
     for (let i = 0, len = parts.length; i < len; i++) {
       const p: string = parts[i]
 
       if (Object.keys(curNode.children).includes(p)) {
-        parentPatterns.push(...curNode.patterns)
         curNode = curNode.children[p]
         const pattern = getPattern(p)
         if (pattern) {
@@ -64,10 +62,8 @@ export class Node<T> {
       const pattern = getPattern(p)
       if (pattern) {
         curNode.patterns.push(pattern)
-        parentPatterns.push(...curNode.patterns)
         possibleKeys.push(pattern[1])
       }
-      parentPatterns.push(...curNode.patterns)
       curNode = curNode.children[p]
     }
 

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -44,13 +44,11 @@ export class Node<T> {
     const parts = splitRoutingPath(path)
 
     const possibleKeys: string[] = []
-    const parentPatterns: Pattern[] = []
 
     for (let i = 0, len = parts.length; i < len; i++) {
       const p: string = parts[i]
 
       if (Object.keys(curNode.children).includes(p)) {
-        parentPatterns.push(...curNode.patterns)
         curNode = curNode.children[p]
         const pattern = getPattern(p)
         if (pattern) {
@@ -64,10 +62,8 @@ export class Node<T> {
       const pattern = getPattern(p)
       if (pattern) {
         curNode.patterns.push(pattern)
-        parentPatterns.push(...curNode.patterns)
         possibleKeys.push(pattern[1])
       }
-      parentPatterns.push(...curNode.patterns)
       curNode = curNode.children[p]
     }
 


### PR DESCRIPTION
It appears that `parentPatterns` is updated but its content is never referenced.


### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
