### PR TITLE
perf(hono-base): don't import `HTTPException`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -7,7 +7,6 @@
 import { compose } from './compose'
 import { Context } from './context'
 import type { ExecutionContext } from './context'
-import { HTTPException } from './http-exception'
 import { HonoRequest } from './request'
 import type { Router } from './router'
 import { METHODS, METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router'
@@ -34,12 +33,18 @@ import { getPath, getPathNoStrict, getQueryStrings, mergePath } from './utils/ur
  */
 export const COMPOSED_HANDLER = Symbol('composedHandler')
 
+/**
+ * Symbol for the property name to mark whether it is HTTPException.
+ */
+export const IS_HTTP_EXCEPTION = Symbol('isHTTPException')
+
 const notFoundHandler = (c: Context) => {
   return c.text('404 Not Found', 404)
 }
 
 const errorHandler = (err: Error, c: Context) => {
-  if (err instanceof HTTPException) {
+  if ((err as any)[IS_HTTP_EXCEPTION]) {
+    //@ts-expect-error `getResponse()` is not typed.
     return err.getResponse()
   }
   console.error(err)

--- a/src/http-exception.ts
+++ b/src/http-exception.ts
@@ -3,6 +3,7 @@
  * This module provides the `HTTPException` class.
  */
 
+import { IS_HTTP_EXCEPTION } from './hono-base'
 import type { StatusCode } from './utils/http-status'
 
 /**
@@ -46,6 +47,7 @@ type HTTPExceptionOptions = {
 export class HTTPException extends Error {
   readonly res?: Response
   readonly status: StatusCode
+  private [IS_HTTP_EXCEPTION]: boolean = true
 
   /**
    * Creates an instance of `HTTPException`.


### PR DESCRIPTION
This is like a `refactor` but is made a `perf` since reducing the bundle size for the performance.

With this PR, the `hono-base.ts` does not need to import the `HTTPException` class directly. So, the bundle size for the app that does not use `HTTPException` will be small. To enable it, it does not use `instanceOf`; it will detect by checking the property named a symbol of `IS_HTTP_EXCEPTION.`

Result:

![CleanShot 2024-06-02 at 18 40 35@2x](https://github.com/honojs/hono/assets/10682/bcdcce43-4ba3-48f7-a1ae-fabcbaf98dbf)

It was reduced by 260 bytes. It seems small, but reducing size is important for edge environments such as Cloudflare Workers.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
