### PR TITLE
docs(jsdoc): ETag Middleware

### DIFF
--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -25,6 +25,25 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
   return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
 }
 
+/**
+ * ETag middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/etag}
+ *
+ * @param {ETagOptions} [options] - The options for the ETag middleware.
+ * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/etag/*', etag())
+ * app.get('/etag/abc', (c) => {
+ *   return c.text('Hono is cool')
+ * })
+ * ```
+ */
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false

--- a/deno_dist/middleware/etag/index.ts
+++ b/deno_dist/middleware/etag/index.ts
@@ -32,6 +32,7 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
  *
  * @param {ETagOptions} [options] - The options for the ETag middleware.
  * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
+ * @param {string[]} [options.retainedHeaders=RETAINED_304_HEADERS] - The headers that you want to retain in the 304 Response.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -25,6 +25,25 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
   return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
 }
 
+/**
+ * ETag middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/etag}
+ *
+ * @param {ETagOptions} [options] - The options for the ETag middleware.
+ * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use('/etag/*', etag())
+ * app.get('/etag/abc', (c) => {
+ *   return c.text('Hono is cool')
+ * })
+ * ```
+ */
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -32,6 +32,7 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
  *
  * @param {ETagOptions} [options] - The options for the ETag middleware.
  * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
+ * @param {string[]} [options.retainedHeaders=RETAINED_304_HEADERS] - The headers that you want to retain in the 304 Response.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example


### PR DESCRIPTION
This PR is to add JSDoc for ETag Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
