### PR TITLE
feat(middleware): Introduce IP Limit Middleware

### DIFF
--- a/deno_dist/adapter/deno/conninfo.ts
+++ b/deno_dist/adapter/deno/conninfo.ts
@@ -1,0 +1,18 @@
+import type { GetConnInfo } from '../../helper/conninfo/index.ts'
+
+/**
+ * Get conninfo with Deno
+ * @param c Context
+ * @returns ConnInfo
+ */
+export const getConnInfo: GetConnInfo = (c) => {
+  const { remoteAddr } = c.env
+  return {
+    remote: {
+      address: remoteAddr.hostname,
+      port: remoteAddr.port,
+      transport: remoteAddr.transport,
+      addressType: 'unknown',
+    },
+  }
+}

--- a/deno_dist/adapter/deno/index.ts
+++ b/deno_dist/adapter/deno/index.ts
@@ -1,3 +1,4 @@
 export { serveStatic } from './serve-static.ts'
 export { toSSG, denoFileSystemModule } from './ssg.ts'
 export { upgradeWebSocket } from './websocket.ts'
+export { getConnInfo } from './conninfo.ts'

--- a/deno_dist/helper/conninfo/index.ts
+++ b/deno_dist/helper/conninfo/index.ts
@@ -1,0 +1,45 @@
+import type { Context } from '../../context.ts'
+
+export type AddressType = 'IPv6' | 'IPv4' | 'unknown'
+
+export type NetAddrInfo = {
+  /**
+   * Transport protocol type
+   */
+  transport?: 'tcp' | 'udp'
+  /**
+   * Transport port number
+   */
+  port?: number
+
+  address?: string
+  addressType?: AddressType
+} & (
+  | {
+      /**
+       * Host name such as IP Addr
+       */
+      address: string
+
+      /**
+       * Host name type
+       */
+      addressType: AddressType
+    }
+  | {}
+)
+
+/**
+ * HTTP Connection infomation
+ */
+export interface ConnInfo {
+  /**
+   * Remote infomation
+   */
+  remote: NetAddrInfo
+}
+
+/**
+ * Helper type
+ */
+export type GetConnInfo = (c: Context) => ConnInfo

--- a/package.json
+++ b/package.json
@@ -333,6 +333,11 @@
       "types": "./dist/types/helper/websocket/index.d.ts",
       "import": "./dist/helper/websocket/index.js",
       "require": "./dist/cjs/helper/websocket/index.js"
+    },
+    "./conninfo": {
+      "types": "./dist/types/helper/conninfo/index.d.ts",
+      "import": "./dist/helper/conninfo/index.js",
+      "require": "./dist/cjs/helper/conninfo/index.js"
     }
   },
   "typesVersions": {
@@ -507,6 +512,9 @@
       ],
       "ws": [
         "./dist/types/helper/websocket"
+      ],
+      "conninfo": [
+        "./dist/types/helper/conninfo"
       ]
     }
   },

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -41,12 +41,12 @@ describe('getConnInfo', () => {
     expect(info.remote.addressType).toBe('IPv6')
     expect(info.remote.transport).toBeUndefined()
   })
-  it('Should throw error when user didn\'t give server', () => {
+  it('Should throw error when user did not give server', () => {
     const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: {} })
 
     expect(() => getConnInfo(c)).toThrowError(TypeError)
   })
-  it('Should throw error when requestIP isn\'t function', () => {
+  it('Should throw error when requestIP is not function', () => {
     const c = new Context(new HonoRequest(new Request('http://localhost/')), {
       env: {
         requestIP: 0,

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -41,12 +41,12 @@ describe('getConnInfo', () => {
     expect(info.remote.addressType).toBe('IPv6')
     expect(info.remote.transport).toBeUndefined()
   })
-  it("Should throw error when user didn't give server", () => {
+  it(`Should throw error when user didn't give server`, () => {
     const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: {} })
 
     expect(() => getConnInfo(c)).toThrowError(TypeError)
   })
-  it("Should throw error when requestIP isn't function", () => {
+  it(`Should throw error when requestIP isn't function`, () => {
     const c = new Context(new HonoRequest(new Request('http://localhost/')), {
       env: {
         requestIP: 0,

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -2,26 +2,56 @@ import { Context } from '../../context'
 import { HonoRequest } from '../../request'
 import { getConnInfo } from './conninfo'
 
+const createRandomBunServer = () => {
+  const address = Math.random().toString()
+  const port = Math.floor(Math.random() * (65535 + 1))
+  return {
+    address,
+    port,
+    server: {
+      requestIP() {
+        return {
+          address,
+          family: 'IPv6',
+          port,
+        }
+      },
+    },
+  }
+}
 describe('getConnInfo', () => {
   it('Should info is valid', () => {
-    const address = Math.random().toString()
-    const port = Math.floor(Math.random() * (65535 + 1))
-    const c = new Context(new HonoRequest(new Request('http://localhost/')), {
-      env: {
-        requestIP() {
-          return {
-            address,
-            family: 'IPv6',
-            port,
-          }
-        },
-      },
-    })
+    const { port, server, address } = createRandomBunServer()
+    const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: server })
     const info = getConnInfo(c)
 
     expect(info.remote.port).toBe(port)
     expect(info.remote.address).toBe(address)
     expect(info.remote.addressType).toBe('IPv6')
     expect(info.remote.transport).toBeUndefined()
+  })
+  it('Should getConnInfo works when env is { server: server }', () => {
+    const { port, server, address } = createRandomBunServer()
+    const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: { server } })
+
+    const info = getConnInfo(c)
+
+    expect(info.remote.port).toBe(port)
+    expect(info.remote.address).toBe(address)
+    expect(info.remote.addressType).toBe('IPv6')
+    expect(info.remote.transport).toBeUndefined()
+  })
+  it("Should throw error when user didn't give server", () => {
+    const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: {} })
+
+    expect(() => getConnInfo(c)).toThrowError(TypeError)
+  })
+  it("Should throw error when requestIP isn't function", () => {
+    const c = new Context(new HonoRequest(new Request('http://localhost/')), {
+      env: {
+        requestIP: 0,
+      },
+    })
+    expect(() => getConnInfo(c)).toThrowError(TypeError)
   })
 })

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -1,0 +1,27 @@
+import { Context } from '../../context'
+import { getConnInfo } from './conninfo'
+import { HonoRequest } from '../../request'
+
+describe('getConnInfo', () => {
+  it('Should info is valid', () => {
+    const address = Math.random().toString()
+    const port = Math.floor(Math.random() * (65535 + 1))
+    const c = new Context(new HonoRequest(new Request('/')), {
+      env: {
+        requestIP() {
+          return {
+            address,
+            family: 'IPv6',
+            port
+          }
+        }
+      }
+    })
+    const info = getConnInfo(c)
+    
+    expect(info.remote.port).toBe(port)
+    expect(info.remote.address).toBe(address)
+    expect(info.remote.addressType).toBe('IPv6')
+    expect(info.remote.transport).toBeUndefined()
+  })
+})

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -41,12 +41,12 @@ describe('getConnInfo', () => {
     expect(info.remote.addressType).toBe('IPv6')
     expect(info.remote.transport).toBeUndefined()
   })
-  it(`Should throw error when user didn't give server`, () => {
+  it('Should throw error when user didn\'t give server', () => {
     const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: {} })
 
     expect(() => getConnInfo(c)).toThrowError(TypeError)
   })
-  it(`Should throw error when requestIP isn't function`, () => {
+  it('Should throw error when requestIP isn\'t function', () => {
     const c = new Context(new HonoRequest(new Request('http://localhost/')), {
       env: {
         requestIP: 0,

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -6,7 +6,7 @@ describe('getConnInfo', () => {
   it('Should info is valid', () => {
     const address = Math.random().toString()
     const port = Math.floor(Math.random() * (65535 + 1))
-    const c = new Context(new HonoRequest(new Request('/')), {
+    const c = new Context(new HonoRequest(new Request('http://localhost/')), {
       env: {
         requestIP() {
           return {

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -1,6 +1,6 @@
 import { Context } from '../../context'
-import { getConnInfo } from './conninfo'
 import { HonoRequest } from '../../request'
+import { getConnInfo } from './conninfo'
 
 describe('getConnInfo', () => {
   it('Should info is valid', () => {

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -12,13 +12,13 @@ describe('getConnInfo', () => {
           return {
             address,
             family: 'IPv6',
-            port
+            port,
           }
-        }
-      }
+        },
+      },
     })
     const info = getConnInfo(c)
-    
+
     expect(info.remote.port).toBe(port)
     expect(info.remote.address).toBe(address)
     expect(info.remote.addressType).toBe('IPv6')

--- a/src/adapter/bun/conninfo.ts
+++ b/src/adapter/bun/conninfo.ts
@@ -19,10 +19,10 @@ export const getConnInfo: GetConnInfo = (c: Context) => {
     | undefined
 
   if (!server) {
-    throw new TypeError('env has to include 2nd argument of fetch.')
+    throw new TypeError('env has to include the 2nd argument of fetch.')
   }
   if (typeof server.requestIP !== 'function') {
-    throw new TypeError('server.requestIP is not function.')
+    throw new TypeError('server.requestIP is not a function.')
   }
   const info = server.requestIP(c.req.raw)
 

--- a/src/adapter/bun/conninfo.ts
+++ b/src/adapter/bun/conninfo.ts
@@ -1,0 +1,25 @@
+import { Context } from '../..'
+import type { GetConnInfo } from '../../helper/conninfo'
+
+/**
+ * Get ConnInfo with Bun
+ * @param c Context
+ * @returns ConnInfo
+ */
+export const getConnInfo: GetConnInfo = (c: Context) => {
+  const info = (c.env as {
+    requestIP(req: Request): {
+      address: string
+      family: string
+      port: number
+    }
+  }).requestIP(c.req.raw)
+
+  return {
+    remote: {
+      address: info.address,
+      addressType: (info.family === 'IPv6' || info.family === 'IPv4') ? info.family : 'unknown',
+      port: info.port
+    }
+  }
+}

--- a/src/adapter/bun/conninfo.ts
+++ b/src/adapter/bun/conninfo.ts
@@ -8,15 +8,23 @@ import type { GetConnInfo } from '../../helper/conninfo'
  * @returns ConnInfo
  */
 export const getConnInfo: GetConnInfo = (c: Context) => {
-  const info = (
-    c.env as {
-      requestIP(req: Request): {
-        address: string
-        family: string
-        port: number
+  const server = ('server' in c.env ? c.env.server : c.env) as
+    | {
+        requestIP?: (req: Request) => {
+          address: string
+          family: string
+          port: number
+        }
       }
-    }
-  ).requestIP(c.req.raw)
+    | undefined
+
+  if (!server) {
+    throw new TypeError('env has to include 2nd argument of fetch.')
+  }
+  if (typeof server.requestIP !== 'function') {
+    throw new TypeError('server.requestIP is not function.')
+  }
+  const info = server.requestIP(c.req.raw)
 
   return {
     remote: {

--- a/src/adapter/bun/conninfo.ts
+++ b/src/adapter/bun/conninfo.ts
@@ -7,19 +7,21 @@ import type { GetConnInfo } from '../../helper/conninfo'
  * @returns ConnInfo
  */
 export const getConnInfo: GetConnInfo = (c: Context) => {
-  const info = (c.env as {
-    requestIP(req: Request): {
-      address: string
-      family: string
-      port: number
+  const info = (
+    c.env as {
+      requestIP(req: Request): {
+        address: string
+        family: string
+        port: number
+      }
     }
-  }).requestIP(c.req.raw)
+  ).requestIP(c.req.raw)
 
   return {
     remote: {
       address: info.address,
-      addressType: (info.family === 'IPv6' || info.family === 'IPv4') ? info.family : 'unknown',
-      port: info.port
-    }
+      addressType: info.family === 'IPv6' || info.family === 'IPv4' ? info.family : 'unknown',
+      port: info.port,
+    },
   }
 }

--- a/src/adapter/bun/conninfo.ts
+++ b/src/adapter/bun/conninfo.ts
@@ -1,4 +1,5 @@
-import { Context } from '../..'
+// @denoify-ignore
+import type { Context } from '../..'
 import type { GetConnInfo } from '../../helper/conninfo'
 
 /**

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -2,3 +2,4 @@
 export { serveStatic } from './serve-static'
 export { bunFileSystemModule, toSSG } from './ssg'
 export { createBunWebSocket } from './websocket'
+export { getConnInfo } from './conninfo'

--- a/src/adapter/cloudflare-workers/conninfo.test.ts
+++ b/src/adapter/cloudflare-workers/conninfo.test.ts
@@ -7,11 +7,11 @@ describe('getConnInfo', () => {
     const address = Math.random().toString()
     const req = new Request('/', {
       headers: {
-        'cf-connecting-ip': address
-      }
+        'cf-connecting-ip': address,
+      },
     })
     const c = new Context(new HonoRequest(req))
-    
+
     const info = getConnInfo(c)
 
     expect(info.remote.address).toBe(address)

--- a/src/adapter/cloudflare-workers/conninfo.test.ts
+++ b/src/adapter/cloudflare-workers/conninfo.test.ts
@@ -1,5 +1,5 @@
-import { HonoRequest } from '../../request'
 import { Context } from '../../context'
+import { HonoRequest } from '../../request'
 import { getConnInfo } from './conninfo'
 
 describe('getConnInfo', () => {

--- a/src/adapter/cloudflare-workers/conninfo.test.ts
+++ b/src/adapter/cloudflare-workers/conninfo.test.ts
@@ -5,7 +5,7 @@ import { getConnInfo } from './conninfo'
 describe('getConnInfo', () => {
   it('Should getConnInfo works', () => {
     const address = Math.random().toString()
-    const req = new Request('/', {
+    const req = new Request('http://localhost/', {
       headers: {
         'cf-connecting-ip': address,
       },

--- a/src/adapter/cloudflare-workers/conninfo.test.ts
+++ b/src/adapter/cloudflare-workers/conninfo.test.ts
@@ -1,0 +1,19 @@
+import { HonoRequest } from '../../request'
+import { Context } from '../../context'
+import { getConnInfo } from './conninfo'
+
+describe('getConnInfo', () => {
+  it('Should getConnInfo works', () => {
+    const address = Math.random().toString()
+    const req = new Request('/', {
+      headers: {
+        'cf-connecting-ip': address
+      }
+    })
+    const c = new Context(new HonoRequest(req))
+    
+    const info = getConnInfo(c)
+
+    expect(info.remote.address).toBe(address)
+  })
+})

--- a/src/adapter/cloudflare-workers/conninfo.ts
+++ b/src/adapter/cloudflare-workers/conninfo.ts
@@ -3,6 +3,6 @@ import { GetConnInfo } from '../../helper/conninfo'
 export const getConnInfo: GetConnInfo = (c) => ({
   remote: {
     address: c.req.header('cf-connecting-ip'),
-    addressType: 'unknown'
-  }
+    addressType: 'unknown',
+  },
 })

--- a/src/adapter/cloudflare-workers/conninfo.ts
+++ b/src/adapter/cloudflare-workers/conninfo.ts
@@ -1,0 +1,8 @@
+import { GetConnInfo } from '../../helper/conninfo'
+
+export const getConnInfo: GetConnInfo = (c) => ({
+  remote: {
+    address: c.req.header('cf-connecting-ip'),
+    addressType: 'unknown'
+  }
+})

--- a/src/adapter/cloudflare-workers/conninfo.ts
+++ b/src/adapter/cloudflare-workers/conninfo.ts
@@ -1,4 +1,5 @@
-import { GetConnInfo } from '../../helper/conninfo'
+// @denoify-ignore
+import type { GetConnInfo } from '../../helper/conninfo'
 
 export const getConnInfo: GetConnInfo = (c) => ({
   remote: {

--- a/src/adapter/deno/conninfo.test.ts
+++ b/src/adapter/deno/conninfo.test.ts
@@ -7,7 +7,7 @@ describe('getConnInfo', () => {
     const transport = 'tcp'
     const address = Math.random().toString()
     const port = Math.floor(Math.random() * (65535 + 1))
-    const c = new Context(new HonoRequest(new Request('/')), {
+    const c = new Context(new HonoRequest(new Request('http://localhost/')), {
       env: {
         remoteAddr: {
           transport,

--- a/src/adapter/deno/conninfo.test.ts
+++ b/src/adapter/deno/conninfo.test.ts
@@ -1,0 +1,25 @@
+import { Context } from '../../context'
+import { getConnInfo } from './conninfo'
+import { HonoRequest } from '../../request'
+
+describe('getConnInfo', () => {
+  it('Should info is valid', () => {
+    const transport = 'tcp'
+    const address = Math.random().toString()
+    const port = Math.floor(Math.random() * (65535 + 1))
+    const c = new Context(new HonoRequest(new Request('/')), {
+      env: {
+        remoteAddr: {
+          transport,
+          hostname: address,
+          port
+        }
+      }
+    })
+    const info = getConnInfo(c)
+    
+    expect(info.remote.port).toBe(port)
+    expect(info.remote.address).toBe(address)
+    expect(info.remote.transport).toBe(transport)
+  })
+})

--- a/src/adapter/deno/conninfo.test.ts
+++ b/src/adapter/deno/conninfo.test.ts
@@ -1,6 +1,6 @@
 import { Context } from '../../context'
-import { getConnInfo } from './conninfo'
 import { HonoRequest } from '../../request'
+import { getConnInfo } from './conninfo'
 
 describe('getConnInfo', () => {
   it('Should info is valid', () => {

--- a/src/adapter/deno/conninfo.test.ts
+++ b/src/adapter/deno/conninfo.test.ts
@@ -12,12 +12,12 @@ describe('getConnInfo', () => {
         remoteAddr: {
           transport,
           hostname: address,
-          port
-        }
-      }
+          port,
+        },
+      },
     })
     const info = getConnInfo(c)
-    
+
     expect(info.remote.port).toBe(port)
     expect(info.remote.address).toBe(address)
     expect(info.remote.transport).toBe(transport)

--- a/src/adapter/deno/conninfo.ts
+++ b/src/adapter/deno/conninfo.ts
@@ -12,7 +12,7 @@ export const getConnInfo: GetConnInfo = (c) => {
       address: remoteAddr.hostname,
       port: remoteAddr.port,
       transport: remoteAddr.transport,
-      addressType: 'unknown'
-    }
+      addressType: 'unknown',
+    },
   }
 }

--- a/src/adapter/deno/conninfo.ts
+++ b/src/adapter/deno/conninfo.ts
@@ -1,0 +1,18 @@
+import type { GetConnInfo } from '../../helper/conninfo'
+
+/**
+ * Get conninfo with Deno
+ * @param c Context
+ * @returns ConnInfo
+ */
+export const getConnInfo: GetConnInfo = (c) => {
+  const { remoteAddr } = c.env
+  return {
+    remote: {
+      address: remoteAddr.hostname,
+      port: remoteAddr.port,
+      transport: remoteAddr.transport,
+      addressType: 'unknown'
+    }
+  }
+}

--- a/src/adapter/deno/index.ts
+++ b/src/adapter/deno/index.ts
@@ -1,3 +1,4 @@
 export { serveStatic } from './serve-static'
 export { toSSG, denoFileSystemModule } from './ssg'
 export { upgradeWebSocket } from './websocket'
+export { getConnInfo } from './conninfo'

--- a/src/helper/conninfo/index.ts
+++ b/src/helper/conninfo/index.ts
@@ -14,17 +14,20 @@ export type NetAddrInfo = {
 
   address?: string
   addressType?: AddressType
-} & ({
-  /**
-   * Host name such as IP Addr
-   */
-  address: string
+} & (
+  | {
+      /**
+       * Host name such as IP Addr
+       */
+      address: string
 
-  /**
-   * Host name type
-   */
-  addressType: AddressType
-} | {})
+      /**
+       * Host name type
+       */
+      addressType: AddressType
+    }
+  | {}
+)
 
 /**
  * HTTP Connection infomation

--- a/src/helper/conninfo/index.ts
+++ b/src/helper/conninfo/index.ts
@@ -1,0 +1,42 @@
+import type { Context } from '../../context'
+
+export type AddressType = 'IPv6' | 'IPv4' | 'unknown'
+
+export type NetAddrInfo = {
+  /**
+   * Transport protocol type
+   */
+  transport?: 'tcp' | 'udp'
+  /**
+   * Transport port number
+   */
+  port?: number
+
+  address?: string
+  addressType?: AddressType
+} & ({
+  /**
+   * Host name such as IP Addr
+   */
+  address: string
+
+  /**
+   * Host name type
+   */
+  addressType: AddressType
+} | {})
+
+/**
+ * HTTP Connection infomation
+ */
+export interface ConnInfo {
+  /**
+   * Remote infomation
+   */
+  remote: NetAddrInfo
+}
+
+/**
+ * Helper type
+ */
+export type GetConnInfo = (c: Context) => ConnInfo


### PR DESCRIPTION
Recreated #2787
***
I created IP Limit Middleware.

You can limit request by IP Address.

For example, you can limit request, this server accepts local-only requests:
```ts
import { Hono } from 'hono'
import { ipLimit } from 'hono/ip-limit'
import { getConnInfo } from 'hono/...'

const app = new Hono()

app.use('*', ipLimit(getConnInfo, {
  deny: [],
  allow: ['127.0.0.1', '::1']
}))
app.get('/', c => c.text('Hello world!'))
```
`deny` takes precedence over `allow`.

Rules supported some syntax:

| Title | example of IPv4 | example of IPv6 |
| --- | --- | --- |
| static | `0.0.0.0` | `::1` |
| CIDR | `192.168.2.1/24` | `abcd::ef01/64` |
| Wildcard | `192.*.2.*` |  |

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun denoify` to generate files for Deno
- [x] `bun run format:fix && bun run lint:fix` to format the code
