### PR TITLE
refactor: remove `Prettify` as duplicated with `Simplify`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ import type {
   IfAnyThenEmptyObject,
   IsAny,
   JSONValue,
-  Prettify,
   RemoveBlankRecord,
   Simplify,
   UnionToIntersection,
@@ -1617,7 +1616,7 @@ export type ToSchema<
   P extends string,
   I extends Input | Input['in'],
   RorO // Response or Output
-> = Prettify<{
+> = Simplify<{
   [K in P]: {
     [K2 in M as AddDollar<K2>]: Simplify<
       {
@@ -1670,7 +1669,7 @@ type ExtractParams<Path extends string> = string extends Path
 
 type FlattenIfIntersect<T> = T extends infer O ? { [K in keyof O]: O[K] } : never
 
-export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = Prettify<{
+export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = Simplify<{
   [P in keyof OrigSchema as MergePath<SubPath, P & string>]: {
     [M in keyof OrigSchema[P]]: MergeEndpointParamsWithPath<OrigSchema[P][M], SubPath>
   }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -58,7 +58,3 @@ export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> 
   : true
 
 export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false
-
-export type Prettify<T> = {
-  [K in keyof T]: T[K]
-} & {}


### PR DESCRIPTION
I just realized the older `Prettify` is the same as `Simplify`, but I remove the former and keep `Simplify` as it's more commonly used wording for this type.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
