### PR TITLE
feat: expose built-in MIME types

### DIFF
--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -19,7 +19,7 @@ export const getExtension = (mimeType: string): string | undefined => {
   }
 }
 
-const baseMimes: Record<string, string> = {
+export const baseMimes: Record<string, string> = {
   aac: 'audio/aac',
   avi: 'video/x-msvideo',
   avif: 'image/avif',

--- a/deno_dist/utils/mime.ts
+++ b/deno_dist/utils/mime.ts
@@ -19,7 +19,8 @@ export const getExtension = (mimeType: string): string | undefined => {
   }
 }
 
-export const baseMimes: Record<string, string> = {
+export { baseMimes as mimes }
+const baseMimes: Record<string, string> = {
   aac: 'audio/aac',
   avi: 'video/x-msvideo',
   avif: 'image/avif',

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -19,7 +19,7 @@ export const getExtension = (mimeType: string): string | undefined => {
   }
 }
 
-const baseMimes: Record<string, string> = {
+export const baseMimes: Record<string, string> = {
   aac: 'audio/aac',
   avi: 'video/x-msvideo',
   avif: 'image/avif',

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -19,7 +19,8 @@ export const getExtension = (mimeType: string): string | undefined => {
   }
 }
 
-export const baseMimes: Record<string, string> = {
+export { baseMimes as mimes }
+const baseMimes: Record<string, string> = {
   aac: 'audio/aac',
   avi: 'video/x-msvideo',
   avif: 'image/avif',


### PR DESCRIPTION
This allows users reuse builtin MIME types while adding some custom.

```js
import { baseMimes, getMimeType } from 'hono/utils/mime';

const mimes = {
  ...baseMimes,
  'my-own-ext': 'text/plain',
};

getMimeType('base.my-own-ext', mimes)
```

### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `yarn denoify` to generate files for Deno
