### PR TITLE
feat(jsx/dom): introduce react-dom/client APIs and React.version

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -39,6 +39,7 @@
     "./jsx/dom": "./src/jsx/dom/index.ts",
     "./jsx/dom/jsx-dev-runtime": "./src/jsx/dom/jsx-dev-runtime.ts",
     "./jsx/dom/jsx-runtime": "./src/jsx/dom/jsx-runtime.ts",
+    "./jsx/dom/client": "./src/jsx/dom/client.ts",
     "./jsx/dom/css": "./src/jsx/dom/css.ts",
     "./jwt": "./src/middleware/jwt/jwt.ts",
     "./timing": "./src/middleware/timing/timing.ts",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
       "import": "./dist/jsx/dom/jsx-runtime.js",
       "require": "./dist/cjs/jsx/dom/jsx-runtime.js"
     },
+    "./jsx/dom/client": {
+      "types": "./dist/types/jsx/dom/client.d.ts",
+      "import": "./dist/jsx/dom/client.js",
+      "require": "./dist/cjs/jsx/dom/client.js"
+    },
     "./jsx/dom/css": {
       "types": "./dist/types/jsx/dom/css.d.ts",
       "import": "./dist/jsx/dom/css.js",
@@ -422,6 +427,9 @@
       ],
       "jsx/dom": [
         "./dist/types/jsx/dom"
+      ],
+      "jsx/dom/client": [
+        "./dist/types/jsx/dom/client.d.ts"
       ],
       "jsx/dom/css": [
         "./dist/types/jsx/dom/css.d.ts"

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -357,3 +357,5 @@ export const cloneElement = <T extends JSXNode | JSX.Element>(
     ...(children as (string | number | HtmlEscapedString)[])
   ) as T
 }
+
+export const reactAPICompatVersion = '18.0.0-hono-jsx'

--- a/src/jsx/dom/client.test.tsx
+++ b/src/jsx/dom/client.test.tsx
@@ -1,0 +1,119 @@
+/** @jsxImportSource ../ */
+import { JSDOM } from 'jsdom'
+import { createRoot, hydrateRoot } from './client'
+import { useEffect } from '.'
+
+describe('createRoot', () => {
+  beforeAll(() => {
+    global.requestAnimationFrame = (cb) => setTimeout(cb)
+  })
+
+  let dom: JSDOM
+  let rootElement: HTMLElement
+  beforeEach(() => {
+    dom = new JSDOM('<html><body><div id="root"></div></body></html>', {
+      runScripts: 'dangerously',
+    })
+    global.document = dom.window.document
+    global.HTMLElement = dom.window.HTMLElement
+    global.SVGElement = dom.window.SVGElement
+    global.Text = dom.window.Text
+    rootElement = document.getElementById('root') as HTMLElement
+  })
+
+  it('render / unmount', async () => {
+    const cleanup = vi.fn()
+    const App = () => {
+      useEffect(() => cleanup, [])
+      return <h1>Hello</h1>
+    }
+    const root = createRoot(rootElement)
+    root.render(<App />)
+    expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
+    await new Promise((resolve) => setTimeout(resolve))
+    root.unmount()
+    await Promise.resolve()
+    expect(rootElement.innerHTML).toBe('')
+    expect(cleanup).toHaveBeenCalled()
+  })
+
+  it('call render twice', async () => {
+    const App = <h1>Hello</h1>
+    const App2 = <h1>World</h1>
+    const root = createRoot(rootElement)
+    root.render(App)
+    expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
+
+    const createElementSpy = vi.spyOn(dom.window.document, 'createElement')
+
+    root.render(App2)
+    await Promise.resolve()
+    expect(rootElement.innerHTML).toBe('<h1>World</h1>')
+
+    expect(createElementSpy).not.toHaveBeenCalled()
+  })
+
+  it('call render after unmount', async () => {
+    const App = <h1>Hello</h1>
+    const App2 = <h1>World</h1>
+    const root = createRoot(rootElement)
+    root.render(App)
+    expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
+    root.unmount()
+    expect(() => root.render(App2)).toThrow('Cannot update an unmounted root')
+  })
+})
+
+describe('hydrateRoot', () => {
+  let dom: JSDOM
+  let rootElement: HTMLElement
+  beforeEach(() => {
+    dom = new JSDOM('<html><body><div id="root"></div></body></html>', {
+      runScripts: 'dangerously',
+    })
+    global.document = dom.window.document
+    global.HTMLElement = dom.window.HTMLElement
+    global.SVGElement = dom.window.SVGElement
+    global.Text = dom.window.Text
+    rootElement = document.getElementById('root') as HTMLElement
+  })
+
+  it('should return root object', async () => {
+    const cleanup = vi.fn()
+    const App = () => {
+      useEffect(() => cleanup, [])
+      return <h1>Hello</h1>
+    }
+    const root = hydrateRoot(rootElement, <App />)
+    expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
+    await new Promise((resolve) => setTimeout(resolve))
+    root.unmount()
+    await Promise.resolve()
+    expect(rootElement.innerHTML).toBe('')
+    expect(cleanup).toHaveBeenCalled()
+  })
+
+  it('call render', async () => {
+    const App = <h1>Hello</h1>
+    const App2 = <h1>World</h1>
+    const root = hydrateRoot(rootElement, App)
+    expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
+
+    const createElementSpy = vi.spyOn(dom.window.document, 'createElement')
+
+    root.render(App2)
+    await Promise.resolve()
+    expect(rootElement.innerHTML).toBe('<h1>World</h1>')
+
+    expect(createElementSpy).not.toHaveBeenCalled()
+  })
+
+  it('call render after unmount', async () => {
+    const App = <h1>Hello</h1>
+    const App2 = <h1>World</h1>
+    const root = hydrateRoot(rootElement, App)
+    expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
+    root.unmount()
+    expect(() => root.render(App2)).toThrow('Cannot update an unmounted root')
+  })
+})

--- a/src/jsx/dom/client.ts
+++ b/src/jsx/dom/client.ts
@@ -3,11 +3,17 @@
  * This module provides APIs for `hono/jsx/dom/client`, which is compatible with `react-dom/client`.
  */
 
+import type { Child } from '../base'
 import { useState } from '../hooks'
 import { buildNode, renderNode } from './render'
 import type { NodeObject } from './render'
 
-type CreateRootOptions = Record<string, unknown>
+export interface Root {
+  render(children: Child): void
+  unmount(): void
+}
+export type RootOptions = Record<string, unknown>
+
 /**
  * Create a root object for rendering
  * @param element Render target
@@ -16,8 +22,8 @@ type CreateRootOptions = Record<string, unknown>
  */
 export const createRoot = (
   element: HTMLElement | DocumentFragment,
-  options: CreateRootOptions = {}
-) => {
+  options: RootOptions = {}
+): Root => {
   let setJsxNode:
     | undefined // initial state
     | ((jsxNode: unknown) => void) // rendered
@@ -69,9 +75,9 @@ export const createRoot = (
  */
 export const hydrateRoot = (
   element: HTMLElement | DocumentFragment,
-  reactNode: unknown,
-  options: CreateRootOptions = {}
-) => {
+  reactNode: Child,
+  options: RootOptions = {}
+): Root => {
   const root = createRoot(element, options)
   root.render(reactNode)
   return root

--- a/src/jsx/dom/client.ts
+++ b/src/jsx/dom/client.ts
@@ -1,3 +1,8 @@
+/**
+ * @module
+ * This module provides APIs for `hono/jsx/dom/client`, which is compatible with `react-dom/client`.
+ */
+
 import { useState } from '../hooks'
 import { buildNode, renderNode } from './render'
 import type { NodeObject } from './render'

--- a/src/jsx/dom/client.ts
+++ b/src/jsx/dom/client.ts
@@ -1,0 +1,73 @@
+import { useState } from '../hooks'
+import { buildNode, renderNode } from './render'
+import type { NodeObject } from './render'
+
+type CreateRootOptions = Record<string, unknown>
+/**
+ * Create a root object for rendering
+ * @param element Render target
+ * @param options Options for createRoot (not supported yet)
+ * @returns Root object has `render` and `unmount` methods
+ */
+export const createRoot = (
+  element: HTMLElement | DocumentFragment,
+  options: CreateRootOptions = {}
+) => {
+  let setJsxNode:
+    | undefined // initial state
+    | ((jsxNode: unknown) => void) // rendered
+    | null = // unmounted
+    undefined
+
+  if (Object.keys(options).length > 0) {
+    console.warn('createRoot options are not supported yet')
+  }
+
+  return {
+    render(jsxNode: unknown) {
+      if (setJsxNode === null) {
+        // unmounted
+        throw new Error('Cannot update an unmounted root')
+      }
+      if (setJsxNode) {
+        // rendered
+        setJsxNode(jsxNode)
+      } else {
+        renderNode(
+          buildNode({
+            tag: () => {
+              const [_jsxNode, _setJsxNode] = useState(jsxNode)
+              setJsxNode = _setJsxNode
+              return _jsxNode
+            },
+            props: {},
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any) as NodeObject,
+          element
+        )
+      }
+    },
+    unmount() {
+      setJsxNode?.(null)
+      setJsxNode = null
+    },
+  }
+}
+
+/**
+ * Create a root object and hydrate app to the target element.
+ * In hono/jsx/dom, hydrate is equivalent to render.
+ * @param element Render target
+ * @param reactNode A JSXNode to render
+ * @param options Options for createRoot (not supported yet)
+ * @returns Root object has `render` and `unmount` methods
+ */
+export const hydrateRoot = (
+  element: HTMLElement | DocumentFragment,
+  reactNode: unknown,
+  options: CreateRootOptions = {}
+) => {
+  const root = createRoot(element, options)
+  root.render(reactNode)
+  return root
+}

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -24,6 +24,7 @@ import DefaultExport, {
   isValidElement,
   memo,
   render,
+  version,
 } from '.'
 
 describe('Common', () => {
@@ -2123,8 +2124,15 @@ describe('jsx', () => {
   })
 })
 
+describe('version', () => {
+  it('should be defined with semantic versioning format', () => {
+    expect(version).toMatch(/^\d+\.\d+\.\d+-hono-jsx$/)
+  })
+})
+
 describe('default export', () => {
   ;[
+    'version',
     'memo',
     'Fragment',
     'isValidElement',

--- a/src/jsx/dom/index.ts
+++ b/src/jsx/dom/index.ts
@@ -1,4 +1,4 @@
-import { isValidElement, memo } from '../base'
+import { isValidElement, memo, reactAPICompatVersion } from '../base'
 import type { Child, DOMAttributes, JSX, JSXNode, Props } from '../base'
 import { Children } from '../children'
 import { useContext } from '../context'
@@ -67,6 +67,7 @@ const cloneElement = <T extends JSXNode | JSX.Element>(
 }
 
 export {
+  reactAPICompatVersion as version,
   createElement as jsx,
   useState,
   useEffect,
@@ -104,6 +105,7 @@ export {
 }
 
 export default {
+  version: reactAPICompatVersion,
   useState,
   useEffect,
   useRef,

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -487,7 +487,7 @@ export const build = (
   }
 }
 
-const buildNode = (node: Child): Node | undefined => {
+export const buildNode = (node: Child): Node | undefined => {
   if (node === undefined || node === null || typeof node === 'boolean') {
     return undefined
   } else if (typeof node === 'string' || typeof node === 'number') {
@@ -590,9 +590,7 @@ export const update = async (
   return promise
 }
 
-export const render = (jsxNode: unknown, container: Container) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const node = buildNode({ tag: '', props: { children: jsxNode } } as any) as NodeObject
+export const renderNode = (node: NodeObject, container: Container) => {
   const context: Context = []
   ;(context as Context)[4] = true // start top level render
   build(context, node, undefined)
@@ -602,6 +600,11 @@ export const render = (jsxNode: unknown, container: Container) => {
   apply(node, fragment)
   replaceContainer(node, fragment, container)
   container.replaceChildren(fragment)
+}
+
+export const render = (jsxNode: unknown, container: Container) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  renderNode(buildNode({ tag: '', props: { children: jsxNode } } as any) as NodeObject, container)
 }
 
 export const flushSync = (callback: () => void) => {

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -602,7 +602,7 @@ export const renderNode = (node: NodeObject, container: Container) => {
   container.replaceChildren(fragment)
 }
 
-export const render = (jsxNode: unknown, container: Container) => {
+export const render = (jsxNode: Child, container: Container) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   renderNode(buildNode({ tag: '', props: { children: jsxNode } } as any) as NodeObject, container)
 }

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -3,7 +3,7 @@
 import { html } from '../helper/html'
 import { Hono } from '../hono'
 import { Suspense, renderToReadableStream } from './streaming'
-import DefaultExport, { Fragment, createContext, memo, useContext } from '.'
+import DefaultExport, { Fragment, createContext, memo, useContext, version } from '.'
 import type { Context, FC, PropsWithChildren } from '.'
 
 interface SiteData {
@@ -729,8 +729,15 @@ d.replaceWith(c.content)
   })
 })
 
+describe('version', () => {
+  it('should be defined with semantic versioning format', () => {
+    expect(version).toMatch(/^\d+\.\d+\.\d+-hono-jsx$/)
+  })
+})
+
 describe('default export', () => {
   ;[
+    'version',
     'memo',
     'Fragment',
     'isValidElement',

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -1,4 +1,4 @@
-import { Fragment, cloneElement, isValidElement, jsx, memo } from './base'
+import { Fragment, cloneElement, isValidElement, jsx, memo, reactAPICompatVersion } from './base'
 import type { DOMAttributes } from './base'
 import { Children } from './children'
 import { ErrorBoundary } from './components'
@@ -28,6 +28,7 @@ import {
 import { Suspense } from './streaming'
 
 export {
+  reactAPICompatVersion as version,
   jsx,
   memo,
   Fragment,
@@ -63,6 +64,7 @@ export {
 }
 
 export default {
+  version: reactAPICompatVersion,
   memo,
   Fragment,
   isValidElement,


### PR DESCRIPTION
Fixes #2792

### version

There seems to be a library that does conditional branching on the major version number of `React.version`.

This is like a UserAgent of a web browser (e.g. Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537. 36), which is a string for compatibility and somewhat unpleasant to use, and we do not recommend its use, but if this improves compatibility, it should be added.

### createRoot / hydrateRoot

Some options are not yet supported, but they can be rendered in the way recommended by React since version 18, as shown in the following diff.

https://github.com/usualoma/hono-react-compat-demo/commit/38773555179ef54f8564ca1963720ac16f720987


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
