### PR TITLE
docs(jsdoc): add JSDoc for Middleware

### DIFF
--- a/deno_dist/middleware/basic-auth/index.ts
+++ b/deno_dist/middleware/basic-auth/index.ts
@@ -46,11 +46,11 @@ type BasicAuthOptions =
  * @see {@link https://hono.dev/middleware/builtin/basic-auth}
  *
  * @param {BasicAuthOptions} options - The options for the basic authentication middleware.
- * @param {string} [options.username] - The username for authentication.
- * @param {string} [options.password] - The password for authentication.
+ * @param {string} options.username - The username for authentication.
+ * @param {string} options.password - The password for authentication.
  * @param {string} [options.realm="Secure Area"] - The realm attribute for the WWW-Authenticate header.
- * @param {Function} [options.hashFunction=] - The hash function used for secure comparison.
- * @param {Function} [options.verifyUser=] - The function to verify user credentials.
+ * @param {Function} [options.hashFunction] - The hash function used for secure comparison.
+ * @param {Function} [options.verifyUser] - The function to verify user credentials.
  * @returns {MiddlewareHandler} The middleware handler function.
  * @throws {HTTPException} If neither "username and password" nor "verifyUser" options are provided.
  *

--- a/deno_dist/middleware/basic-auth/index.ts
+++ b/deno_dist/middleware/basic-auth/index.ts
@@ -40,6 +40,37 @@ type BasicAuthOptions =
       hashFunction?: Function
     }
 
+/**
+ * Basic authentication middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/basic-auth}
+ *
+ * @param {BasicAuthOptions} options - The options for the basic authentication middleware.
+ * @param {string} [options.username] - The username for authentication.
+ * @param {string} [options.password] - The password for authentication.
+ * @param {string} [options.realm="Secure Area"] - The realm attribute for the WWW-Authenticate header.
+ * @param {Function} [options.hashFunction=] - The hash function used for secure comparison.
+ * @param {Function} [options.verifyUser=] - The function to verify user credentials.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ * @throws {HTTPException} If neither "username and password" nor "verifyUser" options are provided.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '/auth/*',
+ *   basicAuth({
+ *     username: 'hono',
+ *     password: 'acoolproject',
+ *   })
+ * )
+ *
+ * app.get('/auth/page', (c) => {
+ *   return c.text('You are authorized')
+ * })
+ * ```
+ */
 export const basicAuth = (
   options: BasicAuthOptions,
   ...users: { username: string; password: string }[]

--- a/deno_dist/middleware/bearer-auth/index.ts
+++ b/deno_dist/middleware/bearer-auth/index.ts
@@ -23,6 +23,35 @@ type BearerAuthOptions =
       hashFunction?: Function
     }
 
+/**
+ * Bearer authentication middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/bearer-auth}
+ *
+ * @param {BearerAuthOptions} options - The options for the bearer authentication middleware.
+ * @param {string | string[]} [options.token] - The string or array of strings to validate the incoming bearer token against.
+ * @param {Function} [options.verifyToken] - The function to verify the token.
+ * @param {string} [options.realm=""] - The domain name of the realm, as part of the returned WWW-Authenticate challenge header.
+ * @param {string} [options.prefix="Bearer"] - The prefix (or known as `schema`) for the Authorization header value.
+ * @param {string} [options.headerName=Authorization] - The header name.
+ * @param {Function} [options.hashFunction] - A function to handle hashing for safe comparison of authentication tokens.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ * @throws {Error} If neither "token" nor "verifyToken" options are provided.
+ * @throws {HTTPException} If authentication fails, with 401 status code for missing or invalid token, or 400 status code for invalid request.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * const token = 'honoiscool'
+ *
+ * app.use('/api/*', bearerAuth({ token }))
+ *
+ * app.get('/api/page', (c) => {
+ *   return c.json({ message: 'You are authorized' })
+ * })
+ * ```
+ */
 export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
   if (!('token' in options || 'verifyToken' in options)) {
     throw new Error('bearer auth middleware requires options for "token"')

--- a/deno_dist/middleware/body-limit/index.ts
+++ b/deno_dist/middleware/body-limit/index.ts
@@ -18,21 +18,34 @@ class BodyLimitError extends Error {
 }
 
 /**
- * Body Limit Middleware
+ * Body limit middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/body-limit}
+ *
+ * @param {BodyLimitOptions} options - The options for the body limit middleware.
+ * @param {number} options.maxSize - The maximum body size allowed.
+ * @param {OnError} [options.onError] - The error handler to be invoked if the specified body size is exceeded.
+ * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
  * ```ts
+ * const app = new Hono()
+ *
  * app.post(
- *  '/hello',
- *  bodyLimit({
- *    maxSize: 100 * 1024, // 100kb
- *    onError: (c) => {
- *      return c.text('overflow :(', 413)
- *    }
- *  }),
- *  (c) => {
- *    return c.text('pass :)')
- *  }
+ *   '/upload',
+ *   bodyLimit({
+ *     maxSize: 50 * 1024, // 50kb
+ *     onError: (c) => {
+ *       return c.text('overflow :(', 413)
+ *     },
+ *   }),
+ *   async (c) => {
+ *     const body = await c.req.parseBody()
+ *     if (body['file'] instanceof File) {
+ *       console.log(`Got file sized: ${body['file'].size}`)
+ *     }
+ *     return c.text('pass :)')
+ *   }
  * )
  * ```
  */

--- a/deno_dist/middleware/cache/index.ts
+++ b/deno_dist/middleware/cache/index.ts
@@ -1,6 +1,31 @@
 import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 
+/**
+ * cache middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/cache}
+ *
+ * @param {Object} options - The options for the cache middleware.
+ * @param {string | Function} options.cacheName - The name of the cache. Can be used to store multiple caches with different identifiers.
+ * @param {boolean} [options.wait=false] - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. Required to be true for the Deno environment.
+ * @param {string} [options.cacheControl] - A string of directives for the `Cache-Control` header.
+ * @param {string | string[]} [options.vary] - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
+ * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ * @throws {Error} If the `vary` option includes "*".
+ *
+ * @example
+ * ```ts
+ * app.get(
+ *   '*',
+ *   cache({
+ *     cacheName: 'my-app',
+ *     cacheControl: 'max-age=3600',
+ *   })
+ * )
+ * ```
+ */
 export const cache = (options: {
   cacheName: string | ((c: Context) => Promise<string> | string)
   wait?: boolean

--- a/deno_dist/middleware/compress/index.ts
+++ b/deno_dist/middleware/compress/index.ts
@@ -6,6 +6,22 @@ interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
 }
 
+/**
+ * Compress middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/compress}
+ *
+ * @param {CompressionOptions} [options] - The options for the compress middleware.
+ * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(compress())
+ * ```
+ */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   return async function compress(ctx, next) {
     await next()

--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -10,6 +10,45 @@ type CORSOptions = {
   exposeHeaders?: string[]
 }
 
+/**
+ * CORS middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/cors}
+ *
+ * @param {CORSOptions} [options] - The options for the CORS middleware.
+ * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
+ * @param {string[]} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
+ * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
+ * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
+ * @param {string[]} [options.exposeHeaders=[]] - The value of "Access-Control-Expose-Headers" CORS header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/api/*', cors())
+ * app.use(
+ *   '/api2/*',
+ *   cors({
+ *     origin: 'http://example.com',
+ *     allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
+ *     allowMethods: ['POST', 'GET', 'OPTIONS'],
+ *     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+ *     maxAge: 600,
+ *     credentials: true,
+ *   })
+ * )
+ *
+ * app.all('/api/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * app.all('/api2/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * ```
+ */
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',

--- a/deno_dist/middleware/csrf/index.ts
+++ b/deno_dist/middleware/csrf/index.ts
@@ -11,6 +11,43 @@ const isSafeMethodRe = /^(GET|HEAD)$/
 const isRequestedByFormElementRe =
   /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/
 
+/**
+ * CSRF protection middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/csrf}
+ *
+ * @param {CSRFOptions} [options] - The options for the CSRF protection middleware.
+ * @param {string|string[]|(origin: string, context: Context) => boolean} [options.origin] - Specify origins.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(csrf())
+ *
+ * // Specifying origins with using `origin` option
+ * // string
+ * app.use(csrf({ origin: 'myapp.example.com' }))
+ *
+ * // string[]
+ * app.use(
+ *   csrf({
+ *     origin: ['myapp.example.com', 'development.myapp.example.com'],
+ *   })
+ * )
+ *
+ * // Function
+ * // It is strongly recommended that the protocol be verified to ensure a match to `$`.
+ * // You should *never* do a forward match.
+ * app.use(
+ *   '*',
+ *   csrf({
+ *     origin: (origin) => /https:\/\/(\w+\.)?myapp\.example\.com$/.test(origin),
+ *   })
+ * )
+ * ```
+ */
 export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
   const handler: IsAllowedOriginHandler = ((optsOrigin) => {
     if (!optsOrigin) {

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -25,6 +25,26 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
   return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
 }
 
+/**
+ * ETag middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/etag}
+ *
+ * @param {ETagOptions} [options] - The options for the ETag middleware.
+ * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
+ * @param {string[]} [options.retainedHeaders=RETAINED_304_HEADERS] - The headers that you want to retain in the 304 Response.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/etag/*', etag())
+ * app.get('/etag/abc', (c) => {
+ *   return c.text('Hono is cool')
+ * })
+ * ```
+ */
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false

--- a/deno_dist/middleware/jsx-renderer/index.ts
+++ b/deno_dist/middleware/jsx-renderer/index.ts
@@ -67,6 +67,40 @@ const createRenderer =
     }
   }
 
+/**
+ * JSX renderer middleware for hono.
+ *
+ * @see {@link{https://hono.dev/middleware/builtin/jsx-renderer}}
+ *
+ * @param {ComponentWithChildren} [component] - The component to render, which can accept children and props.
+ * @param {RendererOptions} [options] - The options for the JSX renderer middleware.
+ * @param {boolean | string} [options.docType=true] - The DOCTYPE to be added at the beginning of the HTML. If set to false, no DOCTYPE will be added.
+ * @param {boolean | Record<string, string>} [options.stream=false] - If set to true, enables streaming response with default headers. If a record is provided, custom headers will be used.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.get(
+ *   '/page/*',
+ *   jsxRenderer(({ children }) => {
+ *     return (
+ *       <html>
+ *         <body>
+ *           <header>Menu</header>
+ *           <div>{children}</div>
+ *         </body>
+ *       </html>
+ *     )
+ *   })
+ * )
+ *
+ * app.get('/page/about', (c) => {
+ *   return c.render(<h1>About me!</h1>)
+ * })
+ * ```
+ */
 export const jsxRenderer = (
   component?: ComponentWithChildren,
   options?: RendererOptions
@@ -82,6 +116,30 @@ export const jsxRenderer = (
     return next()
   }
 
+/**
+ * useRequestContext for Hono.
+ *
+ * @template E - The environment type.
+ * @template P - The parameter type.
+ * @template I - The input type.
+ * @returns {Context<E, P, I>} An instance of Context.
+ *
+ * @example
+ * ```ts
+ * const RequestUrlBadge: FC = () => {
+ *   const c = useRequestContext()
+ *   return <b>{c.req.url}</b>
+ * }
+ *
+ * app.get('/page/info', (c) => {
+ *   return c.render(
+ *     <div>
+ *       You are accessing: <RequestUrlBadge />
+ *     </div>
+ *   )
+ * })
+ * ```
+ */
 export const useRequestContext = <
   E extends Env = any,
   P extends string = any,

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -13,6 +13,33 @@ declare module '../../context.ts' {
   }
 }
 
+/**
+ * JWT Auth middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/jwt}
+ *
+ * @param {object} options - The options for the JWT middleware.
+ * @param {string} options.secret - A value of your secret key.
+ * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
+ * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '/auth/*',
+ *   jwt({
+ *     secret: 'it-is-very-secret',
+ *   })
+ * )
+ *
+ * app.get('/auth/page', (c) => {
+ *   return c.text('You are authorized')
+ * })
+ * ```
+ */
 export const jwt = (options: {
   secret: string
   cookie?: string

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -19,7 +19,7 @@ declare module '../../context.ts' {
  * @see {@link https://hono.dev/middleware/builtin/jwt}
  *
  * @param {object} options - The options for the JWT middleware.
- * @param {string} options.secret - A value of your secret key.
+ * @param {string} [options.secret] - A value of your secret key.
  * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
  * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
  * @returns {MiddlewareHandler} The middleware handler function.

--- a/deno_dist/middleware/logger/index.ts
+++ b/deno_dist/middleware/logger/index.ts
@@ -55,6 +55,22 @@ function log(
   fn(out)
 }
 
+/**
+ * Logger middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/logger}
+ *
+ * @param {PrintFunc} [fn=console.log] - Optional function for customized logging behavior.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(logger())
+ * app.get('/', (c) => c.text('Hello Hono!'))
+ * ```
+ */
 export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async function logger(c, next) {
     const { method } = c.req

--- a/deno_dist/middleware/method-override/index.ts
+++ b/deno_dist/middleware/method-override/index.ts
@@ -29,21 +29,29 @@ type MethodOverrideOptions = {
 const DEFAULT_METHOD_FORM_NAME = '_method'
 
 /**
- * Method Override Middleware
+ * Method Override Middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/method-override}
+ *
+ * @param {MethodOverrideOptions} options - The options for the method override middleware.
+ * @param {Hono} options.app - The instance of Hono is used in your application.
+ * @param {string} [options.form=_method] - Form key with a value containing the method name.
+ * @param {string} [options.header] - Header name with a value containing the method name.
+ * @param {string} [options.query] - Query parameter key with a value containing the method name.
+ * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
- * // with form input method
+ * ```ts
  * const app = new Hono()
- * app.use('/books/*', methodOverride({ app })) // the default `form` value is `_method`
- * app.use('/authors/*', methodOverride({ app, form: 'method' }))
  *
- * @example
- * // with custom header
- * app.use('/books/*', methodOverride({ app, header: 'X-HTTP-METHOD-OVERRIDE' }))
+ * // If no options are specified, the value of `_method` in the form,
+ * // e.g. DELETE, is used as the method.
+ * app.use('/posts', methodOverride({ app }))
  *
- * @example
- * // with query parameter
- * app.use('/books/*', methodOverride({ app, query: '_method' }))
+ * app.delete('/posts', (c) => {
+ *   // ....
+ * })
+ * ```
  */
 export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandler =>
   async function methodOverride(c, next) {

--- a/deno_dist/middleware/pretty-json/index.ts
+++ b/deno_dist/middleware/pretty-json/index.ts
@@ -4,6 +4,25 @@ type prettyOptions = {
   space: number
 }
 
+/**
+ * Pretty JSON middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/pretty-json}
+ *
+ * @param {prettyOptions} [options] - The options for the pretty JSON middleware.
+ * @param {number} [options.space=2] - Number of spaces for indentation.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(prettyJSON()) // With options: prettyJSON({ space: 4 })
+ * app.get('/', (c) => {
+ *   return c.json({ message: 'Hono!' })
+ * })
+ * ```
+ */
 export const prettyJSON = (options: prettyOptions = { space: 2 }): MiddlewareHandler => {
   return async function prettyJSON(c, next) {
     const pretty = c.req.query('pretty') || c.req.query('pretty') === '' ? true : false

--- a/deno_dist/middleware/secure-headers/index.ts
+++ b/deno_dist/middleware/secure-headers/index.ts
@@ -115,6 +115,7 @@ const generateNonce = () => {
   crypto.getRandomValues(buffer)
   return Buffer.from(buffer).toString('base64')
 }
+
 export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
   const nonce =
     ctx.get('secureHeadersNonce') ||
@@ -126,6 +127,35 @@ export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
   return `'nonce-${nonce}'`
 }
 
+/**
+ * Secure Headers Middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/secure-headers}
+ *
+ * @param {Partial<SecureHeadersOptions>} [customOptions] - The options for the secure headers middleware.
+ * @param {ContentSecurityPolicyOptions} [customOptions.contentSecurityPolicy] - Settings for the Content-Security-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginEmbedderPolicy=false] - Settings for the Cross-Origin-Embedder-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginResourcePolicy=true] - Settings for the Cross-Origin-Resource-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginOpenerPolicy=true] - Settings for the Cross-Origin-Opener-Policy header.
+ * @param {overridableHeader} [customOptions.originAgentCluster=true] - Settings for the Origin-Agent-Cluster header.
+ * @param {overridableHeader} [customOptions.referrerPolicy=true] - Settings for the Referrer-Policy header.
+ * @param {ReportingEndpointOptions[]} [customOptions.reportingEndpoints] - Settings for the Reporting-Endpoints header.
+ * @param {ReportToOptions[]} [customOptions.reportTo] - Settings for the Report-To header.
+ * @param {overridableHeader} [customOptions.strictTransportSecurity=true] - Settings for the Strict-Transport-Security header.
+ * @param {overridableHeader} [customOptions.xContentTypeOptions=true] - Settings for the X-Content-Type-Options header.
+ * @param {overridableHeader} [customOptions.xDnsPrefetchControl=true] - Settings for the X-DNS-Prefetch-Control header.
+ * @param {overridableHeader} [customOptions.xDownloadOptions=true] - Settings for the X-Download-Options header.
+ * @param {overridableHeader} [customOptions.xFrameOptions=true] - Settings for the X-Frame-Options header.
+ * @param {overridableHeader} [customOptions.xPermittedCrossDomainPolicies=true] - Settings for the X-Permitted-Cross-Domain-Policies header.
+ * @param {overridableHeader} [customOptions.xXssProtection=true] - Settings for the X-XSS-Protection header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ * app.use(secureHeaders())
+ * ```
+ */
 export const secureHeaders = (customOptions?: SecureHeadersOptions): MiddlewareHandler => {
   const options = { ...DEFAULT_OPTIONS, ...customOptions }
   const headersToSet = getFilteredHeaders(options)

--- a/deno_dist/middleware/timing/index.ts
+++ b/deno_dist/middleware/timing/index.ts
@@ -31,6 +31,45 @@ const getTime = (): number => {
   return Date.now()
 }
 
+/**
+ * Server-Timing Middleware middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/timing}
+ *
+ * @param {TimingOptions} [config] - The options for the timing middleware.
+ * @param {boolean} [config.total=true] - Show the total response time.
+ * @param {boolean | ((c: Context) => boolean)} [config.enabled=true] - Whether timings should be added to the headers or not.
+ * @param {string} [config.totalDescription=Total Response Time] - Description for the total response time.
+ * @param {boolean} [config.autoEnd=true] - If `startTime()` should end automatically at the end of the request.
+ * @param {boolean | string | ((c: Context) => boolean | string)} [config.crossOrigin=false] - The origin this timings header should be readable.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * // add the middleware to your router
+ * app.use(timing());
+ *
+ * app.get('/', async (c) => {
+ *   // add custom metrics
+ *   setMetric(c, 'region', 'europe-west3')
+ *
+ *   // add custom metrics with timing, must be in milliseconds
+ *   setMetric(c, 'custom', 23.8, 'My custom Metric')
+ *
+ *   // start a new timer
+ *   startTime(c, 'db');
+ *
+ *   const data = await db.findMany(...);
+ *
+ *   // end the timer
+ *   endTime(c, 'db');
+ *
+ *   return c.json({ response: data });
+ * });
+ * ```
+ */
 export const timing = (config?: TimingOptions): MiddlewareHandler => {
   const options: TimingOptions = {
     ...{
@@ -84,6 +123,21 @@ interface SetMetric {
   (c: Context, name: string, description?: string): void
 }
 
+/**
+ * Set a metric for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the metric.
+ * @param {number | string} [valueDescription] - The value or description of the metric.
+ * @param {string} [description] - The description of the metric.
+ * @param {number} [precision] - The precision of the metric value.
+ *
+ * @example
+ * ```ts
+ * setMetric(c, 'region', 'europe-west3')
+ * setMetric(c, 'custom', 23.8, 'My custom Metric')
+ * ```
+ */
 export const setMetric: SetMetric = (
   c: Context,
   name: string,
@@ -110,6 +164,18 @@ export const setMetric: SetMetric = (
   }
 }
 
+/**
+ * Start a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {string} [description] - The description of the timer.
+ *
+ * @example
+ * ```ts
+ * startTime(c, 'db')
+ * ```
+ */
 export const startTime = (c: Context, name: string, description?: string) => {
   const metrics = c.get('metric')
   if (!metrics) {
@@ -119,6 +185,18 @@ export const startTime = (c: Context, name: string, description?: string) => {
   metrics.timers.set(name, { description, start: getTime() })
 }
 
+/**
+ * End a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {number} [precision] - The precision of the timer value.
+ *
+ * @example
+ * ```ts
+ * endTime(c, 'db')
+ * ```
+ */
 export const endTime = (c: Context, name: string, precision?: number) => {
   const metrics = c.get('metric')
   if (!metrics) {

--- a/deno_dist/middleware/trailing-slash/index.ts
+++ b/deno_dist/middleware/trailing-slash/index.ts
@@ -1,9 +1,19 @@
 import type { MiddlewareHandler } from '../../types.ts'
 
 /**
- * Trim the trailing slash from the URL if it does have one. For example, `/path/to/page/` will be redirected to `/path/to/page`.
- * @access public
- * @example app.use(trimTrailingSlash())
+ * Trailing slash middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(trimTrailingSlash())
+ * app.get('/about/me/', (c) => c.text('With Trailing Slash'))
+ * ```
  */
 export const trimTrailingSlash = (): MiddlewareHandler => {
   return async function trimTrailingSlash(c, next) {
@@ -24,9 +34,19 @@ export const trimTrailingSlash = (): MiddlewareHandler => {
 }
 
 /**
+ * Append trailing slash middleware for Hono.
  * Append a trailing slash to the URL if it doesn't have one. For example, `/path/to/page` will be redirected to `/path/to/page/`.
- * @access public
- * @example app.use(appendTrailingSlash())
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(appendTrailingSlash())
+ * ```
  */
 export const appendTrailingSlash = (): MiddlewareHandler => {
   return async function appendTrailingSlash(c, next) {

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -46,11 +46,11 @@ type BasicAuthOptions =
  * @see {@link https://hono.dev/middleware/builtin/basic-auth}
  *
  * @param {BasicAuthOptions} options - The options for the basic authentication middleware.
- * @param {string} [options.username] - The username for authentication.
- * @param {string} [options.password] - The password for authentication.
+ * @param {string} options.username - The username for authentication.
+ * @param {string} options.password - The password for authentication.
  * @param {string} [options.realm="Secure Area"] - The realm attribute for the WWW-Authenticate header.
- * @param {Function} [options.hashFunction=] - The hash function used for secure comparison.
- * @param {Function} [options.verifyUser=] - The function to verify user credentials.
+ * @param {Function} [options.hashFunction] - The hash function used for secure comparison.
+ * @param {Function} [options.verifyUser] - The function to verify user credentials.
  * @returns {MiddlewareHandler} The middleware handler function.
  * @throws {HTTPException} If neither "username and password" nor "verifyUser" options are provided.
  *

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -40,6 +40,37 @@ type BasicAuthOptions =
       hashFunction?: Function
     }
 
+/**
+ * Basic authentication middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/basic-auth}
+ *
+ * @param {BasicAuthOptions} options - The options for the basic authentication middleware.
+ * @param {string} [options.username] - The username for authentication.
+ * @param {string} [options.password] - The password for authentication.
+ * @param {string} [options.realm="Secure Area"] - The realm attribute for the WWW-Authenticate header.
+ * @param {Function} [options.hashFunction=] - The hash function used for secure comparison.
+ * @param {Function} [options.verifyUser=] - The function to verify user credentials.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ * @throws {HTTPException} If neither "username and password" nor "verifyUser" options are provided.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '/auth/*',
+ *   basicAuth({
+ *     username: 'hono',
+ *     password: 'acoolproject',
+ *   })
+ * )
+ *
+ * app.get('/auth/page', (c) => {
+ *   return c.text('You are authorized')
+ * })
+ * ```
+ */
 export const basicAuth = (
   options: BasicAuthOptions,
   ...users: { username: string; password: string }[]

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -23,6 +23,35 @@ type BearerAuthOptions =
       hashFunction?: Function
     }
 
+/**
+ * Bearer authentication middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/bearer-auth}
+ *
+ * @param {BearerAuthOptions} options - The options for the bearer authentication middleware.
+ * @param {string | string[]} [options.token] - The string or array of strings to validate the incoming bearer token against.
+ * @param {Function} [options.verifyToken] - The function to verify the token.
+ * @param {string} [options.realm=""] - The domain name of the realm, as part of the returned WWW-Authenticate challenge header.
+ * @param {string} [options.prefix="Bearer"] - The prefix (or known as `schema`) for the Authorization header value.
+ * @param {string} [options.headerName=Authorization] - The header name.
+ * @param {Function} [options.hashFunction] - A function to handle hashing for safe comparison of authentication tokens.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ * @throws {Error} If neither "token" nor "verifyToken" options are provided.
+ * @throws {HTTPException} If authentication fails, with 401 status code for missing or invalid token, or 400 status code for invalid request.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * const token = 'honoiscool'
+ *
+ * app.use('/api/*', bearerAuth({ token }))
+ *
+ * app.get('/api/page', (c) => {
+ *   return c.json({ message: 'You are authorized' })
+ * })
+ * ```
+ */
 export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
   if (!('token' in options || 'verifyToken' in options)) {
     throw new Error('bearer auth middleware requires options for "token"')

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -18,21 +18,34 @@ class BodyLimitError extends Error {
 }
 
 /**
- * Body Limit Middleware
+ * Body limit middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/body-limit}
+ *
+ * @param {BodyLimitOptions} options - The options for the body limit middleware.
+ * @param {number} options.maxSize - The maximum body size allowed.
+ * @param {OnError} [options.onError] - The error handler to be invoked if the specified body size is exceeded.
+ * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
  * ```ts
+ * const app = new Hono()
+ *
  * app.post(
- *  '/hello',
- *  bodyLimit({
- *    maxSize: 100 * 1024, // 100kb
- *    onError: (c) => {
- *      return c.text('overflow :(', 413)
- *    }
- *  }),
- *  (c) => {
- *    return c.text('pass :)')
- *  }
+ *   '/upload',
+ *   bodyLimit({
+ *     maxSize: 50 * 1024, // 50kb
+ *     onError: (c) => {
+ *       return c.text('overflow :(', 413)
+ *     },
+ *   }),
+ *   async (c) => {
+ *     const body = await c.req.parseBody()
+ *     if (body['file'] instanceof File) {
+ *       console.log(`Got file sized: ${body['file'].size}`)
+ *     }
+ *     return c.text('pass :)')
+ *   }
  * )
  * ```
  */

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -1,6 +1,31 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
+/**
+ * cache middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/cache}
+ *
+ * @param {Object} options - The options for the cache middleware.
+ * @param {string | Function} options.cacheName - The name of the cache. Can be used to store multiple caches with different identifiers.
+ * @param {boolean} [options.wait=false] - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. Required to be true for the Deno environment.
+ * @param {string} [options.cacheControl] - A string of directives for the `Cache-Control` header.
+ * @param {string | string[]} [options.vary] - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
+ * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ * @throws {Error} If the `vary` option includes "*".
+ *
+ * @example
+ * ```ts
+ * app.get(
+ *   '*',
+ *   cache({
+ *     cacheName: 'my-app',
+ *     cacheControl: 'max-age=3600',
+ *   })
+ * )
+ * ```
+ */
 export const cache = (options: {
   cacheName: string | ((c: Context) => Promise<string> | string)
   wait?: boolean

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -6,6 +6,22 @@ interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
 }
 
+/**
+ * Compress middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/compress}
+ *
+ * @param {CompressionOptions} [options] - The options for the compress middleware.
+ * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(compress())
+ * ```
+ */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   return async function compress(ctx, next) {
     await next()

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -10,6 +10,45 @@ type CORSOptions = {
   exposeHeaders?: string[]
 }
 
+/**
+ * CORS middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/cors}
+ *
+ * @param {CORSOptions} [options] - The options for the CORS middleware.
+ * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
+ * @param {string[]} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
+ * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
+ * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
+ * @param {string[]} [options.exposeHeaders=[]] - The value of "Access-Control-Expose-Headers" CORS header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/api/*', cors())
+ * app.use(
+ *   '/api2/*',
+ *   cors({
+ *     origin: 'http://example.com',
+ *     allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
+ *     allowMethods: ['POST', 'GET', 'OPTIONS'],
+ *     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+ *     maxAge: 600,
+ *     credentials: true,
+ *   })
+ * )
+ *
+ * app.all('/api/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * app.all('/api2/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * ```
+ */
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',

--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -11,6 +11,43 @@ const isSafeMethodRe = /^(GET|HEAD)$/
 const isRequestedByFormElementRe =
   /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/
 
+/**
+ * CSRF protection middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/csrf}
+ *
+ * @param {CSRFOptions} [options] - The options for the CSRF protection middleware.
+ * @param {string|string[]|(origin: string, context: Context) => boolean} [options.origin] - Specify origins.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(csrf())
+ *
+ * // Specifying origins with using `origin` option
+ * // string
+ * app.use(csrf({ origin: 'myapp.example.com' }))
+ *
+ * // string[]
+ * app.use(
+ *   csrf({
+ *     origin: ['myapp.example.com', 'development.myapp.example.com'],
+ *   })
+ * )
+ *
+ * // Function
+ * // It is strongly recommended that the protocol be verified to ensure a match to `$`.
+ * // You should *never* do a forward match.
+ * app.use(
+ *   '*',
+ *   csrf({
+ *     origin: (origin) => /https:\/\/(\w+\.)?myapp\.example\.com$/.test(origin),
+ *   })
+ * )
+ * ```
+ */
 export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
   const handler: IsAllowedOriginHandler = ((optsOrigin) => {
     if (!optsOrigin) {

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -25,6 +25,26 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
   return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
 }
 
+/**
+ * ETag middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/etag}
+ *
+ * @param {ETagOptions} [options] - The options for the ETag middleware.
+ * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
+ * @param {string[]} [options.retainedHeaders=RETAINED_304_HEADERS] - The headers that you want to retain in the 304 Response.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/etag/*', etag())
+ * app.get('/etag/abc', (c) => {
+ *   return c.text('Hono is cool')
+ * })
+ * ```
+ */
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -67,6 +67,40 @@ const createRenderer =
     }
   }
 
+/**
+ * JSX renderer middleware for hono.
+ *
+ * @see {@link{https://hono.dev/middleware/builtin/jsx-renderer}}
+ *
+ * @param {ComponentWithChildren} [component] - The component to render, which can accept children and props.
+ * @param {RendererOptions} [options] - The options for the JSX renderer middleware.
+ * @param {boolean | string} [options.docType=true] - The DOCTYPE to be added at the beginning of the HTML. If set to false, no DOCTYPE will be added.
+ * @param {boolean | Record<string, string>} [options.stream=false] - If set to true, enables streaming response with default headers. If a record is provided, custom headers will be used.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.get(
+ *   '/page/*',
+ *   jsxRenderer(({ children }) => {
+ *     return (
+ *       <html>
+ *         <body>
+ *           <header>Menu</header>
+ *           <div>{children}</div>
+ *         </body>
+ *       </html>
+ *     )
+ *   })
+ * )
+ *
+ * app.get('/page/about', (c) => {
+ *   return c.render(<h1>About me!</h1>)
+ * })
+ * ```
+ */
 export const jsxRenderer = (
   component?: ComponentWithChildren,
   options?: RendererOptions
@@ -82,6 +116,30 @@ export const jsxRenderer = (
     return next()
   }
 
+/**
+ * useRequestContext for Hono.
+ *
+ * @template E - The environment type.
+ * @template P - The parameter type.
+ * @template I - The input type.
+ * @returns {Context<E, P, I>} An instance of Context.
+ *
+ * @example
+ * ```ts
+ * const RequestUrlBadge: FC = () => {
+ *   const c = useRequestContext()
+ *   return <b>{c.req.url}</b>
+ * }
+ *
+ * app.get('/page/info', (c) => {
+ *   return c.render(
+ *     <div>
+ *       You are accessing: <RequestUrlBadge />
+ *     </div>
+ *   )
+ * })
+ * ```
+ */
 export const useRequestContext = <
   E extends Env = any,
   P extends string = any,

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -13,6 +13,33 @@ declare module '../../context' {
   }
 }
 
+/**
+ * JWT Auth middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/jwt}
+ *
+ * @param {object} options - The options for the JWT middleware.
+ * @param {string} [options.secret] - A value of your secret key.
+ * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
+ * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '/auth/*',
+ *   jwt({
+ *     secret: 'it-is-very-secret',
+ *   })
+ * )
+ *
+ * app.get('/auth/page', (c) => {
+ *   return c.text('You are authorized')
+ * })
+ * ```
+ */
 export const jwt = (options: {
   secret: string
   cookie?: string

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -55,6 +55,22 @@ function log(
   fn(out)
 }
 
+/**
+ * Logger middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/logger}
+ *
+ * @param {PrintFunc} [fn=console.log] - Optional function for customized logging behavior.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(logger())
+ * app.get('/', (c) => c.text('Hello Hono!'))
+ * ```
+ */
 export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async function logger(c, next) {
     const { method } = c.req

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -29,21 +29,29 @@ type MethodOverrideOptions = {
 const DEFAULT_METHOD_FORM_NAME = '_method'
 
 /**
- * Method Override Middleware
+ * Method Override Middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/method-override}
+ *
+ * @param {MethodOverrideOptions} options - The options for the method override middleware.
+ * @param {Hono} options.app - The instance of Hono is used in your application.
+ * @param {string} [options.form=_method] - Form key with a value containing the method name.
+ * @param {string} [options.header] - Header name with a value containing the method name.
+ * @param {string} [options.query] - Query parameter key with a value containing the method name.
+ * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
- * // with form input method
+ * ```ts
  * const app = new Hono()
- * app.use('/books/*', methodOverride({ app })) // the default `form` value is `_method`
- * app.use('/authors/*', methodOverride({ app, form: 'method' }))
  *
- * @example
- * // with custom header
- * app.use('/books/*', methodOverride({ app, header: 'X-HTTP-METHOD-OVERRIDE' }))
+ * // If no options are specified, the value of `_method` in the form,
+ * // e.g. DELETE, is used as the method.
+ * app.use('/posts', methodOverride({ app }))
  *
- * @example
- * // with query parameter
- * app.use('/books/*', methodOverride({ app, query: '_method' }))
+ * app.delete('/posts', (c) => {
+ *   // ....
+ * })
+ * ```
  */
 export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandler =>
   async function methodOverride(c, next) {

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -4,6 +4,25 @@ type prettyOptions = {
   space: number
 }
 
+/**
+ * Pretty JSON middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/pretty-json}
+ *
+ * @param {prettyOptions} [options] - The options for the pretty JSON middleware.
+ * @param {number} [options.space=2] - Number of spaces for indentation.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(prettyJSON()) // With options: prettyJSON({ space: 4 })
+ * app.get('/', (c) => {
+ *   return c.json({ message: 'Hono!' })
+ * })
+ * ```
+ */
 export const prettyJSON = (options: prettyOptions = { space: 2 }): MiddlewareHandler => {
   return async function prettyJSON(c, next) {
     const pretty = c.req.query('pretty') || c.req.query('pretty') === '' ? true : false

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -114,6 +114,7 @@ const generateNonce = () => {
   crypto.getRandomValues(buffer)
   return Buffer.from(buffer).toString('base64')
 }
+
 export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
   const nonce =
     ctx.get('secureHeadersNonce') ||
@@ -125,6 +126,35 @@ export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
   return `'nonce-${nonce}'`
 }
 
+/**
+ * Secure Headers Middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/secure-headers}
+ *
+ * @param {Partial<SecureHeadersOptions>} [customOptions] - The options for the secure headers middleware.
+ * @param {ContentSecurityPolicyOptions} [customOptions.contentSecurityPolicy] - Settings for the Content-Security-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginEmbedderPolicy=false] - Settings for the Cross-Origin-Embedder-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginResourcePolicy=true] - Settings for the Cross-Origin-Resource-Policy header.
+ * @param {overridableHeader} [customOptions.crossOriginOpenerPolicy=true] - Settings for the Cross-Origin-Opener-Policy header.
+ * @param {overridableHeader} [customOptions.originAgentCluster=true] - Settings for the Origin-Agent-Cluster header.
+ * @param {overridableHeader} [customOptions.referrerPolicy=true] - Settings for the Referrer-Policy header.
+ * @param {ReportingEndpointOptions[]} [customOptions.reportingEndpoints] - Settings for the Reporting-Endpoints header.
+ * @param {ReportToOptions[]} [customOptions.reportTo] - Settings for the Report-To header.
+ * @param {overridableHeader} [customOptions.strictTransportSecurity=true] - Settings for the Strict-Transport-Security header.
+ * @param {overridableHeader} [customOptions.xContentTypeOptions=true] - Settings for the X-Content-Type-Options header.
+ * @param {overridableHeader} [customOptions.xDnsPrefetchControl=true] - Settings for the X-DNS-Prefetch-Control header.
+ * @param {overridableHeader} [customOptions.xDownloadOptions=true] - Settings for the X-Download-Options header.
+ * @param {overridableHeader} [customOptions.xFrameOptions=true] - Settings for the X-Frame-Options header.
+ * @param {overridableHeader} [customOptions.xPermittedCrossDomainPolicies=true] - Settings for the X-Permitted-Cross-Domain-Policies header.
+ * @param {overridableHeader} [customOptions.xXssProtection=true] - Settings for the X-XSS-Protection header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ * app.use(secureHeaders())
+ * ```
+ */
 export const secureHeaders = (customOptions?: SecureHeadersOptions): MiddlewareHandler => {
   const options = { ...DEFAULT_OPTIONS, ...customOptions }
   const headersToSet = getFilteredHeaders(options)

--- a/src/middleware/timing/index.ts
+++ b/src/middleware/timing/index.ts
@@ -31,6 +31,45 @@ const getTime = (): number => {
   return Date.now()
 }
 
+/**
+ * Server-Timing Middleware middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/timing}
+ *
+ * @param {TimingOptions} [config] - The options for the timing middleware.
+ * @param {boolean} [config.total=true] - Show the total response time.
+ * @param {boolean | ((c: Context) => boolean)} [config.enabled=true] - Whether timings should be added to the headers or not.
+ * @param {string} [config.totalDescription=Total Response Time] - Description for the total response time.
+ * @param {boolean} [config.autoEnd=true] - If `startTime()` should end automatically at the end of the request.
+ * @param {boolean | string | ((c: Context) => boolean | string)} [config.crossOrigin=false] - The origin this timings header should be readable.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * // add the middleware to your router
+ * app.use(timing());
+ *
+ * app.get('/', async (c) => {
+ *   // add custom metrics
+ *   setMetric(c, 'region', 'europe-west3')
+ *
+ *   // add custom metrics with timing, must be in milliseconds
+ *   setMetric(c, 'custom', 23.8, 'My custom Metric')
+ *
+ *   // start a new timer
+ *   startTime(c, 'db');
+ *
+ *   const data = await db.findMany(...);
+ *
+ *   // end the timer
+ *   endTime(c, 'db');
+ *
+ *   return c.json({ response: data });
+ * });
+ * ```
+ */
 export const timing = (config?: TimingOptions): MiddlewareHandler => {
   const options: TimingOptions = {
     ...{
@@ -84,6 +123,21 @@ interface SetMetric {
   (c: Context, name: string, description?: string): void
 }
 
+/**
+ * Set a metric for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the metric.
+ * @param {number | string} [valueDescription] - The value or description of the metric.
+ * @param {string} [description] - The description of the metric.
+ * @param {number} [precision] - The precision of the metric value.
+ *
+ * @example
+ * ```ts
+ * setMetric(c, 'region', 'europe-west3')
+ * setMetric(c, 'custom', 23.8, 'My custom Metric')
+ * ```
+ */
 export const setMetric: SetMetric = (
   c: Context,
   name: string,
@@ -110,6 +164,18 @@ export const setMetric: SetMetric = (
   }
 }
 
+/**
+ * Start a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {string} [description] - The description of the timer.
+ *
+ * @example
+ * ```ts
+ * startTime(c, 'db')
+ * ```
+ */
 export const startTime = (c: Context, name: string, description?: string) => {
   const metrics = c.get('metric')
   if (!metrics) {
@@ -119,6 +185,18 @@ export const startTime = (c: Context, name: string, description?: string) => {
   metrics.timers.set(name, { description, start: getTime() })
 }
 
+/**
+ * End a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {number} [precision] - The precision of the timer value.
+ *
+ * @example
+ * ```ts
+ * endTime(c, 'db')
+ * ```
+ */
 export const endTime = (c: Context, name: string, precision?: number) => {
   const metrics = c.get('metric')
   if (!metrics) {

--- a/src/middleware/trailing-slash/index.ts
+++ b/src/middleware/trailing-slash/index.ts
@@ -1,9 +1,19 @@
 import type { MiddlewareHandler } from '../../types'
 
 /**
- * Trim the trailing slash from the URL if it does have one. For example, `/path/to/page/` will be redirected to `/path/to/page`.
- * @access public
- * @example app.use(trimTrailingSlash())
+ * Trailing slash middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(trimTrailingSlash())
+ * app.get('/about/me/', (c) => c.text('With Trailing Slash'))
+ * ```
  */
 export const trimTrailingSlash = (): MiddlewareHandler => {
   return async function trimTrailingSlash(c, next) {
@@ -24,9 +34,19 @@ export const trimTrailingSlash = (): MiddlewareHandler => {
 }
 
 /**
+ * Append trailing slash middleware for Hono.
  * Append a trailing slash to the URL if it doesn't have one. For example, `/path/to/page` will be redirected to `/path/to/page/`.
- * @access public
- * @example app.use(appendTrailingSlash())
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(appendTrailingSlash())
+ * ```
  */
 export const appendTrailingSlash = (): MiddlewareHandler => {
   return async function appendTrailingSlash(c, next) {


### PR DESCRIPTION
In this PR, let's write the JSDoc for all builtin Middleware.  Only Middleware is addressed here; other documentation than Middleware is done in other PRs. Example #2677.

Will fix #1338

---

- [x] [Basic Auth Middleware](https://hono.dev/middleware/builtin/basic-auth) https://github.com/honojs/hono/pull/2680/commits/3ba73862283b2c1e859782f67a9b77326b6659e6
- [x] [Bearer Authentication](https://hono.dev/middleware/builtin/bearer-auth)
- [x] [Body Limit](https://hono.dev/middleware/builtin/body-limit)
- [x] [Cache](https://hono.dev/middleware/builtin/cache)
- [x] [Compress](https://hono.dev/middleware/builtin/compress)
- [x] [CORS](https://hono.dev/middleware/builtin/cors)
- [x] [CSRF Protection](https://hono.dev/middleware/builtin/csrf)
- [x] [ETag](https://hono.dev/middleware/builtin/etag)
- [x] [JSX Renderer](https://hono.dev/middleware/builtin/jsx-renderer)
- [x] [JWT](https://hono.dev/middleware/builtin/jwt)
- [x] [Logger](https://hono.dev/middleware/builtin/logger)
- [x] [Method Override](https://hono.dev/middleware/builtin/method-override)
- [x] [Pretty JSON](https://hono.dev/middleware/builtin/pretty-json)
- [x] [Secure Headers](https://hono.dev/middleware/builtin/secure-headers)
- [x] [Timing](https://hono.dev/middleware/builtin/timing)
- [x] [Trailing Slash](https://hono.dev/middleware/builtin/trailing-slash)