### PR TITLE
feat(jsx): support htmlfor attribute alias

### DIFF
--- a/src/jsx/utils.test.ts
+++ b/src/jsx/utils.test.ts
@@ -1,4 +1,74 @@
-import { styleObjectForEach } from './utils'
+import { normalizeIntrinsicElementProps, styleObjectForEach } from './utils';
+
+
+describe('normalizeIntrinsicElementProps', () => {
+  it('should convert className to class', () => {
+    const props: Record<string, unknown> = {
+      className: 'test-class',
+      id: 'test-id',
+    };
+
+    normalizeIntrinsicElementProps(props);
+
+    expect(props).toEqual({
+      class: 'test-class',
+      id: 'test-id',
+    });
+  });
+
+  it('should convert htmlFor to for', () => {
+    const props: Record<string, unknown> = {
+      htmlFor: 'test-for',
+      name: 'test-name',
+    };
+
+    normalizeIntrinsicElementProps(props);
+
+    expect(props).toEqual({
+      for: 'test-for',
+      name: 'test-name',
+    });
+  });
+
+  it('should convert multiple attribute aliases', () => {
+    const props: Record<string, unknown> = {
+      className: 'test-class',
+      htmlFor: 'test-for',
+      type: 'text',
+    };
+
+    normalizeIntrinsicElementProps(props);
+
+    expect(props).toEqual({
+      class: 'test-class',
+      for: 'test-for',
+      type: 'text',
+    });
+  });
+
+  it('should not modify props without className or htmlFor', () => {
+    const props: Record<string, unknown> = {
+      id: 'test-id',
+      name: 'test-name',
+    };
+
+    normalizeIntrinsicElementProps(props);
+
+    expect(props).toEqual({
+      id: 'test-id',
+      name: 'test-name',
+    });
+  });
+
+  it('should handle empty props', () => {
+    const props: Record<string, unknown> = {};
+
+    normalizeIntrinsicElementProps(props);
+
+    expect(props).toEqual({});
+  });
+});
+
 
 describe('styleObjectForEach', () => {
   describe('Should output the number as it is, when a number type is passed', () => {

--- a/src/jsx/utils.test.ts
+++ b/src/jsx/utils.test.ts
@@ -1,74 +1,72 @@
-import { normalizeIntrinsicElementProps, styleObjectForEach } from './utils';
-
+import { normalizeIntrinsicElementProps, styleObjectForEach } from './utils'
 
 describe('normalizeIntrinsicElementProps', () => {
   it('should convert className to class', () => {
     const props: Record<string, unknown> = {
       className: 'test-class',
       id: 'test-id',
-    };
+    }
 
-    normalizeIntrinsicElementProps(props);
+    normalizeIntrinsicElementProps(props)
 
     expect(props).toEqual({
       class: 'test-class',
       id: 'test-id',
-    });
-  });
+    })
+  })
 
   it('should convert htmlFor to for', () => {
     const props: Record<string, unknown> = {
       htmlFor: 'test-for',
       name: 'test-name',
-    };
+    }
 
-    normalizeIntrinsicElementProps(props);
+    normalizeIntrinsicElementProps(props)
 
     expect(props).toEqual({
       for: 'test-for',
       name: 'test-name',
-    });
-  });
+    })
+  })
 
   it('should convert multiple attribute aliases', () => {
     const props: Record<string, unknown> = {
       className: 'test-class',
       htmlFor: 'test-for',
       type: 'text',
-    };
+    }
 
-    normalizeIntrinsicElementProps(props);
+    normalizeIntrinsicElementProps(props)
 
     expect(props).toEqual({
       class: 'test-class',
       for: 'test-for',
       type: 'text',
-    });
-  });
+    })
+  })
 
   it('should not modify props without className or htmlFor', () => {
     const props: Record<string, unknown> = {
       id: 'test-id',
       name: 'test-name',
-    };
+    }
 
-    normalizeIntrinsicElementProps(props);
+    normalizeIntrinsicElementProps(props)
 
     expect(props).toEqual({
       id: 'test-id',
       name: 'test-name',
-    });
-  });
+    })
+  })
 
   it('should handle empty props', () => {
-    const props: Record<string, unknown> = {};
+    const props: Record<string, unknown> = {}
 
-    normalizeIntrinsicElementProps(props);
+    normalizeIntrinsicElementProps(props)
 
-    expect(props).toEqual({});
-  });
-});
-
+    expect(props).toEqual({})
+  })
+})
 
 describe('styleObjectForEach', () => {
   describe('Should output the number as it is, when a number type is passed', () => {

--- a/src/jsx/utils.ts
+++ b/src/jsx/utils.ts
@@ -3,6 +3,10 @@ export const normalizeIntrinsicElementProps = (props: Record<string, unknown>): 
     props['class'] = props['className']
     delete props['className']
   }
+  if (props && 'htmlFor' in props) {
+    props['for'] = props['htmlFor']
+    delete props['htmlFor']
+  }
 }
 
 export const styleObjectForEach = (
@@ -19,12 +23,12 @@ export const styleObjectForEach = (
       v == null
         ? null
         : typeof v === 'number'
-        ? !key.match(
+          ? !key.match(
             /^(?:a|border-im|column(?:-c|s)|flex(?:$|-[^b])|grid-(?:ar|[^a])|font-w|li|or|sca|st|ta|wido|z)|ty$/
           )
-          ? `${v}px`
-          : `${v}`
-        : v
+            ? `${v}px`
+            : `${v}`
+          : v
     )
   }
 }

--- a/src/jsx/utils.ts
+++ b/src/jsx/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Normalizes intrinsic element properties by converting JSX element properties
+ * to their corresponding HTML attributes.
+ *
+ * @param props - JSX element properties.
+ */
 export const normalizeIntrinsicElementProps = (props: Record<string, unknown>): void => {
   if (props && 'className' in props) {
     props['class'] = props['className']
@@ -23,12 +29,12 @@ export const styleObjectForEach = (
       v == null
         ? null
         : typeof v === 'number'
-          ? !key.match(
+        ? !key.match(
             /^(?:a|border-im|column(?:-c|s)|flex(?:$|-[^b])|grid-(?:ar|[^a])|font-w|li|or|sca|st|ta|wido|z)|ty$/
           )
-            ? `${v}px`
-            : `${v}`
-          : v
+          ? `${v}px`
+          : `${v}`
+        : v
     )
   }
 }


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

To enhance compatibility with React in hono/jsx, we have added support for the `htmlFor` alias. (The relevant code in React can be found at [this file](https://github.com/facebook/react/blob/3730b40e9bbacef0279f6d120b344c1544cb38ba/packages/react-dom-bindings/src/shared/getAttributeAlias.js#L12))

By supporting `htmlFor` in hono/jsx, we gain the following benefits:

Composite components utilizing HTML-only toggles, such as a `<label htmlFor="toggle">` and `<input type="checkbox" id="toggle"/>` combination, will function properly.

For instance, in daisyUI, which works purely with Tailwind, the Drawer component will operate as intended without any code modifications when used with hono/jsx.
