### PR TITLE
fix(hono-base): return 404 if lacking response in a single sync handler

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -441,7 +441,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
                 resolved || (c.finalized ? c.res : this.notFoundHandler(c))
             )
             .catch((err: Error) => this.handleError(err, c))
-        : res
+        : res ?? this.notFoundHandler(c)
     }
 
     const composed = compose<Context>(matchResult[0], this.errorHandler, this.notFoundHandler)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2182,6 +2182,23 @@ describe('Multiple handler - async', () => {
   })
 })
 
+describe('Lack returning response with a single handler', () => {
+  const app = new Hono()
+  // @ts-expect-error it should return Response to type it
+  app.get('/sync', () => {})
+  app.get('/async', async () => {})
+
+  it('Should return 404 response if lacking returning response', async () => {
+    const res = await app.request('/sync')
+    expect(res.status).toBe(404)
+  })
+
+  it('Should return 404 response if lacking returning response in an async handler', async () => {
+    const res = await app.request('/async')
+    expect(res.status).toBe(404)
+  })
+})
+
 describe('Context is not finalized', () => {
   it('should throw error - lack `await next()`', async () => {
     const app = new Hono()


### PR DESCRIPTION
This PR enables returning a 404 response if lacking returning `Response` in a single handler.

If an async handler that is not used with middleware lacks a returning `Response`, the response is 404.

![CleanShot 2024-06-06 at 05 28 02@2x](https://github.com/honojs/hono/assets/10682/66cd7b68-aded-4464-8bca-6fd812f9d97c)

But if it is not an async handler, it will not return `Response` correctly.

![CleanShot 2024-06-06 at 05 27 45@2x](https://github.com/honojs/hono/assets/10682/88d30323-eb85-4a40-8a8a-da4bff22d300)

This PR will fix it and make it return a 404 response.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
