### PR TITLE
fix(types): `ToSchema` compatibility

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,11 @@ import type { Hono } from './hono'
 import type { StatusCode } from './utils/http-status'
 import type {
   IfAnyThenEmptyObject,
+  IsAny,
   JSONValue,
   Prettify,
   RemoveBlankRecord,
+  Simplify,
   UnionToIntersection,
 } from './utils/types'
 
@@ -28,7 +30,11 @@ export type Env = {
 
 export type Next = () => Promise<void>
 
-export type ExtractInput<I extends Input | Input['in']> = I extends Input ? (unknown extends I['in'] ? {} : I['in']) : I
+export type ExtractInput<I extends Input | Input['in']> = I extends Input
+  ? unknown extends I['in']
+    ? {}
+    : I['in']
+  : I
 export type Input = {
   in?: {}
   out?: {}
@@ -1597,17 +1603,34 @@ export type ToSchema<
   M extends string,
   P extends string,
   I extends Input | Input['in'],
-  R extends TypedResponse
+  RorO // Response or Output
 > = Prettify<{
   [K in P]: {
-    [K2 in M as AddDollar<K2>]: R extends TypedResponse<infer T, infer U, infer F>
-      ? {
-          input: AddParam<ExtractInput<I>, P>
-          output: unknown extends T ? {} : T
-          outputFormat: I extends { outputFormat: string } ? I['outputFormat'] : F
-          status: U
-        }
-      : never
+    [K2 in M as AddDollar<K2>]: Simplify<
+      {
+        input: AddParam<ExtractInput<I>, P>
+      } & (IsAny<RorO> extends true
+        ? {
+            output: {}
+            outputFormat: ResponseFormat
+            status: StatusCode
+          }
+        : RorO extends TypedResponse<infer T, infer U, infer F>
+        ? {
+            output: unknown extends T ? {} : T
+            outputFormat: I extends { outputFormat: string } ? I['outputFormat'] : F
+            status: U
+          }
+        : {
+            output: unknown extends RorO ? {} : RorO
+            outputFormat: unknown extends RorO
+              ? 'json'
+              : I extends { outputFormat: string }
+              ? I['outputFormat']
+              : 'json'
+            status: StatusCode
+          })
+    >
   }
 }>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1605,8 +1605,6 @@ export type ToSchema<
           output: unknown extends T ? {} : T
           outputFormat: I extends { outputFormat: string }
             ? I['outputFormat']
-            : unknown extends F
-            ? never
             : F
           status: U
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type Env = {
 
 export type Next = () => Promise<void>
 
+export type ExtractInput<I extends Input | Input['in']> = I extends Input ? (unknown extends I['in'] ? {} : I['in']) : I
 export type Input = {
   in?: {}
   out?: {}
@@ -1595,17 +1596,15 @@ type ExtractKey<S> = S extends Record<infer Key, unknown>
 export type ToSchema<
   M extends string,
   P extends string,
-  I extends Input,
+  I extends Input | Input['in'],
   R extends TypedResponse
 > = Prettify<{
   [K in P]: {
     [K2 in M as AddDollar<K2>]: R extends TypedResponse<infer T, infer U, infer F>
       ? {
-          input: unknown extends I['in'] ? AddParam<{}, P> : AddParam<I['in'], P>
+          input: AddParam<ExtractInput<I>, P>
           output: unknown extends T ? {} : T
-          outputFormat: I extends { outputFormat: string }
-            ? I['outputFormat']
-            : F
+          outputFormat: I extends { outputFormat: string } ? I['outputFormat'] : F
           status: U
         }
       : never


### PR DESCRIPTION
Resolves honojs/middleware#496

This PR make `ToSchema` compatible with older versions.

Some informations about the issue:
> Okay, so on `4.3.0` we have two types breaking on `ToSchema`:
> 
> * Update from `O` is output to `extends TypedResponse` - 8129a3a
> * Update from `I` accepting `Input['in']` to `Input` - ea4e998
> 
> Previously I thought `ToSchema` is only for internal use so I didn't think much about it, but if it is exposed for other libraries I think we should revert `ToSchema` and creates a new `ToSchemaV2` for future uses to revert the breaking changes?


### Author should do the followings, if applicable

- [ ] Add tests - Need help adding tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
