### PR TITLE
perf(types): add type annotations

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -1,6 +1,6 @@
 import type { HonoRequest } from './request.ts'
-import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types.ts'
-import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html.ts'
+import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types.ts'
+import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html.ts'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status.ts'
 import type { JSONValue, JSONParsed, IsAny, Simplify } from './utils/types.ts'
 
@@ -224,7 +224,18 @@ export class Context<
    */
   render: Renderer = (...args) => this.renderer(...args)
 
-  setLayout = (layout: Layout<PropsForRenderer & { Layout: Layout }>) => (this.layout = layout)
+  setLayout: (
+    layout: Layout<
+      PropsForRenderer & {
+        Layout: Layout
+      }
+    >
+  ) => Layout<
+    PropsForRenderer & {
+      Layout: Layout
+    }
+  > = (layout) => (this.layout = layout)
+
   getLayout = () => this.layout
 
   /**

--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -224,17 +224,13 @@ export class Context<
    */
   render: Renderer = (...args) => this.renderer(...args)
 
-  setLayout: (
-    layout: Layout<
-      PropsForRenderer & {
-        Layout: Layout
-      }
-    >
-  ) => Layout<
+  setLayout = (
+    layout: Layout<PropsForRenderer & { Layout: Layout }>
+  ): Layout<
     PropsForRenderer & {
       Layout: Layout
     }
-  > = (layout) => (this.layout = layout)
+  > => (this.layout = layout)
 
   getLayout = () => this.layout
 

--- a/deno_dist/helper/accepts/accepts.ts
+++ b/deno_dist/helper/accepts/accepts.ts
@@ -25,7 +25,7 @@ export interface acceptsOptions extends acceptsConfig {
   match?: (accepts: Accept[], config: acceptsConfig) => string
 }
 
-export const parseAccept = (acceptHeader: string) => {
+export const parseAccept = (acceptHeader: string): Accept[] => {
   // Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
   const accepts = acceptHeader.split(',') // ['text/html', 'application/xhtml+xml', 'application/xml;q=0.9', 'image/webp', '*/*;q=0.8']
   return accepts.map((accept) => {
@@ -42,7 +42,7 @@ export const parseAccept = (acceptHeader: string) => {
   })
 }
 
-export const defaultMatch = (accepts: Accept[], config: acceptsConfig) => {
+export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {
   const { supports, default: defaultSupport } = config
   const accept = accepts.sort((a, b) => b.q - a.q).find((accept) => supports.includes(accept.type))
   return accept ? accept.type : defaultSupport
@@ -61,7 +61,7 @@ export const defaultMatch = (accepts: Accept[], config: acceptsConfig) => {
  * })
  * ```
  */
-export const accepts = (c: Context, options: acceptsOptions) => {
+export const accepts = (c: Context, options: acceptsOptions): string => {
   const acceptHeader = c.req.header(options.header)
   if (!acceptHeader) {
     return options.default

--- a/deno_dist/helper/adapter/index.ts
+++ b/deno_dist/helper/adapter/index.ts
@@ -30,7 +30,7 @@ export const env = <T extends Record<string, unknown>, C extends Context = Conte
   return runtimeEnvHandlers[runtime]()
 }
 
-export const getRuntimeKey = () => {
+export const getRuntimeKey = (): Runtime => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 

--- a/deno_dist/helper/cookie/index.ts
+++ b/deno_dist/helper/cookie/index.ts
@@ -118,7 +118,7 @@ export const setSignedCookie = async (
   c.header('set-cookie', cookie, { append: true })
 }
 
-export const deleteCookie = (c: Context, name: string, opt?: CookieOptions) => {
+export const deleteCookie = (c: Context, name: string, opt?: CookieOptions): string | undefined => {
   const deletedCookie = getCookie(c, name)
   setCookie(c, name, '', { ...opt, maxAge: 0 })
   return deletedCookie

--- a/deno_dist/helper/css/common.ts
+++ b/deno_dist/helper/css/common.ts
@@ -3,12 +3,12 @@ export const PSEUDO_GLOBAL_SELECTOR = ':-hono-global'
 export const isPseudoGlobalSelectorRe = new RegExp(`^${PSEUDO_GLOBAL_SELECTOR}{(.*)}$`)
 export const DEFAULT_STYLE_ID = 'hono-css'
 
-export const SELECTOR = Symbol()
-export const CLASS_NAME = Symbol()
-export const STYLE_STRING = Symbol()
-export const SELECTORS = Symbol()
-export const EXTERNAL_CLASS_NAMES = Symbol()
-const CSS_ESCAPED = Symbol()
+export const SELECTOR: unique symbol = Symbol()
+export const CLASS_NAME: unique symbol = Symbol()
+export const STYLE_STRING: unique symbol = Symbol()
+export const SELECTORS: unique symbol = Symbol()
+export const EXTERNAL_CLASS_NAMES: unique symbol = Symbol()
+const CSS_ESCAPED: unique symbol = Symbol()
 
 export interface CssClassName {
   [SELECTOR]: string
@@ -49,12 +49,12 @@ const toHash = (str: string): string => {
   return 'css-' + out
 }
 
-const cssStringReStr = [
+const cssStringReStr: string = [
   '"(?:(?:\\\\[\\s\\S]|[^"\\\\])*)"', // double quoted string
   // eslint-disable-next-line quotes
   "'(?:(?:\\\\[\\s\\S]|[^'\\\\])*)'", // single quoted string
 ].join('|')
-const minifyCssRe = new RegExp(
+const minifyCssRe: RegExp = new RegExp(
   [
     '(' + cssStringReStr + ')', // $1: quoted string
 

--- a/deno_dist/helper/css/index.ts
+++ b/deno_dist/helper/css/index.ts
@@ -53,7 +53,7 @@ interface StyleType {
  * `createCssContext` is an experimental feature.
  * The API might be changed.
  */
-export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultContext => {
+export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultContextType => {
   const [cssJsxDomObject, StyleRenderToDom] = createCssJsxDomObjects({ id })
 
   const contextMap: WeakMap<object, usedClassNameData> = new WeakMap()
@@ -167,7 +167,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultConte
   }
 }
 
-interface DefaultContext {
+interface DefaultContextType {
   css: CssType
   cx: CxType
   keyframes: KeyframesType
@@ -175,7 +175,7 @@ interface DefaultContext {
   Style: StyleType
 }
 
-const defaultContext: DefaultContext = createCssContext({
+const defaultContext: DefaultContextType = createCssContext({
   id: DEFAULT_STYLE_ID,
 })
 

--- a/deno_dist/helper/css/index.ts
+++ b/deno_dist/helper/css/index.ts
@@ -24,12 +24,36 @@ type usedClassNameData = [
   Record<string, true> // class name already added
 ]
 
+interface CssType {
+  (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string>
+}
+
+interface CxType {
+  (
+    ...args: (CssClassName | Promise<string> | string | boolean | null | undefined)[]
+  ): Promise<string>
+}
+
+interface KeyframesType {
+  (strings: TemplateStringsArray, ...values: CssVariableType[]): CssClassNameCommon
+}
+
+interface ViewTransitionType {
+  (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string>
+  (content: Promise<string>): Promise<string>
+  (): Promise<string>
+}
+
+interface StyleType {
+  (args?: { children?: Promise<string> }): HtmlEscapedString
+}
+
 /**
  * @experimental
  * `createCssContext` is an experimental feature.
  * The API might be changed.
  */
-export const createCssContext = ({ id }: { id: Readonly<string> }) => {
+export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultContext => {
   const [cssJsxDomObject, StyleRenderToDom] = createCssJsxDomObjects({ id })
 
   const contextMap: WeakMap<object, usedClassNameData> = new WeakMap()
@@ -106,13 +130,11 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
     return promise
   }
 
-  const css = (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string> => {
+  const css: CssType = (strings, ...values) => {
     return newCssClassNameObject(cssCommon(strings, values))
   }
 
-  const cx = (
-    ...args: (CssClassName | Promise<string> | string | boolean | null | undefined)[]
-  ): Promise<string> => {
+  const cx: CxType = (...args) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     args = cxCommon(args as any) as any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -121,20 +143,15 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
 
   const keyframes = keyframesCommon
 
-  type ViewTransitionType = {
-    (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string>
-    (content: Promise<string>): Promise<string>
-    (): Promise<string>
-  }
   const viewTransition: ViewTransitionType = ((
     strings: TemplateStringsArray | Promise<string> | undefined,
     ...values: CssVariableType[]
-  ): Promise<string> => {
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return newCssClassNameObject(viewTransitionCommon(strings as any, values))
   }) as ViewTransitionType
 
-  const Style = ({ children }: { children?: Promise<string> } = {}) =>
+  const Style: StyleType = ({ children } = {}) =>
     children
       ? raw(`<style id="${id}">${(children as unknown as CssClassName)[STYLE_STRING]}</style>`)
       : raw(`<style id="${id}"></style>`)
@@ -150,7 +167,17 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
   }
 }
 
-const defaultContext = createCssContext({ id: DEFAULT_STYLE_ID })
+interface DefaultContext {
+  css: CssType
+  cx: CxType
+  keyframes: KeyframesType
+  viewTransition: ViewTransitionType
+  Style: StyleType
+}
+
+const defaultContext: DefaultContext = createCssContext({
+  id: DEFAULT_STYLE_ID,
+})
 
 /**
  * @experimental

--- a/deno_dist/helper/dev/index.ts
+++ b/deno_dist/helper/dev/index.ts
@@ -15,7 +15,7 @@ interface RouteData {
   isMiddleware: boolean
 }
 
-const handlerName = (handler: Function) => {
+const handlerName = (handler: Function): string => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
 
@@ -68,7 +68,7 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
     })
 }
 
-export const getRouterName = <E extends Env>(app: Hono<E>) => {
+export const getRouterName = <E extends Env>(app: Hono<E>): string => {
   app.router.match('GET', '/')
   return app.router.name
 }

--- a/deno_dist/helper/factory/index.ts
+++ b/deno_dist/helper/factory/index.ts
@@ -216,7 +216,7 @@ export class Factory<E extends Env = any, P extends string = any> {
    * @experimental
    * `createApp` is an experimental feature.
    */
-  createApp = () => {
+  createApp = (): Hono<E> => {
     const app = new Hono<E>()
     if (this.initApp) {
       this.initApp(app)
@@ -234,8 +234,8 @@ export class Factory<E extends Env = any, P extends string = any> {
 
 export const createFactory = <E extends Env = any, P extends string = any>(init?: {
   initApp?: InitApp<E>
-}) => new Factory<E, P>(init)
+}): Factory<E, P> => new Factory<E, P>(init)
 
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
   middleware: MiddlewareHandler<E, P, I>
-) => createFactory<E, P>().createMiddleware<I>(middleware)
+): MiddlewareHandler<E, P, I> => createFactory<E, P>().createMiddleware<I>(middleware)

--- a/deno_dist/helper/streaming/sse.ts
+++ b/deno_dist/helper/streaming/sse.ts
@@ -62,7 +62,7 @@ export const streamSSE = (
   c: Context,
   cb: (stream: SSEStreamingApi) => Promise<void>,
   onError?: (e: Error, stream: SSEStreamingApi) => Promise<void>
-) => {
+): Response => {
   const { readable, writable } = new TransformStream()
   const stream = new SSEStreamingApi(writable, readable)
 

--- a/deno_dist/helper/testing/index.ts
+++ b/deno_dist/helper/testing/index.ts
@@ -1,6 +1,8 @@
 import { hc } from '../../client/index.ts'
+import type { Client } from '../../client/types.ts'
 import type { ExecutionContext } from '../../context.ts'
 import type { Hono } from '../../hono.ts'
+import type { UnionToIntersection } from '../../utils/types.ts'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExtractEnv<T> = T extends Hono<infer E, any, any> ? E : never
@@ -10,7 +12,7 @@ export const testClient = <T extends Hono<any, any, any>>(
   app: T,
   Env?: ExtractEnv<T>['Bindings'] | {},
   executionCtx?: ExecutionContext
-) => {
+): UnionToIntersection<Client<T>> => {
   const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
     return app.request(input, init, Env, executionCtx)
   }

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -233,7 +233,7 @@ class Hono<
    * })
    * ```
    */
-  onError: (handler: ErrorHandler<E>) => Hono<E, S, BasePath> = (handler) => {
+  onError = (handler: ErrorHandler<E>): Hono<E, S, BasePath> => {
     this.errorHandler = handler
     return this
   }
@@ -247,7 +247,7 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#not-found
    */
-  notFound: (handler: NotFoundHandler<E>) => Hono<E, S, BasePath> = (handler) => {
+  notFound = (handler: NotFoundHandler<E>): Hono<E, S, BasePath> => {
     this.notFoundHandler = handler
     return this
   }
@@ -391,12 +391,12 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#request
    */
-  request: (
+  request = (
     input: RequestInfo | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => Response | Promise<Response> = (input, requestInit, Env, executionCtx) => {
+  ): Response | Promise<Response> => {
     if (input instanceof Request) {
       if (requestInit !== undefined) {
         input = new Request(input, requestInit)

--- a/deno_dist/hono-base.ts
+++ b/deno_dist/hono-base.ts
@@ -233,7 +233,7 @@ class Hono<
    * })
    * ```
    */
-  onError = (handler: ErrorHandler<E>) => {
+  onError: (handler: ErrorHandler<E>) => Hono<E, S, BasePath> = (handler) => {
     this.errorHandler = handler
     return this
   }
@@ -247,7 +247,7 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#not-found
    */
-  notFound = (handler: NotFoundHandler<E>) => {
+  notFound: (handler: NotFoundHandler<E>) => Hono<E, S, BasePath> = (handler) => {
     this.notFoundHandler = handler
     return this
   }
@@ -391,12 +391,12 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#request
    */
-  request = (
+  request: (
     input: RequestInfo | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => {
+  ) => Response | Promise<Response> = (input, requestInit, Env, executionCtx) => {
     if (input instanceof Request) {
       if (requestInit !== undefined) {
         input = new Request(input, requestInit)

--- a/deno_dist/jsx/dom/context.ts
+++ b/deno_dist/jsx/dom/context.ts
@@ -5,7 +5,7 @@ import { globalContexts } from '../context.ts'
 import { Fragment } from './jsx-runtime.ts'
 import { setInternalTagFlag } from './utils.ts'
 
-export const createContextProviderFunction = <T>(values: T[]) =>
+export const createContextProviderFunction = <T>(values: T[]): Function =>
   setInternalTagFlag(({ value, children }: { value: T; children: Child[] }) => {
     if (!children) {
       return undefined

--- a/deno_dist/jsx/dom/css.ts
+++ b/deno_dist/jsx/dom/css.ts
@@ -56,7 +56,16 @@ const splitRule = (rule: string): string[] => {
   return result
 }
 
-export const createCssJsxDomObjects = ({ id }: { id: Readonly<string> }) => {
+interface CreateCssJsxDomObjectsType {
+  (args: { id: Readonly<string> }): readonly [
+    {
+      toString(this: CssClassName): string
+    },
+    FC<PropsWithChildren<void>>
+  ]
+}
+
+export const createCssJsxDomObjects: CreateCssJsxDomObjectsType = ({ id }) => {
   let styleSheet: CSSStyleSheet | null | undefined = undefined
   const findStyleSheet = (): [CSSStyleSheet, Set<string>] | [] => {
     if (!styleSheet) {

--- a/deno_dist/jsx/dom/jsx-dev-runtime.ts
+++ b/deno_dist/jsx/dom/jsx-dev-runtime.ts
@@ -28,4 +28,4 @@ export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXN
   ) as JSXNode
 }
 
-export const Fragment = (props: Record<string, unknown>) => jsxDEV('', props, undefined)
+export const Fragment = (props: Record<string, unknown>): JSXNode => jsxDEV('', props, undefined)

--- a/deno_dist/jsx/dom/utils.ts
+++ b/deno_dist/jsx/dom/utils.ts
@@ -1,6 +1,6 @@
 import { DOM_INTERNAL_TAG } from '../constants.ts'
 
-export const setInternalTagFlag = (fn: Function) => {
+export const setInternalTagFlag = (fn: Function): Function => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(fn as any)[DOM_INTERNAL_TAG] = true
   return fn

--- a/deno_dist/jsx/hooks/index.ts
+++ b/deno_dist/jsx/hooks/index.ts
@@ -18,7 +18,10 @@ export type EffectData = [
   (() => void) | undefined // effect
 ]
 
-const resolvedPromiseValueMap = new WeakMap<Promise<unknown>, unknown>()
+const resolvedPromiseValueMap: WeakMap<Promise<unknown>, unknown> = new WeakMap<
+  Promise<unknown>,
+  unknown
+>()
 
 const isDepsChanged = (
   prevDeps: readonly unknown[] | undefined,

--- a/deno_dist/jsx/jsx-runtime.ts
+++ b/deno_dist/jsx/jsx-runtime.ts
@@ -2,7 +2,11 @@ export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime.ts'
 export { jsxDEV as jsxs } from './jsx-dev-runtime.ts'
 
 import { raw, html } from '../helper/html/index.ts'
+import type { HtmlEscapedString } from '../utils/html.ts'
 export { html as jsxTemplate }
-export const jsxAttr = (name: string, value: string | Promise<string>) =>
+export const jsxAttr = (
+  name: string,
+  value: string | Promise<string>
+): HtmlEscapedString | Promise<HtmlEscapedString> =>
   typeof value === 'string' ? raw(name + '="' + html`${value}` + '"') : html`${name}="${value}"`
 export const jsxEscape = (value: string) => value

--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -3,11 +3,13 @@ import type { Context, PropsForRenderer } from '../../context.ts'
 import { html, raw } from '../../helper/html/index.ts'
 import { jsx, createContext, useContext, Fragment } from '../../jsx/index.ts'
 import type { FC, PropsWithChildren, JSXNode } from '../../jsx/index.ts'
+import type { Context as JSXContext } from '../../jsx/index.ts'
 import { renderToReadableStream } from '../../jsx/streaming.ts'
 import type { Env, Input, MiddlewareHandler } from '../../types.ts'
 import type { HtmlEscapedString } from '../../utils/html.ts'
 
-export const RequestContext = createContext<Context | null>(null)
+export const RequestContext: JSXContext<Context<any, any, {}> | null> =
+  createContext<Context | null>(null)
 
 type RendererOptions = {
   docType?: boolean | string

--- a/deno_dist/middleware/timing/index.ts
+++ b/deno_dist/middleware/timing/index.ts
@@ -24,7 +24,7 @@ interface TimingOptions {
   crossOrigin: boolean | string | ((c: Context) => boolean | string)
 }
 
-const getTime = () => {
+const getTime = (): number => {
   try {
     return performance.now()
   } catch {}

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -289,7 +289,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/request#url
    */
-  get url() {
+  get url(): string {
     return this.raw.url
   }
 
@@ -303,7 +303,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/request#method
    */
-  get method() {
+  get method(): string {
     return this.raw.method
   }
 

--- a/deno_dist/router/smart-router/router.ts
+++ b/deno_dist/router/smart-router/router.ts
@@ -59,7 +59,7 @@ export class SmartRouter<T> implements Router<T> {
     return res as Result<T>
   }
 
-  get activeRouter() {
+  get activeRouter(): Router<T> {
     if (this.routes || this.routers.length !== 1) {
       throw new Error('No active router has been determined yet.')
     }

--- a/deno_dist/utils/buffer.ts
+++ b/deno_dist/utils/buffer.ts
@@ -48,7 +48,10 @@ export const bufferToString = (buffer: ArrayBuffer): string => {
   return buffer
 }
 
-export const bufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
+export const bufferToFormData = (
+  arrayBuffer: ArrayBuffer,
+  contentType: string
+): Promise<FormData> => {
   const response = new Response(arrayBuffer, {
     headers: {
       'Content-Type': contentType,

--- a/deno_dist/utils/color.ts
+++ b/deno_dist/utils/color.ts
@@ -1,4 +1,4 @@
-export function getColorEnabled() {
+export function getColorEnabled(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { process, Deno } = globalThis as any
 

--- a/deno_dist/utils/jwt/utf8.ts
+++ b/deno_dist/utils/jwt/utf8.ts
@@ -1,2 +1,2 @@
-export const utf8Encoder = new TextEncoder()
-export const utf8Decoder = new TextDecoder()
+export const utf8Encoder: TextEncoder = new TextEncoder()
+export const utf8Decoder: TextDecoder = new TextDecoder()

--- a/deno_dist/utils/stream.ts
+++ b/deno_dist/utils/stream.ts
@@ -30,7 +30,7 @@ export class StreamingApi {
     })
   }
 
-  async write(input: Uint8Array | string) {
+  async write(input: Uint8Array | string): Promise<StreamingApi> {
     try {
       if (typeof input === 'string') {
         input = this.encoder.encode(input)
@@ -42,12 +42,12 @@ export class StreamingApi {
     return this
   }
 
-  async writeln(input: string) {
+  async writeln(input: string): Promise<StreamingApi> {
     await this.write(input + '\n')
     return this
   }
 
-  sleep(ms: number) {
+  sleep(ms: number): Promise<unknown> {
     return new Promise((res) => setTimeout(res, ms))
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -224,17 +224,13 @@ export class Context<
    */
   render: Renderer = (...args) => this.renderer(...args)
 
-  setLayout: (
-    layout: Layout<
-      PropsForRenderer & {
-        Layout: Layout
-      }
-    >
-  ) => Layout<
+  setLayout = (
+    layout: Layout<PropsForRenderer & { Layout: Layout }>
+  ): Layout<
     PropsForRenderer & {
       Layout: Layout
     }
-  > = (layout) => (this.layout = layout)
+  > => (this.layout = layout)
 
   getLayout = () => this.layout
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import type { HonoRequest } from './request'
-import type { Env, FetchEventLike, NotFoundHandler, Input, TypedResponse } from './types'
-import { resolveCallback, HtmlEscapedCallbackPhase } from './utils/html'
+import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types'
+import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
 import type { JSONValue, JSONParsed, IsAny, Simplify } from './utils/types'
 
@@ -224,7 +224,18 @@ export class Context<
    */
   render: Renderer = (...args) => this.renderer(...args)
 
-  setLayout = (layout: Layout<PropsForRenderer & { Layout: Layout }>) => (this.layout = layout)
+  setLayout: (
+    layout: Layout<
+      PropsForRenderer & {
+        Layout: Layout
+      }
+    >
+  ) => Layout<
+    PropsForRenderer & {
+      Layout: Layout
+    }
+  > = (layout) => (this.layout = layout)
+
   getLayout = () => this.layout
 
   /**

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -25,7 +25,7 @@ export interface acceptsOptions extends acceptsConfig {
   match?: (accepts: Accept[], config: acceptsConfig) => string
 }
 
-export const parseAccept = (acceptHeader: string) => {
+export const parseAccept = (acceptHeader: string): Accept[] => {
   // Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
   const accepts = acceptHeader.split(',') // ['text/html', 'application/xhtml+xml', 'application/xml;q=0.9', 'image/webp', '*/*;q=0.8']
   return accepts.map((accept) => {
@@ -42,7 +42,7 @@ export const parseAccept = (acceptHeader: string) => {
   })
 }
 
-export const defaultMatch = (accepts: Accept[], config: acceptsConfig) => {
+export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {
   const { supports, default: defaultSupport } = config
   const accept = accepts.sort((a, b) => b.q - a.q).find((accept) => supports.includes(accept.type))
   return accept ? accept.type : defaultSupport
@@ -61,7 +61,7 @@ export const defaultMatch = (accepts: Accept[], config: acceptsConfig) => {
  * })
  * ```
  */
-export const accepts = (c: Context, options: acceptsOptions) => {
+export const accepts = (c: Context, options: acceptsOptions): string => {
   const acceptHeader = c.req.header(options.header)
   if (!acceptHeader) {
     return options.default

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -30,7 +30,7 @@ export const env = <T extends Record<string, unknown>, C extends Context = Conte
   return runtimeEnvHandlers[runtime]()
 }
 
-export const getRuntimeKey = () => {
+export const getRuntimeKey = (): Runtime => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const global = globalThis as any
 

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -118,7 +118,7 @@ export const setSignedCookie = async (
   c.header('set-cookie', cookie, { append: true })
 }
 
-export const deleteCookie = (c: Context, name: string, opt?: CookieOptions) => {
+export const deleteCookie = (c: Context, name: string, opt?: CookieOptions): string | undefined => {
   const deletedCookie = getCookie(c, name)
   setCookie(c, name, '', { ...opt, maxAge: 0 })
   return deletedCookie

--- a/src/helper/css/common.ts
+++ b/src/helper/css/common.ts
@@ -3,12 +3,12 @@ export const PSEUDO_GLOBAL_SELECTOR = ':-hono-global'
 export const isPseudoGlobalSelectorRe = new RegExp(`^${PSEUDO_GLOBAL_SELECTOR}{(.*)}$`)
 export const DEFAULT_STYLE_ID = 'hono-css'
 
-export const SELECTOR = Symbol()
-export const CLASS_NAME = Symbol()
-export const STYLE_STRING = Symbol()
-export const SELECTORS = Symbol()
-export const EXTERNAL_CLASS_NAMES = Symbol()
-const CSS_ESCAPED = Symbol()
+export const SELECTOR: unique symbol = Symbol()
+export const CLASS_NAME: unique symbol = Symbol()
+export const STYLE_STRING: unique symbol = Symbol()
+export const SELECTORS: unique symbol = Symbol()
+export const EXTERNAL_CLASS_NAMES: unique symbol = Symbol()
+const CSS_ESCAPED: unique symbol = Symbol()
 
 export interface CssClassName {
   [SELECTOR]: string
@@ -49,12 +49,12 @@ const toHash = (str: string): string => {
   return 'css-' + out
 }
 
-const cssStringReStr = [
+const cssStringReStr: string = [
   '"(?:(?:\\\\[\\s\\S]|[^"\\\\])*)"', // double quoted string
   // eslint-disable-next-line quotes
   "'(?:(?:\\\\[\\s\\S]|[^'\\\\])*)'", // single quoted string
 ].join('|')
-const minifyCssRe = new RegExp(
+const minifyCssRe: RegExp = new RegExp(
   [
     '(' + cssStringReStr + ')', // $1: quoted string
 

--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -53,7 +53,7 @@ interface StyleType {
  * `createCssContext` is an experimental feature.
  * The API might be changed.
  */
-export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultContext => {
+export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultContextType => {
   const [cssJsxDomObject, StyleRenderToDom] = createCssJsxDomObjects({ id })
 
   const contextMap: WeakMap<object, usedClassNameData> = new WeakMap()
@@ -167,7 +167,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultConte
   }
 }
 
-interface DefaultContext {
+interface DefaultContextType {
   css: CssType
   cx: CxType
   keyframes: KeyframesType
@@ -175,7 +175,7 @@ interface DefaultContext {
   Style: StyleType
 }
 
-const defaultContext: DefaultContext = createCssContext({
+const defaultContext: DefaultContextType = createCssContext({
   id: DEFAULT_STYLE_ID,
 })
 

--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -24,12 +24,36 @@ type usedClassNameData = [
   Record<string, true> // class name already added
 ]
 
+interface CssType {
+  (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string>
+}
+
+interface CxType {
+  (
+    ...args: (CssClassName | Promise<string> | string | boolean | null | undefined)[]
+  ): Promise<string>
+}
+
+interface KeyframesType {
+  (strings: TemplateStringsArray, ...values: CssVariableType[]): CssClassNameCommon
+}
+
+interface ViewTransitionType {
+  (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string>
+  (content: Promise<string>): Promise<string>
+  (): Promise<string>
+}
+
+interface StyleType {
+  (args?: { children?: Promise<string> }): HtmlEscapedString
+}
+
 /**
  * @experimental
  * `createCssContext` is an experimental feature.
  * The API might be changed.
  */
-export const createCssContext = ({ id }: { id: Readonly<string> }) => {
+export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultContext => {
   const [cssJsxDomObject, StyleRenderToDom] = createCssJsxDomObjects({ id })
 
   const contextMap: WeakMap<object, usedClassNameData> = new WeakMap()
@@ -106,13 +130,11 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
     return promise
   }
 
-  const css = (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string> => {
+  const css: CssType = (strings, ...values) => {
     return newCssClassNameObject(cssCommon(strings, values))
   }
 
-  const cx = (
-    ...args: (CssClassName | Promise<string> | string | boolean | null | undefined)[]
-  ): Promise<string> => {
+  const cx: CxType = (...args) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     args = cxCommon(args as any) as any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -121,20 +143,15 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
 
   const keyframes = keyframesCommon
 
-  type ViewTransitionType = {
-    (strings: TemplateStringsArray, ...values: CssVariableType[]): Promise<string>
-    (content: Promise<string>): Promise<string>
-    (): Promise<string>
-  }
   const viewTransition: ViewTransitionType = ((
     strings: TemplateStringsArray | Promise<string> | undefined,
     ...values: CssVariableType[]
-  ): Promise<string> => {
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return newCssClassNameObject(viewTransitionCommon(strings as any, values))
   }) as ViewTransitionType
 
-  const Style = ({ children }: { children?: Promise<string> } = {}) =>
+  const Style: StyleType = ({ children } = {}) =>
     children
       ? raw(`<style id="${id}">${(children as unknown as CssClassName)[STYLE_STRING]}</style>`)
       : raw(`<style id="${id}"></style>`)
@@ -150,7 +167,17 @@ export const createCssContext = ({ id }: { id: Readonly<string> }) => {
   }
 }
 
-const defaultContext = createCssContext({ id: DEFAULT_STYLE_ID })
+interface DefaultContext {
+  css: CssType
+  cx: CxType
+  keyframes: KeyframesType
+  viewTransition: ViewTransitionType
+  Style: StyleType
+}
+
+const defaultContext: DefaultContext = createCssContext({
+  id: DEFAULT_STYLE_ID,
+})
 
 /**
  * @experimental

--- a/src/helper/dev/index.ts
+++ b/src/helper/dev/index.ts
@@ -15,7 +15,7 @@ interface RouteData {
   isMiddleware: boolean
 }
 
-const handlerName = (handler: Function) => {
+const handlerName = (handler: Function): string => {
   return handler.name || (isMiddleware(handler) ? '[middleware]' : '[handler]')
 }
 
@@ -68,7 +68,7 @@ export const showRoutes = <E extends Env>(hono: Hono<E>, opts?: ShowRoutesOption
     })
 }
 
-export const getRouterName = <E extends Env>(app: Hono<E>) => {
+export const getRouterName = <E extends Env>(app: Hono<E>): string => {
   app.router.match('GET', '/')
   return app.router.name
 }

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -216,7 +216,7 @@ export class Factory<E extends Env = any, P extends string = any> {
    * @experimental
    * `createApp` is an experimental feature.
    */
-  createApp = () => {
+  createApp = (): Hono<E> => {
     const app = new Hono<E>()
     if (this.initApp) {
       this.initApp(app)
@@ -234,8 +234,8 @@ export class Factory<E extends Env = any, P extends string = any> {
 
 export const createFactory = <E extends Env = any, P extends string = any>(init?: {
   initApp?: InitApp<E>
-}) => new Factory<E, P>(init)
+}): Factory<E, P> => new Factory<E, P>(init)
 
 export const createMiddleware = <E extends Env = any, P extends string = any, I extends Input = {}>(
   middleware: MiddlewareHandler<E, P, I>
-) => createFactory<E, P>().createMiddleware<I>(middleware)
+): MiddlewareHandler<E, P, I> => createFactory<E, P>().createMiddleware<I>(middleware)

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -62,7 +62,7 @@ export const streamSSE = (
   c: Context,
   cb: (stream: SSEStreamingApi) => Promise<void>,
   onError?: (e: Error, stream: SSEStreamingApi) => Promise<void>
-) => {
+): Response => {
   const { readable, writable } = new TransformStream()
   const stream = new SSEStreamingApi(writable, readable)
 

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -1,6 +1,8 @@
 import { hc } from '../../client'
+import type { Client } from '../../client/types'
 import type { ExecutionContext } from '../../context'
 import type { Hono } from '../../hono'
+import type { UnionToIntersection } from '../../utils/types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExtractEnv<T> = T extends Hono<infer E, any, any> ? E : never
@@ -10,7 +12,7 @@ export const testClient = <T extends Hono<any, any, any>>(
   app: T,
   Env?: ExtractEnv<T>['Bindings'] | {},
   executionCtx?: ExecutionContext
-) => {
+): UnionToIntersection<Client<T>> => {
   const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
     return app.request(input, init, Env, executionCtx)
   }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -233,7 +233,7 @@ class Hono<
    * })
    * ```
    */
-  onError: (handler: ErrorHandler<E>) => Hono<E, S, BasePath> = (handler) => {
+  onError = (handler: ErrorHandler<E>): Hono<E, S, BasePath> => {
     this.errorHandler = handler
     return this
   }
@@ -247,7 +247,7 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#not-found
    */
-  notFound: (handler: NotFoundHandler<E>) => Hono<E, S, BasePath> = (handler) => {
+  notFound = (handler: NotFoundHandler<E>): Hono<E, S, BasePath> => {
     this.notFoundHandler = handler
     return this
   }
@@ -391,12 +391,12 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#request
    */
-  request: (
+  request = (
     input: RequestInfo | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => Response | Promise<Response> = (input, requestInit, Env, executionCtx) => {
+  ): Response | Promise<Response> => {
     if (input instanceof Request) {
       if (requestInit !== undefined) {
         input = new Request(input, requestInit)

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -233,7 +233,7 @@ class Hono<
    * })
    * ```
    */
-  onError = (handler: ErrorHandler<E>) => {
+  onError: (handler: ErrorHandler<E>) => Hono<E, S, BasePath> = (handler) => {
     this.errorHandler = handler
     return this
   }
@@ -247,7 +247,7 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#not-found
    */
-  notFound = (handler: NotFoundHandler<E>) => {
+  notFound: (handler: NotFoundHandler<E>) => Hono<E, S, BasePath> = (handler) => {
     this.notFoundHandler = handler
     return this
   }
@@ -391,12 +391,12 @@ class Hono<
    * ```
    * @see https://hono.dev/api/hono#request
    */
-  request = (
+  request: (
     input: RequestInfo | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => {
+  ) => Response | Promise<Response> = (input, requestInit, Env, executionCtx) => {
     if (input instanceof Request) {
       if (requestInit !== undefined) {
         input = new Request(input, requestInit)

--- a/src/jsx/dom/context.ts
+++ b/src/jsx/dom/context.ts
@@ -5,7 +5,7 @@ import { globalContexts } from '../context'
 import { Fragment } from './jsx-runtime'
 import { setInternalTagFlag } from './utils'
 
-export const createContextProviderFunction = <T>(values: T[]) =>
+export const createContextProviderFunction = <T>(values: T[]): Function =>
   setInternalTagFlag(({ value, children }: { value: T; children: Child[] }) => {
     if (!children) {
       return undefined

--- a/src/jsx/dom/css.ts
+++ b/src/jsx/dom/css.ts
@@ -56,7 +56,16 @@ const splitRule = (rule: string): string[] => {
   return result
 }
 
-export const createCssJsxDomObjects = ({ id }: { id: Readonly<string> }) => {
+interface CreateCssJsxDomObjectsType {
+  (args: { id: Readonly<string> }): readonly [
+    {
+      toString(this: CssClassName): string
+    },
+    FC<PropsWithChildren<void>>
+  ]
+}
+
+export const createCssJsxDomObjects: CreateCssJsxDomObjectsType = ({ id }) => {
   let styleSheet: CSSStyleSheet | null | undefined = undefined
   const findStyleSheet = (): [CSSStyleSheet, Set<string>] | [] => {
     if (!styleSheet) {

--- a/src/jsx/dom/jsx-dev-runtime.ts
+++ b/src/jsx/dom/jsx-dev-runtime.ts
@@ -28,4 +28,4 @@ export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXN
   ) as JSXNode
 }
 
-export const Fragment = (props: Record<string, unknown>) => jsxDEV('', props, undefined)
+export const Fragment = (props: Record<string, unknown>): JSXNode => jsxDEV('', props, undefined)

--- a/src/jsx/dom/utils.ts
+++ b/src/jsx/dom/utils.ts
@@ -1,6 +1,6 @@
 import { DOM_INTERNAL_TAG } from '../constants'
 
-export const setInternalTagFlag = (fn: Function) => {
+export const setInternalTagFlag = (fn: Function): Function => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(fn as any)[DOM_INTERNAL_TAG] = true
   return fn

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -18,7 +18,10 @@ export type EffectData = [
   (() => void) | undefined // effect
 ]
 
-const resolvedPromiseValueMap = new WeakMap<Promise<unknown>, unknown>()
+const resolvedPromiseValueMap: WeakMap<Promise<unknown>, unknown> = new WeakMap<
+  Promise<unknown>,
+  unknown
+>()
 
 const isDepsChanged = (
   prevDeps: readonly unknown[] | undefined,

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -2,7 +2,11 @@ export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
 export { jsxDEV as jsxs } from './jsx-dev-runtime'
 
 import { raw, html } from '../helper/html'
+import type { HtmlEscapedString } from '../utils/html'
 export { html as jsxTemplate }
-export const jsxAttr = (name: string, value: string | Promise<string>) =>
+export const jsxAttr = (
+  name: string,
+  value: string | Promise<string>
+): HtmlEscapedString | Promise<HtmlEscapedString> =>
   typeof value === 'string' ? raw(name + '="' + html`${value}` + '"') : html`${name}="${value}"`
 export const jsxEscape = (value: string) => value

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -3,11 +3,13 @@ import type { Context, PropsForRenderer } from '../../context'
 import { html, raw } from '../../helper/html'
 import { jsx, createContext, useContext, Fragment } from '../../jsx'
 import type { FC, PropsWithChildren, JSXNode } from '../../jsx'
+import type { Context as JSXContext } from '../../jsx'
 import { renderToReadableStream } from '../../jsx/streaming'
 import type { Env, Input, MiddlewareHandler } from '../../types'
 import type { HtmlEscapedString } from '../../utils/html'
 
-export const RequestContext = createContext<Context | null>(null)
+export const RequestContext: JSXContext<Context<any, any, {}> | null> =
+  createContext<Context | null>(null)
 
 type RendererOptions = {
   docType?: boolean | string

--- a/src/middleware/timing/index.ts
+++ b/src/middleware/timing/index.ts
@@ -24,7 +24,7 @@ interface TimingOptions {
   crossOrigin: boolean | string | ((c: Context) => boolean | string)
 }
 
-const getTime = () => {
+const getTime = (): number => {
   try {
     return performance.now()
   } catch {}

--- a/src/request.ts
+++ b/src/request.ts
@@ -289,7 +289,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/request#url
    */
-  get url() {
+  get url(): string {
     return this.raw.url
   }
 
@@ -303,7 +303,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/request#method
    */
-  get method() {
+  get method(): string {
     return this.raw.method
   }
 

--- a/src/router/smart-router/router.ts
+++ b/src/router/smart-router/router.ts
@@ -59,7 +59,7 @@ export class SmartRouter<T> implements Router<T> {
     return res as Result<T>
   }
 
-  get activeRouter() {
+  get activeRouter(): Router<T> {
     if (this.routes || this.routers.length !== 1) {
       throw new Error('No active router has been determined yet.')
     }

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -48,7 +48,10 @@ export const bufferToString = (buffer: ArrayBuffer): string => {
   return buffer
 }
 
-export const bufferToFormData = (arrayBuffer: ArrayBuffer, contentType: string) => {
+export const bufferToFormData = (
+  arrayBuffer: ArrayBuffer,
+  contentType: string
+): Promise<FormData> => {
   const response = new Response(arrayBuffer, {
     headers: {
       'Content-Type': contentType,

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,4 @@
-export function getColorEnabled() {
+export function getColorEnabled(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { process, Deno } = globalThis as any
 

--- a/src/utils/jwt/utf8.ts
+++ b/src/utils/jwt/utf8.ts
@@ -1,2 +1,2 @@
-export const utf8Encoder = new TextEncoder()
-export const utf8Decoder = new TextDecoder()
+export const utf8Encoder: TextEncoder = new TextEncoder()
+export const utf8Decoder: TextDecoder = new TextDecoder()

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -30,7 +30,7 @@ export class StreamingApi {
     })
   }
 
-  async write(input: Uint8Array | string) {
+  async write(input: Uint8Array | string): Promise<StreamingApi> {
     try {
       if (typeof input === 'string') {
         input = this.encoder.encode(input)
@@ -42,12 +42,12 @@ export class StreamingApi {
     return this
   }
 
-  async writeln(input: string) {
+  async writeln(input: string): Promise<StreamingApi> {
     await this.write(input + '\n')
     return this
   }
 
-  sleep(ms: number) {
+  sleep(ms: number): Promise<unknown> {
     return new Promise((res) => setTimeout(res, ms))
   }
 


### PR DESCRIPTION
This PR added type annotations to reduce "[Slow Types](https://jsr.io/docs/about-slow-types)".

We are planning to support the [JSR](https://jsr.io/). For this, it's better to remove [Slow Types](https://jsr.io/docs/about-slow-types). Adding type annotations is one big issue in reducing Slow Types. In addition, it will improve TypeScript inferring performance.

It could be included in PRs to support the JSR, but not only that, so make it a separate PR and merge it into the `main` now.