### PR TITLE
feat(bun): WebSocket helper supports that env be `{ server: server }`

### DIFF
--- a/src/adapter/bun/conninfo.ts
+++ b/src/adapter/bun/conninfo.ts
@@ -1,5 +1,6 @@
 import type { Context } from '../..'
 import type { GetConnInfo } from '../../helper/conninfo'
+import { getBunServer } from './server'
 
 /**
  * Get ConnInfo with Bun
@@ -7,15 +8,7 @@ import type { GetConnInfo } from '../../helper/conninfo'
  * @returns ConnInfo
  */
 export const getConnInfo: GetConnInfo = (c: Context) => {
-  const server = ('server' in c.env ? c.env.server : c.env) as
-    | {
-        requestIP?: (req: Request) => {
-          address: string
-          family: string
-          port: number
-        }
-      }
-    | undefined
+  const server = getBunServer(c)
 
   if (!server) {
     throw new TypeError('env has to include the 2nd argument of fetch.')

--- a/src/adapter/bun/server.test.ts
+++ b/src/adapter/bun/server.test.ts
@@ -1,6 +1,7 @@
 import { Context } from '../../context'
 import { HonoRequest } from '../../request'
-import { type BunServer, getBunServer } from './server'
+import {  getBunServer } from './server'
+import type {BunServer} from './server'
 
 describe('getBunServer', () => {
   it('Should success to pick Server', () => {

--- a/src/adapter/bun/server.test.ts
+++ b/src/adapter/bun/server.test.ts
@@ -6,10 +6,10 @@ describe('getBunServer', () => {
   it('Should success to pick Server', () => {
     const server = {} as BunServer
 
-    expect(getBunServer(new Context(new HonoRequest(new Request('/')), { env: server }))).toBe(
+    expect(getBunServer(new Context(new HonoRequest(new Request('http://localhost/')), { env: server }))).toBe(
       server
     )
-    expect(getBunServer(new Context(new HonoRequest(new Request('/')), { env: { server } }))).toBe(
+    expect(getBunServer(new Context(new HonoRequest(new Request('http://localhost/')), { env: { server } }))).toBe(
       server
     )
   })

--- a/src/adapter/bun/server.test.ts
+++ b/src/adapter/bun/server.test.ts
@@ -1,7 +1,7 @@
 import { Context } from '../../context'
 import { HonoRequest } from '../../request'
-import {  getBunServer } from './server'
-import type {BunServer} from './server'
+import { getBunServer } from './server'
+import type { BunServer } from './server'
 
 describe('getBunServer', () => {
   it('Should success to pick Server', () => {

--- a/src/adapter/bun/server.test.ts
+++ b/src/adapter/bun/server.test.ts
@@ -1,0 +1,16 @@
+import { Context } from '../../context'
+import { HonoRequest } from '../../request'
+import { type BunServer, getBunServer } from './server'
+
+describe('getBunServer', () => {
+  it('Should success to pick Server', () => {
+    const server = {} as BunServer
+
+    expect(getBunServer(new Context(new HonoRequest(new Request('/')), { env: server }))).toBe(
+      server
+    )
+    expect(getBunServer(new Context(new HonoRequest(new Request('/')), { env: { server } }))).toBe(
+      server
+    )
+  })
+})

--- a/src/adapter/bun/server.test.ts
+++ b/src/adapter/bun/server.test.ts
@@ -6,11 +6,13 @@ describe('getBunServer', () => {
   it('Should success to pick Server', () => {
     const server = {} as BunServer
 
-    expect(getBunServer(new Context(new HonoRequest(new Request('http://localhost/')), { env: server }))).toBe(
-      server
-    )
-    expect(getBunServer(new Context(new HonoRequest(new Request('http://localhost/')), { env: { server } }))).toBe(
-      server
-    )
+    expect(
+      getBunServer(new Context(new HonoRequest(new Request('http://localhost/')), { env: server }))
+    ).toBe(server)
+    expect(
+      getBunServer(
+        new Context(new HonoRequest(new Request('http://localhost/')), { env: { server } })
+      )
+    ).toBe(server)
   })
 })

--- a/src/adapter/bun/server.ts
+++ b/src/adapter/bun/server.ts
@@ -1,0 +1,29 @@
+/**
+ * Getting Bun Server Object for Bun adapters
+ * @module
+ */
+import type { Context } from "../../context"
+
+/**
+ * Bun Server Object
+ */
+export interface BunServer {
+    requestIP?: (req: Request) => {
+        address: string
+        family: string
+        port: number
+    }
+    upgrade<T>(
+        req: Request,
+        options?: {
+            data: T
+        }
+    ): boolean
+}
+
+/**
+ * Get Bun Server Object from Context
+ * @param c Context
+ * @returns Bun Server
+ */
+export const getBunServer = (c: Context): BunServer | undefined => ('server' in c.env ? c.env.server : c.env) as BunServer | undefined

--- a/src/adapter/bun/server.ts
+++ b/src/adapter/bun/server.ts
@@ -2,23 +2,23 @@
  * Getting Bun Server Object for Bun adapters
  * @module
  */
-import type { Context } from "../../context"
+import type { Context } from '../../context'
 
 /**
  * Bun Server Object
  */
 export interface BunServer {
-    requestIP?: (req: Request) => {
-        address: string
-        family: string
-        port: number
+  requestIP?: (req: Request) => {
+    address: string
+    family: string
+    port: number
+  }
+  upgrade<T>(
+    req: Request,
+    options?: {
+      data: T
     }
-    upgrade<T>(
-        req: Request,
-        options?: {
-            data: T
-        }
-    ): boolean
+  ): boolean
 }
 
 /**
@@ -26,4 +26,5 @@ export interface BunServer {
  * @param c Context
  * @returns Bun Server
  */
-export const getBunServer = (c: Context): BunServer | undefined => ('server' in c.env ? c.env.server : c.env) as BunServer | undefined
+export const getBunServer = (c: Context): BunServer | undefined =>
+  ('server' in c.env ? c.env.server : c.env) as BunServer | undefined


### PR DESCRIPTION
Resolves #2645 and #2696

In ConnInfo helper on Bun, you can give Hono env like `{ server: server }`.
However WebSocket Helper can't receive `{ server: server }`, so I created this PR. WebSocket helper on Bun can receive like it if we merged this.
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
