### PR TITLE
refactor(aws-lambda): Object.hasOwn is recommended

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -473,11 +473,11 @@ export const getProcessor = (event: LambdaEvent): EventProcessor<LambdaEvent> =>
 }
 
 const isProxyEventALB = (event: LambdaEvent): event is ALBProxyEvent => {
-  return Object.prototype.hasOwnProperty.call(event.requestContext, 'elb')
+  return Object.hasOwn(event.requestContext, 'elb')
 }
 
 const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => {
-  return Object.prototype.hasOwnProperty.call(event, 'rawPath')
+  return Object.hasOwn(event, 'rawPath')
 }
 
 export const isContentTypeBinary = (contentType: string) => {


### PR DESCRIPTION
Refer. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn


> It is recommended over [Object.prototype.hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) because it works for [null-prototype objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) and with objects that have overridden the inherited hasOwnProperty() method. While it is possible to workaround these problems by calling Object.prototype.hasOwnProperty() on an external object, Object.hasOwn() is more intuitive.

`Object.hasOwn` is supported since Node.js v16.9.0 which is [the minimum supported Node.js version in AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
And,  Hono also declares it requires Node.js v16+: 
https://github.com/honojs/hono/blob/dfbc6c47643e027af484cfc028050124a21d9158/package.json#L600

So I don't think this is going to be a breaking change for Hono+Lambda users

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
