### PR TITLE
refactor(middleware/serve-static): call getContent only once if the file does not exist

### DIFF
--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -64,9 +64,12 @@ export const serveStatic = <E extends Env = Env>(
         return await next()
       }
       pathWithOutDefaultDocument = pathResolve(pathWithOutDefaultDocument)
-      content = await getContent(pathWithOutDefaultDocument, c)
-      if (content) {
-        path = pathWithOutDefaultDocument
+
+      if (pathWithOutDefaultDocument !== path) {
+        content = await getContent(pathWithOutDefaultDocument, c)
+        if (content) {
+          path = pathWithOutDefaultDocument
+        }
       }
     }
 


### PR DESCRIPTION
Refactored so that `getContent()` was called twice in the same path when 404, so it is now called once.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
