### PR TITLE
refactor(cloudflare-workers): Suppress eslint noise

### DIFF
--- a/src/adapter/cloudflare-workers/websocket.test.ts
+++ b/src/adapter/cloudflare-workers/websocket.test.ts
@@ -20,6 +20,7 @@ describe('upgradeWebSocket middleware', () => {
     app.get(
       '/ws',
       upgradeWebSocket(() => ({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onMessage(evt, ws) {
           console.log('evt')
           resolve(evt.data)


### PR DESCRIPTION
As a contributor, it is annoying to see unaddressed warnings on `pnpm lint`.


```
/Users/exoego/IdeaProjects/hono/src/adapter/cloudflare-workers/websocket.test.ts
  23:24  warning  'ws' is defined but never used  @typescript-eslint/no-unused-vars

✖ 1 problem (0 errors, 1 warning)
```



### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
