### PR TITLE
docs(jsdoc): Pretty JSON Middleware

### DIFF
--- a/deno_dist/middleware/pretty-json/index.ts
+++ b/deno_dist/middleware/pretty-json/index.ts
@@ -4,6 +4,25 @@ type prettyOptions = {
   space: number
 }
 
+/**
+ * Pretty JSON middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/pretty-json}
+ *
+ * @param {prettyOptions} [options] - The options for the pretty JSON middleware.
+ * @param {number} [options.space=2] - Number of spaces for indentation.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(prettyJSON()) // With options: prettyJSON({ space: 4 })
+ * app.get('/', (c) => {
+ *   return c.json({ message: 'Hono!' })
+ * })
+ * ```
+ */
 export const prettyJSON = (options: prettyOptions = { space: 2 }): MiddlewareHandler => {
   return async function prettyJSON(c, next) {
     const pretty = c.req.query('pretty') || c.req.query('pretty') === '' ? true : false

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -4,6 +4,25 @@ type prettyOptions = {
   space: number
 }
 
+/**
+ * Pretty JSON middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/pretty-json}
+ *
+ * @param {prettyOptions} [options] - The options for the pretty JSON middleware.
+ * @param {number} [options.space=2] - Number of spaces for indentation.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(prettyJSON()) // With options: prettyJSON({ space: 4 })
+ * app.get('/', (c) => {
+ *   return c.json({ message: 'Hono!' })
+ * })
+ * ```
+ */
 export const prettyJSON = (options: prettyOptions = { space: 2 }): MiddlewareHandler => {
   return async function prettyJSON(c, next) {
     const pretty = c.req.query('pretty') || c.req.query('pretty') === '' ? true : false


### PR DESCRIPTION
This PR is to add JSDoc for Pretty JSON Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
