### PR TITLE
refactor(hono-base): make 2nd arg of `app.route()` required

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -215,14 +215,9 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     SubBasePath extends string
   >(
     path: SubPath,
-    app?: Hono<SubEnv, SubSchema, SubBasePath>
+    app: Hono<SubEnv, SubSchema, SubBasePath>
   ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
     const subApp = this.basePath(path)
-
-    if (!app) {
-      return subApp
-    }
-
     app.routes.map((r) => {
       let handler
       if (app.errorHandler === errorHandler) {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -3503,6 +3503,7 @@ describe('Compatible with extended Hono classes, such Zod OpenAPI Hono.', () => 
   class ExtendedHono extends Hono {
     // @ts-ignore
     route(path: string, app?: Hono) {
+      // @ts-ignore
       super.route(path, app)
       return this
     }


### PR DESCRIPTION
The second arg of `app.route()` was optional, but the "optional" was deprecated and obsolete when releasing `v4.0.0`. So, the second arg (app) is required now. This PR corrects that forgotten handling it.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
