### PR TITLE
feat: custom response in hono/streaming

### DIFF
--- a/src/helper/streaming/stream.test.ts
+++ b/src/helper/streaming/stream.test.ts
@@ -65,4 +65,22 @@ describe('Basic Streaming Helper', () => {
     expect(onError).toBeCalledTimes(1)
     expect(onError).toBeCalledWith(new Error('error'), expect.anything()) // 2nd argument is StreamingApi instance
   })
+
+  it('Check custom response', async () => {
+    const res = stream(
+      c,
+      async () => {
+        // do nothing
+      },
+      undefined,
+      (c, stream) =>
+        c.body(stream.responseReadable, {
+          headers: { 'content-type': 'application/octet-stream' },
+          status: 206,
+        }) // responseFactory
+    )
+
+    expect(res.headers.get('content-type')).toBe('application/octet-stream')
+    expect(res.status).toBe(206)
+  })
 })

--- a/src/helper/streaming/stream.ts
+++ b/src/helper/streaming/stream.ts
@@ -4,7 +4,8 @@ import { StreamingApi } from '../../utils/stream'
 export const stream = (
   c: Context,
   cb: (stream: StreamingApi) => Promise<void>,
-  onError?: (e: Error, stream: StreamingApi) => Promise<void>
+  onError?: (e: Error, stream: StreamingApi) => Promise<void>,
+  responseFactory?: (c: Context, stream: StreamingApi) => Response
 ): Response => {
   const { readable, writable } = new TransformStream()
   const stream = new StreamingApi(writable, readable)
@@ -21,5 +22,6 @@ export const stream = (
       stream.close()
     }
   })()
-  return c.newResponse(stream.responseReadable)
+  if (!responseFactory) return c.newResponse(stream.responseReadable)
+  return responseFactory(c, stream)
 }


### PR DESCRIPTION
related: https://github.com/orgs/honojs/discussions/2617

## proposed signature

added new argument

```typescript
// typeof stream()
(
  c: Context,
  cb: (stream: StreamingApi) => Promise<void>,
  onError?: (e: Error, stream: StreamingApi) => Promise<void>,
  responseFactory?: (c: Context, stream: StreamingApi) => Response // new!
): Response
```

same fix can be applied to `streamText` and `streamSSE`.

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun denoify` to generate files for Deno
