### PR TITLE
fix(cors): allow custom vary header

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -5,6 +5,7 @@ describe('CORS by Middleware', () => {
   const app = new Hono()
 
   app.use('/api/*', cors())
+
   app.use(
     '/api2/*',
     cors({
@@ -39,25 +40,23 @@ describe('CORS by Middleware', () => {
       origin: 'http://example.com',
     })
   )
-  app.use(
-    '/api6/*',
-    cors({
-      origin: 'http://example.com',
-    })
-  )
 
   app.get('/api/abc', (c) => {
     return c.json({ success: true })
   })
+
   app.get('/api2/abc', (c) => {
     return c.json({ success: true })
   })
+
   app.get('/api3/abc', (c) => {
     return c.json({ success: true })
   })
+
   app.get('/api4/abc', (c) => {
     return c.json({ success: true })
   })
+
   app.get('/api5/abc', () => {
     return new Response(JSON.stringify({ success: true }))
   })
@@ -126,6 +125,18 @@ describe('CORS by Middleware', () => {
     })
     res = await app.request(req)
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+  })
+
+  it('Allow different Vary header value', async () => {
+    const res = await app.request('http://localhost/api3/abc', {
+      headers: {
+        Vary: 'accept-encoding',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+    expect(res.headers.get('Vary')).toBe('accept-encoding')
   })
 
   it('Allow origins by function', async () => {

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -89,7 +89,13 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
     // Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard).
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
     if (opts.origin !== '*') {
-      set('Vary', 'Origin')
+      const existingVary = c.req.header('Vary')
+
+      if (existingVary) {
+        set('Vary', existingVary)
+      } else {
+        set('Vary', 'Origin')
+      }
     }
 
     if (opts.credentials) {


### PR DESCRIPTION
Fixes #2932 allow developers to use custom vary header value, it will helps to support many use cases with custom vary headers such as [CF Polished](https://developers.cloudflare.com/images/polish/cf-polished-statuses/).

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
