### PR TITLE
feat: add `forMiddleware` types to Input

### DIFF
--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -1,4 +1,3 @@
-import type { UpgradedWebSocketResponseInputJSONType } from '../helper/websocket/index.ts'
 import type { Hono } from '../hono.ts'
 import type { Schema } from '../types.ts'
 import type { HasRequiredKeys } from '../utils/types.ts'
@@ -33,10 +32,10 @@ export type ClientRequest<S extends Schema> = {
         : {}
       : {}
   ) => URL
-} & (S['$get'] extends { input: { json: UpgradedWebSocketResponseInputJSONType } }
+} & (S['$get'] extends { forMiddleware: { websocket: unknown } }
     ? S['$get'] extends { input: infer I }
       ? {
-          $ws: (args?: Omit<I, 'json'>) => WebSocket
+          $ws: (args?: I) => WebSocket
         }
       : {}
     : {})

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -32,7 +32,7 @@ export type ClientRequest<S extends Schema> = {
         : {}
       : {}
   ) => URL
-} & (S['$get'] extends { forMiddleware: { websocket: unknown } }
+} & (S['$get'] extends { stash: { websocket: unknown } }
     ? S['$get'] extends { input: infer I }
       ? {
           $ws: (args?: I) => WebSocket

--- a/deno_dist/helper/websocket/index.ts
+++ b/deno_dist/helper/websocket/index.ts
@@ -12,8 +12,6 @@ export interface WSEvents {
   onError?: (evt: Event, ws: WSContext) => void
 }
 
-export type UpgradedWebSocketResponseInputJSONType = '__websocket'
-
 /**
  * Upgrade WebSocket Type
  */
@@ -23,8 +21,8 @@ export type UpgradeWebSocket = (
   any,
   string,
   {
-    in: {
-      json: UpgradedWebSocketResponseInputJSONType
+    forMiddleware: {
+      websocket: unknown
     }
   }
 >

--- a/deno_dist/helper/websocket/index.ts
+++ b/deno_dist/helper/websocket/index.ts
@@ -21,7 +21,7 @@ export type UpgradeWebSocket = (
   any,
   string,
   {
-    forMiddleware: {
+    stash: {
       websocket: unknown
     }
   }

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1619,6 +1619,7 @@ export type Schema = {
         param?: Record<string, string>
       }
       output: any
+      stash?: Record<string, unknown>
     }
   }
 }

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -118,7 +118,7 @@ export interface HandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -134,7 +134,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -152,7 +152,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -170,7 +170,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -190,7 +190,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -210,7 +210,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -237,7 +237,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -259,7 +259,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -289,7 +289,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -320,7 +320,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, P, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -353,7 +353,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -387,7 +387,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -423,7 +423,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -460,7 +460,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, P, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -499,7 +499,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -539,7 +539,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I9, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -581,7 +581,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -686,12 +686,12 @@ export interface HandlerInterface<
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
     E,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 }
@@ -924,7 +924,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -944,7 +944,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -966,7 +966,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -995,7 +995,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1027,7 +1027,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1062,7 +1062,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1100,7 +1100,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1141,7 +1141,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1185,7 +1185,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1241,7 +1241,7 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method[], path, handler)
   <

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1607,7 +1607,7 @@ export type ToSchema<M extends string, P extends string, I extends Input, O> = P
     [K2 in M as AddDollar<K2>]: {
       input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
       output: unknown extends O ? {} : O
-      stash: unknown extends I['stash'] ? {} : I['stash']
+      stash: Record<string, unknown> extends I['stash'] ? {} : I['stash']
     }
   }
 }>

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -29,7 +29,7 @@ export type Next = () => Promise<void>
 export type Input = {
   in?: {}
   out?: {}
-  forMiddleware?: {}
+  stash?: {}
 }
 
 export type BlankSchema = {}
@@ -1607,7 +1607,7 @@ export type ToSchema<M extends string, P extends string, I extends Input, O> = P
     [K2 in M as AddDollar<K2>]: {
       input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
       output: unknown extends O ? {} : O
-      forMiddleware: unknown extends I['forMiddleware'] ? {} : I['forMiddleware']
+      stash: unknown extends I['stash'] ? {} : I['stash']
     }
   }
 }>

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -29,6 +29,7 @@ export type Next = () => Promise<void>
 export type Input = {
   in?: {}
   out?: {}
+  forMiddleware?: {}
 }
 
 export type BlankSchema = {}
@@ -100,11 +101,7 @@ export interface HandlerInterface<
     E2 extends Env = E
   >(
     handler: H<E2, P, I, R>
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+  ): Hono<IntersectNonAnyTypes<[E, E2]>, S & ToSchema<M, P, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler)
   <
@@ -624,7 +621,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, P, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I10, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -669,7 +666,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -680,7 +677,7 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any
   >(
     ...handlers: H<E, P, I, R>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
@@ -1231,8 +1228,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S &
-      ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponseData<HandlerResponse<any>>>,
     BasePath
   >
 
@@ -1257,7 +1253,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1277,7 +1273,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1299,7 +1295,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1328,7 +1324,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1360,7 +1356,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1395,7 +1391,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1433,7 +1429,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1474,7 +1470,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1521,7 +1517,7 @@ export interface OnHandlerInterface<
       ToSchema<
         Ms[number],
         MergePath<BasePath, P>,
-        I9['in'],
+        I9,
         MergeTypedResponseData<HandlerResponse<any>>
       >,
     BasePath
@@ -1573,7 +1569,7 @@ export interface OnHandlerInterface<
       ToSchema<
         Ms[number],
         MergePath<BasePath, P>,
-        I10['in'],
+        I10,
         MergeTypedResponseData<HandlerResponse<any>>
       >,
     BasePath
@@ -1584,18 +1580,14 @@ export interface OnHandlerInterface<
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<
-    E,
-    S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.on(method | method[], path[], ...handlers[])
   <I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     methods: string | string[],
     paths: string[],
     ...handlers: H<E, any, I, R>[]
-  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<string, string, I, MergeTypedResponseData<R>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -1610,11 +1602,12 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = Prettify<{
+export type ToSchema<M extends string, P extends string, I extends Input, O> = Prettify<{
   [K in P]: {
     [K2 in M as AddDollar<K2>]: {
-      input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
+      input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
       output: unknown extends O ? {} : O
+      forMiddleware: unknown extends I['forMiddleware'] ? {} : I['forMiddleware']
     }
   }
 }>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -32,7 +32,7 @@ export type ClientRequest<S extends Schema> = {
         : {}
       : {}
   ) => URL
-} & (S['$get'] extends { forMiddleware: { websocket: unknown } }
+} & (S['$get'] extends { stash: { websocket: unknown } }
     ? S['$get'] extends { input: infer I }
       ? {
           $ws: (args?: I) => WebSocket

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,3 @@
-import type { UpgradedWebSocketResponseInputJSONType } from '../helper/websocket'
 import type { Hono } from '../hono'
 import type { Schema } from '../types'
 import type { HasRequiredKeys } from '../utils/types'
@@ -33,10 +32,10 @@ export type ClientRequest<S extends Schema> = {
         : {}
       : {}
   ) => URL
-} & (S['$get'] extends { input: { json: UpgradedWebSocketResponseInputJSONType } }
+} & (S['$get'] extends { forMiddleware: { websocket: unknown } }
     ? S['$get'] extends { input: infer I }
       ? {
-          $ws: (args?: Omit<I, 'json'>) => WebSocket
+          $ws: (args?: I) => WebSocket
         }
       : {}
     : {})

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -168,19 +168,21 @@ describe('createHandler', () => {
       ToSchema<
         'get',
         '/posts',
-        { in: {
-          header: {
-            auth: string
+        {
+          in: {
+            header: {
+              auth: string
+            }
+          } & {
+            query: {
+              page: string
+            }
+          } & {
+            json: {
+              id: number
+            }
           }
-        } & {
-          query: {
-            page: string
-          }
-        } & {
-          json: {
-            id: number
-          }
-        }},
+        },
         {
           auth: string
           page: string

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -109,8 +109,10 @@ describe('createHandler', () => {
         'get',
         '/posts',
         {
-          query: {
-            page: string
+          in: {
+            query: {
+              page: string
+            }
           }
         },
         {
@@ -166,7 +168,7 @@ describe('createHandler', () => {
       ToSchema<
         'get',
         '/posts',
-        {
+        { in: {
           header: {
             auth: string
           }
@@ -178,7 +180,7 @@ describe('createHandler', () => {
           json: {
             id: number
           }
-        },
+        }},
         {
           auth: string
           page: string

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -12,8 +12,6 @@ export interface WSEvents {
   onError?: (evt: Event, ws: WSContext) => void
 }
 
-export type UpgradedWebSocketResponseInputJSONType = '__websocket'
-
 /**
  * Upgrade WebSocket Type
  */
@@ -23,8 +21,8 @@ export type UpgradeWebSocket = (
   any,
   string,
   {
-    in: {
-      json: UpgradedWebSocketResponseInputJSONType
+    forMiddleware: {
+      websocket: unknown
     }
   }
 >

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -21,7 +21,7 @@ export type UpgradeWebSocket = (
   any,
   string,
   {
-    forMiddleware: {
+    stash: {
       websocket: unknown
     }
   }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -94,7 +94,7 @@ describe('HandlerInterface', () => {
             output: {
               message: string
             }
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -132,7 +132,7 @@ describe('HandlerInterface', () => {
             output: {
               message: string
             }
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -159,7 +159,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -187,7 +187,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -211,7 +211,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
-            forMiddleware: {}
+            stash: {}
           }
         }
       } & {
@@ -225,7 +225,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -263,7 +263,7 @@ describe('OnHandlerInterface', () => {
           output: {
             success: boolean
           }
-          forMiddleware: {}
+          stash: {}
         }
       }
     }
@@ -311,7 +311,7 @@ describe('Schema', () => {
             message: string
             success: boolean
           }
-          forMiddleware: {}
+          stash: {}
         }
       }
     }
@@ -330,7 +330,7 @@ describe('Support c.json(undefined)', () => {
         $get: {
           input: {}
           output: undefined
-          forMiddleware: {}
+          stash: {}
         }
       }
     }
@@ -416,7 +416,7 @@ describe('`json()`', () => {
           output: {
             message: string
           }
-          forMiddleware: {}
+          stash: {}
         }
       }
     }
@@ -536,18 +536,18 @@ describe('ToSchema', () => {
             }
           }
           output: {}
-          forMiddleware: {}
+          stash: {}
         }
       }
     }
     type verify = Expect<Equal<Expected, Actual>>
   })
-  it('Should work forMiddleware', () => {
+  it('Should work stash', () => {
     type Actual = ToSchema<
       'get',
       '/',
       {
-        forMiddleware: {
+        stash: {
           x: boolean
         }
       },
@@ -556,7 +556,7 @@ describe('ToSchema', () => {
     expectTypeOf<Actual>().toEqualTypeOf<{
       '/': {
         $get: {
-          forMiddleware: { x: boolean }
+          stash: { x: boolean }
           input: {}
           output: {}
         }
@@ -598,7 +598,7 @@ describe('MergeSchemaPath', () => {
             title: string
           }
         }
-        forMiddleware: {}
+        stash: {}
       },
       {
         message: string
@@ -788,7 +788,7 @@ describe('Different types using json()', () => {
               | {
                   default: boolean
                 }
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -830,7 +830,7 @@ describe('Different types using json()', () => {
               | {
                   default: boolean
                 }
-            forMiddleware: {}
+            stash: {}
           }
         }
       }
@@ -855,7 +855,7 @@ describe('json() in an async handler', () => {
           output: {
             ok: boolean
           }
-          forMiddleware: {}
+          stash: {}
         }
       }
     }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -94,6 +94,7 @@ describe('HandlerInterface', () => {
             output: {
               message: string
             }
+            forMiddleware: {}
           }
         }
       }
@@ -131,6 +132,7 @@ describe('HandlerInterface', () => {
             output: {
               message: string
             }
+            forMiddleware: {}
           }
         }
       }
@@ -157,6 +159,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
+            forMiddleware: {}
           }
         }
       }
@@ -184,6 +187,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
+            forMiddleware: {}
           }
         }
       }
@@ -206,7 +210,8 @@ describe('HandlerInterface', () => {
                 foo: string
               }
             }
-            output: {}
+            output: {},
+            forMiddleware: {}
           }
         }
       } & {
@@ -220,6 +225,7 @@ describe('HandlerInterface', () => {
               }
             }
             output: {}
+            forMiddleware: {}
           }
         }
       }
@@ -257,6 +263,7 @@ describe('OnHandlerInterface', () => {
           output: {
             success: boolean
           }
+          forMiddleware: {}
         }
       }
     }
@@ -272,9 +279,11 @@ describe('Schema', () => {
         'post',
         '/api/posts/:id',
         {
-          json: {
-            id: number
-            title: string
+          in: {
+            json: {
+              id: number
+              title: string
+            }
           }
         },
         {
@@ -301,7 +310,8 @@ describe('Schema', () => {
           output: {
             message: string
             success: boolean
-          }
+          },
+          forMiddleware: {}
         }
       }
     }
@@ -319,7 +329,8 @@ describe('Support c.json(undefined)', () => {
       '/this/is/a/test': {
         $get: {
           input: {}
-          output: undefined
+          output: undefined,
+          forMiddleware: {}
         }
       }
     }
@@ -404,7 +415,8 @@ describe('`json()`', () => {
           input: {}
           output: {
             message: string
-          }
+          },
+          forMiddleware: {}
         }
       }
     }
@@ -499,13 +511,19 @@ describe('AddParam', () => {
         id: string
       }
     }
+    const a = ({} as Actual)
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
 
 describe('ToSchema', () => {
   it('Should convert parameters to schema correctly', () => {
-    type Actual = ToSchema<'get', '/:id', { param: { id: string }; query: { page: string } }, {}>
+    type Actual = ToSchema<
+      'get',
+      '/:id',
+      { in: { param: { id: string }; query: { page: string } } },
+      {}
+    >
     type Expected = {
       '/:id': {
         $get: {
@@ -518,6 +536,7 @@ describe('ToSchema', () => {
             }
           }
           output: {}
+          forMiddleware: {}
         }
       }
     }
@@ -552,10 +571,13 @@ describe('MergeSchemaPath', () => {
       'post',
       '/posts',
       {
-        json: {
-          id: number
-          title: string
-        }
+        in: {
+          json: {
+            id: number
+            title: string
+          }
+        },
+        forMiddleware: {}
       },
       {
         message: string
@@ -745,6 +767,7 @@ describe('Different types using json()', () => {
               | {
                   default: boolean
                 }
+            forMiddleware: {}
           }
         }
       }
@@ -786,6 +809,7 @@ describe('Different types using json()', () => {
               | {
                   default: boolean
                 }
+            forMiddleware: {}
           }
         }
       }
@@ -810,6 +834,7 @@ describe('json() in an async handler', () => {
           output: {
             ok: boolean
           }
+          forMiddleware: {}
         }
       }
     }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -210,7 +210,7 @@ describe('HandlerInterface', () => {
                 foo: string
               }
             }
-            output: {},
+            output: {}
             forMiddleware: {}
           }
         }
@@ -310,7 +310,7 @@ describe('Schema', () => {
           output: {
             message: string
             success: boolean
-          },
+          }
           forMiddleware: {}
         }
       }
@@ -329,7 +329,7 @@ describe('Support c.json(undefined)', () => {
       '/this/is/a/test': {
         $get: {
           input: {}
-          output: undefined,
+          output: undefined
           forMiddleware: {}
         }
       }
@@ -415,7 +415,7 @@ describe('`json()`', () => {
           input: {}
           output: {
             message: string
-          },
+          }
           forMiddleware: {}
         }
       }
@@ -511,7 +511,7 @@ describe('AddParam', () => {
         id: string
       }
     }
-    const a = ({} as Actual)
+    const a = {} as Actual
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
@@ -576,7 +576,7 @@ describe('MergeSchemaPath', () => {
             id: number
             title: string
           }
-        },
+        }
         forMiddleware: {}
       },
       {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -511,7 +511,7 @@ describe('AddParam', () => {
         id: string
       }
     }
-    const a = {} as Actual
+
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
@@ -541,6 +541,27 @@ describe('ToSchema', () => {
       }
     }
     type verify = Expect<Equal<Expected, Actual>>
+  })
+  it('Should work forMiddleware', () => {
+    type Actual = ToSchema<
+      'get',
+      '/',
+      {
+        forMiddleware: {
+          x: boolean
+        }
+      },
+      {}
+    >
+    expectTypeOf<Actual>().toEqualTypeOf<{
+      '/': {
+        $get: {
+          forMiddleware: { x: boolean }
+          input: {}
+          output: {}
+        }
+      }
+    }>()
   })
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export type Next = () => Promise<void>
 export type Input = {
   in?: {}
   out?: {}
+  forMiddleware?: {}
 }
 
 export type BlankSchema = {}
@@ -100,11 +101,7 @@ export interface HandlerInterface<
     E2 extends Env = E
   >(
     handler: H<E2, P, I, R>
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+  ): Hono<IntersectNonAnyTypes<[E, E2]>, S & ToSchema<M, P, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, handler)
   <
@@ -118,7 +115,7 @@ export interface HandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -134,7 +131,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, P, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -152,7 +149,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -170,7 +167,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, P, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -190,7 +187,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -210,7 +207,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, P, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -237,7 +234,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -259,7 +256,7 @@ export interface HandlerInterface<
     ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, P, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -289,7 +286,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -320,7 +317,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, P, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -353,7 +350,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -387,7 +384,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, P, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -423,7 +420,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -460,7 +457,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, P, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -499,7 +496,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -539,7 +536,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, P, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I9, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -581,7 +578,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -624,7 +621,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, P, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, P, I10, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -669,7 +666,7 @@ export interface HandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -680,18 +677,18 @@ export interface HandlerInterface<
     R extends HandlerResponse<any> = any
   >(
     ...handlers: H<E, P, I, R>[]
-  ): Hono<E, S & ToSchema<M, P, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, P, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path, ...handlers[])
   <P extends string, I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(path)
   <P extends string, R extends HandlerResponse<any> = any, I extends Input = {}>(path: P): Hono<
     E,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 }
@@ -924,7 +921,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -944,7 +941,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -966,7 +963,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -995,7 +992,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1027,7 +1024,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1062,7 +1059,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1100,7 +1097,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1141,7 +1138,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1185,7 +1182,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1231,8 +1228,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S &
-      ToSchema<M, MergePath<BasePath, P>, I10['in'], MergeTypedResponseData<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponseData<HandlerResponse<any>>>,
     BasePath
   >
 
@@ -1241,7 +1237,7 @@ export interface OnHandlerInterface<
     method: M,
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.get(method[], path, handler)
   <
@@ -1257,7 +1253,7 @@ export interface OnHandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1277,7 +1273,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I2, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1299,7 +1295,7 @@ export interface OnHandlerInterface<
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I3, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1328,7 +1324,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I4, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1360,7 +1356,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I5, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1395,7 +1391,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I6, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1433,7 +1429,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I7, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1474,7 +1470,7 @@ export interface OnHandlerInterface<
     ]
   ): Hono<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8['in'], MergeTypedResponseData<R>>,
+    S & ToSchema<Ms[number], MergePath<BasePath, P>, I8, MergeTypedResponseData<R>>,
     BasePath
   >
 
@@ -1521,7 +1517,7 @@ export interface OnHandlerInterface<
       ToSchema<
         Ms[number],
         MergePath<BasePath, P>,
-        I9['in'],
+        I9,
         MergeTypedResponseData<HandlerResponse<any>>
       >,
     BasePath
@@ -1573,7 +1569,7 @@ export interface OnHandlerInterface<
       ToSchema<
         Ms[number],
         MergePath<BasePath, P>,
-        I10['in'],
+        I10,
         MergeTypedResponseData<HandlerResponse<any>>
       >,
     BasePath
@@ -1584,18 +1580,14 @@ export interface OnHandlerInterface<
     methods: string[],
     path: P,
     ...handlers: H<E, MergePath<BasePath, P>, I, R>[]
-  ): Hono<
-    E,
-    S & ToSchema<string, MergePath<BasePath, P>, I['in'], MergeTypedResponseData<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<string, MergePath<BasePath, P>, I, MergeTypedResponseData<R>>, BasePath>
 
   // app.on(method | method[], path[], ...handlers[])
   <I extends Input = BlankInput, R extends HandlerResponse<any> = any>(
     methods: string | string[],
     paths: string[],
     ...handlers: H<E, any, I, R>[]
-  ): Hono<E, S & ToSchema<string, string, I['in'], MergeTypedResponseData<R>>, BasePath>
+  ): Hono<E, S & ToSchema<string, string, I, MergeTypedResponseData<R>>, BasePath>
 }
 
 type ExtractKey<S> = S extends Record<infer Key, unknown>
@@ -1610,11 +1602,12 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 //////                            //////
 ////////////////////////////////////////
 
-export type ToSchema<M extends string, P extends string, I extends Input['in'], O> = Prettify<{
+export type ToSchema<M extends string, P extends string, I extends Input, O> = Prettify<{
   [K in P]: {
     [K2 in M as AddDollar<K2>]: {
-      input: unknown extends I ? AddParam<{}, P> : AddParam<I, P>
+      input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
       output: unknown extends O ? {} : O
+      forMiddleware: unknown extends I['forMiddleware'] ? {} : I['forMiddleware']
     }
   }
 }>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1619,6 +1619,7 @@ export type Schema = {
         param?: Record<string, string>
       }
       output: any
+      stash?: Record<string, unknown>
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1607,7 +1607,7 @@ export type ToSchema<M extends string, P extends string, I extends Input, O> = P
     [K2 in M as AddDollar<K2>]: {
       input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
       output: unknown extends O ? {} : O
-      stash: unknown extends I['stash'] ? {} : I['stash']
+      stash: Record<string, unknown> extends I['stash'] ? {} : I['stash']
     }
   }
 }>

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type Next = () => Promise<void>
 export type Input = {
   in?: {}
   out?: {}
-  forMiddleware?: {}
+  stash?: {}
 }
 
 export type BlankSchema = {}
@@ -1607,7 +1607,7 @@ export type ToSchema<M extends string, P extends string, I extends Input, O> = P
     [K2 in M as AddDollar<K2>]: {
       input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
       output: unknown extends O ? {} : O
-      forMiddleware: unknown extends I['forMiddleware'] ? {} : I['forMiddleware']
+      stash: unknown extends I['stash'] ? {} : I['stash']
     }
   }
 }>

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -57,6 +57,7 @@ describe('Validator middleware', () => {
           query: undefined
         }
         output: {}
+        forMiddleware: {}
       }
     }
   }
@@ -287,6 +288,7 @@ describe('Validator middleware with a custom validation function', () => {
             id: number
           }
         }
+        forMiddleware: {}
       }
     }
   }
@@ -348,6 +350,7 @@ describe('Validator middleware with Zod validates JSON', () => {
             title: string
           }
         }
+        forMiddleware: {}
       }
     }
   }
@@ -635,6 +638,7 @@ describe('Validator middleware with Zod multiple validators', () => {
           page: number
           title: string
         }
+        forMiddleware: {}
       }
     }
   }
@@ -692,6 +696,7 @@ it('With path parameters', () => {
           }
         }
         output: {}
+        forMiddleware: {}
       }
     }
   }
@@ -738,6 +743,7 @@ it('`on`', () => {
         output: {
           success: boolean
         }
+        forMiddleware: {}
       }
     }
   }
@@ -928,6 +934,7 @@ describe('Validator with using Zod directly', () => {
           output: {
             message: string
           }
+          forMiddleware: {}
         }
       }
     }>()
@@ -961,6 +968,7 @@ describe('Transform', () => {
           output: {
             page: number
           }
+          forMiddleware: {}
         }
       }
     }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -57,7 +57,7 @@ describe('Validator middleware', () => {
           query: undefined
         }
         output: {}
-        forMiddleware: {}
+        stash: {}
       }
     }
   }
@@ -288,7 +288,7 @@ describe('Validator middleware with a custom validation function', () => {
             id: number
           }
         }
-        forMiddleware: {}
+        stash: {}
       }
     }
   }
@@ -350,7 +350,7 @@ describe('Validator middleware with Zod validates JSON', () => {
             title: string
           }
         }
-        forMiddleware: {}
+        stash: {}
       }
     }
   }
@@ -638,7 +638,7 @@ describe('Validator middleware with Zod multiple validators', () => {
           page: number
           title: string
         }
-        forMiddleware: {}
+        stash: {}
       }
     }
   }
@@ -696,7 +696,7 @@ it('With path parameters', () => {
           }
         }
         output: {}
-        forMiddleware: {}
+        stash: {}
       }
     }
   }
@@ -743,7 +743,7 @@ it('`on`', () => {
         output: {
           success: boolean
         }
-        forMiddleware: {}
+        stash: {}
       }
     }
   }
@@ -934,7 +934,7 @@ describe('Validator with using Zod directly', () => {
           output: {
             message: string
           }
-          forMiddleware: {}
+          stash: {}
         }
       }
     }>()
@@ -968,7 +968,7 @@ describe('Transform', () => {
           output: {
             page: number
           }
-          forMiddleware: {}
+          stash: {}
         }
       }
     }


### PR DESCRIPTION
I added a `forMiddleware` prop to `Input`.
In WebSocket helper, helper uses `json` property for telling data to client, but I think it isn't smart because websocket helper actually doesn't use JSON.

This PR adds properties for various helpers and middleware to tell data to clients.

In creating this PR, I enabled that `ToSchema` receives `Input` instead of `Input['in']`.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
