### PR TITLE
feat: expose serve-static builder

### DIFF
--- a/deno_dist/adapter/deno/serve-static.ts
+++ b/deno_dist/adapter/deno/serve-static.ts
@@ -18,7 +18,7 @@ export const serveStatic = <E extends Env = Env>(
       } catch (e) {
         console.warn(`${e}`)
       }
-      return file ? file.readable : undefined
+      return file ? file.readable : null
     }
     const pathResolve = (path: string) => {
       return `./${path}`

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -5,7 +5,7 @@ import type { RedirectStatusCode, StatusCode } from './utils/http-status.ts'
 import type { JSONValue, InterfaceToType, JSONParsed, IsAny } from './utils/types.ts'
 
 type HeaderRecord = Record<string, string | string[]>
-type Data = string | ArrayBuffer | ReadableStream
+export type Data = string | ArrayBuffer | ReadableStream
 
 export interface ExecutionContext {
   waitUntil(promise: Promise<unknown>): void

--- a/deno_dist/middleware/serve-static/index.ts
+++ b/deno_dist/middleware/serve-static/index.ts
@@ -19,7 +19,6 @@ const defaultPathResolve = (path: string) => path
  */
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getContent: (path: string, c: Context<E>) => Promise<Data | Response | null>
     pathResolve?: (path: string) => string
   }

--- a/deno_dist/middleware/serve-static/index.ts
+++ b/deno_dist/middleware/serve-static/index.ts
@@ -20,7 +20,7 @@ const defaultPathResolve = (path: string) => path
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getContent: (path: string) => any
+    getContent: (path: string, c: Context<E>) => any
     pathResolve?: (path: string) => string
   }
 ): MiddlewareHandler => {
@@ -49,7 +49,7 @@ export const serveStatic = <E extends Env = Env>(
     const pathResolve = options.pathResolve ?? defaultPathResolve
 
     path = pathResolve(path)
-    let content = await getContent(path)
+    let content = await getContent(path, c)
 
     if (!content) {
       let pathWithOutDefaultDocument = getFilePathWithoutDefaultDocument({
@@ -60,7 +60,7 @@ export const serveStatic = <E extends Env = Env>(
         return await next()
       }
       pathWithOutDefaultDocument = pathResolve(pathWithOutDefaultDocument)
-      content = await getContent(pathWithOutDefaultDocument)
+      content = await getContent(pathWithOutDefaultDocument, c)
       if (content) {
         path = pathWithOutDefaultDocument
       }

--- a/deno_dist/middleware/serve-static/index.ts
+++ b/deno_dist/middleware/serve-static/index.ts
@@ -66,6 +66,10 @@ export const serveStatic = <E extends Env = Env>(
       }
     }
 
+    if (content instanceof Response) {
+      return c.newResponse(content.body, content)
+    }
+
     if (content) {
       let mimeType: string | undefined
       if (options.mimes) {
@@ -76,11 +80,7 @@ export const serveStatic = <E extends Env = Env>(
       if (mimeType) {
         c.header('Content-Type', mimeType)
       }
-      if (content instanceof Response) {
-        return c.newResponse(content.body, content)
-      } else {
-        return c.body(content)
-      }
+      return c.body(content)
     }
 
     await options.onNotFound?.(path, c)

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
       "import": "./dist/helper/factory/index.js",
       "require": "./dist/cjs/helper/factory/index.js"
     },
-    "./base-serve-static": {
+    "./serve-static": {
       "types": "./dist/types/middleware/serve-static/index.d.ts",
       "import": "./dist/middleware/serve-static/index.js",
       "require": "./dist/cjs/middleware/serve-static/index.js"
@@ -480,7 +480,7 @@
       "factory": [
         "./dist/types/helper/factory/index.d.ts"
       ],
-      "base-serve-static": [
+      "serve-static": [
         "./dist/types/middleware/serve-static"
       ],
       "cloudflare-workers": [

--- a/package.json
+++ b/package.json
@@ -280,9 +280,9 @@
       "require": "./dist/cjs/helper/factory/index.js"
     },
     "./base-serve-static": {
-      "types": "./dist/types/middlware/serve-static/index.d.ts",
-      "import": "./dist/middlware/serve-static/index.js",
-      "require": "./dist/cjs/middlware/serve-static/index.js"
+      "types": "./dist/types/middleware/serve-static/index.d.ts",
+      "import": "./dist/middleware/serve-static/index.js",
+      "require": "./dist/cjs/middleware/serve-static/index.js"
     },
     "./cloudflare-workers": {
       "types": "./dist/types/adapter/cloudflare-workers/index.d.ts",
@@ -481,7 +481,7 @@
         "./dist/types/helper/factory/index.d.ts"
       ],
       "base-serve-static": [
-        "./dist/types/middlware/serve-static"
+        "./dist/types/middleware/serve-static"
       ],
       "cloudflare-workers": [
         "./dist/types/adapter/cloudflare-workers"

--- a/package.json
+++ b/package.json
@@ -279,6 +279,11 @@
       "import": "./dist/helper/factory/index.js",
       "require": "./dist/cjs/helper/factory/index.js"
     },
+    "./base-serve-static": {
+      "types": "./dist/types/middlware/serve-static/index.d.ts",
+      "import": "./dist/middlware/serve-static/index.js",
+      "require": "./dist/cjs/middlware/serve-static/index.js"
+    },
     "./cloudflare-workers": {
       "types": "./dist/types/adapter/cloudflare-workers/index.d.ts",
       "import": "./dist/adapter/cloudflare-workers/index.js",
@@ -474,6 +479,9 @@
       ],
       "factory": [
         "./dist/types/helper/factory/index.d.ts"
+      ],
+      "base-serve-static": [
+        "./dist/types/middlware/serve-static"
       ],
       "cloudflare-workers": [
         "./dist/types/adapter/cloudflare-workers"

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -18,7 +18,7 @@ export const serveStatic = <E extends Env = Env>(
       } catch (e) {
         console.warn(`${e}`)
       }
-      return file ? file.readable : undefined
+      return file ? file.readable : null
     }
     const pathResolve = (path: string) => {
       return `./${path}`

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,7 +5,7 @@ import type { RedirectStatusCode, StatusCode } from './utils/http-status'
 import type { JSONValue, InterfaceToType, JSONParsed, IsAny } from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
-type Data = string | ArrayBuffer | ReadableStream
+export type Data = string | ArrayBuffer | ReadableStream
 
 export interface ExecutionContext {
   waitUntil(promise: Promise<unknown>): void

--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -7,9 +7,9 @@ describe('Serve Static Middleware', () => {
 
   const serveStatic = createMiddleware(async (c, next) => {
     const mw = baseServeStatic({
-      getContent: (path) => {
+      getContent: async (path) => {
         if (path.endsWith('not-found.txt')) {
-          return undefined
+          return null
         }
         return `Hello in ${path}`
       },

--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -1,23 +1,19 @@
-import { createMiddleware } from '../../helper'
 import { Hono } from '../../hono'
 import { serveStatic as baseServeStatic } from '.'
 
 describe('Serve Static Middleware', () => {
   const app = new Hono()
 
-  const serveStatic = createMiddleware(async (c, next) => {
-    const mw = baseServeStatic({
-      getContent: async (path) => {
-        if (path.endsWith('not-found.txt')) {
-          return null
-        }
-        return `Hello in ${path}`
-      },
-      pathResolve: (path) => {
-        return `./${path}`
-      },
-    })
-    return await mw(c, next)
+  const serveStatic = baseServeStatic({
+    getContent: async (path) => {
+      if (path.endsWith('not-found.txt')) {
+        return null
+      }
+      return `Hello in ${path}`
+    },
+    pathResolve: (path) => {
+      return `./${path}`
+    },
   })
 
   app.get('/static/*', serveStatic)
@@ -55,5 +51,25 @@ describe('Serve Static Middleware', () => {
     } as Request)
     expect(res.status).toBe(404)
     expect(await res.text()).toBe('404 Not Found')
+  })
+
+  it('Should return response object content as-is', async () => {
+    const body = new ReadableStream()
+    const response = new Response(body)
+    const app = new Hono().use(
+      '*',
+      baseServeStatic({
+        getContent: async () => {
+          return response
+        },
+      })
+    )
+
+    const res = await app.fetch({
+      method: 'GET',
+      url: 'http://localhost',
+    } as Request)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe(body)
   })
 })

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -1,4 +1,4 @@
-import type { Context } from '../../context'
+import type { Context, Data } from '../../context'
 import type { Env, MiddlewareHandler } from '../../types'
 import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath'
 import { getMimeType } from '../../utils/mime'
@@ -20,7 +20,7 @@ const defaultPathResolve = (path: string) => path
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getContent: (path: string, c: Context<E>) => any
+    getContent: (path: string, c: Context<E>) => Promise<Data | Response | null>
     pathResolve?: (path: string) => string
   }
 ): MiddlewareHandler => {
@@ -76,7 +76,11 @@ export const serveStatic = <E extends Env = Env>(
       if (mimeType) {
         c.header('Content-Type', mimeType)
       }
-      return c.body(content)
+      if (content instanceof Response) {
+        return c.newResponse(content.body, content)
+      } else {
+        return c.body(content)
+      }
     }
 
     await options.onNotFound?.(path, c)

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -19,7 +19,6 @@ const defaultPathResolve = (path: string) => path
  */
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getContent: (path: string, c: Context<E>) => Promise<Data | Response | null>
     pathResolve?: (path: string) => string
   }

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -20,7 +20,7 @@ const defaultPathResolve = (path: string) => path
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getContent: (path: string) => any
+    getContent: (path: string, c: Context<E>) => any
     pathResolve?: (path: string) => string
   }
 ): MiddlewareHandler => {
@@ -49,7 +49,7 @@ export const serveStatic = <E extends Env = Env>(
     const pathResolve = options.pathResolve ?? defaultPathResolve
 
     path = pathResolve(path)
-    let content = await getContent(path)
+    let content = await getContent(path, c)
 
     if (!content) {
       let pathWithOutDefaultDocument = getFilePathWithoutDefaultDocument({
@@ -60,7 +60,7 @@ export const serveStatic = <E extends Env = Env>(
         return await next()
       }
       pathWithOutDefaultDocument = pathResolve(pathWithOutDefaultDocument)
-      content = await getContent(pathWithOutDefaultDocument)
+      content = await getContent(pathWithOutDefaultDocument, c)
       if (content) {
         path = pathWithOutDefaultDocument
       }

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -66,6 +66,10 @@ export const serveStatic = <E extends Env = Env>(
       }
     }
 
+    if (content instanceof Response) {
+      return c.newResponse(content.body, content)
+    }
+
     if (content) {
       let mimeType: string | undefined
       if (options.mimes) {
@@ -76,11 +80,7 @@ export const serveStatic = <E extends Env = Env>(
       if (mimeType) {
         c.header('Content-Type', mimeType)
       }
-      if (content instanceof Response) {
-        return c.newResponse(content.body, content)
-      } else {
-        return c.body(content)
-      }
+      return c.body(content)
     }
 
     await options.onNotFound?.(path, c)


### PR DESCRIPTION
This allows accessing `middleware/serve-static` from third-party

### Use case

I run my own handler based on Cloudflare R2 to avoid the limitations of Cloudflare KV / Pages. And I found that most of the code I needed there was already built into hono.

So what I expect is like:

```ts
import { Hono } from 'hono';
import { serveStatic as makeServe } from 'hono/base-serve-static';

const app = new Hono<Env>();

const serveContent = makeServe<Env>({
  getContent: async (path, c) => {
    // retrieve
    let response = await cache.match(c.req.raw);

    // ...get R2 object
    if (!response) {
      let obj = await c.env.CONTENT.get(path);
      if (obj) {
        response = obj.body;
        c.executionCtx.waitUntil(cache.put(c.req.raw, obj.body));
      }
    }

    c.body(response);
  },
});

app.use(serveContent);

export default app;
```

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
