### PR TITLE
fix(request): infer params in a path includes one or more optional parameter

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -6,7 +6,6 @@ import type {
   ParamKeys,
   ParamKeyToRecord,
   RemoveQuestion,
-  UndefinedIfHavingQuestion,
   ValidationTargets,
   RouterRoute,
 } from './types.ts'
@@ -76,9 +75,10 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/routing#path-parameter
    */
-  param<P2 extends string = P>(
-    key: RemoveQuestion<ParamKeys<P2>>
-  ): UndefinedIfHavingQuestion<ParamKeys<P2>>
+  param<P2 extends ParamKeys<P> = ParamKeys<P>>(key: P2 extends `${infer _}?` ? never : P2): string
+  param<P2 extends RemoveQuestion<ParamKeys<P>> = RemoveQuestion<ParamKeys<P>>>(
+    key: P2
+  ): string | undefined
   param<P2 extends string = P>(): UnionToIntersection<ParamKeyToRecord<ParamKeys<P2>>>
   param(key?: string): unknown {
     return key ? this.getDecodedParam(key) : this.getAllDecodedParams()

--- a/deno_dist/types.ts
+++ b/deno_dist/types.ts
@@ -1622,9 +1622,7 @@ export type ToSchema<M extends string, P extends string, I extends Input['in'], 
 export type Schema = {
   [Path: string]: {
     [Method: `$${Lowercase<string>}`]: {
-      input: Partial<ValidationTargets> & {
-        param?: Record<string, string>
-      }
+      input: Partial<ValidationTargets>
       output: any
     }
   }
@@ -1729,7 +1727,7 @@ export type ValidationTargets = {
   json: any
   form: Record<string, string | File>
   query: Record<string, string | string[]>
-  param: Record<string, string>
+  param: Record<string, string> | Record<string, string | undefined>
   header: Record<string, string>
   cookie: Record<string, string>
 }
@@ -1774,8 +1772,6 @@ export type InputToDataByTarget<
   : never
 
 export type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
-
-export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,7 +6,6 @@ import type {
   ParamKeys,
   ParamKeyToRecord,
   RemoveQuestion,
-  UndefinedIfHavingQuestion,
   ValidationTargets,
   RouterRoute,
 } from './types'
@@ -76,9 +75,10 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/routing#path-parameter
    */
-  param<P2 extends string = P>(
-    key: RemoveQuestion<ParamKeys<P2>>
-  ): UndefinedIfHavingQuestion<ParamKeys<P2>>
+  param<P2 extends ParamKeys<P> = ParamKeys<P>>(key: P2 extends `${infer _}?` ? never : P2): string
+  param<P2 extends RemoveQuestion<ParamKeys<P>> = RemoveQuestion<ParamKeys<P>>>(
+    key: P2
+  ): string | undefined
   param<P2 extends string = P>(): UnionToIntersection<ParamKeyToRecord<ParamKeys<P2>>>
   param(key?: string): unknown {
     return key ? this.getDecodedParam(key) : this.getAllDecodedParams()

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -18,7 +18,6 @@ import type {
   ParamKeyToRecord,
   RemoveQuestion,
   ToSchema,
-  UndefinedIfHavingQuestion,
 } from './types'
 import type { Expect, Equal } from './utils/types'
 import { validator } from './validator'
@@ -432,6 +431,26 @@ describe('Path parameters', () => {
       type verify = Expect<Equal<Expected, Actual>>
     })
   })
+
+  describe('Path parameters in app', () => {
+    test('Optional parameters - /api/:a/:b?', () => {
+      const app = new Hono()
+      const routes = app.get('/api/:a/:b?', (c) => {
+        const a = c.req.param('a')
+        const b = c.req.param('b')
+        expectTypeOf(a).toEqualTypeOf<string>()
+        expectTypeOf(b).toEqualTypeOf<string | undefined>()
+        return c.json({ a, b })
+      })
+      type T = ExtractSchema<typeof routes>
+      type Output = T['/api/:a/:b?']['$get']['output']
+      type Expected = {
+        a: string
+        b: string | undefined
+      }
+      type verify = Expect<Equal<Expected, Output>>
+    })
+  })
 })
 
 describe('For HonoRequest', () => {
@@ -462,17 +481,6 @@ describe('For HonoRequest', () => {
   test('RemoveQuestion', () => {
     type Actual = RemoveQuestion<'/animal/type?'>
     type verify = Expect<Equal<'/animal/type', Actual>>
-  })
-
-  describe('UndefinedIfHavingQuestion', () => {
-    test('With ?', () => {
-      type Actual = UndefinedIfHavingQuestion<'/animal/type?'>
-      type verify = Expect<Equal<string | undefined, Actual>>
-    })
-    test('Without ?', () => {
-      type Actual = UndefinedIfHavingQuestion<'/animal/type'>
-      type verify = Expect<Equal<string, Actual>>
-    })
   })
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1622,9 +1622,7 @@ export type ToSchema<M extends string, P extends string, I extends Input['in'], 
 export type Schema = {
   [Path: string]: {
     [Method: `$${Lowercase<string>}`]: {
-      input: Partial<ValidationTargets> & {
-        param?: Record<string, string>
-      }
+      input: Partial<ValidationTargets>
       output: any
     }
   }
@@ -1729,7 +1727,7 @@ export type ValidationTargets = {
   json: any
   form: Record<string, string | File>
   query: Record<string, string | string[]>
-  param: Record<string, string>
+  param: Record<string, string> | Record<string, string | undefined>
   header: Record<string, string>
   cookie: Record<string, string>
 }
@@ -1774,8 +1772,6 @@ export type InputToDataByTarget<
   : never
 
 export type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
-
-export type UndefinedIfHavingQuestion<T> = T extends `${infer _}?` ? string | undefined : string
 
 ////////////////////////////////////////
 //////                            //////


### PR DESCRIPTION
Fixes #2574, #2575

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn denoify` to generate files for Deno
