### PR TITLE
fix(types): add `_` prefix to `TypedResponse` properties

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -284,9 +284,9 @@ describe('TypedResponse', () => {
   test('unknown', () => {
     type Actual = TypedResponse
     type Expected = {
-      data: unknown
-      status: StatusCode
-      format: ResponseFormat
+      _data: unknown
+      _status: StatusCode
+      _format: ResponseFormat
     }
     type verify = Expect<Equal<Expected, Actual>>
   })
@@ -294,9 +294,9 @@ describe('TypedResponse', () => {
   test('text auto infer', () => {
     type Actual = TypedResponse<string>
     type Expected = {
-      data: string
-      status: StatusCode
-      format: 'text'
+      _data: string
+      _status: StatusCode
+      _format: 'text'
     }
     type verify = Expect<Equal<Expected, Actual>>
   })
@@ -304,9 +304,9 @@ describe('TypedResponse', () => {
   test('json auto infer', () => {
     type Actual = TypedResponse<{ ok: true }>
     type Expected = {
-      data: { ok: true }
-      status: StatusCode
-      format: 'json'
+      _data: { ok: true }
+      _status: StatusCode
+      _format: 'json'
     }
     type verify = Expect<Equal<Expected, Actual>>
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1753,9 +1753,9 @@ export type TypedResponse<
     ? 'json'
     : ResponseFormat
 > = {
-  data: T
-  status: U
-  format: F
+  _data: T
+  _status: U
+  _format: F
 }
 
 type MergeTypedResponse<T> = T extends Promise<infer T2>


### PR DESCRIPTION
Closes #2895

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
