### PR TITLE
ci: Report coverage with CodeCov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       # deno excluded because it does not contain Deno-specific coverage
-      # bun excluded because it does use vitest for testing
+      # bun excluded because it uses built-in test tool which does not support coverage in v8/istanbul format.
       - main
       - fastly
       - node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,31 @@ on:
       - 'LICENSE'
 
 jobs:
+  coverage:
+    name: 'Coverage'
+    runs-on: ubuntu-latest
+    needs:
+      # deno excluded because it does not contain Deno-specific coverage
+      # bun excluded because it does use vitest for testing
+      - main
+      - fastly
+      - node
+      - wrangler
+      - lambda
+      - lambda-edge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: ./coverage
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          directory: ./coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   main:
     name: 'Main'
     runs-on: ubuntu-latest
@@ -28,6 +53,10 @@ jobs:
       - run: bun run lint
       - run: bun run build
       - run: bun run test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-main
+          path: coverage/
 
   jsr-dry-run:
     name: "Checking if it's valid for JSR"
@@ -70,6 +99,10 @@ jobs:
       - run: bun install
       - run: bun run build
       - run: bun run test:fastly
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-fastly
+          path: coverage/
 
   node:
     name: 'Node.js v${{ matrix.node }}'
@@ -86,6 +119,11 @@ jobs:
       - run: bun install
       - run: bun run build
       - run: bun run test:node
+      - uses: actions/upload-artifact@v4
+        if: matrix.node == '22.x'
+        with:
+          name: coverage-node
+          path: coverage/
 
   wrangler:
     name: 'Cloudflare Workers'
@@ -96,6 +134,10 @@ jobs:
       - run: bun install
       - run: bun run build
       - run: bun run test:wrangler
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-wrangler
+          path: coverage/
 
   lambda:
     name: 'AWS Lambda'
@@ -106,6 +148,10 @@ jobs:
       - run: bun install
       - run: bun run build
       - run: bun run test:lambda
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lambda
+          path: coverage/
 
   lambda-edge:
     name: 'Lambda@Edge'
@@ -116,3 +162,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: bun run test:lambda-edge
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lambda-edge
+          path: coverage/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     needs:
       # deno excluded because it does not contain Deno-specific coverage
       # bun excluded because it uses built-in test tool which does not support coverage in v8/istanbul format.
+      # refer https://github.com/oven-sh/bun/issues/4015
       - main
       - fastly
       - node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     name: 'Coverage'
     runs-on: ubuntu-latest
     needs:
-      # deno excluded because it does not contain Deno-specific coverage
       # bun excluded because it uses built-in test tool which does not support coverage in v8/istanbul format.
       # refer https://github.com/oven-sh/bun/issues/4015
       - main
@@ -77,9 +76,13 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - run: env NAME=Deno deno test --allow-read --allow-env --allow-write -c runtime_tests/deno/deno.json runtime_tests/deno
-      - run: deno test -c runtime_tests/deno-jsx/deno.precompile.json runtime_tests/deno-jsx
-      - run: deno test -c runtime_tests/deno-jsx/deno.react-jsx.json runtime_tests/deno-jsx
+      - run: env NAME=Deno deno test --coverage=coverage/raw/deno-runtime --allow-read --allow-env --allow-write -c runtime_tests/deno/deno.json runtime_tests/deno
+      - run: deno test -c runtime_tests/deno-jsx/deno.precompile.json --coverage=coverage/raw/deno-precompile-jsx runtime_tests/deno-jsx
+      - run: deno test -c runtime_tests/deno-jsx/deno.react-jsx.json --coverage=coverage/raw/deno-react-jsx runtime_tests/deno-jsx
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-deno
+          path: coverage/
 
   bun:
     name: 'Bun'

--- a/.vitest.config/jsx-runtime-default.ts
+++ b/.vitest.config/jsx-runtime-default.ts
@@ -8,5 +8,8 @@ if (config.test) {
     '**/src/jsx/dom/**/(*.)+(spec|test).+(ts|tsx|js)',
     'src/jsx/hooks/dom.test.tsx',
   ]
+  if (config.test.coverage) {
+    config.test.coverage.reportsDirectory = './coverage/raw/jsx-runtime'
+  }
 }
 export default config

--- a/.vitest.config/jsx-runtime-dom.ts
+++ b/.vitest.config/jsx-runtime-dom.ts
@@ -8,5 +8,8 @@ if (config.test) {
     '**/src/jsx/dom/**/(*.)+(spec|test).+(ts|tsx|js)',
     'src/jsx/hooks/dom.test.tsx',
   ]
+  if (config.test.coverage) {
+    config.test.coverage.reportsDirectory = './coverage/raw/jsx-dom'
+  }
 }
 export default config

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# Edit "test.coverage.exclude" option in vitest.config.ts to exclude specific files from coverage reports.
+# We can also use "ignore" option in codecov.yml, but it is not recognized by vitest, so results may differ on local.
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+        informational: true # Don't fail the build even if coverage is below target
+    project:
+      default:
+        target: 75%
+        threshold: 1%

--- a/runtime_tests/bun/vitest.config.ts
+++ b/runtime_tests/bun/vitest.config.ts
@@ -1,9 +1,14 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
+import config from '../../vitest.config'
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['**/runtime_tests/bun/**/*.+(ts|tsx|js)'],
+    coverage: {
+      ...config.test?.coverage,
+      reportsDirectory: './coverage/raw/runtime-bun',
+    },
   },
 })

--- a/runtime_tests/fastly/vitest.config.ts
+++ b/runtime_tests/fastly/vitest.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import fastlyCompute from 'vite-plugin-fastly-js-compute'
 import { defineConfig } from 'vitest/config'
+import config from '../../vitest.config'
 
 export default defineConfig({
   plugins: [fastlyCompute()],
@@ -8,5 +9,9 @@ export default defineConfig({
     globals: true,
     include: ['**/runtime_tests/fastly/**/(*.)+(test).+(ts|tsx)'],
     exclude: ['**/runtime_tests/fastly/vitest.config.ts'],
+    coverage: {
+      ...config.test?.coverage,
+      reportsDirectory: './coverage/raw/runtime-fastly',
+    },
   },
 })

--- a/runtime_tests/lambda-edge/vitest.config.ts
+++ b/runtime_tests/lambda-edge/vitest.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
+import config from '../../vitest.config'
 
 export default defineConfig({
   test: {
@@ -9,5 +10,9 @@ export default defineConfig({
     globals: true,
     include: ['**/runtime_tests/lambda-edge/**/*.+(ts|tsx|js)'],
     exclude: ['**/runtime_tests/lambda-edge/vitest.config.ts'],
+    coverage: {
+      ...config.test?.coverage,
+      reportsDirectory: './coverage/raw/runtime-lambda-edge',
+    },
   },
 })

--- a/runtime_tests/lambda/vitest.config.ts
+++ b/runtime_tests/lambda/vitest.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
+import config from '../../vitest.config'
 
 export default defineConfig({
   test: {
@@ -9,5 +10,9 @@ export default defineConfig({
     globals: true,
     include: ['**/runtime_tests/lambda/**/*.+(ts|tsx|js)'],
     exclude: ['**/runtime_tests/lambda/vitest.config.ts', '**/runtime_tests/lambda/mock.ts'],
+    coverage: {
+      ...config.test?.coverage,
+      reportsDirectory: './coverage/raw/runtime-lambda',
+    },
   },
 })

--- a/runtime_tests/node/vitest.config.ts
+++ b/runtime_tests/node/vitest.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
+import config from '../../vitest.config'
 
 export default defineConfig({
   test: {
@@ -9,5 +10,9 @@ export default defineConfig({
     globals: true,
     include: ['**/runtime_tests/node/**/*.+(ts|tsx|js)'],
     exclude: ['**/runtime_tests/node/vitest.config.ts'],
+    coverage: {
+      ...config.test?.coverage,
+      reportsDirectory: './coverage/raw/runtime-node',
+    },
   },
 })

--- a/runtime_tests/wrangler/vitest.config.ts
+++ b/runtime_tests/wrangler/vitest.config.ts
@@ -1,10 +1,15 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
+import config from '../../vitest.config'
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['**/runtime_tests/wrangler/**/(*.)+(test).+(ts|tsx)'],
     exclude: ['**/runtime_tests/wrangler/vitest.config.ts'],
+    coverage: {
+      ...config.test?.coverage,
+      reportsDirectory: './coverage/raw/runtime-wrangler',
+    },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
       provider: 'v8',
       reportsDirectory: './coverage/raw/default',
       reporter: ['json'],
+      exclude: [
+        ...(configDefaults.coverage.exclude ?? []),
+        'benchmarks',
+        'runtime_tests',
+        'build.ts',
+        'src/test-utils',
+      ]
     },
     pool: 'forks',
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,8 +12,10 @@ export default defineConfig({
     exclude: [...configDefaults.exclude, '**/sandbox/**', '**/*.case.test.+(ts|tsx|js)'],
     setupFiles: ['./src/test-utils/setup-vitest.ts'],
     coverage: {
+      enabled: true,
       provider: 'v8',
-      reporter: ['text'],
+      reportsDirectory: './coverage/raw/default',
+      reporter: ['json'],
     },
     pool: 'forks',
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         'runtime_tests',
         'build.ts',
         'src/test-utils',
+        'src/**/types.ts', // types are compile-time only, so their coverage cannot be measured
       ]
     },
     pool: 'forks',


### PR DESCRIPTION
Closes #2857
Closes #1391
Closes #175

This PR configures Vitest to generate coverage in JSON format per each test suite.
Multiple coverage files are uploaded into CodeCov, then CodeCov automatically merges those uploaded coverages smartly.

https://github.com/exoego/hono/pull/3 is a working demo how CodeCov bot reports coverage changes on each PR
You can also see [the demo coverage on my CodeCov account](https://app.codecov.io/github/exoego/hono):
![image](https://github.com/honojs/hono/assets/127635/eafddcde-d976-48a0-b30b-b9da6e2ad1ea)
(this demo coverage is not "accurate" since it includes unexpected files like `benchmarks` and `runtime_tests`. Such unexpected files are excluded in this PR)

### :warning: Attention :warning: 

Repo administrator should set `CODECOV_TOKEN` as GitHub secret for Actions.
The token can be obtained in https://app.codecov.io/github/honojs/hono/settings
or maybe https://app.codecov.io/github/honojs/hono

### Note

CodeCov is free for open-source repos while some enterprise-level features are not available.
https://about.codecov.io/pricing/

This PR does not enable coverage report on terminal (`text` reporter).
Because it is required to merge multiple coverage.
I will implement that in a separate PR if needed.

You can configure behavior in `codecov.yml`. Refer https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
