### PR TITLE
feat(jsx): bump react compat version to 19.0.0-hono-jsx

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -357,4 +357,4 @@ export const cloneElement = <T extends JSXNode | JSX.Element>(
   ) as T
 }
 
-export const reactAPICompatVersion = '18.0.0-hono-jsx'
+export const reactAPICompatVersion = '19.0.0-hono-jsx'


### PR DESCRIPTION
#2959
First of all, in the react-19-compat branch, we should bump the version number