### PR TITLE
chore(pr_template): Use Bun instead of yarn

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 
 - [ ] Add tests
 - [ ] Run tests
-- [ ] `yarn denoify` to generate files for Deno
+- [ ] `bun denoify` to generate files for Deno


### PR DESCRIPTION
I feel strange when I create PR.

This project recommends Bun by default, so I think PR Template should use `bun denoify` instead of `yarn denoify`.

### Author should do the followings, if applicable

- [ ] Add tests
- [x] Run tests
- [ ] `yarn denoify` to generate files for Deno
