### PR TITLE
refactor(secure-headers): don't use `Partial` for the options

### DIFF
--- a/deno_dist/middleware/secure-headers/index.ts
+++ b/deno_dist/middleware/secure-headers/index.ts
@@ -58,7 +58,7 @@ interface SecureHeadersOptions {
   crossOriginEmbedderPolicy?: overridableHeader
   crossOriginResourcePolicy?: overridableHeader
   crossOriginOpenerPolicy?: overridableHeader
-  originAgentCluster: overridableHeader
+  originAgentCluster?: overridableHeader
   referrerPolicy?: overridableHeader
   reportingEndpoints?: ReportingEndpointOptions[]
   reportTo?: ReportToOptions[]
@@ -126,7 +126,7 @@ export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
   return `'nonce-${nonce}'`
 }
 
-export const secureHeaders = (customOptions?: Partial<SecureHeadersOptions>): MiddlewareHandler => {
+export const secureHeaders = (customOptions?: SecureHeadersOptions): MiddlewareHandler => {
   const options = { ...DEFAULT_OPTIONS, ...customOptions }
   const headersToSet = getFilteredHeaders(options)
   const callbacks: SecureHeadersCallback[] = []

--- a/src/middleware/secure-headers/index.ts
+++ b/src/middleware/secure-headers/index.ts
@@ -57,7 +57,7 @@ interface SecureHeadersOptions {
   crossOriginEmbedderPolicy?: overridableHeader
   crossOriginResourcePolicy?: overridableHeader
   crossOriginOpenerPolicy?: overridableHeader
-  originAgentCluster: overridableHeader
+  originAgentCluster?: overridableHeader
   referrerPolicy?: overridableHeader
   reportingEndpoints?: ReportingEndpointOptions[]
   reportTo?: ReportToOptions[]
@@ -125,7 +125,7 @@ export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
   return `'nonce-${nonce}'`
 }
 
-export const secureHeaders = (customOptions?: Partial<SecureHeadersOptions>): MiddlewareHandler => {
+export const secureHeaders = (customOptions?: SecureHeadersOptions): MiddlewareHandler => {
   const options = { ...DEFAULT_OPTIONS, ...customOptions }
   const headersToSet = getFilteredHeaders(options)
   const callbacks: SecureHeadersCallback[] = []


### PR DESCRIPTION
It is the same reason as #2712 .

Sometimes `Partial` is used instead of making all option values optional, but this is not necessary in this case.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun denoify` to generate files for Deno
- [ ] `bun run format:fix && bun run lint:fix` to format the code
