### PR TITLE
refactor(compose): Remove type definition of ComposeContext that was defined twice

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -17,10 +17,6 @@ interface ComposeContext {
    */
   res: unknown
 }
-interface ComposeContext {
-  finalized: boolean
-  res: unknown
-}
 
 /**
  * Compose middleware functions into a single function based on `koa-compose` package.


### PR DESCRIPTION
## Overview

There are two `ComposeContexts` with the same type definition.
One of them is unnecessary, so it has been deleted.

https://github.com/honojs/hono/blob/1da43aee3be0ed2a991ee7199a32ed3ad4ad8fe5/src/compose.ts#L5-L23

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
