### PR TITLE
fix(middleware): Context declaration

### DIFF
--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -5,7 +5,7 @@ import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
 import type { SignatureAlgorithm } from '../../utils/jwt/jwa.ts'
 
-declare module 'node:hono' {
+declare module '../../index.ts' {
   interface ContextVariableMap {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jwtPayload: any

--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -3,10 +3,9 @@ import { getCookie } from '../../helper/cookie/index.ts'
 import { HTTPException } from '../../http-exception.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 import { Jwt } from '../../utils/jwt/index.ts'
-import '../../context.ts'
 import type { SignatureAlgorithm } from '../../utils/jwt/jwa.ts'
 
-declare module '../../context.ts' {
+declare module 'node:hono' {
   interface ContextVariableMap {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jwtPayload: any

--- a/deno_dist/middleware/secure-headers/index.ts
+++ b/deno_dist/middleware/secure-headers/index.ts
@@ -1,8 +1,9 @@
 import { Buffer } from "node:buffer";
 import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
+import {} from 'node:hono'
 
-declare module '../../context.ts' {
+declare module 'node:hono' {
   interface ContextVariableMap {
     secureHeadersNonce?: string
   }

--- a/deno_dist/middleware/secure-headers/index.ts
+++ b/deno_dist/middleware/secure-headers/index.ts
@@ -1,9 +1,8 @@
 import { Buffer } from "node:buffer";
 import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
-import {} from 'node:hono'
 
-declare module 'node:hono' {
+declare module '../../index.ts' {
   interface ContextVariableMap {
     secureHeadersNonce?: string
   }

--- a/deno_dist/middleware/timing/index.ts
+++ b/deno_dist/middleware/timing/index.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
 
-declare module 'node:hono' {
+declare module '../../index.ts' {
   interface ContextVariableMap {
     metric?: {
       headers: string[]

--- a/deno_dist/middleware/timing/index.ts
+++ b/deno_dist/middleware/timing/index.ts
@@ -1,8 +1,7 @@
 import type { Context } from '../../context.ts'
 import type { MiddlewareHandler } from '../../types.ts'
-import '../../context.ts'
 
-declare module '../../context.ts' {
+declare module 'node:hono' {
   interface ContextVariableMap {
     metric?: {
       headers: string[]

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -5,7 +5,7 @@ import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
 import type { SignatureAlgorithm } from '../../utils/jwt/jwa'
 
-declare module 'hono' {
+declare module '../..' {
   interface ContextVariableMap {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jwtPayload: any

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -3,10 +3,9 @@ import { getCookie } from '../../helper/cookie'
 import { HTTPException } from '../../http-exception'
 import type { MiddlewareHandler } from '../../types'
 import { Jwt } from '../../utils/jwt'
-import '../../context'
 import type { SignatureAlgorithm } from '../../utils/jwt/jwa'
 
-declare module '../../context' {
+declare module 'hono' {
   interface ContextVariableMap {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jwtPayload: any

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -1,7 +1,8 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
+import {} from 'hono'
 
-declare module '../../context' {
+declare module 'hono' {
   interface ContextVariableMap {
     secureHeadersNonce?: string
   }

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -1,8 +1,7 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
-import {} from 'hono'
 
-declare module 'hono' {
+declare module '../..' {
   interface ContextVariableMap {
     secureHeadersNonce?: string
   }

--- a/src/middleware/timing/index.ts
+++ b/src/middleware/timing/index.ts
@@ -1,8 +1,7 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
-import '../../context'
 
-declare module '../../context' {
+declare module 'hono' {
   interface ContextVariableMap {
     metric?: {
       headers: string[]

--- a/src/middleware/timing/index.ts
+++ b/src/middleware/timing/index.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
-declare module 'hono' {
+declare module '../..' {
   interface ContextVariableMap {
     metric?: {
       headers: string[]


### PR DESCRIPTION
Fixes #2693 

@yusukebe not sure it's the best way though, as `denoify` automatically adds `node:` to `hono` import... Without this import TS yells that `hono` is an "unknown" module...

### The author should do the following, if applicable

- [ ] ~Add tests~ (n/a)
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
