### PR TITLE
feat(jsx/dom): export createRoot and hydrateRoot from jsx/dom/client as default

### DIFF
--- a/src/jsx/dom/client.test.tsx
+++ b/src/jsx/dom/client.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource ../ */
 import { JSDOM } from 'jsdom'
-import { createRoot, hydrateRoot } from './client'
+import DefaultExport, { createRoot, hydrateRoot } from './client'
 import { useEffect } from '.'
 
 describe('createRoot', () => {
@@ -115,5 +115,14 @@ describe('hydrateRoot', () => {
     expect(rootElement.innerHTML).toBe('<h1>Hello</h1>')
     root.unmount()
     expect(() => root.render(App2)).toThrow('Cannot update an unmounted root')
+  })
+})
+
+describe('default export', () => {
+  ;['createRoot', 'hydrateRoot'].forEach((key) => {
+    it(key, () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((DefaultExport as any)[key]).toBeDefined()
+    })
   })
 })

--- a/src/jsx/dom/client.ts
+++ b/src/jsx/dom/client.ts
@@ -82,3 +82,8 @@ export const hydrateRoot = (
   root.render(reactNode)
   return root
 }
+
+export default {
+  createRoot,
+  hydrateRoot,
+}


### PR DESCRIPTION
Small additions to make #2925 easier to implement.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
