### PR TITLE
refactor(conninfo): create `types.ts` for type definitions

### DIFF
--- a/src/helper/conninfo/index.ts
+++ b/src/helper/conninfo/index.ts
@@ -3,48 +3,4 @@
  * ConnInfo Helper for Hono.
  */
 
-import type { Context } from '../../context'
-
-export type AddressType = 'IPv6' | 'IPv4' | 'unknown'
-
-export type NetAddrInfo = {
-  /**
-   * Transport protocol type
-   */
-  transport?: 'tcp' | 'udp'
-  /**
-   * Transport port number
-   */
-  port?: number
-
-  address?: string
-  addressType?: AddressType
-} & (
-  | {
-      /**
-       * Host name such as IP Addr
-       */
-      address: string
-
-      /**
-       * Host name type
-       */
-      addressType: AddressType
-    }
-  | {}
-)
-
-/**
- * HTTP Connection infomation
- */
-export interface ConnInfo {
-  /**
-   * Remote infomation
-   */
-  remote: NetAddrInfo
-}
-
-/**
- * Helper type
- */
-export type GetConnInfo = (c: Context) => ConnInfo
+export type { AddressType, NetAddrInfo, ConnInfo, GetConnInfo } from './types'

--- a/src/helper/conninfo/types.ts
+++ b/src/helper/conninfo/types.ts
@@ -1,0 +1,45 @@
+import type { Context } from '../../context'
+
+export type AddressType = 'IPv6' | 'IPv4' | 'unknown'
+
+export type NetAddrInfo = {
+  /**
+   * Transport protocol type
+   */
+  transport?: 'tcp' | 'udp'
+  /**
+   * Transport port number
+   */
+  port?: number
+
+  address?: string
+  addressType?: AddressType
+} & (
+  | {
+      /**
+       * Host name such as IP Addr
+       */
+      address: string
+
+      /**
+       * Host name type
+       */
+      addressType: AddressType
+    }
+  | {}
+)
+
+/**
+ * HTTP Connection infomation
+ */
+export interface ConnInfo {
+  /**
+   * Remote infomation
+   */
+  remote: NetAddrInfo
+}
+
+/**
+ * Helper type
+ */
+export type GetConnInfo = (c: Context) => ConnInfo


### PR DESCRIPTION
Created `types.ts` separate from `index.ts` for type definitions to measure coverage correctly.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
