### PR TITLE
fix(websocket): the onopen event cannot be triggered during delayed operations in deno

### DIFF
--- a/runtime_tests/deno/hono.test.ts
+++ b/runtime_tests/deno/hono.test.ts
@@ -34,22 +34,3 @@ Deno.test('environment variables', () => {
   const { NAME } = env<{ NAME: string }>(c)
   assertEquals(NAME, 'Deno')
 })
-
-Deno.test('trigger the onOpen event of upgradeWebSocket', async () => {
-  const app = new Hono()
-  const open = new Promise<boolean>(resolve => {
-    app.get('/ws', upgradeWebSocket(async (c) => {
-      await new Promise(resolve => setTimeout(resolve, 5e2))
-      return {
-        onOpen: () => resolve(true)
-      }
-    }))
-    const server = Deno.serve(app.fetch)
-    const socket = new WebSocket('http://127.1:8000/ws')
-    socket.onopen = () => {
-      server.shutdown()
-      socket.close()
-    }
-  })
-  assertEquals(await open, true)
-})

--- a/runtime_tests/deno/hono.test.ts
+++ b/runtime_tests/deno/hono.test.ts
@@ -1,4 +1,3 @@
-import {upgradeWebSocket} from '../../src/adapter/deno/websocket.js'
 import { Context } from '../../src/context.ts'
 import { env, getRuntimeKey } from '../../src/helper/adapter/index.ts'
 import { Hono } from '../../src/hono.ts'

--- a/runtime_tests/deno/hono.test.ts
+++ b/runtime_tests/deno/hono.test.ts
@@ -1,3 +1,4 @@
+import {upgradeWebSocket} from '../../src/adapter/deno/websocket.js'
 import { Context } from '../../src/context.ts'
 import { env, getRuntimeKey } from '../../src/helper/adapter/index.ts'
 import { Hono } from '../../src/hono.ts'
@@ -32,4 +33,23 @@ Deno.test('environment variables', () => {
   const c = new Context(new HonoRequest(new Request('http://localhost/')))
   const { NAME } = env<{ NAME: string }>(c)
   assertEquals(NAME, 'Deno')
+})
+
+Deno.test('trigger the onOpen event of upgradeWebSocket', async () => {
+  const app = new Hono()
+  const open = new Promise<boolean>(resolve => {
+    app.get('/ws', upgradeWebSocket(async (c) => {
+      await new Promise(resolve => setTimeout(resolve, 5e2))
+      return {
+        onOpen: () => resolve(true)
+      }
+    }))
+    const server = Deno.serve(app.fetch)
+    const socket = new WebSocket('http://127.1:8000/ws')
+    socket.onopen = () => {
+      server.shutdown()
+      socket.close()
+    }
+  })
+  assertEquals(await open, true)
 })

--- a/src/adapter/deno/websocket.ts
+++ b/src/adapter/deno/websocket.ts
@@ -4,9 +4,9 @@ export const upgradeWebSocket: UpgradeWebSocket = (createEvents) => async (c, ne
   if (c.req.header('upgrade') !== 'websocket') {
     return await next()
   }
-  const { response, socket } = Deno.upgradeWebSocket(c.req.raw)
 
   const events = await createEvents(c)
+  const { response, socket } = Deno.upgradeWebSocket(c.req.raw)
 
   const wsContext: WSContext = {
     binaryType: 'arraybuffer',


### PR DESCRIPTION
```ts
const app = new Hono()

app.get(
  '/ws',
  upgradeWebSocket(async (c) => {
    await new Promise(resolve => setTimeout(resolve, 5e2)) // Simulate time-consuming operation
    return {
      onOpen: () => console.log('opened') // can't be trigger
    }
  })
)
```
Because `socket.onopen` was triggered before `createEvents`.
Swapping L7 and L9 can solve this problem：

https://github.com/honojs/hono/blob/3d6820b46e51622435aeb0cacc6434d722581aa2/src/adapter/deno/websocket.ts#L7-L9