### PR TITLE
fix(types): fix typo for unofficial status code type

### DIFF
--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -40,7 +40,7 @@ export type ClientErrorStatusCode =
 export type ServerErrorStatusCode = 500 | 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511
 
 /**
- * `UnofficialStatusCode` can be used to specify an informal status code.
+ * `UnofficialStatusCode` can be used to specify an unofficial status code.
  * @example
  *
  * ```ts

--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -38,20 +38,27 @@ export type ClientErrorStatusCode =
   | 431
   | 451
 export type ServerErrorStatusCode = 500 | 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511
+
 /**
- * `UnOfficalStatusCode` can be used to specify an informal status code.
+ * `UnofficialStatusCode` can be used to specify an informal status code.
  * @example
  *
  * ```ts
  * app.get('/', (c) => {
- *   return c.text("hono is cool", 666 as UnOfficalStatusCode)
+ *   return c.text("Unknown Error", 520 as UnofficialStatusCode)
  * })
  * ```
+ */
+export type UnofficialStatusCode = -1
+
+/**
+ * @deprecated
+ * Use `UnofficialStatusCode` instead.
  */
 export type UnOfficalStatusCode = -1
 
 /**
- * If you want to use an unofficial status, use `UnOfficalStatusCode`.
+ * If you want to use an unofficial status, use `UnofficialStatusCode`.
  */
 export type StatusCode =
   | InfoStatusCode
@@ -59,4 +66,5 @@ export type StatusCode =
   | RedirectStatusCode
   | ClientErrorStatusCode
   | ServerErrorStatusCode
+  | UnofficialStatusCode
   | UnOfficalStatusCode

--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -44,7 +44,7 @@ export type ServerErrorStatusCode = 500 | 501 | 502 | 503 | 504 | 505 | 506 | 50
  * @example
  *
  * ```ts
- * app.get('/', (c) => {
+ * app.get('/unknown', (c) => {
  *   return c.text("Unknown Error", 520 as UnofficialStatusCode)
  * })
  * ```


### PR DESCRIPTION
This PR fixes typo for unofficial status code type.

## Deprecate `UnOfficalStatusCode`
Add `UnofficialStatusCode` and announce to use the type instead.
Please remove the type at an appropriate time.

## Improve `UnofficialStatusCode` example
The old example includes that a religious number and meaningless status message.
Use an unofficial status code that actually exists.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
