### PR TITLE
fix(validator): support json api header

### DIFF
--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -130,6 +130,19 @@ describe('Malformed JSON', () => {
     expect(res.status).toBe(200)
   })
 
+  it('Should return 200 response, for request with JSON:API Content-Type application/vnd.api+json', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+      },
+      body: JSON.stringify({
+        any: 'thing',
+      }),
+    })
+    expect(res.status).toBe(200)
+  })
+
   it('Should return 400 response, if Content-Type header does not start with application/json', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -67,7 +67,7 @@ export const validator = <
 
     switch (target) {
       case 'json':
-        if (!contentType || !/^application\/([a-z-]+\+)?json/.test(contentType)) {
+        if (!contentType || !/^application\/([a-z-\.]+\+)?json/.test(contentType)) {
           const message = `Invalid HTTP header: Content-Type=${contentType}`
           throw new HTTPException(400, { message })
         }


### PR DESCRIPTION
The author should do the following, if applicable
  - [x] Add tests
  - [x] Run tests
  - [x] bun run format:fix && bun run lint:fix to format the code

![Screenshot 2024-05-29 at 13 47 15](https://github.com/honojs/hono/assets/117665459/9b3de9db-6f51-45e0-8b77-1059702c75a7)

specs: https://jsonapi.org/format/