### PR TITLE
fix(types): #2912: interfaces array's respond typed as `never`

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -461,6 +461,13 @@ describe('Merge path with `app.route()`', () => {
         ok: true,
       })
     }),
+    http.get('http://localhost/api/searchArray', async () => {
+      return HttpResponse.json([
+        {
+          ok: true,
+        },
+      ])
+    }),
     http.get('http://localhost/api/foo', async () => {
       return HttpResponse.json({
         ok: true,
@@ -535,6 +542,24 @@ describe('Merge path with `app.route()`', () => {
     const data = await res.json()
     type verify = Expect<Equal<Result, typeof data>>
     expect(data.ok).toBe(true)
+  })
+
+  it('Should have correct types - with array of interfaces', async () => {
+    interface Result {
+      ok: boolean
+      okUndefined?: boolean
+    }
+    type Results = Result[]
+
+    const results: Results = [{ ok: true }]
+    const base = new Hono<Env>().basePath('/api')
+    const app = base.get('/searchArray', (c) => c.json(results))
+    type AppType = typeof app
+    const client = hc<AppType>('http://localhost')
+    const res = await client.api.searchArray.$get()
+    const data = await res.json()
+    type verify = Expect<Equal<Results, typeof data>>
+    expect(data[0].ok).toBe(true)
   })
 
   it('Should allow a Date object and return it as a string', async () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import type { HonoRequest } from './request'
 import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
-import type { IsAny, JSONParsed, JSONValue, Simplify } from './utils/types'
+import type { DeepSimplify, IsAny, JSONParsed, JSONValue, Simplify } from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
 
@@ -127,30 +127,30 @@ interface TextRespond {
  * @param {U} [status] - An optional status code for the response.
  * @param {HeaderRecord} [headers] - An optional record of headers to include in the response.
  *
- * @returns {Response & TypedResponse<Simplify<T> extends JSONValue ? (JSONValue extends Simplify<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
+ * @returns {Response & TypedResponse<DeepSimplify<T> extends JSONValue ? (JSONValue extends DeepSimplify<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
 interface JSONRespond {
-  <T extends JSONValue | Simplify<unknown>, U extends StatusCode>(
+  <T extends JSONValue | DeepSimplify<unknown>, U extends StatusCode>(
     object: T,
     status?: U,
     headers?: HeaderRecord
   ): Response &
     TypedResponse<
-      Simplify<T> extends JSONValue
-        ? JSONValue extends Simplify<T>
+      DeepSimplify<T> extends JSONValue
+        ? JSONValue extends DeepSimplify<T>
           ? never
           : JSONParsed<T>
         : never,
       U,
       'json'
     >
-  <T extends JSONValue | Simplify<unknown>, U extends StatusCode>(
-    object: Simplify<T> extends JSONValue ? T : Simplify<T>,
+  <T extends JSONValue | DeepSimplify<unknown>, U extends StatusCode>(
+    object: DeepSimplify<T> extends JSONValue ? T : DeepSimplify<T>,
     init?: ResponseInit
   ): Response &
     TypedResponse<
-      Simplify<T> extends JSONValue
-        ? JSONValue extends Simplify<T>
+      DeepSimplify<T> extends JSONValue
+        ? JSONValue extends DeepSimplify<T>
           ? never
           : JSONParsed<T>
         : never,

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import type { HonoRequest } from './request'
 import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
-import type { DeepSimplify, IsAny, JSONParsed, JSONValue, Simplify } from './utils/types'
+import type { IsAny, JSONParsed, JSONValue, Simplify, SimplifyDeepArray } from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
 
@@ -127,30 +127,30 @@ interface TextRespond {
  * @param {U} [status] - An optional status code for the response.
  * @param {HeaderRecord} [headers] - An optional record of headers to include in the response.
  *
- * @returns {Response & TypedResponse<DeepSimplify<T> extends JSONValue ? (JSONValue extends DeepSimplify<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
+ * @returns {Response & TypedResponse<SimplifyDeepArray<T> extends JSONValue ? (JSONValue extends SimplifyDeepArray<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
 interface JSONRespond {
-  <T extends JSONValue | DeepSimplify<unknown>, U extends StatusCode>(
+  <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode>(
     object: T,
     status?: U,
     headers?: HeaderRecord
   ): Response &
     TypedResponse<
-      DeepSimplify<T> extends JSONValue
-        ? JSONValue extends DeepSimplify<T>
+      SimplifyDeepArray<T> extends JSONValue
+        ? JSONValue extends SimplifyDeepArray<T>
           ? never
           : JSONParsed<T>
         : never,
       U,
       'json'
     >
-  <T extends JSONValue | DeepSimplify<unknown>, U extends StatusCode>(
-    object: DeepSimplify<T> extends JSONValue ? T : DeepSimplify<T>,
+  <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode>(
+    object: SimplifyDeepArray<T> extends JSONValue ? T : SimplifyDeepArray<T>,
     init?: ResponseInit
   ): Response &
     TypedResponse<
-      DeepSimplify<T> extends JSONValue
-        ? JSONValue extends DeepSimplify<T>
+      SimplifyDeepArray<T> extends JSONValue
+        ? JSONValue extends SimplifyDeepArray<T>
           ? never
           : JSONParsed<T>
         : never,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -44,6 +44,11 @@ export type JSONParsed<T> = T extends { toJSON(): infer J }
 // from sindresorhus/type-fest
 export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {}
 
+// Similar to Simplify but will also deeply simplify the type inside array
+export type DeepSimplify<T> = T extends any[]
+  ? { [E in keyof T]: Simplify<T[E]> }
+  : { [KeyType in keyof T]: T[KeyType] } & {}
+
 export type InterfaceToType<T> = T extends Function ? T : { [K in keyof T]: InterfaceToType<T[K]> }
 
 export type RequiredKeysOf<BaseType extends object> = Exclude<

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -41,10 +41,15 @@ export type JSONParsed<T> = T extends { toJSON(): infer J }
   ? { [K in keyof T]: JSONParsed<T[K]> }
   : never
 
-// from sindresorhus/type-fest
+/**
+ * Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
+ * @copyright from sindresorhus/type-fest
+ */
 export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {}
 
-// Similar to Simplify but will also deeply simplify the type inside array
+/**
+ * A simple extension of Simplify that works for array of interfaces.
+ */
 export type SimplifyDeepArray<T> = T extends any[]
   ? { [E in keyof T]: Simplify<T[E]> }
   : { [KeyType in keyof T]: T[KeyType] } & {}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -45,7 +45,7 @@ export type JSONParsed<T> = T extends { toJSON(): infer J }
 export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {}
 
 // Similar to Simplify but will also deeply simplify the type inside array
-export type DeepSimplify<T> = T extends any[]
+export type SimplifyDeepArray<T> = T extends any[]
   ? { [E in keyof T]: Simplify<T[E]> }
   : { [KeyType in keyof T]: T[KeyType] } & {}
 


### PR DESCRIPTION
Resolves #2912

This PR introduces `SimplifyDeepArray` type to handle the case when user response with an array of interfaces.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
