### PR TITLE
feat(utils): specify detailed return type for parseBody

### DIFF
--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -183,7 +183,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/request#parsebody
    */
-  async parseBody<T extends BodyData = BodyData>(options?: ParseBodyOptions): Promise<T> {
+  async parseBody<Options extends Partial<ParseBodyOptions>, T extends BodyData<Options>>(
+    options?: Options
+  ): Promise<T>
+  async parseBody<T extends BodyData>(options?: Partial<ParseBodyOptions>): Promise<T>
+  async parseBody<T extends BodyData = BodyData>(options?: Partial<ParseBodyOptions>): Promise<T> {
     if (this.bodyCache.parsedBody) {
       return this.bodyCache.parsedBody as T
     }

--- a/deno_dist/request.ts
+++ b/deno_dist/request.ts
@@ -187,11 +187,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     options?: Options
   ): Promise<T>
   async parseBody<T extends BodyData>(options?: Partial<ParseBodyOptions>): Promise<T>
-  async parseBody<T extends BodyData = BodyData>(options?: Partial<ParseBodyOptions>): Promise<T> {
+  async parseBody(options?: Partial<ParseBodyOptions>) {
     if (this.bodyCache.parsedBody) {
-      return this.bodyCache.parsedBody as T
+      return this.bodyCache.parsedBody
     }
-    const parsedBody = await parseBody<T>(this, options)
+    const parsedBody = await parseBody(this, options)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
   }

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -4,7 +4,7 @@ type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot } & {}
 type BodyDataValueDotAll = {
   [x: string]: string | File | (string | File)[] | BodyDataValueDotAll
 } & {}
-type Simplify<T> = {
+type SimplifyBodyData<T> = {
   [K in keyof T]: string | File | (string | File)[] | BodyDataValueDotAll extends T[K]
     ? string | File | (string | File)[] | BodyDataValueDotAll
     : string | File | BodyDataValueDot extends T[K]
@@ -30,7 +30,7 @@ type BodyDataValue<T> =
       : T extends { dot: true } | { dot: boolean }
       ? BodyDataValueObject<T> // use dot option
       : never) // without options
-export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Simplify<
+export type BodyData<T extends Partial<ParseBodyOptions> = {}> = SimplifyBodyData<
   Record<string, BodyDataValue<T>>
 >
 

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -60,13 +60,20 @@ export type ParseBodyOptions = {
  * @param {Partial<ParseBodyOptions>} [options] - Options for parsing the body.
  * @returns {Promise<T>} The parsed body data.
  */
-export const parseBody = async <
-  Options extends Partial<ParseBodyOptions>,
-  T extends BodyData<Options> = BodyData<Options>
->(
+interface ParseBody {
+  <Options extends Partial<ParseBodyOptions>, T extends BodyData<Options>>(
+    request: HonoRequest | Request,
+    options?: Options
+  ): Promise<T>
+  <T extends BodyData>(
+    request: HonoRequest | Request,
+    options?: Partial<ParseBodyOptions>
+  ): Promise<T>
+}
+export const parseBody: ParseBody = async (
   request: HonoRequest | Request,
-  options: Options = Object.create(null)
-): Promise<T> => {
+  options = Object.create(null)
+) => {
   const { all = false, dot = false } = options
 
   const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
@@ -76,10 +83,10 @@ export const parseBody = async <
     (contentType !== null && contentType.startsWith('multipart/form-data')) ||
     (contentType !== null && contentType.startsWith('application/x-www-form-urlencoded'))
   ) {
-    return parseFormData<T>(request, { all, dot })
+    return parseFormData(request, { all, dot })
   }
 
-  return {} as T
+  return {}
 }
 
 /**

--- a/deno_dist/utils/body.ts
+++ b/deno_dist/utils/body.ts
@@ -1,5 +1,19 @@
 import { HonoRequest } from '../request.ts'
 
+type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot } & {}
+type BodyDataValueDotAll = {
+  [x: string]: string | File | (string | File)[] | BodyDataValueDotAll
+} & {}
+type Simplify<T> = {
+  [K in keyof T]: string | File | (string | File)[] | BodyDataValueDotAll extends T[K]
+    ? string | File | (string | File)[] | BodyDataValueDotAll
+    : string | File | BodyDataValueDot extends T[K]
+    ? string | File | BodyDataValueDot
+    : string | File | (string | File)[] extends T[K]
+    ? string | File | (string | File)[]
+    : string | File
+} & {}
+
 type BodyDataValueComponent<T> =
   | string
   | File
@@ -16,7 +30,9 @@ type BodyDataValue<T> =
       : T extends { dot: true } | { dot: boolean }
       ? BodyDataValueObject<T> // use dot option
       : never) // without options
-export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Record<string, BodyDataValue<T>>
+export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Simplify<
+  Record<string, BodyDataValue<T>>
+>
 
 export type ParseBodyOptions = {
   /**

--- a/deno_dist/validator/validator.ts
+++ b/deno_dist/validator/validator.ts
@@ -91,7 +91,7 @@ export const validator = <
         try {
           const arrayBuffer = await c.req.arrayBuffer()
           const formData = await bufferToFormData(arrayBuffer, contentType)
-          const form: BodyData = {}
+          const form: BodyData<{ all: true }> = {}
           formData.forEach((value, key) => {
             if (key.endsWith('[]')) {
               if (form[key] === undefined) {

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -310,6 +310,12 @@ describe('Body methods with caching', () => {
           | RecursiveRecord<string, string | File | (string | File)[]>
         >()
       })
+
+      it('specify return type explicitly', async () => {
+        expectTypeOf(
+          await req.parseBody<{ key1: string; key2: string }>({ all: true, dot: true })
+        ).toEqualTypeOf<{ key1: string; key2: string }>()
+      })
     })
   })
 })

--- a/src/request.ts
+++ b/src/request.ts
@@ -183,7 +183,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    * @see https://hono.dev/api/request#parsebody
    */
-  async parseBody<T extends BodyData = BodyData>(options?: ParseBodyOptions): Promise<T> {
+  async parseBody<Options extends Partial<ParseBodyOptions>, T extends BodyData<Options>>(
+    options?: Options
+  ): Promise<T>
+  async parseBody<T extends BodyData>(options?: Partial<ParseBodyOptions>): Promise<T>
+  async parseBody<T extends BodyData = BodyData>(options?: Partial<ParseBodyOptions>): Promise<T> {
     if (this.bodyCache.parsedBody) {
       return this.bodyCache.parsedBody as T
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -187,11 +187,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     options?: Options
   ): Promise<T>
   async parseBody<T extends BodyData>(options?: Partial<ParseBodyOptions>): Promise<T>
-  async parseBody<T extends BodyData = BodyData>(options?: Partial<ParseBodyOptions>): Promise<T> {
+  async parseBody(options?: Partial<ParseBodyOptions>) {
     if (this.bodyCache.parsedBody) {
-      return this.bodyCache.parsedBody as T
+      return this.bodyCache.parsedBody
     }
-    const parsedBody = await parseBody<T>(this, options)
+    const parsedBody = await parseBody(this, options)
     this.bodyCache.parsedBody = parsedBody
     return parsedBody
   }

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -1,5 +1,4 @@
-import { parseBody } from './body'
-import type { BodyData } from './body'
+import { parseBody, type BodyData } from './body'
 
 type RecursiveRecord<K extends string, T> = {
   [key in K]: T | RecursiveRecord<K, T>

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -1,4 +1,9 @@
 import { parseBody } from './body'
+import type { BodyData } from './body'
+
+type RecursiveRecord<K extends string, T> = {
+  [key in K]: T | RecursiveRecord<K, T>
+}
 
 describe('Parse Body Util', () => {
   const FORM_URL = 'https://localhost/form'
@@ -239,5 +244,102 @@ describe('Parse Body Util', () => {
     })
 
     expect(await parseBody(req)).toEqual({})
+  })
+
+  describe('Return type', () => {
+    let req: Request
+    beforeEach(() => {
+      req = createRequest(FORM_URL, 'POST', new FormData())
+    })
+
+    it('without options', async () => {
+      expectTypeOf((await parseBody(req))['key']).toEqualTypeOf<string | File>()
+    })
+
+    it('{all: true}', async () => {
+      expectTypeOf((await parseBody(req, { all: true }))['key']).toEqualTypeOf<
+        string | File | (string | File)[]
+      >()
+    })
+
+    it('{all: boolean}', async () => {
+      expectTypeOf((await parseBody(req, { all: !!Math.random() }))['key']).toEqualTypeOf<
+        string | File | (string | File)[]
+      >()
+    })
+
+    it('{dot: true}', async () => {
+      expectTypeOf((await parseBody(req, { dot: true }))['key']).toEqualTypeOf<
+        string | File | RecursiveRecord<string, string | File>
+      >()
+    })
+
+    it('{dot: boolean}', async () => {
+      expectTypeOf((await parseBody(req, { dot: !!Math.random() }))['key']).toEqualTypeOf<
+        string | File | RecursiveRecord<string, string | File>
+      >()
+    })
+
+    it('{all: true, dot: true}', async () => {
+      expectTypeOf((await parseBody(req, { all: true, dot: true }))['key']).toEqualTypeOf<
+        | string
+        | File
+        | (string | File)[]
+        | RecursiveRecord<string, string | File | (string | File)[]>
+      >()
+    })
+
+    it('{all: boolean, dot: boolean}', async () => {
+      expectTypeOf(
+        (await parseBody(req, { all: !!Math.random(), dot: !!Math.random() }))['key']
+      ).toEqualTypeOf<
+        | string
+        | File
+        | (string | File)[]
+        | RecursiveRecord<string, string | File | (string | File)[]>
+      >()
+    })
+  })
+})
+
+describe('BodyData', () => {
+  it('without options', async () => {
+    expectTypeOf(({} as BodyData)['key']).toEqualTypeOf<string | File>()
+  })
+
+  it('{all: true}', async () => {
+    expectTypeOf(({} as BodyData<{ all: true }>)['key']).toEqualTypeOf<
+      string | File | (string | File)[]
+    >()
+  })
+
+  it('{all: boolean}', async () => {
+    expectTypeOf(({} as BodyData<{ all: boolean }>)['key']).toEqualTypeOf<
+      string | File | (string | File)[]
+    >()
+  })
+
+  it('{dot: true}', async () => {
+    expectTypeOf(({} as BodyData<{ dot: true }>)['key']).toEqualTypeOf<
+      string | File | RecursiveRecord<string, string | File>
+    >()
+  })
+
+  it('{dot: boolean}', async () => {
+    expectTypeOf(({} as BodyData<{ dot: boolean }>)['key']).toEqualTypeOf<
+      string | File | RecursiveRecord<string, string | File>
+    >()
+  })
+
+  it('{all: true, dot: true}', async () => {
+    expectTypeOf(({} as BodyData<{ all: true; dot: true }>)['key']).toEqualTypeOf<
+      string | File | (string | File)[] | RecursiveRecord<string, string | File | (string | File)[]>
+    >()
+  })
+
+  it('{all: boolean, dot: boolean}', async () => {
+    expectTypeOf(({} as BodyData<{ all: boolean; dot: boolean }>)['key']).toEqualTypeOf<
+      string | File | (string | File)[] | RecursiveRecord<string, string | File | (string | File)[]>
+    >()
   })
 })

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -298,6 +298,15 @@ describe('Parse Body Util', () => {
         | RecursiveRecord<string, string | File | (string | File)[]>
       >()
     })
+
+    it('specify return type explicitly', async () => {
+      expectTypeOf(
+        await parseBody<{ key1: string; key2: string }>(req, {
+          all: !!Math.random(),
+          dot: !!Math.random(),
+        })
+      ).toEqualTypeOf<{ key1: string; key2: string }>()
+    })
   })
 })
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -4,7 +4,7 @@ type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot } & {}
 type BodyDataValueDotAll = {
   [x: string]: string | File | (string | File)[] | BodyDataValueDotAll
 } & {}
-type Simplify<T> = {
+type SimplifyBodyData<T> = {
   [K in keyof T]: string | File | (string | File)[] | BodyDataValueDotAll extends T[K]
     ? string | File | (string | File)[] | BodyDataValueDotAll
     : string | File | BodyDataValueDot extends T[K]
@@ -30,7 +30,7 @@ type BodyDataValue<T> =
       : T extends { dot: true } | { dot: boolean }
       ? BodyDataValueObject<T> // use dot option
       : never) // without options
-export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Simplify<
+export type BodyData<T extends Partial<ParseBodyOptions> = {}> = SimplifyBodyData<
   Record<string, BodyDataValue<T>>
 >
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -60,13 +60,20 @@ export type ParseBodyOptions = {
  * @param {Partial<ParseBodyOptions>} [options] - Options for parsing the body.
  * @returns {Promise<T>} The parsed body data.
  */
-export const parseBody = async <
-  Options extends Partial<ParseBodyOptions>,
-  T extends BodyData<Options> = BodyData<Options>
->(
+interface ParseBody {
+  <Options extends Partial<ParseBodyOptions>, T extends BodyData<Options>>(
+    request: HonoRequest | Request,
+    options?: Options
+  ): Promise<T>
+  <T extends BodyData>(
+    request: HonoRequest | Request,
+    options?: Partial<ParseBodyOptions>
+  ): Promise<T>
+}
+export const parseBody: ParseBody = async (
   request: HonoRequest | Request,
-  options: Options = Object.create(null)
-): Promise<T> => {
+  options = Object.create(null)
+) => {
   const { all = false, dot = false } = options
 
   const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
@@ -76,10 +83,10 @@ export const parseBody = async <
     (contentType !== null && contentType.startsWith('multipart/form-data')) ||
     (contentType !== null && contentType.startsWith('application/x-www-form-urlencoded'))
   ) {
-    return parseFormData<T>(request, { all, dot })
+    return parseFormData(request, { all, dot })
   }
 
-  return {} as T
+  return {}
 }
 
 /**

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,7 +1,23 @@
 import { HonoRequest } from '../request'
 
-type BodyDataValue = string | File | (string | File)[] | { [key: string]: BodyDataValue }
-export type BodyData = Record<string, BodyDataValue>
+type BodyDataValueComponent<T> =
+  | string
+  | File
+  | (T extends { all: false }
+      ? never // explicitly set to false
+      : T extends { all: true } | { all: boolean }
+      ? (string | File)[] // use all option
+      : never) // without options
+type BodyDataValueObject<T> = { [key: string]: BodyDataValueComponent<T> | BodyDataValueObject<T> }
+type BodyDataValue<T> =
+  | BodyDataValueComponent<T>
+  | (T extends { dot: false }
+      ? never // explicitly set to false
+      : T extends { dot: true } | { dot: boolean }
+      ? BodyDataValueObject<T> // use dot option
+      : never) // without options
+export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Record<string, BodyDataValue<T>>
+
 export type ParseBodyOptions = {
   /**
    * Determines whether all fields with multiple values should be parsed as arrays.
@@ -44,9 +60,12 @@ export type ParseBodyOptions = {
  * @param {Partial<ParseBodyOptions>} [options] - Options for parsing the body.
  * @returns {Promise<T>} The parsed body data.
  */
-export const parseBody = async <T extends BodyData = BodyData>(
+export const parseBody = async <
+  Options extends Partial<ParseBodyOptions>,
+  T extends BodyData<Options> = BodyData<Options>
+>(
   request: HonoRequest | Request,
-  options: Partial<ParseBodyOptions> = Object.create(null)
+  options: Options = Object.create(null)
 ): Promise<T> => {
   const { all = false, dot = false } = options
 
@@ -71,7 +90,7 @@ export const parseBody = async <T extends BodyData = BodyData>(
  * @param {ParseBodyOptions} options - Options for parsing the form data.
  * @returns {Promise<T>} The parsed body data.
  */
-async function parseFormData<T extends BodyData = BodyData>(
+async function parseFormData<T extends BodyData>(
   request: HonoRequest | Request,
   options: ParseBodyOptions
 ): Promise<T> {
@@ -92,7 +111,7 @@ async function parseFormData<T extends BodyData = BodyData>(
  * @param {ParseBodyOptions} options - Options for parsing the form data.
  * @returns {T} The converted body data.
  */
-function convertFormDataToBodyData<T extends BodyData = BodyData>(
+function convertFormDataToBodyData<T extends BodyData>(
   formData: FormData,
   options: ParseBodyOptions
 ): T {
@@ -134,7 +153,11 @@ function convertFormDataToBodyData<T extends BodyData = BodyData>(
  * @param {string} key - The key to parse.
  * @param {FormDataEntryValue} value - The value to assign.
  */
-const handleParsingAllValues = (form: BodyData, key: string, value: FormDataEntryValue): void => {
+const handleParsingAllValues = (
+  form: BodyData<{ all: true }>,
+  key: string,
+  value: FormDataEntryValue
+): void => {
   if (form[key] !== undefined) {
     if (Array.isArray(form[key])) {
       ;(form[key] as (string | File)[]).push(value)
@@ -153,7 +176,11 @@ const handleParsingAllValues = (form: BodyData, key: string, value: FormDataEntr
  * @param {string} key - The dot notation key.
  * @param {BodyDataValue} value - The value to assign.
  */
-const handleParsingNestedValues = (form: BodyData, key: string, value: BodyDataValue): void => {
+const handleParsingNestedValues = (
+  form: BodyData,
+  key: string,
+  value: BodyDataValue<Partial<ParseBodyOptions>>
+): void => {
   let nestedForm = form
   const keys = key.split('.')
 
@@ -169,7 +196,7 @@ const handleParsingNestedValues = (form: BodyData, key: string, value: BodyDataV
       ) {
         nestedForm[key] = Object.create(null)
       }
-      nestedForm = nestedForm[key] as BodyData
+      nestedForm = nestedForm[key] as unknown as BodyData
     }
   })
 }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,5 +1,19 @@
 import { HonoRequest } from '../request'
 
+type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot } & {}
+type BodyDataValueDotAll = {
+  [x: string]: string | File | (string | File)[] | BodyDataValueDotAll
+} & {}
+type Simplify<T> = {
+  [K in keyof T]: string | File | (string | File)[] | BodyDataValueDotAll extends T[K]
+    ? string | File | (string | File)[] | BodyDataValueDotAll
+    : string | File | BodyDataValueDot extends T[K]
+    ? string | File | BodyDataValueDot
+    : string | File | (string | File)[] extends T[K]
+    ? string | File | (string | File)[]
+    : string | File
+} & {}
+
 type BodyDataValueComponent<T> =
   | string
   | File
@@ -16,7 +30,9 @@ type BodyDataValue<T> =
       : T extends { dot: true } | { dot: boolean }
       ? BodyDataValueObject<T> // use dot option
       : never) // without options
-export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Record<string, BodyDataValue<T>>
+export type BodyData<T extends Partial<ParseBodyOptions> = {}> = Simplify<
+  Record<string, BodyDataValue<T>>
+>
 
 export type ParseBodyOptions = {
   /**

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -91,7 +91,7 @@ export const validator = <
         try {
           const arrayBuffer = await c.req.arrayBuffer()
           const formData = await bufferToFormData(arrayBuffer, contentType)
-          const form: BodyData = {}
+          const form: BodyData<{ all: true }> = {}
           formData.forEach((value, key) => {
             if (key.endsWith('[]')) {
               if (form[key] === undefined) {


### PR DESCRIPTION
### What is this?

More restrictive on the type of value returned from `parseBody()`.

```ts
const value = (await parseBody(req))['key'] // => string | File
const maybeArray = (await parseBody(req, {all: true}))['key'] // => string | File | (string | File)[]
const maybeObject = (await parseBody(req, {dot: true}))['key'] // => string | File | Object
```

### Specification Changes

In v4.3.x, BodyData was defined as follows

https://github.com/honojs/hono/blob/75a7a09fc548da2a1a8f35431c456922db7d6c76/src/utils/body.ts#L3

For applications using it directly, this change results in the following (`(string | File)[]` is no longer included)

```ts
const data: BodyData = {} // means Record<string, string | File>
```

To get the same result as in v4.3.x, you need to do the following.

```ts
const data: BodyData<{all: true}> = {}
```

Although there are some changes from v4.3.x as described above, I think it is useful to restrict the type of `parseBody()`, so I think it is better to include this change.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
