### PR TITLE
docs(jsdoc): change jsdoc of .notFound

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -238,6 +238,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    * @param {NotFoundHandler} handler - request handler for not-found
    * @returns {Hono} changed Hono instance
    *
+   * @example
    * ```ts
    * app.notFound((c) => {
    *   return c.text('Custom 404 Message', 404)

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -232,12 +232,17 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
 
   /**
    * `.notFound()` allows you to customize a Not Found Response.
+   *
+   * @see {@link https://hono.dev/api/hono#not-found}
+   *
+   * @param {NotFoundHandler} handler - request handler for not-found
+   * @returns {Hono} changed Hono instance
+   *
    * ```ts
    * app.notFound((c) => {
    *   return c.text('Custom 404 Message', 404)
    * })
    * ```
-   * @see https://hono.dev/api/hono#not-found
    */
   notFound = (handler: NotFoundHandler<E>): Hono<E, S, BasePath> => {
     this.notFoundHandler = handler


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
