### PR TITLE
docs(jsdoc): CSRF Protection Middleware

### DIFF
--- a/deno_dist/middleware/csrf/index.ts
+++ b/deno_dist/middleware/csrf/index.ts
@@ -11,6 +11,43 @@ const isSafeMethodRe = /^(GET|HEAD)$/
 const isRequestedByFormElementRe =
   /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/
 
+/**
+ * CSRF protection middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/csrf}
+ *
+ * @param {CSRFOptions} [options] - The options for the CSRF protection middleware.
+ * @param {string|string[]|(origin: string, context: Context) => boolean} [options.origin] - Specify origins.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(csrf())
+ *
+ * // Specifying origins with using `origin` option
+ * // string
+ * app.use(csrf({ origin: 'myapp.example.com' }))
+ *
+ * // string[]
+ * app.use(
+ *   csrf({
+ *     origin: ['myapp.example.com', 'development.myapp.example.com'],
+ *   })
+ * )
+ *
+ * // Function
+ * // It is strongly recommended that the protocol be verified to ensure a match to `$`.
+ * // You should *never* do a forward match.
+ * app.use(
+ *   '*',
+ *   csrf({
+ *     origin: (origin) => /https:\/\/(\w+\.)?myapp\.example\.com$/.test(origin),
+ *   })
+ * )
+ * ```
+ */
 export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
   const handler: IsAllowedOriginHandler = ((optsOrigin) => {
     if (!optsOrigin) {

--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -11,6 +11,43 @@ const isSafeMethodRe = /^(GET|HEAD)$/
 const isRequestedByFormElementRe =
   /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/
 
+/**
+ * CSRF protection middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/csrf}
+ *
+ * @param {CSRFOptions} [options] - The options for the CSRF protection middleware.
+ * @param {string|string[]|(origin: string, context: Context) => boolean} [options.origin] - Specify origins.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(csrf())
+ *
+ * // Specifying origins with using `origin` option
+ * // string
+ * app.use(csrf({ origin: 'myapp.example.com' }))
+ *
+ * // string[]
+ * app.use(
+ *   csrf({
+ *     origin: ['myapp.example.com', 'development.myapp.example.com'],
+ *   })
+ * )
+ *
+ * // Function
+ * // It is strongly recommended that the protocol be verified to ensure a match to `$`.
+ * // You should *never* do a forward match.
+ * app.use(
+ *   '*',
+ *   csrf({
+ *     origin: (origin) => /https:\/\/(\w+\.)?myapp\.example\.com$/.test(origin),
+ *   })
+ * )
+ * ```
+ */
 export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
   const handler: IsAllowedOriginHandler = ((optsOrigin) => {
     if (!optsOrigin) {


### PR DESCRIPTION
This PR is to add JSDoc for CSRF Protection Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
