### PR TITLE
fix: Read all chunks when hashing a readable stream

### DIFF
--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -34,11 +34,19 @@ export const createHash = async (data: Data, algorithm: Algorithm): Promise<stri
   if (data instanceof ReadableStream) {
     let body = ''
     const reader = data.getReader()
-    await reader?.read().then(async (chuck) => {
-      const value = await createHash(chuck.value || '', algorithm)
+    let chunks = 0
+    let chunk = await reader?.read()
+    while (chunk && !chunk.done) {
+      chunks++
+      const value = await createHash(chunk.value || '', algorithm)
       body += value
-    })
-    return body
+
+      chunk = await reader?.read()
+    }
+    if (chunks === 1) {
+      return body
+    }
+    data = body
   }
   if (ArrayBuffer.isView(data) || data instanceof ArrayBuffer) {
     sourceBuffer = data


### PR DESCRIPTION
createHash was only reading the first chunk when hashing a readable stream. This breaks etags for longer responses.

On bun the first chunk seems to always be 16384 bytes long, so I added a test there. Could not reproduce on node

### The author should do the following, if applicable


- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
