### PR TITLE
refactor(timing): don't use `Partial` for the options

### DIFF
--- a/deno_dist/middleware/timing/index.ts
+++ b/deno_dist/middleware/timing/index.ts
@@ -17,11 +17,11 @@ interface Timer {
 }
 
 interface TimingOptions {
-  total: boolean
-  enabled: boolean | ((c: Context) => boolean)
-  totalDescription: string
-  autoEnd: boolean
-  crossOrigin: boolean | string | ((c: Context) => boolean | string)
+  total?: boolean
+  enabled?: boolean | ((c: Context) => boolean)
+  totalDescription?: string
+  autoEnd?: boolean
+  crossOrigin?: boolean | string | ((c: Context) => boolean | string)
 }
 
 const getTime = (): number => {
@@ -31,7 +31,7 @@ const getTime = (): number => {
   return Date.now()
 }
 
-export const timing = (config?: Partial<TimingOptions>): MiddlewareHandler => {
+export const timing = (config?: TimingOptions): MiddlewareHandler => {
   const options: TimingOptions = {
     ...{
       total: true,

--- a/src/middleware/timing/index.ts
+++ b/src/middleware/timing/index.ts
@@ -17,11 +17,11 @@ interface Timer {
 }
 
 interface TimingOptions {
-  total: boolean
-  enabled: boolean | ((c: Context) => boolean)
-  totalDescription: string
-  autoEnd: boolean
-  crossOrigin: boolean | string | ((c: Context) => boolean | string)
+  total?: boolean
+  enabled?: boolean | ((c: Context) => boolean)
+  totalDescription?: string
+  autoEnd?: boolean
+  crossOrigin?: boolean | string | ((c: Context) => boolean | string)
 }
 
 const getTime = (): number => {
@@ -31,7 +31,7 @@ const getTime = (): number => {
   return Date.now()
 }
 
-export const timing = (config?: Partial<TimingOptions>): MiddlewareHandler => {
+export const timing = (config?: TimingOptions): MiddlewareHandler => {
   const options: TimingOptions = {
     ...{
       total: true,


### PR DESCRIPTION
`Partial` is convinient. However, it is easy for users to understand that it does not use `Partial`.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun denoify` to generate files for Deno
- [ ] `bun run format:fix && bun run lint:fix` to format the code
