### PR TITLE
docs(jsdoc): JWT Auth Middleware

### DIFF
--- a/deno_dist/middleware/jwt/index.ts
+++ b/deno_dist/middleware/jwt/index.ts
@@ -13,6 +13,33 @@ declare module '../../context.ts' {
   }
 }
 
+/**
+ * JWT Auth middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/jwt}
+ *
+ * @param {object} options - The options for the JWT middleware.
+ * @param {string} options.secret - A value of your secret key.
+ * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
+ * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '/auth/*',
+ *   jwt({
+ *     secret: 'it-is-very-secret',
+ *   })
+ * )
+ *
+ * app.get('/auth/page', (c) => {
+ *   return c.text('You are authorized')
+ * })
+ * ```
+ */
 export const jwt = (options: {
   secret: string
   cookie?: string

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -19,7 +19,7 @@ declare module '../../context' {
  * @see {@link https://hono.dev/middleware/builtin/jwt}
  *
  * @param {object} options - The options for the JWT middleware.
- * @param {string} options.secret - A value of your secret key.
+ * @param {string} [options.secret] - A value of your secret key.
  * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
  * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
  * @returns {MiddlewareHandler} The middleware handler function.

--- a/src/middleware/jwt/index.ts
+++ b/src/middleware/jwt/index.ts
@@ -13,6 +13,33 @@ declare module '../../context' {
   }
 }
 
+/**
+ * JWT Auth middleware for Hono.
+ *
+ * @see {@link https://hono.dev/middleware/builtin/jwt}
+ *
+ * @param {object} options - The options for the JWT middleware.
+ * @param {string} options.secret - A value of your secret key.
+ * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
+ * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '/auth/*',
+ *   jwt({
+ *     secret: 'it-is-very-secret',
+ *   })
+ * )
+ *
+ * app.get('/auth/page', (c) => {
+ *   return c.text('You are authorized')
+ * })
+ * ```
+ */
 export const jwt = (options: {
   secret: string
   cookie?: string


### PR DESCRIPTION
This PR is to add JSDoc for JWT Auth Middleware.
Note that the target of the PR is not `main`.

Related:
- #1338
- #2680

- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
