### PR TITLE
chore: add `text` and `html` for coverage reporter

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       enabled: true,
       provider: 'v8',
       reportsDirectory: './coverage/raw/default',
-      reporter: ['json'],
+      reporter: ['json', 'text', 'html'],
       exclude: [
         ...(configDefaults.coverage.exclude ?? []),
         'benchmarks',
@@ -27,7 +27,7 @@ export default defineConfig({
         'src/**/types.ts',
         'src/jsx/intrinsic-elements.ts',
         'src/utils/http-status.ts',
-      ]
+      ],
     },
     pool: 'forks',
   },


### PR DESCRIPTION
To check the reports in the local machine.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
