### PR TITLE
fix(types): `SimplifyDeepArray` should now actually be "deep"

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -552,8 +552,12 @@ describe('Merge path with `app.route()`', () => {
     interface ExtraDeepInterface {
       l4: DeepInterface
     }
-    type verifyDeepInterface = Expect<Equal<SimplifyDeepArray<DeepInterface> extends JSONValue ? true : false, true>>
-    type verifyExtraDeepInterface = Expect<Equal<SimplifyDeepArray<ExtraDeepInterface> extends JSONValue ? true : false, true>>
+    type verifyDeepInterface = Expect<
+      Equal<SimplifyDeepArray<DeepInterface> extends JSONValue ? true : false, true>
+    >
+    type verifyExtraDeepInterface = Expect<
+      Equal<SimplifyDeepArray<ExtraDeepInterface> extends JSONValue ? true : false, true>
+    >
   })
 
   it('Should have correct types - with array of interfaces', async () => {
@@ -574,10 +578,18 @@ describe('Merge path with `app.route()`', () => {
     expect(data[0].ok).toBe(true)
 
     // A few more types only tests
-    type verifyNestedArrayTyped = Expect<Equal<SimplifyDeepArray<[string, Results]> extends JSONValue ? true : false, true>>
-    type verifyNestedArrayInterfaceArray = Expect<Equal<SimplifyDeepArray<[string, Result[]]> extends JSONValue ? true : false, true>>
-    type verifyExtraNestedArrayTyped = Expect<Equal<SimplifyDeepArray<[string, Results[]]> extends JSONValue ? true : false, true>>
-    type verifyExtraNestedArrayInterfaceArray = Expect<Equal<SimplifyDeepArray<[string, Result[][]]> extends JSONValue ? true : false, true>>
+    type verifyNestedArrayTyped = Expect<
+      Equal<SimplifyDeepArray<[string, Results]> extends JSONValue ? true : false, true>
+    >
+    type verifyNestedArrayInterfaceArray = Expect<
+      Equal<SimplifyDeepArray<[string, Result[]]> extends JSONValue ? true : false, true>
+    >
+    type verifyExtraNestedArrayTyped = Expect<
+      Equal<SimplifyDeepArray<[string, Results[]]> extends JSONValue ? true : false, true>
+    >
+    type verifyExtraNestedArrayInterfaceArray = Expect<
+      Equal<SimplifyDeepArray<[string, Result[][]]> extends JSONValue ? true : false, true>
+    >
   })
 
   it('Should allow a Date object and return it as a string', async () => {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -7,7 +7,7 @@ import { expectTypeOf, vi } from 'vitest'
 import { upgradeWebSocket } from '../adapter/deno/websocket'
 import { Hono } from '../hono'
 import { parse } from '../utils/cookie'
-import type { Equal, Expect } from '../utils/types'
+import type { Equal, Expect, JSONValue, SimplifyDeepArray } from '../utils/types'
 import { validator } from '../validator'
 import { hc } from './client'
 import type { ClientResponse, InferRequestType, InferResponseType } from './types'
@@ -542,6 +542,18 @@ describe('Merge path with `app.route()`', () => {
     const data = await res.json()
     type verify = Expect<Equal<Result, typeof data>>
     expect(data.ok).toBe(true)
+
+    // A few more types only tests
+    interface DeepInterface {
+      l2: {
+        l3: Result
+      }
+    }
+    interface ExtraDeepInterface {
+      l4: DeepInterface
+    }
+    type verifyDeepInterface = Expect<Equal<SimplifyDeepArray<DeepInterface> extends JSONValue ? true : false, true>>
+    type verifyExtraDeepInterface = Expect<Equal<SimplifyDeepArray<ExtraDeepInterface> extends JSONValue ? true : false, true>>
   })
 
   it('Should have correct types - with array of interfaces', async () => {
@@ -560,6 +572,12 @@ describe('Merge path with `app.route()`', () => {
     const data = await res.json()
     type verify = Expect<Equal<Results, typeof data>>
     expect(data[0].ok).toBe(true)
+
+    // A few more types only tests
+    type verifyNestedArrayTyped = Expect<Equal<SimplifyDeepArray<[string, Results]> extends JSONValue ? true : false, true>>
+    type verifyNestedArrayInterfaceArray = Expect<Equal<SimplifyDeepArray<[string, Result[]]> extends JSONValue ? true : false, true>>
+    type verifyExtraNestedArrayTyped = Expect<Equal<SimplifyDeepArray<[string, Results[]]> extends JSONValue ? true : false, true>>
+    type verifyExtraNestedArrayInterfaceArray = Expect<Equal<SimplifyDeepArray<[string, Result[][]]> extends JSONValue ? true : false, true>>
   })
 
   it('Should allow a Date object and return it as a string', async () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -145,7 +145,7 @@ interface JSONRespond {
       'json'
     >
   <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode>(
-    object: SimplifyDeepArray<T> extends JSONValue ? T : SimplifyDeepArray<T>,
+    object: T,
     init?: ResponseInit
   ): Response &
     TypedResponse<

--- a/src/context.ts
+++ b/src/context.ts
@@ -127,37 +127,39 @@ interface TextRespond {
  * @param {U} [status] - An optional status code for the response.
  * @param {HeaderRecord} [headers] - An optional record of headers to include in the response.
  *
- * @returns {Response & TypedResponse<SimplifyDeepArray<T> extends JSONValue ? (JSONValue extends SimplifyDeepArray<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
+ * @returns {JSONRespondReturn<T, U>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
 interface JSONRespond {
   <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode>(
     object: T,
     status?: U,
     headers?: HeaderRecord
-  ): Response &
-    TypedResponse<
-      SimplifyDeepArray<T> extends JSONValue
-        ? JSONValue extends SimplifyDeepArray<T>
-          ? never
-          : JSONParsed<T>
-        : never,
-      U,
-      'json'
-    >
+  ): JSONRespondReturn<T, U>
   <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode>(
     object: T,
     init?: ResponseInit
-  ): Response &
-    TypedResponse<
-      SimplifyDeepArray<T> extends JSONValue
-        ? JSONValue extends SimplifyDeepArray<T>
-          ? never
-          : JSONParsed<T>
-        : never,
-      U,
-      'json'
-    >
+  ): JSONRespondReturn<T, U>
 }
+
+/**
+ * @template T - The type of the JSON value or simplified unknown type.
+ * @template U - The type of the status code.
+ *
+ * @returns {Response & TypedResponse<SimplifyDeepArray<T> extends JSONValue ? (JSONValue extends SimplifyDeepArray<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
+ */
+type JSONRespondReturn<
+  T extends JSONValue | SimplifyDeepArray<unknown>,
+  U extends StatusCode
+> = Response &
+  TypedResponse<
+    SimplifyDeepArray<T> extends JSONValue
+      ? JSONValue extends SimplifyDeepArray<T>
+        ? never
+        : JSONParsed<T>
+      : never,
+    U,
+    'json'
+  >
 
 /**
  * Interface representing a function that responds with HTML content.
@@ -663,7 +665,7 @@ export class Context<
     object: T,
     arg?: U | ResponseInit,
     headers?: HeaderRecord
-  ): ReturnType<JSONRespond> => {
+  ): JSONRespondReturn<T, U> => {
     const body = JSON.stringify(object)
     this.#preparedHeaders ??= {}
     this.#preparedHeaders['content-type'] = 'application/json; charset=UTF-8'

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import type { HonoRequest } from './request'
 import type { Env, FetchEventLike, Input, NotFoundHandler, TypedResponse } from './types'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
-import type { IsAny, JSONParsed, JSONValue, Simplify, SimplifyDeepArray } from './utils/types'
+import type { IsAny, JSONParsed, JSONValue, SimplifyDeepArray } from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
 
@@ -659,7 +659,7 @@ export class Context<
    * })
    * ```
    */
-  json: JSONRespond = <T extends JSONValue | Simplify<unknown>, U extends StatusCode>(
+  json: JSONRespond = <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode>(
     object: T,
     arg?: U | ResponseInit,
     headers?: HeaderRecord

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -51,8 +51,8 @@ export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {}
  * A simple extension of Simplify that works for array of interfaces.
  */
 export type SimplifyDeepArray<T> = T extends any[]
-  ? { [E in keyof T]: Simplify<T[E]> }
-  : { [KeyType in keyof T]: T[KeyType] } & {}
+  ? { [E in keyof T]: SimplifyDeepArray<T[E]> }
+  : Simplify<T>
 
 export type InterfaceToType<T> = T extends Function ? T : { [K in keyof T]: InterfaceToType<T[K]> }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -48,7 +48,7 @@ export type JSONParsed<T> = T extends { toJSON(): infer J }
 export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {}
 
 /**
- * A simple extension of Simplify that works for array of interfaces.
+ * A simple extension of Simplify that will deeply traverse array elements.
  */
 export type SimplifyDeepArray<T> = T extends any[]
   ? { [E in keyof T]: SimplifyDeepArray<T[E]> }


### PR DESCRIPTION
Resolves #2878

#2915 added `SimplifyDeepArray` but it wasn't actually deep so nested interface array was still bugged as `never`.
It is now actually deep and should fix that.

I have also split JSONRespond's return declaration to `JSONRespondReturn` type for DRY-er code structure because of some weird bug with typescript yelling `type is possibly infinite` at line ~664 when `ReturnType<JSONRespond>` is used as return declaration,
We could remove this type-split commit and put the full type declaration at line ~668 if you prefer not splitting it.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
