### PR TITLE
docs(jsdoc): CORS Middleware

### DIFF
--- a/deno_dist/middleware/cors/index.ts
+++ b/deno_dist/middleware/cors/index.ts
@@ -10,6 +10,45 @@ type CORSOptions = {
   exposeHeaders?: string[]
 }
 
+/**
+ * CORS middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/cors}
+ *
+ * @param {CORSOptions} [options] - The options for the CORS middleware.
+ * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
+ * @param {string[]} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
+ * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
+ * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
+ * @param {string[]} [options.exposeHeaders=[]] - The value of "Access-Control-Expose-Headers" CORS header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/api/*', cors())
+ * app.use(
+ *   '/api2/*',
+ *   cors({
+ *     origin: 'http://example.com',
+ *     allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
+ *     allowMethods: ['POST', 'GET', 'OPTIONS'],
+ *     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+ *     maxAge: 600,
+ *     credentials: true,
+ *   })
+ * )
+ *
+ * app.all('/api/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * app.all('/api2/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * ```
+ */
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -10,6 +10,45 @@ type CORSOptions = {
   exposeHeaders?: string[]
 }
 
+/**
+ * CORS middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/cors}
+ *
+ * @param {CORSOptions} [options] - The options for the CORS middleware.
+ * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
+ * @param {string[]} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
+ * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
+ * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
+ * @param {string[]} [options.exposeHeaders=[]] - The value of "Access-Control-Expose-Headers" CORS header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/api/*', cors())
+ * app.use(
+ *   '/api2/*',
+ *   cors({
+ *     origin: 'http://example.com',
+ *     allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
+ *     allowMethods: ['POST', 'GET', 'OPTIONS'],
+ *     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+ *     maxAge: 600,
+ *     credentials: true,
+ *   })
+ * )
+ *
+ * app.all('/api/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * app.all('/api2/abc', (c) => {
+ *   return c.json({ success: true })
+ * })
+ * ```
+ */
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const defaults: CORSOptions = {
     origin: '*',


### PR DESCRIPTION
This PR is to add JSDoc for CORS Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
