### PR TITLE
fix(hono-jsx): make ref unrequried for forward ref

### DIFF
--- a/deno_dist/jsx/hooks/index.ts
+++ b/deno_dist/jsx/hooks/index.ts
@@ -370,8 +370,8 @@ export const createRef = <T>(): RefObject<T> => {
 }
 
 export const forwardRef = <T, P = {}>(
-  Component: (props: P, ref: RefObject<T>) => JSX.Element
-): ((props: P & { ref: RefObject<T> }) => JSX.Element) => {
+  Component: (props: P, ref?: RefObject<T>) => JSX.Element
+): ((props: P & { ref?: RefObject<T> }) => JSX.Element) => {
   return (props) => {
     const { ref, ...rest } = props
     return Component(rest as P, ref)

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -497,6 +497,14 @@ describe('Hooks', () => {
       expect(root.innerHTML).toBe('<div></div>')
       expect(ref.current).toBeInstanceOf(HTMLElement)
     })
+
+    it('can run without ref', () => {
+      const App = forwardRef((props,) => {
+        return <div {...props} />
+      })
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<div></div>')
+    })
   })
 
   describe('useImperativeHandle()', () => {

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -499,7 +499,7 @@ describe('Hooks', () => {
     })
 
     it('can run without ref', () => {
-      const App = forwardRef((props,) => {
+      const App = forwardRef((props) => {
         return <div {...props} />
       })
       render(<App />, root)

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -370,8 +370,8 @@ export const createRef = <T>(): RefObject<T> => {
 }
 
 export const forwardRef = <T, P = {}>(
-  Component: (props: P, ref: RefObject<T>) => JSX.Element
-): ((props: P & { ref: RefObject<T> }) => JSX.Element) => {
+  Component: (props: P, ref?: RefObject<T>) => JSX.Element
+): ((props: P & { ref?: RefObject<T> }) => JSX.Element) => {
   return (props) => {
     const { ref, ...rest } = props
     return Component(rest as P, ref)


### PR DESCRIPTION
My problem -  hono forward ref always need me to put ref. It's not true. It should be like "if i need to forward ref (maybe by thirdparty library like mantine, they love to put ref to your custom components)

Does hono works correct? Yes no error runtime throws, code works fine. 
What my code fixes? 
THIS:
 <img width="478" alt="Screenshot 2024-05-18 at 16 41 02" src="https://github.com/honojs/hono/assets/23248488/77fccfad-ee2e-4e97-84e0-43213434b6c7">
<img width="548" alt="Screenshot 2024-05-18 at 16 41 07" src="https://github.com/honojs/hono/assets/23248488/32725d9e-3219-4d19-9e7f-a3b2e2968e3c">

i have to always cover with ts expect error every time i use component that i need to forward ref.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
