### PR TITLE
refactor(hono-base): don't check 1st argument of `app.on()`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -144,9 +144,6 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
 
     // Implementation of app.on(method, path, ...handlers[])
     this.on = (method: string | string[], path: string | string[], ...handlers: H[]) => {
-      if (!method) {
-        return this
-      }
       for (const p of [path].flat()) {
         this.#path = p
         for (const m of [method].flat()) {


### PR DESCRIPTION
This PR removes checking the actual value of the first argument on `app.on()`. I think it is ok not to check because the argument is typed as required. And if the coming actual value is undefined, it will be checked in the initialization phase, so it's no problem just throwing an error.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
