### PR TITLE
chore: Author should include JSDoc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,4 @@
 - [ ] Add tests
 - [ ] Run tests
 - [ ] `bun run format:fix && bun run lint:fix` to format the code
+- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code


### PR DESCRIPTION
Closes #2718 

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
