### PR TITLE
fix(client): shuold not remove tailing slash from top-level URL

### DIFF
--- a/deno_dist/client/utils.ts
+++ b/deno_dist/client/utils.ts
@@ -25,6 +25,9 @@ export const replaceUrlProtocol = (urlString: string, protocol: 'ws' | 'http') =
 }
 
 export const removeIndexString = (urlSting: string) => {
+  if (/^https?:\/\/[^\/]+?\/index$/.test(urlSting)) {
+    return urlSting.replace(/\/index$/, '/')
+  }
   return urlSting.replace(/\/index$/, '')
 }
 

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -78,7 +78,7 @@ describe('removeIndexString', () => {
   it('Should remove last `/index` string', () => {
     let url = 'http://localhost/index'
     let newUrl = removeIndexString(url)
-    expect(newUrl).toBe('http://localhost')
+    expect(newUrl).toBe('http://localhost/')
 
     url = '/index'
     newUrl = removeIndexString(url)

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -25,6 +25,9 @@ export const replaceUrlProtocol = (urlString: string, protocol: 'ws' | 'http') =
 }
 
 export const removeIndexString = (urlSting: string) => {
+  if (/^https?:\/\/[^\/]+?\/index$/.test(urlSting)) {
+    return urlSting.replace(/\/index$/, '/')
+  }
   return urlSting.replace(/\/index$/, '')
 }
 


### PR DESCRIPTION
`removeIndexString` should not remove a trailing slash from a top-level URL.

Fixes #2522

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
