### PR TITLE
fix(jsx): rename `Hono` to `JSX` and export `JSX` namespace

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -3,7 +3,10 @@ import { escapeToBuffer, stringBufferToString } from '../utils/html'
 import type { HtmlEscaped, HtmlEscapedString, StringBuffer } from '../utils/html'
 import type { Context } from './context'
 import { globalContexts } from './context'
-import type { Hono, IntrinsicElements as IntrinsicElementsDefined } from './intrinsic-elements'
+import type {
+  JSX as HonoJSX,
+  IntrinsicElements as IntrinsicElementsDefined,
+} from './intrinsic-elements'
 import { normalizeIntrinsicElementProps, styleObjectForEach } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,7 +16,7 @@ export type FC<P = Props> = {
   defaultProps?: Partial<P> | undefined
   displayName?: string | undefined
 }
-export type DOMAttributes = Hono.HTMLAttributes
+export type DOMAttributes = HonoJSX.HTMLAttributes
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -104,4 +104,4 @@ export default {
 
 export type * from './types'
 
-export { JSX } from './intrinsic-elements'
+export type { JSX } from './intrinsic-elements'

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -103,3 +103,5 @@ export default {
 }
 
 export type * from './types'
+
+export { JSX } from './intrinsic-elements'

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -8,7 +8,7 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace Hono {
+export namespace JSX {
   export type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
   export type CSSProperties = {}
   type AnyAttributes = { [attributeName: string]: any }
@@ -726,4 +726,4 @@ export namespace Hono {
   }
 }
 
-export interface IntrinsicElements extends Hono.IntrinsicElements {}
+export interface IntrinsicElements extends JSX.IntrinsicElements {}

--- a/src/jsx/types.ts
+++ b/src/jsx/types.ts
@@ -2,14 +2,14 @@
  * All types exported from "hono/jsx" are in this file.
  */
 import type { Child, JSXNode } from './base'
-import type { Hono } from './intrinsic-elements'
+import type { JSX } from './intrinsic-elements'
 
 export type { Child, JSXNode, FC } from './base'
 export type { RefObject } from './hooks'
 export type { Context } from './context'
 
 export type PropsWithChildren<P = unknown> = P & { children?: Child | undefined }
-export type CSSProperties = Hono.CSSProperties
+export type CSSProperties = JSX.CSSProperties
 
 /**
  * React types


### PR DESCRIPTION
Fixes #2927

Currently, the definition for HTML tags elements and attributes are exported as a namespace named `Hono` in `jsx/intrinsic-elements.ts`. This is not bad, but the namespace `Hono` is not exported for users. So, it's impossible to extend the values such as `HTMLAttributes`.  In this PR, it will be exported from `hono/jsx`. And I renamed `Hono` to `JSX` because the name `Hono` will cause confusion. That namespace was not used in a global. So I think it will not be a breaking change.

With this PR, you can write the JSX with the HTMX attribute with the following code:

```tsx
// You may have to write `import "typed-htmx"`

declare module 'hono/jsx' {
  namespace JSX {
    interface HTMLAttributes extends HtmxAttributes {}
  }
}

app.get('/', (c) => {
  return c.render(
    <div hx-get="/foo">
      <h1>Hello!</h1>
    </div>
  )
})
```

By the way, it was exported in `global` before `v4.4.0`, but it was not valid for JSR publishing and polluted the global. So, it was changed to exported locally in the module.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
