### PR TITLE
feat(hc): add `init` option

### DIFF
--- a/deno_dist/client/client.ts
+++ b/deno_dist/client/client.ts
@@ -123,6 +123,7 @@ class ClientRequestImpl {
       body: setBody ? this.rBody : undefined,
       method: methodUpperCase,
       headers: headers,
+      ...opt?.init,
     })
   }
 }

--- a/deno_dist/client/types.ts
+++ b/deno_dist/client/types.ts
@@ -6,17 +6,24 @@ import type { HasRequiredKeys } from '../utils/types.ts'
 
 type HonoRequest = (typeof Hono.prototype)['request']
 
-export type ClientRequestOptions<T = unknown> = keyof T extends never
+export type ClientRequestOptions<T = unknown> = {
+  fetch?: typeof fetch | HonoRequest
+  /**
+   * Standard `RequestInit`, caution that this take highest priority
+   * and could be used to overwrite things that Hono sets for you, like `body | method | headers`.
+   *
+   * If you want to add some headers, use in `headers` instead of `init`
+   */
+  init?: RequestInit
+} & (keyof T extends never
   ? {
       headers?:
         | Record<string, string>
         | (() => Record<string, string> | Promise<Record<string, string>>)
-      fetch?: typeof fetch | HonoRequest
     }
   : {
       headers: T | (() => T | Promise<T>)
-      fetch?: typeof fetch | HonoRequest
-    }
+    })
 
 export type ClientRequest<S extends Schema> = {
   [M in keyof S]: S[M] extends Endpoint & { input: infer R }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -123,6 +123,7 @@ class ClientRequestImpl {
       body: setBody ? this.rBody : undefined,
       method: methodUpperCase,
       headers: headers,
+      ...opt?.init,
     })
   }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -6,17 +6,24 @@ import type { HasRequiredKeys } from '../utils/types'
 
 type HonoRequest = (typeof Hono.prototype)['request']
 
-export type ClientRequestOptions<T = unknown> = keyof T extends never
+export type ClientRequestOptions<T = unknown> = {
+  fetch?: typeof fetch | HonoRequest
+  /**
+   * Standard `RequestInit`, caution that this take highest priority
+   * and could be used to overwrite things that Hono sets for you, like `body | method | headers`.
+   *
+   * If you want to add some headers, use in `headers` instead of `init`
+   */
+  init?: RequestInit
+} & (keyof T extends never
   ? {
       headers?:
         | Record<string, string>
         | (() => Record<string, string> | Promise<Record<string, string>>)
-      fetch?: typeof fetch | HonoRequest
     }
   : {
       headers: T | (() => T | Promise<T>)
-      fetch?: typeof fetch | HonoRequest
-    }
+    })
 
 export type ClientRequest<S extends Schema> = {
   [M in keyof S]: S[M] extends Endpoint & { input: infer R }


### PR DESCRIPTION
Initally I used a function to merge the headers, but then realized it could be great if it could be used as highest priority control, added comment to tell user to be careful instead.

Resolves #2485

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
