### PR TITLE
chore: Exclude type-only files from coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
         'runtime_tests',
         'build.ts',
         'src/test-utils',
-        'src/**/types.ts', // types are compile-time only, so their coverage cannot be measured
+
+        // types are compile-time only, so their coverage cannot be measured
+        'src/**/types.ts',
+        'src/jsx/intrinsic-elements.ts',
+        'src/utils/http-status.ts',
       ]
     },
     pool: 'forks',


### PR DESCRIPTION
These two type-only files are relatively-large uncovered files.
https://github.com/honojs/hono/blob/f634c824510f265976f4f15312e098ab37aefb21/src/jsx/intrinsic-elements.ts
https://github.com/honojs/hono/blob/f634c824510f265976f4f15312e098ab37aefb21/src/utils/http-status.ts

This change will increase coverage dramatically
```
##             main    #2890      +/-   ##
+ Coverage   87.88%   93.06%   +5.18%     
```

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
