### PR TITLE
refactor(aws-lambda): remove unused setHeadersToResult

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -379,26 +379,7 @@ class ALBProcessor extends EventProcessor<ALBProxyEvent> {
     }
     return headers
   }
-  protected setHeadersToResult(
-    event: ALBProxyEvent,
-    result: APIGatewayProxyResult,
-    headers: Headers
-  ): void {
-    // When multiValueHeaders is present in event set multiValueHeaders in result
-    if (event.multiValueHeaders) {
-      const multiValueHeaders: { [key: string]: string[] } = {}
-      for (const [key, value] of headers.entries()) {
-        multiValueHeaders[key] = [value]
-      }
-      result.multiValueHeaders = multiValueHeaders
-    } else {
-      const singleValueHeaders: Record<string, string> = {}
-      for (const [key, value] of headers.entries()) {
-        singleValueHeaders[key] = value
-      }
-      result.headers = singleValueHeaders
-    }
-  }
+
   protected getPath(event: ALBProxyEvent): string {
     return event.path
   }


### PR DESCRIPTION
`setHeadersToResult` was added in https://github.com/honojs/hono/pull/2657 but seems not used.

@yiss Please confirm it should be deleted or called.
If it should be called, I'll add tests and fix implementation.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
