### PR TITLE
docs(jsdoc): Server-Timing Middleware

### DIFF
--- a/deno_dist/middleware/timing/index.ts
+++ b/deno_dist/middleware/timing/index.ts
@@ -31,6 +31,45 @@ const getTime = (): number => {
   return Date.now()
 }
 
+/**
+ * Server-Timing Middleware middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/timing}
+ *
+ * @param {TimingOptions} [config] - The options for the timing middleware.
+ * @param {boolean} [config.total=true] - Show the total response time.
+ * @param {boolean | ((c: Context) => boolean)} [config.enabled=true] - Whether timings should be added to the headers or not.
+ * @param {string} [config.totalDescription=Total Response Time] - Description for the total response time.
+ * @param {boolean} [config.autoEnd=true] - If `startTime()` should end automatically at the end of the request.
+ * @param {boolean | string | ((c: Context) => boolean | string)} [config.crossOrigin=false] - The origin this timings header should be readable.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * // add the middleware to your router
+ * app.use(timing());
+ *
+ * app.get('/', async (c) => {
+ *   // add custom metrics
+ *   setMetric(c, 'region', 'europe-west3')
+ *
+ *   // add custom metrics with timing, must be in milliseconds
+ *   setMetric(c, 'custom', 23.8, 'My custom Metric')
+ *
+ *   // start a new timer
+ *   startTime(c, 'db');
+ *
+ *   const data = await db.findMany(...);
+ *
+ *   // end the timer
+ *   endTime(c, 'db');
+ *
+ *   return c.json({ response: data });
+ * });
+ * ```
+ */
 export const timing = (config?: Partial<TimingOptions>): MiddlewareHandler => {
   const options: TimingOptions = {
     ...{
@@ -84,6 +123,21 @@ interface SetMetric {
   (c: Context, name: string, description?: string): void
 }
 
+/**
+ * Set a metric for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the metric.
+ * @param {number | string} [valueDescription] - The value or description of the metric.
+ * @param {string} [description] - The description of the metric.
+ * @param {number} [precision] - The precision of the metric value.
+ *
+ * @example
+ * ```ts
+ * setMetric(c, 'region', 'europe-west3')
+ * setMetric(c, 'custom', 23.8, 'My custom Metric')
+ * ```
+ */
 export const setMetric: SetMetric = (
   c: Context,
   name: string,
@@ -110,6 +164,18 @@ export const setMetric: SetMetric = (
   }
 }
 
+/**
+ * Start a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {string} [description] - The description of the timer.
+ *
+ * @example
+ * ```ts
+ * startTime(c, 'db')
+ * ```
+ */
 export const startTime = (c: Context, name: string, description?: string) => {
   const metrics = c.get('metric')
   if (!metrics) {
@@ -119,6 +185,18 @@ export const startTime = (c: Context, name: string, description?: string) => {
   metrics.timers.set(name, { description, start: getTime() })
 }
 
+/**
+ * End a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {number} [precision] - The precision of the timer value.
+ *
+ * @example
+ * ```ts
+ * endTime(c, 'db')
+ * ```
+ */
 export const endTime = (c: Context, name: string, precision?: number) => {
   const metrics = c.get('metric')
   if (!metrics) {

--- a/src/middleware/timing/index.ts
+++ b/src/middleware/timing/index.ts
@@ -31,6 +31,45 @@ const getTime = (): number => {
   return Date.now()
 }
 
+/**
+ * Server-Timing Middleware middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/timing}
+ *
+ * @param {TimingOptions} [config] - The options for the timing middleware.
+ * @param {boolean} [config.total=true] - Show the total response time.
+ * @param {boolean | ((c: Context) => boolean)} [config.enabled=true] - Whether timings should be added to the headers or not.
+ * @param {string} [config.totalDescription=Total Response Time] - Description for the total response time.
+ * @param {boolean} [config.autoEnd=true] - If `startTime()` should end automatically at the end of the request.
+ * @param {boolean | string | ((c: Context) => boolean | string)} [config.crossOrigin=false] - The origin this timings header should be readable.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * // add the middleware to your router
+ * app.use(timing());
+ *
+ * app.get('/', async (c) => {
+ *   // add custom metrics
+ *   setMetric(c, 'region', 'europe-west3')
+ *
+ *   // add custom metrics with timing, must be in milliseconds
+ *   setMetric(c, 'custom', 23.8, 'My custom Metric')
+ *
+ *   // start a new timer
+ *   startTime(c, 'db');
+ *
+ *   const data = await db.findMany(...);
+ *
+ *   // end the timer
+ *   endTime(c, 'db');
+ *
+ *   return c.json({ response: data });
+ * });
+ * ```
+ */
 export const timing = (config?: Partial<TimingOptions>): MiddlewareHandler => {
   const options: TimingOptions = {
     ...{
@@ -84,6 +123,21 @@ interface SetMetric {
   (c: Context, name: string, description?: string): void
 }
 
+/**
+ * Set a metric for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the metric.
+ * @param {number | string} [valueDescription] - The value or description of the metric.
+ * @param {string} [description] - The description of the metric.
+ * @param {number} [precision] - The precision of the metric value.
+ *
+ * @example
+ * ```ts
+ * setMetric(c, 'region', 'europe-west3')
+ * setMetric(c, 'custom', 23.8, 'My custom Metric')
+ * ```
+ */
 export const setMetric: SetMetric = (
   c: Context,
   name: string,
@@ -110,6 +164,18 @@ export const setMetric: SetMetric = (
   }
 }
 
+/**
+ * Start a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {string} [description] - The description of the timer.
+ *
+ * @example
+ * ```ts
+ * startTime(c, 'db')
+ * ```
+ */
 export const startTime = (c: Context, name: string, description?: string) => {
   const metrics = c.get('metric')
   if (!metrics) {
@@ -119,6 +185,18 @@ export const startTime = (c: Context, name: string, description?: string) => {
   metrics.timers.set(name, { description, start: getTime() })
 }
 
+/**
+ * End a timer for the timing middleware.
+ *
+ * @param {Context} c - The context of the request.
+ * @param {string} name - The name of the timer.
+ * @param {number} [precision] - The precision of the timer value.
+ *
+ * @example
+ * ```ts
+ * endTime(c, 'db')
+ * ```
+ */
 export const endTime = (c: Context, name: string, precision?: number) => {
   const metrics = c.get('metric')
   if (!metrics) {


### PR DESCRIPTION
This PR is to add JSDoc for Server-Timing Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
