### PR TITLE
ci: set ".github/**" at paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.vscode/**'
+      - '.github/**'
       - 'README.md'
       - '.gitignore'
       - 'LICENSE'


### PR DESCRIPTION
I don't think “.github” needs "ci" of actions either.
https://github.com/honojs/hono/pull/2850