### PR TITLE
feat(context): `c.redirect()` supports `TypedResponse`

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -10,7 +10,7 @@ import { parse } from '../utils/cookie'
 import type { Equal, Expect } from '../utils/types'
 import { validator } from '../validator'
 import { hc } from './client'
-import type { InferRequestType, InferResponseType } from './types'
+import type { ClientResponse, InferRequestType, InferResponseType } from './types'
 
 describe('Basic - JSON', () => {
   const app = new Hono()
@@ -1054,5 +1054,59 @@ describe('Text response', () => {
     type Actual = ReturnType<typeof res.text>
     type Expected = Promise<string>
     type verify = Expect<Equal<Expected, Actual>>
+  })
+})
+
+describe('Redirect response - only types', () => {
+  const server = setupServer(
+    http.get('http://localhost/', async () => {
+      return HttpResponse.redirect('/')
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  const condition = () => true
+  const app = new Hono().get('/', async (c) => {
+    const ok = condition()
+    const temporary = condition()
+    if (ok) {
+      return c.json({ ok: true }, 200)
+    }
+    if (temporary) {
+      return c.redirect('/302')
+    }
+    return c.redirect('/301', 301)
+  })
+
+  const client = hc<typeof app>('http://localhost/')
+  const req = client.index.$get
+
+  it('Should infer request type the type correctly', () => {
+    type Actual = InferResponseType<typeof req>
+    type Expected =
+      | {
+          ok: boolean
+        }
+      | undefined
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer response type correctly', async () => {
+    const res = await req()
+    if (res.ok) {
+      const data = await res.json()
+      expectTypeOf(data).toMatchTypeOf({ ok: true })
+    }
+    if (res.status === 301) {
+      type Expected = ClientResponse<undefined, 301, 'redirect'>
+      type verify = Expect<Equal<Expected, typeof res>>
+    }
+    if (res.status === 302) {
+      type Expected = ClientResponse<undefined, 302, 'redirect'>
+      type verify = Expect<Equal<Expected, typeof res>>
+    }
   })
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -716,10 +716,13 @@ export class Context<
    * })
    * ```
    */
-  redirect = (location: string, status: RedirectStatusCode = 302): Response => {
+  redirect = <T extends RedirectStatusCode = 302>(
+    location: string,
+    status?: T
+  ): Response & TypedResponse<undefined, T, 'redirect'> => {
     this.#headers ??= new Headers()
     this.#headers.set('Location', location)
-    return this.newResponse(null, status)
+    return this.newResponse(null, status ?? 302) as any
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1742,7 +1742,7 @@ export type MergePath<A extends string, B extends string> = B extends ''
 //////                            //////
 ////////////////////////////////////////
 
-export type KnownResponseFormat = 'json' | 'text'
+export type KnownResponseFormat = 'json' | 'text' | 'redirect'
 export type ResponseFormat = KnownResponseFormat | string
 
 export type TypedResponse<


### PR DESCRIPTION
Related to #2897

This PR enables `c.redirect()` to return `TypedResponse`. So, you can handle redirect responses in the RPC mode.

```ts
const routes = app.get('/profile', (c) => {
  if (!flag) {
    return c.redirect('/')
  }
  return c.json({ name: 'abc' }, 200)
})

const client = hc<typeof routes>('/')

const res = await client.profile.$get()

if (res.status === 302) {
  console.log(res.headers.get('Location'))
} else {
  const data = await res.json()
  //    ^ { name: string }
}
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
