### PR TITLE
fix(context): keep response cookies in newResponse instead of overwriting

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -382,6 +382,13 @@ export class Context<
 
     if (this.#res) {
       this.#res.headers.forEach((v, k) => {
+        if (k === 'set-cookie' && this.#res) {
+          const cookies = this.#res.headers.getSetCookie()
+          for (const cookie of cookies) {
+            this.#headers?.append('set-cookie', cookie)
+          }
+          return
+        }
         this.#headers?.set(k, v)
       })
       setHeaders(this.#headers, this.#preparedHeaders)

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -249,14 +249,10 @@ describe('Context header', () => {
   it('Should keep previous cookies in response headers', () => {
     c.res.headers.append('set-cookie', 'foo=bar; Path=/')
     setCookie(c, 'foo2', 'bar2', { path: '/' })
-
     const res = c.json({ message: 'Hello' })
-
     const cookies = res.headers.getSetCookie()
-
-    console.debug('test cookies', cookies)
-
-    expect(cookies.length).toBe(2)
+    expect(cookies.includes('foo=bar; Path=/')).toBe(true)
+    expect(cookies.includes('foo2=bar2; Path=/')).toBe(true)
   })
 })
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,4 +1,5 @@
 import { Context } from './context'
+import { setCookie } from './helper'
 import { HonoRequest } from './request'
 
 describe('Context', () => {
@@ -243,6 +244,19 @@ describe('Context header', () => {
     res.headers.append('set-cookie', 'foo2=bar2; Path=/')
     c.res = res
     expect(c.res.headers.getSetCookie().length).toBe(2)
+  })
+
+  it('Should keep previous cookies in response headers', () => {
+    c.res.headers.append('set-cookie',  'foo=bar; Path=/')
+    setCookie(c, 'foo2', 'bar2', { path: '/' })
+
+    const res = c.json({ message: 'Hello' })
+    
+    const cookies = res.headers.getSetCookie()
+
+    console.debug('test cookies', cookies)
+
+    expect(cookies.length).toBe(2)
   })
 })
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -247,11 +247,11 @@ describe('Context header', () => {
   })
 
   it('Should keep previous cookies in response headers', () => {
-    c.res.headers.append('set-cookie',  'foo=bar; Path=/')
+    c.res.headers.append('set-cookie', 'foo=bar; Path=/')
     setCookie(c, 'foo2', 'bar2', { path: '/' })
 
     const res = c.json({ message: 'Hello' })
-    
+
     const cookies = res.headers.getSetCookie()
 
     console.debug('test cookies', cookies)

--- a/src/context.ts
+++ b/src/context.ts
@@ -354,6 +354,7 @@ export class Context<
   ): Response => {
     // Optimized
     if (this.#isFresh && !headers && !arg && this.#status === 200) {
+      console.debug('[Hono] fresh: newResponse: return new Response(data, { headers: this.#preparedHeaders })')
       return new Response(data, {
         headers: this.#preparedHeaders,
       })
@@ -382,6 +383,13 @@ export class Context<
 
     if (this.#res) {
       this.#res.headers.forEach((v, k) => {
+        if (k === 'set-cookie' && this.#res) {
+          const cookies = this.#res.headers.getSetCookie()
+          for (const cookie of cookies) {
+            this.#headers?.append('set-cookie', cookie)
+          }
+          return
+        }
         this.#headers?.set(k, v)
       })
       setHeaders(this.#headers, this.#preparedHeaders)

--- a/src/context.ts
+++ b/src/context.ts
@@ -354,7 +354,6 @@ export class Context<
   ): Response => {
     // Optimized
     if (this.#isFresh && !headers && !arg && this.#status === 200) {
-      console.debug('[Hono] fresh: newResponse: return new Response(data, { headers: this.#preparedHeaders })')
       return new Response(data, {
         headers: this.#preparedHeaders,
       })


### PR DESCRIPTION
Potential fix for https://github.com/honojs/hono/issues/2554

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
