### PR TITLE
fix(validator): `form` supports multiple values with `foo[]`

### DIFF
--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -93,7 +93,15 @@ export const validator = <
           const formData = await bufferToFormData(arrayBuffer, contentType)
           const form: BodyData = {}
           formData.forEach((value, key) => {
-            form[key] = value
+            if (key.endsWith('[]')) {
+              if (form[key] === undefined) {
+                form[key] = [value]
+              } else if (Array.isArray(form[key])) {
+                ;(form[key] as unknown[]).push(value)
+              }
+            } else {
+              form[key] = value
+            }
           })
           value = form
           c.req.bodyCache.formData = formData

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -257,6 +257,33 @@ describe('Cached contents', () => {
   })
 })
 
+describe('Form with multiple values', () => {
+  const app = new Hono()
+
+  app.post(
+    '/',
+    validator('form', (value) => value),
+    async (c) => {
+      const data = c.req.valid('form')
+      return c.json(data)
+    }
+  )
+
+  it('Should return `foo[]` as an array', async () => {
+    const form = new FormData()
+    form.append('foo[]', 'bar1')
+    form.append('foo[]', 'bar2')
+    const res = await app.request('/', {
+      method: 'POST',
+      body: form,
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      'foo[]': ['bar1', 'bar2'],
+    })
+  })
+})
+
 describe('Validator middleware with a custom validation function', () => {
   const app = new Hono()
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -93,7 +93,15 @@ export const validator = <
           const formData = await bufferToFormData(arrayBuffer, contentType)
           const form: BodyData = {}
           formData.forEach((value, key) => {
-            form[key] = value
+            if (key.endsWith('[]')) {
+              if (form[key] === undefined) {
+                form[key] = [value]
+              } else if (Array.isArray(form[key])) {
+                ;(form[key] as unknown[]).push(value)
+              }
+            } else {
+              form[key] = value
+            }
           })
           value = form
           c.req.bodyCache.formData = formData


### PR DESCRIPTION
Fixes #2625

This PR enables the validator to parse an array form value, such as the key is a `foo[]`. You should specify a key with the `[]` suffix for an array content.

Usage:

```ts
import { Hono } from 'hono'
import { z } from 'zod'
import { zValidator } from '@hono/zod-validator'

const app = new Hono()

const schema = z.object({
  'foo[]': z.array(z.string())
})

app.post('/', zValidator('form', schema), (c) => {
  const data = c.req.valid('form')
  const fooArray = data['foo[]']
  return c.json({
    fooArray
  })
})

export default app
```

### Author should do the followings, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
