### PR TITLE
chore(deno): change path including deno_dist

### DIFF
--- a/benchmarks/deno/hono.ts
+++ b/benchmarks/deno/hono.ts
@@ -1,4 +1,5 @@
-import { Hono, RegExpRouter } from '../../deno_dist/mod.ts'
+import { Hono } from '../../src/index.ts'
+import { RegExpRouter } from '../../src/router/reg-exp-router/index.ts'
 
 const app = new Hono({ router: new RegExpRouter() })
 

--- a/benchmarks/routers-deno/src/hono.mts
+++ b/benchmarks/routers-deno/src/hono.mts
@@ -1,7 +1,7 @@
-import type { Router } from '../../../deno_dist/router.ts'
-import { RegExpRouter } from '../../../deno_dist/router/reg-exp-router/index.ts'
-import { TrieRouter } from '../../../deno_dist/router/trie-router/index.ts'
-import { PatternRouter } from '../../../deno_dist/router/pattern-router/index.ts'
+import type { Router } from '../../../src/router.ts'
+import { RegExpRouter } from '../../../src/router/reg-exp-router/index.ts'
+import { TrieRouter } from '../../../src/router/trie-router/index.ts'
+import { PatternRouter } from '../../../src/router/pattern-router/index.ts'
 import type { RouterInterface } from './tool.mts'
 import { routes, handler } from './tool.mts'
 

--- a/runtime_tests/deno-jsx/deno.precompile.json
+++ b/runtime_tests/deno-jsx/deno.precompile.json
@@ -11,7 +11,6 @@
     "sloppy-imports"
   ],
   "imports": {
-    "hono/jsx/jsx-runtime": "../../src/jsx/jsx-runtime.ts",
-    "../../deno_dist/jsx/jsx-runtime": "../../src/jsx/jsx-runtime.ts"
+    "hono/jsx/jsx-runtime": "../../src/jsx/jsx-runtime.ts"
   }
 }

--- a/runtime_tests/deno-jsx/deno.react-jsx.json
+++ b/runtime_tests/deno-jsx/deno.react-jsx.json
@@ -11,7 +11,6 @@
     "sloppy-imports"
   ],
   "imports": {
-    "hono/jsx/jsx-runtime": "../../src/jsx/jsx-runtime.ts",
-    "../../deno_dist/jsx/jsx-runtime": "../../src/jsx/jsx-runtime.ts"
+    "hono/jsx/jsx-runtime": "../../src/jsx/jsx-runtime.ts"
   }
 }


### PR DESCRIPTION
Fix path including deno_dist.
`--unstable-sloppy-imports` flag is now required on benchmark due to jsr aliases.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [ ] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
