### PR TITLE
docs(jsdoc): Compress Middleware

### DIFF
--- a/deno_dist/middleware/compress/index.ts
+++ b/deno_dist/middleware/compress/index.ts
@@ -6,6 +6,22 @@ interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
 }
 
+/**
+ * Compress middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/compress}
+ *
+ * @param {CompressionOptions} [options] - The options for the compress middleware.
+ * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(compress())
+ * ```
+ */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   return async function compress(ctx, next) {
     await next()

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -6,6 +6,22 @@ interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
 }
 
+/**
+ * Compress middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/compress}
+ *
+ * @param {CompressionOptions} [options] - The options for the compress middleware.
+ * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(compress())
+ * ```
+ */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   return async function compress(ctx, next) {
     await next()


### PR DESCRIPTION
This PR is to add JSDoc for Compress Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
