### PR TITLE
feat(factory): add `createApp()`

### DIFF
--- a/deno_dist/helper/factory/index.ts
+++ b/deno_dist/helper/factory/index.ts
@@ -1,7 +1,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Hono } from '../../hono.ts'
 import type { Env, H, HandlerResponse, Input, MiddlewareHandler } from '../../types.ts'
 
+type InitApp<E extends Env = Env> = (app: Hono<E>) => void
+
 export class Factory<E extends Env = any, P extends string = any> {
+  private initApp?: InitApp<E>
+
+  constructor(init?: { initApp?: InitApp<E> }) {
+    this.initApp = init?.initApp
+  }
+
+  /**
+   * @experimental
+   * `createApp` is an experimental feature.
+   */
+  createApp = () => {
+    const app = new Hono<E>()
+    if (this.initApp) {
+      this.initApp(app)
+    }
+    return app
+  }
+
   createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
 
   createHandlers<I extends Input = {}, R extends HandlerResponse<any> = any>(
@@ -209,7 +230,9 @@ export class Factory<E extends Env = any, P extends string = any> {
   }
 }
 
-export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
+export const createFactory = <E extends Env = any, P extends string = any>(init?: {
+  initApp?: InitApp<E>
+}) => new Factory<E, P>(init)
 
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
   middleware: MiddlewareHandler<E, P, I>

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -194,3 +194,25 @@ describe('createHandler', () => {
     })
   })
 })
+
+describe('createApp', () => {
+  type Env = { Variables: { foo: string } }
+  const factory = createFactory<Env>({
+    initApp: (app) => {
+      app.use((c, next) => {
+        c.set('foo', 'bar')
+        return next()
+      })
+    },
+  })
+  const app = factory.createApp()
+  it('Should set the correct type and initialize the app', async () => {
+    app.get('/', (c) => {
+      expectTypeOf(c.var.foo).toEqualTypeOf<string>()
+      return c.text(c.var.foo)
+    })
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('bar')
+  })
+})

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -1,7 +1,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Hono } from '../../hono'
 import type { Env, H, HandlerResponse, Input, MiddlewareHandler } from '../../types'
 
+type InitApp<E extends Env = Env> = (app: Hono<E>) => void
+
 export class Factory<E extends Env = any, P extends string = any> {
+  private initApp?: InitApp<E>
+
+  constructor(init?: { initApp?: InitApp<E> }) {
+    this.initApp = init?.initApp
+  }
+
+  /**
+   * @experimental
+   * `createApp` is an experimental feature.
+   */
+  createApp = () => {
+    const app = new Hono<E>()
+    if (this.initApp) {
+      this.initApp(app)
+    }
+    return app
+  }
+
   createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
 
   createHandlers<I extends Input = {}, R extends HandlerResponse<any> = any>(
@@ -209,7 +230,9 @@ export class Factory<E extends Env = any, P extends string = any> {
   }
 }
 
-export const createFactory = <E extends Env = any, P extends string = any>() => new Factory<E, P>()
+export const createFactory = <E extends Env = any, P extends string = any>(init?: {
+  initApp?: InitApp<E>
+}) => new Factory<E, P>(init)
 
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
   middleware: MiddlewareHandler<E, P, I>


### PR DESCRIPTION
This PR introduces `createApp()` in `hono/factory` as an experimental feature. If you use this method with `createFactory()`, you can avoid redundancy in the definition of `Env` types.

Before:

```ts
const app = new Hono<Env>()

const mw = createMiddleware<Env>(async(c, next) => {
  await next()
})
```

With this PR:

```ts
const factory = createFactory<Env>()

const app = factory.createApp()

const mw = factory.createMiddleware(async (c, next) => {
  await next()
})
```

Using the "Simple Factory" pattern with the Factory helper, there is no need to write type definitions in `global.d.ts` with possible type conflicts. Also, you don't have to have `Env` definitions in multiple places.

```ts
// factory-with-db.ts
type Env = {
  Bindings: {
    MY_DB: D1Database
  }
  Variables: {
    db: DrizzleD1Database
  }
}

export default createFactory<Env>({
  initApp: (app) => {
    app.use(async (c, next) => {
      const db = drizzle(c.env.MY_DB)
      c.set('db', db)
      await next()
    })
  },
})
```

```ts
// crud.ts
import factoryWithDB from './factory-with-db'

const app = factoryWithDB.createApp()

app.post('/posts', (c) => {
  c.var.db.insert
})
```

In the future, I recommend the use of this "Simple Factory" pattern for larger applications, such as those using HonoX.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
