### PR TITLE
feat(utils/cookie): allow setting cookie SameSite attribute in lowercase too

### DIFF
--- a/deno_dist/utils/cookie.ts
+++ b/deno_dist/utils/cookie.ts
@@ -17,7 +17,7 @@ export type CookieOptions = {
   path?: string
   secure?: boolean
   signingSecret?: string
-  sameSite?: 'Strict' | 'Lax' | 'None'
+  sameSite?: 'Strict' | 'Lax' | 'None' | 'strict' | 'lax' | 'none'
   partitioned?: boolean
   prefix?: CookiePrefixOptions
 } & PartitionCookieConstraint
@@ -188,7 +188,7 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.sameSite) {
-    cookie += `; SameSite=${opt.sameSite}`
+    cookie += `; SameSite=${opt.sameSite.charAt(0).toUpperCase() + opt.sameSite.slice(1)}`
   }
 
   if (opt.partitioned) {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -17,7 +17,7 @@ export type CookieOptions = {
   path?: string
   secure?: boolean
   signingSecret?: string
-  sameSite?: 'Strict' | 'Lax' | 'None'
+  sameSite?: 'Strict' | 'Lax' | 'None' | 'strict' | 'lax' | 'none'
   partitioned?: boolean
   prefix?: CookiePrefixOptions
 } & PartitionCookieConstraint
@@ -188,7 +188,7 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.sameSite) {
-    cookie += `; SameSite=${opt.sameSite}`
+    cookie += `; SameSite=${opt.sameSite.charAt(0).toUpperCase() + opt.sameSite.slice(1)}`
   }
 
   if (opt.partitioned) {


### PR DESCRIPTION
Added support for allowing `lax`, `strict`, and `none` values for the `SameSite` attribute in the `setCookie` function.

While the [RFC](https://datatracker.ietf.org/doc/html/draft-west-first-party-cookies-07#section-4.1) suggests that the `SameSite` attribute should `Strict`, `Lax`, `None` as values, there is no indication that the `SameSite` attribute should be case-sensitive.

Libraries like lucia (Undelying [`olso`](https://github.com/pilcrowOnPaper/oslo/blob/26f8c9dabc2dac6212c855602614d91991e87889/src/cookie/index.ts#L7)) returns cookie objects with lowercase `SameSite` attribute values, which conficts with the `SameSite` attribute values in the `setCookie` function. This needs us to convert the `SameSite` attribute values from lucia to the correct case-sensitive values which is a huge pain.

Libraires like Next.js (underlying [`@edge-runtime/cookie`](https://github.com/vercel/edge-runtime/blob/529e4d5d4df3050eb634cd59d17a0e1801789226/packages/cookies/src/serialize.ts#L102)) allow both cases and uses the lowercase value.

While I could have asked lucia to change the case of the `SameSite` attribute values, Its less likely to happen as changing the case of the `SameSite` attribute values would break existing codebases. So its better to allow both cases for the `SameSite` attribute values.

I have updated the `setCookie` function to allow `lax`, `strict`, and `none` values for the `SameSite` attribute. While keeping the return value in the original case-sensitive form to stay true to the RFC.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
