### PR TITLE
refactor(websocket): remove unused condition

### DIFF
--- a/src/adapter/cloudflare-workers/websocket.test.ts
+++ b/src/adapter/cloudflare-workers/websocket.test.ts
@@ -22,7 +22,6 @@ describe('upgradeWebSocket middleware', () => {
       upgradeWebSocket(() => ({
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onMessage(evt, ws) {
-          console.log('evt')
           resolve(evt.data)
         },
       }))

--- a/src/adapter/cloudflare-workers/websocket.ts
+++ b/src/adapter/cloudflare-workers/websocket.ts
@@ -28,31 +28,22 @@ export const upgradeWebSocket: UpgradeWebSocket = (createEvents) => async (c, ne
     send: (source) => server.send(source),
   }
   if (events.onOpen) {
-    server.addEventListener('open', (evt: Event) => events.onOpen && events.onOpen(evt, wsContext))
+    server.addEventListener('open', (evt: Event) => events.onOpen?.(evt, wsContext))
   }
   if (events.onClose) {
-    server.addEventListener(
-      'close',
-      (evt: CloseEvent) => events.onClose && events.onClose(evt, wsContext)
-    )
+    server.addEventListener('close', (evt: CloseEvent) => events.onClose?.(evt, wsContext))
   }
   if (events.onMessage) {
-    server.addEventListener(
-      'message',
-      (evt: MessageEvent) => events.onMessage && events.onMessage(evt, wsContext)
-    )
+    server.addEventListener('message', (evt: MessageEvent) => events.onMessage?.(evt, wsContext))
   }
   if (events.onError) {
-    server.addEventListener(
-      'error',
-      (evt: Event) => events.onError && events.onError(evt, wsContext)
-    )
+    server.addEventListener('error', (evt: Event) => events.onError?.(evt, wsContext))
   }
-  // @ts-expect-error server.accept is not typed
-  server.accept()
+
+  // @ts-expect-error - server.accept is not typed
+  server.accept?.()
   return new Response(null, {
-    status: 101,
-    // @ts-expect-error type not typed
+    // @ts-expect-error - webSocket is not typed
     webSocket: client,
   })
 }

--- a/src/adapter/deno/websocket.ts
+++ b/src/adapter/deno/websocket.ts
@@ -21,10 +21,10 @@ export const upgradeWebSocket: UpgradeWebSocket = (createEvents) => async (c, ne
     url: socket.url ? new URL(socket.url) : null,
     send: (source) => socket.send(source),
   }
-  socket.onopen = (evt) => events.onOpen && events.onOpen(evt, wsContext)
-  socket.onmessage = (evt) => events.onMessage && events.onMessage(evt, wsContext)
-  socket.onclose = (evt) => events.onClose && events.onClose(evt, wsContext)
-  socket.onerror = (evt) => events.onError && events.onError(evt, wsContext)
+  socket.onopen = (evt) => events.onOpen?.(evt, wsContext)
+  socket.onmessage = (evt) => events.onMessage?.(evt, wsContext)
+  socket.onclose = (evt) => events.onClose?.(evt, wsContext)
+  socket.onerror = (evt) => events.onError?.(evt, wsContext)
 
   return response
 }


### PR DESCRIPTION
Looking at WSEvents type, we don't really need extra AND condition here, just make sure `undefined` is not invoked by specifying `?.()`
```ts
// EVENT is onOpen, onClose, onMessage, onError
(property) WSEvents.EVENT?: ((evt: CloseEvent, ws: WSContext) => void) | undefined
```

Also removes console logs in websocket test.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
