### PR TITLE
feat(hono-base): add `replaceRequest` option for `app.mount`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -305,7 +305,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    *
    * @param {string} path - base Path
    * @param {Function} applicationHandler - other Request Handler
-   * @param {Function | undefined} optionHandler - other Request Handler with Hono Context
+   * @param {MountOptions} [options] - options of `.mount()`
    * @returns {Hono} mounted Hono instance
    *
    * @example
@@ -319,6 +319,15 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    *
    * const app = new Hono()
    * app.mount('/itty-router', ittyRouter.handle)
+   * ```
+   *
+   * @example
+   * ```ts
+   * const app = new Hono()
+   * // Send the request to another application without modification.
+   * app.mount('/app', anotherApp, {
+   *   replaceRequest: (req) => req,
+   * })
    * ```
    */
   mount(

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -273,7 +273,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     // prepare handlers for request
     const getOptions: (c: Context) => unknown[] = optionHandler
       ? (c) => {
-          const options = optionHandler(c)
+          const options = optionHandler!(c)
           return Array.isArray(options) ? options : [options]
         }
       : (c) => {
@@ -294,7 +294,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     })()
 
     const handler: MiddlewareHandler = async (c, next) => {
-      const res = await applicationHandler(replaceRequest(c.req.raw), ...getOptions(c))
+      const res = await applicationHandler(replaceRequest!(c.req.raw), ...getOptions(c))
 
       if (res) {
         return res

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2656,7 +2656,7 @@ describe('app.mount()', () => {
     })
   })
 
-  describe('With rewritePath option', () => {
+  describe('With replaceRequest option', () => {
     const anotherApp = (req: Request) => {
       const path = getPath(req)
       if (path === '/app') {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2655,6 +2655,27 @@ describe('app.mount()', () => {
       expect(await res.text()).toBe('Not Found from AnotherApp')
     })
   })
+
+  describe('With rewritePath option', () => {
+    const anotherApp = (req: Request) => {
+      const path = getPath(req)
+      if (path === '/app') {
+        return new Response(getPath(req))
+      }
+      return new Response(null, { status: 404 })
+    }
+
+    const app = new Hono()
+    app.mount('/app', anotherApp, {
+      rewritePath: (path) => path,
+    })
+
+    it('Should return 200 response with the correct path', async () => {
+      const res = await app.request('/app')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('/app')
+    })
+  })
 })
 
 describe('HEAD method', () => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2667,7 +2667,7 @@ describe('app.mount()', () => {
 
     const app = new Hono()
     app.mount('/app', anotherApp, {
-      rewritePath: (path) => path,
+      replaceRequest: (req) => req,
     })
 
     it('Should return 200 response with the correct path', async () => {


### PR DESCRIPTION
Resolves #2781

This PR introduces the `rewritePath` option to `app.mount()`. With the current spec, if you use `app.mount()`, the path to pass to your mounted application will be changed. The base path will be removed.

```ts
app.mount('/sub-app', subApp.handle)
```

If you access `/sub-app/hello/foo`, the subApp receives `/hello/foo`. This is good behavior for some apps, but it's bad for some apps like #2781.

With the `rewritePath` option, you can specify the path to pass to the sub-application. If you don't want to remove the base path, you can write the following:

```ts
app.mount('/sub-app', subApp.handle, {
  rewritePath: (path) => path,
})
```

### The pain point

The logic will be a little bit complex. As for this, the application size will be slightly increased. Eitherway, I think we can reduce the size in other places.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
