### PR TITLE
fix(client): Don't show `$ws` when not used WebSockets

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -33,14 +33,13 @@ export type ClientRequest<S extends Schema> = {
         : {}
       : {}
   ) => URL
-} & {
-  // WebSocket
-  $ws: S['$get'] extends { input: { json: UpgradedWebSocketResponseInputJSONType } }
+} & (S['$get'] extends { input: { json: UpgradedWebSocketResponseInputJSONType } }
     ? S['$get'] extends { input: infer I }
-      ? (args?: Omit<I, 'json'>) => WebSocket
-      : never
-    : never
-}
+      ? {
+          $ws: (args?: Omit<I, 'json'>) => WebSocket
+        }
+      : {}
+    : {})
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type BlankRecordToNever<T> = T extends any

--- a/deno_dist/helper/websocket/index.ts
+++ b/deno_dist/helper/websocket/index.ts
@@ -12,7 +12,7 @@ export interface WSEvents {
   onError?: (evt: Event, ws: WSContext) => void
 }
 
-export type UpgradedWebSocketResponseInputJSONType = '__websocket' | undefined
+export type UpgradedWebSocketResponseInputJSONType = '__websocket'
 
 /**
  * Upgrade WebSocket Type

--- a/src/client/types.test.ts
+++ b/src/client/types.test.ts
@@ -1,0 +1,21 @@
+import { expectTypeOf } from 'vitest'
+import { Hono } from '..'
+import { upgradeWebSocket } from '../helper'
+import { hc } from '.'
+
+describe('WebSockets', () => {
+  const app = new Hono()
+    .get('/ws', upgradeWebSocket((c) => ({})))
+    .get('/', c => c.json({}))
+  const client = hc<typeof app>('/')
+  
+  it('WebSocket route', () => {
+    expectTypeOf(client.ws).toMatchTypeOf<{
+      $ws: () => WebSocket
+    }>()
+  })
+  it('Not WebSocket Route', () => {
+    expectTypeOf<typeof client.index extends { $ws: () => WebSocket } ? false : true>()
+      .toEqualTypeOf(true)
+  })
+})

--- a/src/client/types.test.ts
+++ b/src/client/types.test.ts
@@ -5,17 +5,21 @@ import { hc } from '.'
 
 describe('WebSockets', () => {
   const app = new Hono()
-    .get('/ws', upgradeWebSocket((c) => ({})))
-    .get('/', c => c.json({}))
+    .get(
+      '/ws',
+      upgradeWebSocket((c) => ({}))
+    )
+    .get('/', (c) => c.json({}))
   const client = hc<typeof app>('/')
-  
+
   it('WebSocket route', () => {
     expectTypeOf(client.ws).toMatchTypeOf<{
       $ws: () => WebSocket
     }>()
   })
   it('Not WebSocket Route', () => {
-    expectTypeOf<typeof client.index extends { $ws: () => WebSocket } ? false : true>()
-      .toEqualTypeOf(true)
+    expectTypeOf<
+      typeof client.index extends { $ws: () => WebSocket } ? false : true
+    >().toEqualTypeOf(true)
   })
 })

--- a/src/client/types.test.ts
+++ b/src/client/types.test.ts
@@ -7,7 +7,7 @@ describe('WebSockets', () => {
   const app = new Hono()
     .get(
       '/ws',
-      upgradeWebSocket((c) => ({}))
+      upgradeWebSocket(() => ({}))
     )
     .get('/', (c) => c.json({}))
   const client = hc<typeof app>('/')

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -33,14 +33,13 @@ export type ClientRequest<S extends Schema> = {
         : {}
       : {}
   ) => URL
-} & {
-  // WebSocket
-  $ws: S['$get'] extends { input: { json: UpgradedWebSocketResponseInputJSONType } }
+} & (S['$get'] extends { input: { json: UpgradedWebSocketResponseInputJSONType } }
     ? S['$get'] extends { input: infer I }
-      ? (args?: Omit<I, 'json'>) => WebSocket
-      : never
-    : never
-}
+      ? {
+          $ws: (args?: Omit<I, 'json'>) => WebSocket
+        }
+      : {}
+    : {})
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type BlankRecordToNever<T> = T extends any

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -12,7 +12,7 @@ export interface WSEvents {
   onError?: (evt: Event, ws: WSContext) => void
 }
 
-export type UpgradedWebSocketResponseInputJSONType = '__websocket' | undefined
+export type UpgradedWebSocketResponseInputJSONType = '__websocket'
 
 /**
  * Upgrade WebSocket Type


### PR DESCRIPTION
In client, IntelliSense always shows `(route).$ws` property.
I think client doesn't have to show `(route).$ws` property when route doesn't use WebSocket helper.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
