### PR TITLE
feat(hono-base): tweaks `fetch` signature for better compatibility with `deno serve`

### DIFF
--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -371,8 +371,12 @@ class Hono<
    * `.fetch()` will be entry point of your app.
    * @see https://hono.dev/api/hono#fetch
    */
-  fetch = (request: Request, Env?: E['Bindings'] | {}, executionCtx?: ExecutionContext) => {
-    return this.dispatch(request, executionCtx, Env, request.method)
+  fetch: (
+    request: Request,
+    Env?: E['Bindings'] | {},
+    executionCtx?: ExecutionContext
+  ) => Response | Promise<Response> = (request, ...rest) => {
+    return this.dispatch(request, rest[1], rest[0], request.method)
   }
 
   /**

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -371,8 +371,12 @@ class Hono<
    * `.fetch()` will be entry point of your app.
    * @see https://hono.dev/api/hono#fetch
    */
-  fetch = (request: Request, Env?: E['Bindings'] | {}, executionCtx?: ExecutionContext) => {
-    return this.dispatch(request, executionCtx, Env, request.method)
+  fetch: (
+    request: Request,
+    Env?: E['Bindings'] | {},
+    executionCtx?: ExecutionContext
+  ) => Response | Promise<Response> = (request, ...rest) => {
+    return this.dispatch(request, rest[1], rest[0], request.method)
   }
 
   /**


### PR DESCRIPTION
fixes #2653

Since deno checks `.length` as follows, this PR adjust `app.fetch.length` to be 1.
https://github.com/denoland/deno/blob/dac49a116e094be1a3048305dfb6b10bbddcc030/ext/http/00_serve.ts#L796-L800

We will be able to use `export default app` for `deno serve` with this PR.

This definition may seem a bit odd, but it is not overly complicated; I think the advantage of "you can write `dexport defult app` in deno just as well as in bun" is more significant.

### The author should do the following, if applicable

- <del>[ ] Add tests</del>
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
