### PR TITLE
docs(jsdoc): Trailing Slash Middleware

### DIFF
--- a/deno_dist/middleware/trailing-slash/index.ts
+++ b/deno_dist/middleware/trailing-slash/index.ts
@@ -1,9 +1,19 @@
 import type { MiddlewareHandler } from '../../types.ts'
 
 /**
- * Trim the trailing slash from the URL if it does have one. For example, `/path/to/page/` will be redirected to `/path/to/page`.
- * @access public
- * @example app.use(trimTrailingSlash())
+ * Trailing slash middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(trimTrailingSlash())
+ * app.get('/about/me/', (c) => c.text('With Trailing Slash'))
+ * ```
  */
 export const trimTrailingSlash = (): MiddlewareHandler => {
   return async function trimTrailingSlash(c, next) {
@@ -24,9 +34,19 @@ export const trimTrailingSlash = (): MiddlewareHandler => {
 }
 
 /**
+ * Append trailing slash middleware for Hono.
  * Append a trailing slash to the URL if it doesn't have one. For example, `/path/to/page` will be redirected to `/path/to/page/`.
- * @access public
- * @example app.use(appendTrailingSlash())
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(appendTrailingSlash())
+ * ```
  */
 export const appendTrailingSlash = (): MiddlewareHandler => {
   return async function appendTrailingSlash(c, next) {

--- a/src/middleware/trailing-slash/index.ts
+++ b/src/middleware/trailing-slash/index.ts
@@ -1,9 +1,19 @@
 import type { MiddlewareHandler } from '../../types'
 
 /**
- * Trim the trailing slash from the URL if it does have one. For example, `/path/to/page/` will be redirected to `/path/to/page`.
- * @access public
- * @example app.use(trimTrailingSlash())
+ * Trailing slash middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(trimTrailingSlash())
+ * app.get('/about/me/', (c) => c.text('With Trailing Slash'))
+ * ```
  */
 export const trimTrailingSlash = (): MiddlewareHandler => {
   return async function trimTrailingSlash(c, next) {
@@ -24,9 +34,19 @@ export const trimTrailingSlash = (): MiddlewareHandler => {
 }
 
 /**
+ * Append trailing slash middleware for Hono.
  * Append a trailing slash to the URL if it doesn't have one. For example, `/path/to/page` will be redirected to `/path/to/page/`.
- * @access public
- * @example app.use(appendTrailingSlash())
+ *
+ * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(appendTrailingSlash())
+ * ```
  */
 export const appendTrailingSlash = (): MiddlewareHandler => {
   return async function appendTrailingSlash(c, next) {


### PR DESCRIPTION
This PR is to add JSDoc for Trailing Slash Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code