### PR TITLE
feat(validator): check for json subtypes in validator

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -67,7 +67,7 @@ export const validator = <
 
     switch (target) {
       case 'json':
-        if (!contentType || !contentType.startsWith('application/json')) {
+        if (!contentType || !contentType.match(/^application\/[a-z-]*\+json(\s*;.*)?$/)) {
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -67,7 +67,7 @@ export const validator = <
 
     switch (target) {
       case 'json':
-        if (!contentType || !contentType.match(/^application\/[a-z-]*\+json(\s*;.*)?$/)) {
+        if (!contentType || !/^application\/([a-z-]+\+)?json/.test(contentType)) {
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -116,6 +116,19 @@ describe('Malformed JSON', () => {
     })
     expect(res.status).toBe(400)
   })
+	
+  it('Should return 200 response, for request with Content-Type which is a subtype like application/merge-patch+json', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+      },
+      body: JSON.stringify({
+        any: 'thing',
+      }),
+    })
+    expect(res.status).toBe(200)
+  })
 
   it('Should return 400 response, if Content-Type header does not start with application/json', async () => {
     const res = await app.request('http://localhost/post', {

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -116,7 +116,7 @@ describe('Malformed JSON', () => {
     })
     expect(res.status).toBe(400)
   })
-	
+
   it('Should return 200 response, for request with Content-Type which is a subtype like application/merge-patch+json', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -66,8 +66,8 @@ export const validator = <
     const contentType = c.req.header('Content-Type')
 
     switch (target) {
-      case 'json': 
-        if (!contentType ||  !contentType.match(/^application\/[a-z-]*\+json(\s*;.*)?$/)) {
+      case 'json':
+        if (!contentType || !contentType.match(/^application\/[a-z-]*\+json(\s*;.*)?$/)) {
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -66,8 +66,8 @@ export const validator = <
     const contentType = c.req.header('Content-Type')
 
     switch (target) {
-      case 'json':
-        if (!contentType || !contentType.startsWith('application/json')) {
+      case 'json': 
+        if (!contentType ||  !contentType.match(/^application\/[a-z-]*\+json(\s*;.*)?$/)) {
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -67,7 +67,7 @@ export const validator = <
 
     switch (target) {
       case 'json':
-        if (!contentType || !contentType.match(/^application\/[a-z-]*\+json(\s*;.*)?$/)) {
+        if (!contentType || !/^application\/([a-z-]+\+)?json/.test(contentType)) {
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }


### PR DESCRIPTION
A minimal fix for #2633 using a regex. 
I liked the simplicity of the current `startsWith`-approach but it excluded subtypes.

I did:
- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
