### PR TITLE
refactor(jsx): reduce code size and improve maintainability

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -7,7 +7,7 @@ import type {
   JSX as HonoJSX,
   IntrinsicElements as IntrinsicElementsDefined,
 } from './intrinsic-elements'
-import { normalizeIntrinsicElementProps, styleObjectForEach } from './utils'
+import { normalizeIntrinsicElementKey, styleObjectForEach } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Props = Record<string, any>
@@ -152,11 +152,8 @@ export class JSXNode implements HtmlEscaped {
 
     buffer[0] += `<${tag}`
 
-    const propsKeys = Object.keys(props || {})
-
-    for (let i = 0, len = propsKeys.length; i < len; i++) {
-      const key = propsKeys[i]
-      const v = props[key]
+    for (let [key, v] of Object.entries(props)) {
+      key = normalizeIntrinsicElementKey(key)
       if (key === 'children') {
         // skip children
       } else if (key === 'style' && typeof v === 'object') {
@@ -283,7 +280,6 @@ export const jsxFn = (
   if (typeof tag === 'function') {
     return new JSXFunctionNode(tag, props, children)
   } else {
-    normalizeIntrinsicElementProps(props)
     return new JSXNode(tag, props, children)
   }
 }

--- a/src/jsx/dom/jsx-dev-runtime.ts
+++ b/src/jsx/dom/jsx-dev-runtime.ts
@@ -4,13 +4,9 @@
  */
 
 import type { JSXNode, Props } from '../base'
-import { normalizeIntrinsicElementProps } from '../utils'
 import { newJSXNode } from './utils'
 
 export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXNode => {
-  if (typeof tag === 'string') {
-    normalizeIntrinsicElementProps(props)
-  }
   return newJSXNode({
     tag,
     props,

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -511,13 +511,12 @@ export const buildNode = (node: Child): Node | undefined => {
     } else {
       const ns = nameSpaceMap[(node as JSXNode).tag as string]
       if (ns) {
-        ;(node as NodeObject).n = `http://www.w3.org/${ns}`
         nameSpaceContext ||= createContext('')
         ;(node as JSXNode).props.children = [
           {
             tag: nameSpaceContext.Provider,
             props: {
-              value: ns,
+              value: ((node as NodeObject).n = `http://www.w3.org/${ns}`),
               children: (node as JSXNode).props.children,
             },
           },

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -5,7 +5,7 @@ import type { Context as JSXContext } from '../context'
 import { globalContexts as globalJSXContexts, useContext } from '../context'
 import type { EffectData } from '../hooks'
 import { STASH_EFFECT } from '../hooks'
-import { styleObjectForEach } from '../utils'
+import { normalizeIntrinsicElementKey, styleObjectForEach } from '../utils'
 import { createContext } from './context' // import dom-specific versions
 import { newJSXNode } from './utils'
 
@@ -120,8 +120,9 @@ const applyProps = (
   oldAttributes?: Props
 ): void => {
   attributes ||= {}
-  for (const [key, value] of Object.entries(attributes)) {
+  for (let [key, value] of Object.entries(attributes)) {
     if (!skipProps.has(key) && (!oldAttributes || oldAttributes[key] !== value)) {
+      key = normalizeIntrinsicElementKey(key)
       const eventSpec = getEventSpec(key)
       if (eventSpec) {
         if (oldAttributes) {
@@ -191,8 +192,9 @@ const applyProps = (
     }
   }
   if (oldAttributes) {
-    for (const [key, value] of Object.entries(oldAttributes)) {
+    for (let [key, value] of Object.entries(oldAttributes)) {
       if (!skipProps.has(key) && !(key in attributes)) {
+        key = normalizeIntrinsicElementKey(key)
         const eventSpec = getEventSpec(key)
         if (eventSpec) {
           container.removeEventListener(eventSpec[0], value, eventSpec[1])

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -17,8 +17,8 @@ const eventAliasMap: Record<string, string> = {
 } as const
 
 const nameSpaceMap: Record<string, string> = {
-  svg: 'http://www.w3.org/2000/svg',
-  math: 'http://www.w3.org/1998/Math/MathML',
+  svg: '2000/svg',
+  math: '1998/Math/MathML',
 } as const
 
 const skipProps: Set<string> = new Set(['children'])
@@ -511,7 +511,7 @@ export const buildNode = (node: Child): Node | undefined => {
     } else {
       const ns = nameSpaceMap[(node as JSXNode).tag as string]
       if (ns) {
-        ;(node as NodeObject).n = ns
+        ;(node as NodeObject).n = `http://www.w3.org/${ns}`
         nameSpaceContext ||= createContext('')
         ;(node as JSXNode).props.children = [
           {

--- a/src/jsx/utils.test.ts
+++ b/src/jsx/utils.test.ts
@@ -1,70 +1,13 @@
-import { normalizeIntrinsicElementProps, styleObjectForEach } from './utils'
+import { normalizeIntrinsicElementKey, styleObjectForEach } from './utils'
 
-describe('normalizeIntrinsicElementProps', () => {
-  it('should convert className to class', () => {
-    const props: Record<string, unknown> = {
-      className: 'test-class',
-      id: 'test-id',
-    }
-
-    normalizeIntrinsicElementProps(props)
-
-    expect(props).toEqual({
-      class: 'test-class',
-      id: 'test-id',
-    })
-  })
-
-  it('should convert htmlFor to for', () => {
-    const props: Record<string, unknown> = {
-      htmlFor: 'test-for',
-      name: 'test-name',
-    }
-
-    normalizeIntrinsicElementProps(props)
-
-    expect(props).toEqual({
-      for: 'test-for',
-      name: 'test-name',
-    })
-  })
-
-  it('should convert multiple attribute aliases', () => {
-    const props: Record<string, unknown> = {
-      className: 'test-class',
-      htmlFor: 'test-for',
-      type: 'text',
-    }
-
-    normalizeIntrinsicElementProps(props)
-
-    expect(props).toEqual({
-      class: 'test-class',
-      for: 'test-for',
-      type: 'text',
-    })
-  })
-
-  it('should not modify props without className or htmlFor', () => {
-    const props: Record<string, unknown> = {
-      id: 'test-id',
-      name: 'test-name',
-    }
-
-    normalizeIntrinsicElementProps(props)
-
-    expect(props).toEqual({
-      id: 'test-id',
-      name: 'test-name',
-    })
-  })
-
-  it('should handle empty props', () => {
-    const props: Record<string, unknown> = {}
-
-    normalizeIntrinsicElementProps(props)
-
-    expect(props).toEqual({})
+describe('normalizeIntrinsicElementKey', () => {
+  test.each`
+    key            | expected
+    ${'className'} | ${'class'}
+    ${'htmlFor'}   | ${'for'}
+    ${'href'}      | ${'href'}
+  `('should convert $key to $expected', ({ key, expected }) => {
+    expect(normalizeIntrinsicElementKey(key)).toBe(expected)
   })
 })
 

--- a/src/jsx/utils.ts
+++ b/src/jsx/utils.ts
@@ -1,19 +1,9 @@
-/**
- * Normalizes intrinsic element properties by converting JSX element properties
- * to their corresponding HTML attributes.
- *
- * @param props - JSX element properties.
- */
-export const normalizeIntrinsicElementProps = (props: Record<string, unknown>): void => {
-  if (props && 'className' in props) {
-    props['class'] = props['className']
-    delete props['className']
-  }
-  if (props && 'htmlFor' in props) {
-    props['for'] = props['htmlFor']
-    delete props['htmlFor']
-  }
-}
+const normalizeElementKeyMap = new Map([
+  ['className', 'class'],
+  ['htmlFor', 'for'],
+])
+export const normalizeIntrinsicElementKey = (key: string): string =>
+  normalizeElementKeyMap.get(key) || key
 
 export const styleObjectForEach = (
   style: Record<string, string | number>,


### PR DESCRIPTION
### Size

Reduce the size a bit.

```bash
$ git checkout main
$ npx esbuild --bundle --minify src/jsx/dom/index.ts | wc
       1     224   10594
$ git checkout feat/reduce-jsx-utils-size
$ npx esbuild --bundle --minify src/jsx/dom/index.ts | wc
       1     220   10517
```

### Maintainability

It is easier to add attributes that should be replaced.

https://github.com/honojs/hono/compare/main...usualoma:hono:feat/reduce-jsx-utils-size?expand=1#diff-7deb9d231b0c7046d4243559f6a3b475560a8f9c6e4e1445f2b98c21a73b7067R1-R4

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
