### PR TITLE
fix(sse): close sse stream on end

### DIFF
--- a/deno_dist/helper/streaming/sse.ts
+++ b/deno_dist/helper/streaming/sse.ts
@@ -53,6 +53,8 @@ const run = async (
     } else {
       console.error(e)
     }
+  } finally {
+    stream.close()
   }
 }
 

--- a/src/helper/streaming/sse.test.ts
+++ b/src/helper/streaming/sse.test.ts
@@ -10,14 +10,17 @@ describe('SSE Streaming helper', () => {
   })
 
   it('Check streamSSE Response', async () => {
+    let spy
     const res = streamSSE(c, async (stream) => {
+      spy = vi.spyOn(stream, 'close').mockImplementation(async () => {})
+
       let id = 0
       const maxIterations = 5
 
       while (id < maxIterations) {
         const message = `Message\nIt is ${id}`
         await stream.writeSSE({ data: message, event: 'time-update', id: String(id++) })
-        await stream.sleep(100)
+        await stream.sleep(10)
       }
     })
 
@@ -44,6 +47,8 @@ describe('SSE Streaming helper', () => {
       expectedValue += `id: ${i}\n\n`
       expect(decodedValue).toBe(expectedValue)
     }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(spy).toHaveBeenCalled()
   })
 
   it('Check streamSSE Response if aborted by client', async () => {

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -53,6 +53,8 @@ const run = async (
     } else {
       console.error(e)
     }
+  } finally {
+    stream.close()
   }
 }
 


### PR DESCRIPTION
Adds a finally block to the SSEStream class. Otherwise streamSSE will error whenever used in Cloudflare Workers.

