### PR TITLE
[WIP] Update secure-headers align with best current practice

### DIFF
--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -77,7 +77,6 @@ const HEADERS_MAP: HeadersMap = {
   xDownloadOptions: ['X-Download-Options', 'noopen'],
   xFrameOptions: ['X-Frame-Options', 'SAMEORIGIN'],
   xPermittedCrossDomainPolicies: ['X-Permitted-Cross-Domain-Policies', 'none'],
-  xXssProtection: ['X-XSS-Protection', '0'],
 }
 
 const DEFAULT_OPTIONS: SecureHeadersOptions = {

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -66,16 +66,16 @@ type HeadersMap = {
 }
 
 const HEADERS_MAP: HeadersMap = {
+  contentSecurityPolicy: ['Content-Security-Policy', "frame-ancestors 'none'"],
   crossOriginEmbedderPolicy: ['Cross-Origin-Embedder-Policy', 'require-corp'],
-  crossOriginResourcePolicy: ['Cross-Origin-Resource-Policy', 'same-origin'],
   crossOriginOpenerPolicy: ['Cross-Origin-Opener-Policy', 'same-origin'],
+  crossOriginResourcePolicy: ['Cross-Origin-Resource-Policy', 'same-origin'],
   originAgentCluster: ['Origin-Agent-Cluster', '?1'],
   referrerPolicy: ['Referrer-Policy', 'strict-origin-when-cross-origin'],
   strictTransportSecurity: ['Strict-Transport-Security', 'max-age=31536000; includesubdomains'],
   xContentTypeOptions: ['X-Content-Type-Options', 'nosniff'],
   xDnsPrefetchControl: ['X-DNS-Prefetch-Control', 'off'],
   xDownloadOptions: ['X-Download-Options', 'noopen'],
-  contentSecurityPolicy: ['Content-Security-Policy', "frame-ancestors 'none'"],
   xPermittedCrossDomainPolicies: ['X-Permitted-Cross-Domain-Policies', 'none'],
 }
 

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -71,7 +71,7 @@ const HEADERS_MAP: HeadersMap = {
   crossOriginOpenerPolicy: ['Cross-Origin-Opener-Policy', 'same-origin'],
   originAgentCluster: ['Origin-Agent-Cluster', '?1'],
   referrerPolicy: ['Referrer-Policy', 'strict-origin-when-cross-origin'],
-  strictTransportSecurity: ['Strict-Transport-Security', 'max-age=15552000; includeSubDomains'],
+  strictTransportSecurity: ['Strict-Transport-Security', 'max-age=31536000; includesubdomains'],
   xContentTypeOptions: ['X-Content-Type-Options', 'nosniff'],
   xDnsPrefetchControl: ['X-DNS-Prefetch-Control', 'off'],
   xDownloadOptions: ['X-Download-Options', 'noopen'],

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -70,7 +70,7 @@ const HEADERS_MAP: HeadersMap = {
   crossOriginResourcePolicy: ['Cross-Origin-Resource-Policy', 'same-origin'],
   crossOriginOpenerPolicy: ['Cross-Origin-Opener-Policy', 'same-origin'],
   originAgentCluster: ['Origin-Agent-Cluster', '?1'],
-  referrerPolicy: ['Referrer-Policy', 'no-referrer'],
+  referrerPolicy: ['Referrer-Policy', 'strict-origin-when-cross-origin'],
   strictTransportSecurity: ['Strict-Transport-Security', 'max-age=15552000; includeSubDomains'],
   xContentTypeOptions: ['X-Content-Type-Options', 'nosniff'],
   xDnsPrefetchControl: ['X-DNS-Prefetch-Control', 'off'],

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -75,7 +75,7 @@ const HEADERS_MAP: HeadersMap = {
   xContentTypeOptions: ['X-Content-Type-Options', 'nosniff'],
   xDnsPrefetchControl: ['X-DNS-Prefetch-Control', 'off'],
   xDownloadOptions: ['X-Download-Options', 'noopen'],
-  xFrameOptions: ['X-Frame-Options', 'SAMEORIGIN'],
+  contentSecurityPolicy: ['Content-Security-Policy', "frame-ancestors 'none'"],
   xPermittedCrossDomainPolicies: ['X-Permitted-Cross-Domain-Policies', 'none'],
 }
 


### PR DESCRIPTION
closes: #2540

update headers in secure-headers middleware align with best practices.

1. `Referrer-Policy` to `strict-origin-when-cross-origin`
as I filed #2540 , `no-referer` also make `origin` header to `null`.
`origin` header is important for avoid unexpected api call from browser (which includes CSRF).
there are no reason to hide referrer from same-origin, so change it to reasonable setting.
`strict-origin-when-cross-origin` is currently default for modern browsers, but explicitly set it is fine.

see also: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#referrer-policy

2. don't use x-xss-protection
 
x-xss-protection is not fully standardized, deprecated, not recommended header. xss filter is depreacted on all browser so there are no reason to serve it even if it intends to disable since there is no guarantee `0` behaves as expected. use CSP instead.

see also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

3. user QPAC registered value. it compress this header field in 1byte on QUIC

there are no reason to shorten `Strict-Transport-Security` 's max-age.
so what is the appropriate value ? => anything long value is fine basically.
in this case you can see the QPACK static table.
https://www.rfc-editor.org/rfc/rfc9204.html#name-static-table-2
the basic values are defined in this table, and qpack will compress it in 1byte on quic transport.

```
56	strict-transport-security	max-age=31536000
57	strict-transport-security	max-age=31536000; includesubdomains
58	strict-transport-security	max-age=31536000; includesubdomains; preload
```

57 is fine here.


4. X-Frame-Options are replaced by frame-ancestors in CSP.
 
it's widely supported in browsers and allow more appropriate directive to customize.


## And more.

Basically, "**kichen-sink**" headers are kind of bad practice.
From point of view of that, the headers below are also ignorable for me.
since only for old browser, or the Risks are not clear (secure for who ?).

`X-Download-Options: noopen`: it's for deprecated IE
`X-Permitted-Cross-Domain-Policies: none'`: it's for deprecated Flash / Silverlight

I don't know it's really required. but don't have strong opinion to delete thought.



### Author should do the followings, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn denoify` to generate files for Deno
