### PR TITLE
fix: avoid duplicating already set headers

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,4 +1,5 @@
-import { isContentTypeBinary, isContentEncodingBinary } from './handler'
+import type { LambdaEvent } from './handler'
+import { getProcessor, isContentEncodingBinary, isContentTypeBinary } from './handler'
 
 describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
@@ -25,5 +26,140 @@ describe('isContentEncodingBinary', () => {
     expect(isContentEncodingBinary('deflate, gzip')).toBe(true)
     expect(isContentEncodingBinary('')).toBe(false)
     expect(isContentEncodingBinary('unknown')).toBe(false)
+  })
+})
+
+describe('EventProcessor.createRequest', () => {
+  it('Should return valid Request object from version 1.0 API Gateway event', () => {
+    const event: LambdaEvent = {
+      version: '1.0',
+      resource: '/my/path',
+      path: '/my/path',
+      httpMethod: 'GET',
+      headers: {
+        header1: 'value1',
+        header2: 'value1',
+      },
+      multiValueHeaders: {
+        header1: ['value1'],
+        header2: ['value1', 'value2', 'value3'],
+      },
+      queryStringParameters: {
+        parameter2: 'value',
+      },
+      multiValueQueryStringParameters: {
+        parameter1: ['value1', 'value2'],
+        parameter2: ['value'],
+      },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'id',
+        authorizer: {
+          claims: null,
+          scopes: null,
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        extendedRequestId: 'request-id',
+        httpMethod: 'GET',
+        identity: {
+          sourceIp: '192.0.2.1',
+          userAgent: 'user-agent',
+          clientCert: {
+            clientCertPem: 'CERT_CONTENT',
+            subjectDN: 'www.example.com',
+            issuerDN: 'Example issuer',
+            serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
+            validity: {
+              notBefore: 'May 28 12:30:02 2019 GMT',
+              notAfter: 'Aug  5 09:36:04 2021 GMT',
+            },
+          },
+        },
+        path: '/my/path',
+        protocol: 'HTTP/1.1',
+        requestId: 'id=',
+        requestTime: '04/Mar/2020:19:15:17 +0000',
+        requestTimeEpoch: 1583349317135,
+        resourcePath: '/my/path',
+        stage: '$default',
+      },
+      pathParameters: {},
+      stageVariables: {},
+      body: 'Hello from Lambda!',
+      isBase64Encoded: false,
+    }
+
+    const processor = getProcessor(event)
+    const request = processor.createRequest(event)
+
+    expect(request.method).toEqual('GET')
+    expect(request.url).toEqual(
+      'https://id.execute-api.us-east-1.amazonaws.com/my/path?parameter2=value'
+    )
+    expect(Object.fromEntries(request.headers)).toEqual({
+      header1: 'value1',
+      header2: 'value1, value2, value3',
+    })
+  })
+
+  it('Should return valid Request object from version 2.0 API Gateway event', () => {
+    const event: LambdaEvent = {
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/my/path',
+      rawQueryString: 'parameter1=value1&parameter1=value2&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: {
+        header1: 'value1',
+        header2: 'value1,value2',
+      },
+      queryStringParameters: {
+        parameter1: 'value1,value2',
+        parameter2: 'value',
+      },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authentication: null,
+        authorizer: {},
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: '192.0.2.1',
+          userAgent: 'agent',
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390,
+      },
+      body: 'Hello from Lambda',
+      pathParameters: {
+        parameter1: 'value1',
+      },
+      isBase64Encoded: false,
+      stageVariables: {
+        stageVariable1: 'value1',
+        stageVariable2: 'value2',
+      },
+    }
+
+    const processor = getProcessor(event)
+    const request = processor.createRequest(event)
+
+    expect(request.method).toEqual('POST')
+    expect(request.url).toEqual(
+      'https://id.execute-api.us-east-1.amazonaws.com/my/path?parameter1=value1&parameter1=value2&parameter2=value'
+    )
+    expect(Object.fromEntries(request.headers)).toEqual({
+      cookie: 'cookie1; cookie2',
+      header1: 'value1',
+      header2: 'value1,value2',
+    })
   })
 })

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -205,7 +205,9 @@ abstract class EventProcessor<E extends LambdaEvent> {
     if (event.multiValueHeaders) {
       for (const [k, values] of Object.entries(event.multiValueHeaders)) {
         if (values) {
-          values.forEach((v) => headers.append(k, v))
+          // avoid duplicating already set headers
+          const foundK = headers.get(k)
+          values.forEach((v) => (!foundK || !foundK.includes(v)) && headers.append(k, v))
         }
       }
     }
@@ -318,7 +320,7 @@ const v1Processor = new (class EventV1Processor extends EventProcessor<
   }
 })()
 
-const getProcessor = (event: LambdaEvent): EventProcessor<LambdaEvent> => {
+export const getProcessor = (event: LambdaEvent): EventProcessor<LambdaEvent> => {
   if (isProxyEventV2(event)) {
     return v2Processor
   } else {


### PR DESCRIPTION
fix #2550

### Description

This pull request avoids duplicating already set headers; this was happening because API Gateway V1 event has "multiValueHeaders" for headers with multiple values.

Currently, Hono AWS Lambda adapter appends any value from these "multiValueHeaders" in the current Header instance. `This leads to duplicated values when a key is already defined`.

### How
- Added a condition to only append a value from "multiValueHeaders" when the current key is not already defined or the current value is not already included;
- added unit tests for the createRequest method from EventProcessor to make sure that the Request is adapted correctly, headers are not duplicated and to avoid future regressions;
> Tests are following the arrange / act / assert pattern.
- `getProcessor` function was exported for unit testing purposes;
- Added a comment because the conditions became a little complex.

### References
https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html


### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno

### Extra
Thanks to @jean-leonco that found the bug in @BemteviSeguros API and @kbrandwijk that opened the issue.

Please let me know if this aligns with the library goals and if the code follows the repository recommendations.

Thanks in advance.