### PR TITLE
feat(middleware): Introduce IP Limit Middleware

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -21,6 +21,7 @@
     "./basic-auth": "./src/middleware/basic-auth/index.ts",
     "./bearer-auth": "./src/middleware/bearer-auth/index.ts",
     "./body-limit": "./src/middleware/body-limit/index.ts",
+    "./ip-limit": "./src/middleware/ip-limit/index.ts",
     "./cache": "./src/middleware/cache/index.ts",
     "./cookie": "./src/helper/cookie/index.ts",
     "./accepts": "./src/helper/accepts/index.ts",
@@ -86,7 +87,8 @@
     "./utils/mime": "./src/utils/mime.ts",
     "./utils/stream": "./src/utils/stream.ts",
     "./utils/types": "./src/utils/types.ts",
-    "./utils/url": "./src/utils/url.ts"
+    "./utils/url": "./src/utils/url.ts",
+    "./utils/ipaddr": "./src/utils/ipaddr.ts"
   },
   "publish": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
       "import": "./dist/middleware/body-limit/index.js",
       "require": "./dist/cjs/middleware/body-limit/index.js"
     },
+    "./ip-limit": {
+      "types": "./dist/types/middleware/ip-limit/index.d.ts",
+      "import": "./dist/middleware/ip-limit/index.js",
+      "require": "./dist/cjs/middleware/ip-limit/index.js"
+    },
     "./cache": {
       "types": "./dist/types/middleware/cache/index.d.ts",
       "import": "./dist/middleware/cache/index.js",
@@ -374,6 +379,9 @@
       ],
       "body-limit": [
         "./dist/types/middleware/body-limit"
+      ],
+      "ip-limit": [
+        "./dist/types/middleware/ip-limit"
       ],
       "cache": [
         "./dist/types/middleware/cache"

--- a/src/middleware/ip-limit/index.test.ts
+++ b/src/middleware/ip-limit/index.test.ts
@@ -1,0 +1,52 @@
+import { Hono } from '../..'
+import type { GetConnInfo } from '../../helper/conninfo'
+import { ipLimit, isMatchForRule } from '.'
+
+describe('ipLimit middleware', () => {
+  it('Should limit', async () => {
+    const getConnInfo: GetConnInfo = (c) => {
+      return {
+        remote: {
+          address: c.env.ip,
+        },
+      }
+    }
+    const app = new Hono<{
+      Bindings: {
+        ip: string
+      }
+    }>()
+    app.use(
+      '*',
+      ipLimit(getConnInfo, {
+        allow: ['192.168.1.0', '192.168.2.0/24'],
+        deny: ['192.168.2.10'],
+      })
+    )
+    app.get('/', (c) => c.text('Hello World!'))
+
+    expect((await app.request('/', {}, { ip: '0.0.0.0' })).status).toBe(403)
+
+    expect((await app.request('/', {}, { ip: '192.168.1.0' })).status).toBe(200)
+
+    expect((await app.request('/', {}, { ip: '192.168.2.5' })).status).toBe(200)
+    expect((await app.request('/', {}, { ip: '192.168.2.10' })).status).toBe(403)
+  })
+})
+
+describe('isMatchForRule', () => {
+  it('IPv4 Wildcard', () => {
+    expect(isMatchForRule({ addr: '192.168.2.1', type: 'IPv4' }, '192.168.2.*')).toBeTruthy()
+    expect(isMatchForRule({ addr: '192.168.3.1', type: 'IPv4' }, '192.168.2.*')).toBeFalsy()
+  })
+  it('CIDR Notation', () => {
+    expect(isMatchForRule({ addr: '192.168.2.0', type: 'IPv4' }, '192.168.2.0/24')).toBeTruthy()
+    expect(isMatchForRule({ addr: '192.168.2.1', type: 'IPv4' }, '192.168.2.0/24')).toBeTruthy()
+
+    expect(isMatchForRule({ addr: '::0', type: 'IPv6' }, '::0/1')).toBeTruthy()
+  })
+  it('Static Rules', () => {
+    expect(isMatchForRule({ addr: '192.168.2.1', type: 'IPv4' }, '192.168.2.1')).toBeTruthy()
+    expect(isMatchForRule({ addr: '1234::5678', type: 'IPv6' }, '1234::5678')).toBeTruthy()
+  })
+})

--- a/src/middleware/ip-limit/index.ts
+++ b/src/middleware/ip-limit/index.ts
@@ -1,0 +1,138 @@
+/**
+ * Middleware for Limiting IP Address
+ * @module
+ */
+
+import type { AddressType, GetConnInfo } from '../../helper/conninfo'
+import { createMiddleware } from '../../helper/factory'
+import { HTTPException } from '../../http-exception'
+import { distinctionRemoteAddr, expandIPv6, ipV4ToBinary, ipV6ToBinary } from '../../utils/ipaddr'
+
+/**
+ * ### IPv4 and IPv6
+ * - `*` match all
+ *
+ * ### IPv4
+ * - `192.168.2.0` static
+ * - `192.168.2.*` wildcard for IPv4
+ * - `192.168.2.0/24` CIDR Notation
+ *
+ * ### IPv6
+ * - `::1` static
+ * - `::1/10` CIDR Notation
+ */
+export type IPLimitRule = string
+
+const IS_CIDR_NOTATION_REGEX = /\/[0-9]{0,3}$/
+export const isMatchForRule = (
+  remote: {
+    addr: string
+    type: AddressType
+  },
+  rule: IPLimitRule
+): boolean => {
+  if (rule === '*') {
+    // Match all
+    return true
+  }
+  if (remote.type === 'IPv4' && rule.includes('*')) {
+    // Wildcard
+    const ruleSections = rule.split('.')
+    const addrSections = remote.addr.split('.')
+
+    let result = true
+    for (let i = 0; i < 4; i++) {
+      const ruleSection = ruleSections[i]
+      if (ruleSection === '*') {
+        continue
+      }
+      const addrSection = addrSections[i]
+      if (addrSection !== ruleSection) {
+        result = false
+        break
+      }
+    }
+    return result
+  }
+
+  if (IS_CIDR_NOTATION_REGEX.test(rule) && (remote.type === 'IPv4' || remote.type === 'IPv6')) {
+    const isIPv4 = remote.type === 'IPv4'
+
+    const splitedRule = rule.split('/')
+    // CIDR
+    const baseRuleAddr = splitedRule[0]
+    if (distinctionRemoteAddr(baseRuleAddr) !== remote.type) {
+      return false
+    }
+    const prefix = parseInt(splitedRule[1])
+
+    const addrToBinary = isIPv4 ? ipV4ToBinary : ipV6ToBinary
+
+    const baseRuleMask = addrToBinary(baseRuleAddr)
+    const remoteMask = addrToBinary(remote.addr)
+    const mask = ((1n << BigInt(prefix)) - 1n) << BigInt((isIPv4 ? 32 : 128) - prefix)
+
+    return (remoteMask & mask) === (baseRuleMask & mask)
+  }
+
+  const ruleAddrConnType = distinctionRemoteAddr(rule)
+  if (ruleAddrConnType === 'IPv4' || ruleAddrConnType === 'IPv6') {
+    // Static
+    if (ruleAddrConnType !== remote.type) {
+      return false
+    }
+    if (remote.type === 'IPv6') {
+      return expandIPv6(remote.addr) === expandIPv6(rule)
+    }
+    return rule === remote.addr // IPv4
+  }
+  throw new TypeError('Rule is unknown')
+}
+
+/**
+ * Rules for IP Limit Middleware
+ */
+export interface IPLimitRules {
+  deny?: IPLimitRule[]
+  allow?: IPLimitRule[]
+}
+
+/**
+ * IP Limit Middleware
+ *
+ * @param getConnInfo getConnInfo helper
+ */
+export const ipLimit = (getConnInfo: GetConnInfo, { deny = [], allow = [] }: IPLimitRules) => {
+  const denyLength = deny.length
+  const allowLength = allow.length
+
+  const blockError = (): HTTPException =>
+    new HTTPException(403, {
+      res: new Response('Unauthorized', {
+        status: 403,
+      }),
+    })
+
+  return createMiddleware(async (c, next) => {
+    const connInfo = getConnInfo(c)
+    const addr = connInfo.remote.address
+    if (!addr) {
+      throw blockError()
+    }
+    const type = connInfo.remote.addressType ?? distinctionRemoteAddr(addr)
+
+    for (let i = 0; i < denyLength; i++) {
+      const isValid = isMatchForRule({ type, addr }, deny[i])
+      if (isValid) {
+        throw blockError()
+      }
+    }
+    for (let i = 0; i < allowLength; i++) {
+      const isValid = isMatchForRule({ type, addr }, allow[i])
+      if (isValid) {
+        return await next()
+      }
+    }
+    throw blockError()
+  })
+}

--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -1,0 +1,39 @@
+import { expandIPv6, distinctionRemoteAddr, ipV4ToBinary, ipV6ToBinary } from './ipaddr'
+
+describe('expandIPv6', () => {
+  it('Should result be valid', () => {
+    expect(expandIPv6('1::1')).toBe('0001:0000:0000:0000:0000:0000:0000:0001')
+    expect(expandIPv6('::1')).toBe('0000:0000:0000:0000:0000:0000:0000:0001')
+    expect(expandIPv6('2001:2::')).toBe('2001:0002:0000:0000:0000:0000:0000:0000')
+    expect(expandIPv6('2001:2::')).toBe('2001:0002:0000:0000:0000:0000:0000:0000')
+    expect(expandIPv6('2001:0:0:db8::1')).toBe('2001:0000:0000:0db8:0000:0000:0000:0001')
+  })
+})
+describe('distinctionRemoteAddr', () => {
+  it('Should result be valud', () => {
+    expect(distinctionRemoteAddr('1::1')).toBe('IPv6')
+    expect(distinctionRemoteAddr('::1')).toBe('IPv6')
+
+    expect(distinctionRemoteAddr('192.168.2.0')).toBe('IPv4')
+    expect(distinctionRemoteAddr('192.168.2.0')).toBe('IPv4')
+
+    expect(distinctionRemoteAddr('example.com')).toBe('unknown')
+  })
+})
+
+describe('ipV4ToBinary', () => {
+  it('Should result is valid', () => {
+    expect(ipV4ToBinary('0.0.0.0')).toBe(0n)
+    expect(ipV4ToBinary('0.0.0.1')).toBe(1n)
+
+    expect(ipV4ToBinary('0.0.1.0')).toBe(1n << 8n)
+  })
+})
+describe('ipV6ToBinary', () => {
+  it('Should result is valid', () => {
+    expect(ipV6ToBinary('::0')).toBe(0n)
+    expect(ipV6ToBinary('::1')).toBe(1n)
+
+    expect(ipV6ToBinary('::f')).toBe(15n)
+  })
+})

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -1,0 +1,71 @@
+/**
+ * Utils for IP Addresses
+ * @module
+ */
+
+import type { AddressType } from '../helper/conninfo'
+
+/**
+ * Expand IPv6 Address
+ * @param ipV6 Shorten IPv6 Address
+ */
+export const expandIPv6 = (ipV6: string) => {
+  const sections = ipV6.split(':')
+  for (let i = 0; i < sections.length; i++) {
+    const node = sections[i]
+    if (node !== '') {
+      sections[i] = node.padStart(4, '0')
+    } else {
+      sections[i + 1] === '' && sections.splice(i + 1, 1)
+      sections[i] = new Array(8 - sections.length + 1).fill('0000').join(':')
+    }
+  }
+  return sections.join(':')
+}
+
+const IPV4_REGEX = /^[0-9]{0,3}\.[0-9]{0,3}\.[0-9]{0,3}\.[0-9]{0,3}$/
+
+/**
+ * Distinction Remote Addr
+ * @param remoteAddr Remote Addr
+ */
+export const distinctionRemoteAddr = (remoteAddr: string): AddressType => {
+  if (IPV4_REGEX.test(remoteAddr)) {
+    return 'IPv4'
+  }
+  if (remoteAddr.includes(':')) {
+    // Domain can't include `:`
+    return 'IPv6'
+  }
+  return 'unknown'
+}
+
+/**
+ * Convert IPv4 to Uint8Array
+ * @param ipV4 IPv4 Address
+ * @returns BigInt
+ */
+export const ipV4ToBinary = (ipV4: string): bigint => {
+  const parts = ipV4.split('.')
+  let result = 0n
+  for (let i = 0; i < 4; i++) {
+    result <<= 8n
+    result += BigInt(parts[i])
+  }
+  return result
+}
+
+/**
+ * Convert IPv6 to Uint8Array
+ * @param ipV6 IPv6 Address
+ * @returns BigInt
+ */
+export const ipV6ToBinary = (ipV6: string): bigint => {
+  const sections = expandIPv6(ipV6).split(':')
+  let result = 0n
+  for (let i = 0; i < 8; i++) {
+    result <<= 16n
+    result += BigInt(parseInt(sections[i], 16))
+  }
+  return result
+}


### PR DESCRIPTION
I created IP Limit Middleware.

You can limit request by IP Address.

For example, you can limit request, this server accepts local-only requests:
```ts
import { Hono } from 'hono'
import { ipLimit } from 'hono/ip-limit'
import { getConnInfo } from 'hono/...'

const app = new Hono()

app.use('*', ipLimit(getConnInfo, {
  deny: [],
  allow: ['127.0.0.1', '::1']
}))
app.get('/', c => c.text('Hello world!'))
```
`deny` takes precedence over `allow`.

Rules supported some syntax:

| Title | example of IPv4 | example of IPv6 |
| --- | --- | --- |
| static | `0.0.0.0` | `::1` |
| CIDR | `192.168.2.1/24` | `abcd::ef01/64` |
| Wildcard | `192.*.2.*` |  |

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
