### PR TITLE
fix(jsx/dom): Fixed to not add "px" for certain properties, even if numeric value is given

### DIFF
--- a/src/jsx/utils.test.ts
+++ b/src/jsx/utils.test.ts
@@ -1,0 +1,91 @@
+import { styleObjectForEach } from './utils'
+
+describe('styleObjectForEach', () => {
+  describe('Should output the number as it is, when a number type is passed', () => {
+    test.each`
+      property
+      ${'animationIterationCount'}
+      ${'aspectRatio'}
+      ${'borderImageOutset'}
+      ${'borderImageSlice'}
+      ${'borderImageWidth'}
+      ${'columnCount'}
+      ${'columns'}
+      ${'flex'}
+      ${'flexGrow'}
+      ${'flexPositive'}
+      ${'flexShrink'}
+      ${'flexNegative'}
+      ${'flexOrder'}
+      ${'gridArea'}
+      ${'gridRow'}
+      ${'gridRowEnd'}
+      ${'gridRowSpan'}
+      ${'gridRowStart'}
+      ${'gridColumn'}
+      ${'gridColumnEnd'}
+      ${'gridColumnSpan'}
+      ${'gridColumnStart'}
+      ${'fontWeight'}
+      ${'lineClamp'}
+      ${'lineHeight'}
+      ${'opacity'}
+      ${'order'}
+      ${'orphans'}
+      ${'scale'}
+      ${'tabSize'}
+      ${'widows'}
+      ${'zIndex'}
+      ${'zoom'}
+      ${'fillOpacity'}
+      ${'floodOpacity'}
+      ${'stopOpacity'}
+      ${'strokeDasharray'}
+      ${'strokeDashoffset'}
+      ${'strokeMiterlimit'}
+      ${'strokeOpacity'}
+      ${'strokeWidth'}
+    `('$property', ({ property }) => {
+      const fn = vi.fn()
+      styleObjectForEach({ [property]: 1 }, fn)
+      expect(fn).toBeCalledWith(
+        property.replace(/[A-Z]/g, (m: string) => `-${m.toLowerCase()}`),
+        '1'
+      )
+    })
+  })
+  describe('Should output with px suffix, when a number type is passed', () => {
+    test.each`
+      property
+      ${'borderBottomWidth'}
+      ${'borderLeftWidth'}
+      ${'borderRightWidth'}
+      ${'borderTopWidth'}
+      ${'borderWidth'}
+      ${'bottom'}
+      ${'fontSize'}
+      ${'height'}
+      ${'left'}
+      ${'margin'}
+      ${'marginBottom'}
+      ${'marginLeft'}
+      ${'marginRight'}
+      ${'marginTop'}
+      ${'padding'}
+      ${'paddingBottom'}
+      ${'paddingLeft'}
+      ${'paddingRight'}
+      ${'paddingTop'}
+      ${'right'}
+      ${'top'}
+      ${'width'}
+    `('$property', ({ property }) => {
+      const fn = vi.fn()
+      styleObjectForEach({ [property]: 1 }, fn)
+      expect(fn).toBeCalledWith(
+        property.replace(/[A-Z]/g, (m: string) => `-${m.toLowerCase()}`),
+        '1px'
+      )
+    })
+  })
+})

--- a/src/jsx/utils.ts
+++ b/src/jsx/utils.ts
@@ -6,15 +6,25 @@ export const normalizeIntrinsicElementProps = (props: Record<string, unknown>): 
 }
 
 export const styleObjectForEach = (
-  style: Record<string, string>,
+  style: Record<string, string | number>,
   fn: (key: string, value: string | null) => void
 ): void => {
   for (const [k, v] of Object.entries(style)) {
+    const key =
+      k[0] === '-' || !/[A-Z]/.test(k)
+        ? k // a CSS variable or a lowercase only property
+        : k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`) // a camelCase property. convert to kebab-case
     fn(
-      k[0] === '-'
-        ? k // CSS variable
-        : k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`), // style property. convert to kebab-case
-      v == null ? null : typeof v === 'number' ? v + 'px' : (v as string)
+      key,
+      v == null
+        ? null
+        : typeof v === 'number'
+        ? !key.match(
+            /^(?:a|border-im|column(?:-c|s)|flex(?:$|-[^b])|grid-(?:ar|[^a])|font-w|li|or|sca|st|ta|wido|z)|ty$/
+          )
+          ? `${v}px`
+          : `${v}`
+        : v
     )
   }
 }


### PR DESCRIPTION
Fix #2774

Change in #2553 to add "px" when a value of type number is passed. However, it was found that some properties need to output number as is, as defined in React as follows.

https://github.com/facebook/react/blob/46339720d75337ae1d1e113fd56ac99e7fd1a0b3/packages/react-dom-bindings/src/shared/isUnitlessNumber.js#L14-L84

Keeping the entire list would increase the code, so this PR implementation was made smaller by excluding 'deprecated' and 'vendor-prefixed' items from the React list, and then grouping them into regular expressions.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
