### PR TITLE
fix(middleware/body-limit): set default duplex option for readable stream

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -396,13 +396,6 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     }
     input = input.toString()
     const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
-
-    // Always adds default duplex option on Hono.request
-    if (requestInit) {
-      // @ts-expect-error - duplex do not have any type yet
-      requestInit.duplex = 'half'
-    }
-
     const req = new Request(path, requestInit)
     return this.fetch(req, Env, executionCtx)
   }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -396,6 +396,13 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     }
     input = input.toString()
     const path = /^https?:\/\//.test(input) ? input : `http://localhost${mergePath('/', input)}`
+
+    // Always adds default duplex option on Hono.request
+    if (requestInit) {
+      // @ts-expect-error - duplex do not have any type yet
+      requestInit.duplex = 'half'
+    }
+
     const req = new Request(path, requestInit)
     return this.fetch(req, Env, executionCtx)
   }

--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -1,17 +1,6 @@
 import { Hono } from '../../hono'
 import { bodyLimit } from '.'
 
-const GlobalRequest = globalThis.Request
-globalThis.Request = class Request extends GlobalRequest {
-  constructor(input: Request | string, init: RequestInit) {
-    if (init) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(init as any).duplex ??= 'half'
-    }
-    super(input, init)
-  }
-} as typeof GlobalRequest
-
 const buildRequestInit = (init: RequestInit = {}): RequestInit => {
   const headers: Record<string, string> = {
     'Content-Type': 'text/plain',
@@ -24,6 +13,8 @@ const buildRequestInit = (init: RequestInit = {}): RequestInit => {
     headers,
     body: null,
     ...init,
+    // @ts-expect-error - duplex do not have any type yet
+    duplex: 'half',
   }
 }
 

--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from '../../hono'
 import { bodyLimit } from '.'
 
-const buildRequestInit = (init: RequestInit = {}): RequestInit => {
+const buildRequestInit = (init: RequestInit = {}): RequestInit & { duplex: 'half' } => {
   const headers: Record<string, string> = {
     'Content-Type': 'text/plain',
   }
@@ -13,7 +13,6 @@ const buildRequestInit = (init: RequestInit = {}): RequestInit => {
     headers,
     body: null,
     ...init,
-    // @ts-expect-error - duplex do not have any type yet
     duplex: 'half',
   }
 }
@@ -76,30 +75,6 @@ describe('Body Limit Middleware', () => {
           },
         })
         const res = await app.request('/body-limit-15byte', buildRequestInit({ body: stream }))
-
-        expect(res).not.toBeNull()
-        expect(res.status).toBe(200)
-        expect(await res.text()).toBe('abc')
-      })
-
-      it('should return 200 response without user-defined duplex option', async () => {
-        const contents = ['a', 'b', 'c']
-
-        app.post('/hello', async (c) => {
-          return c.text(await c.req.raw.text())
-        })
-
-        const res = await app.request('/hello', {
-          method: 'POST',
-          body: new ReadableStream({
-            start(controller) {
-              while (contents.length) {
-                controller.enqueue(new TextEncoder().encode(contents.shift() as string))
-              }
-              controller.close()
-            },
-          }),
-        })
 
         expect(res).not.toBeNull()
         expect(res.status).toBe(200)

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -103,8 +103,8 @@ export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
       },
     })
 
-    // @ts-expect-error - duplex do not have any type yet
-    c.req.raw = new Request(c.req.raw, { body: reader, duplex: 'half' })
+    const requestInit: RequestInit & { duplex: 'half' } = { body: reader, duplex: 'half' }
+    c.req.raw = new Request(c.req.raw, requestInit as RequestInit)
 
     await next()
 

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -103,7 +103,8 @@ export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
       },
     })
 
-    c.req.raw = new Request(c.req.raw, { body: reader })
+    // @ts-expect-error - duplex do not have any type yet
+    c.req.raw = new Request(c.req.raw, { body: reader, duplex: 'half' })
 
     await next()
 


### PR DESCRIPTION
Fixes #2627

In this case we do not need globalThis.Request anymore.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
