### PR TITLE
fix(context): Retain all cookies when passing `ResponseInit` to `c.body`

### DIFF
--- a/deno_dist/context.ts
+++ b/deno_dist/context.ts
@@ -2,7 +2,7 @@ import type { HonoRequest } from './request.ts'
 import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types.ts'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html.ts'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status.ts'
-import type { JSONValue, JSONParsed, IsAny, Simplify } from './utils/types.ts'
+import type { IsAny, JSONParsed, JSONValue, Simplify } from './utils/types.ts'
 
 type HeaderRecord = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
@@ -380,7 +380,11 @@ export class Context<
       if (this.#headers) {
         // If the header is set by c.header() and arg.headers, c.header() will be prioritized.
         this.#headers.forEach((v, k) => {
-          header.set(k, v)
+          if (k === 'set-cookie') {
+            header.append(k, v)
+          } else {
+            header.set(k, v)
+          }
         })
       }
       const headers = setHeaders(header, this.#preparedHeaders)

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -308,6 +308,22 @@ describe('Pass a ResponseInit to respond methods', () => {
     expect(await res.text()).toBe('<h2>Hello</h2>')
   })
 
+  it('c.body() should retain context cookies from context and original response', async () => {
+    setCookie(c, 'context', '1')
+    setCookie(c, 'context', '2')
+
+    const originalResponse = new Response('', {
+      headers: {
+        'set-cookie': 'response=1; Path=/',
+      },
+    })
+    const res = c.body('', originalResponse)
+    const cookies = res.headers.getSetCookie()
+    expect(cookies.includes('context=1; Path=/')).toBe(true)
+    expect(cookies.includes('context=2; Path=/')).toBe(true)
+    expect(cookies.includes('response=1; Path=/')).toBe(true)
+  })
+
   it('c.text()', async () => {
     const originalResponse = new Response(JSON.stringify({ foo: 'bar' }))
     const res = c.text('foo', originalResponse)

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import type { HonoRequest } from './request'
 import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
-import type { JSONValue, JSONParsed, IsAny, Simplify } from './utils/types'
+import type { IsAny, JSONParsed, JSONValue, Simplify } from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
 export type Data = string | ArrayBuffer | ReadableStream
@@ -380,7 +380,11 @@ export class Context<
       if (this.#headers) {
         // If the header is set by c.header() and arg.headers, c.header() will be prioritized.
         this.#headers.forEach((v, k) => {
-          header.set(k, v)
+          if (k === 'set-cookie') {
+            header.append(k, v)
+          } else {
+            header.set(k, v)
+          }
         })
       }
       const headers = setHeaders(header, this.#preparedHeaders)


### PR DESCRIPTION
It seems cookie headers are not correctly appended when passing `ResponseInit` as a second parameter to `c.body(..., res)`.

Support for setting cookies was recently added to `@hono/trpc-server` in
https://github.com/honojs/middleware/pull/517, but this bug prevents multiple cookies from being set.

[Here's a reproduction](https://github.com/codeflows/hono-cookie-test/tree/main)

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
