### PR TITLE
docs(jsdoc): Logger Middleware

### DIFF
--- a/deno_dist/middleware/logger/index.ts
+++ b/deno_dist/middleware/logger/index.ts
@@ -55,6 +55,22 @@ function log(
   fn(out)
 }
 
+/**
+ * Logger middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/logger}
+ *
+ * @param {PrintFunc} [fn=console.log] - Optional function for customized logging behavior.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(logger())
+ * app.get('/', (c) => c.text('Hello Hono!'))
+ * ```
+ */
 export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async function logger(c, next) {
     const { method } = c.req

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -55,6 +55,22 @@ function log(
   fn(out)
 }
 
+/**
+ * Logger middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/logger}
+ *
+ * @param {PrintFunc} [fn=console.log] - Optional function for customized logging behavior.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(logger())
+ * app.get('/', (c) => c.text('Hello Hono!'))
+ * ```
+ */
 export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async function logger(c, next) {
     const { method } = c.req


### PR DESCRIPTION
This PR is to add JSDoc for Logger Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
