### PR TITLE
fix(method-override): remove un-needed import of URLSearchParams in method override middleware

### DIFF
--- a/deno_dist/middleware/method-override/index.ts
+++ b/deno_dist/middleware/method-override/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'node:url'
 import type { Context } from '../../context.ts'
 import type { Hono } from '../../hono.ts'
 import type { MiddlewareHandler } from '../../types.ts'

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url'
 import type { Context } from '../../context'
 import type { Hono } from '../../hono'
 import type { MiddlewareHandler } from '../../types'


### PR DESCRIPTION
this PR simply removes the `URLSearchParams` import from the node-specific package `url`.

when running hono and using the method override middleware in cloudflare workers, wrangler complains about the use of the `url` package. it prompts you to add the `node_compat` flag.

this seems a bit erroneous to me, since node has had `URLSearchParams` as a global since version 10. maybe i'm missing something specific about other runtimes, but all tests pass.

please nuke this PR if i'm flat-out wrong ;)

- [ ] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [ ] `bun run format:fix && bun run lint:fix` to format the code
