### PR TITLE
use correct return type for c.html depending on input

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -36,7 +36,7 @@ describe('Context', () => {
   })
 
   it('c.html()', async () => {
-    const res = await c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
+    const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)
     expect(res.headers.get('Content-Type')).toMatch('text/html')
     expect(await res.text()).toBe('<h1>Hello! Hono!</h1>')
@@ -44,13 +44,14 @@ describe('Context', () => {
   })
 
   it('c.html() with async', async () => {
-    const res = await c.html(
-      new Promise((resolve) => setTimeout(() => resolve('<h1>Hello! Hono!</h1>'), 0)),
+    const resPromise: Promise<Response> = c.html(
+      new Promise<string>((resolve) => setTimeout(() => resolve('<h1>Hello! Hono!</h1>'), 0)),
       201,
       {
         'X-Custom': 'Message',
       }
     )
+    const res = await resPromise
     expect(res.status).toBe(201)
     expect(res.headers.get('Content-Type')).toMatch('text/html')
     expect(await res.text()).toBe('<h1>Hello! Hono!</h1>')

--- a/src/context.ts
+++ b/src/context.ts
@@ -175,10 +175,14 @@ type JSONRespondReturn<
  * @returns A Response object or a Promise that resolves to a Response object.
  */
 interface HTMLRespond {
-  (html: string | Promise<string>, status?: StatusCode, headers?: HeaderRecord):
-    | Response
-    | Promise<Response>
-  (html: string | Promise<string>, init?: ResponseInit): Response | Promise<Response>
+  <T extends string | Promise<string>>(
+    html: T,
+    status?: StatusCode,
+    headers?: HeaderRecord
+  ): T extends string ? Response : Promise<Response>
+  <T extends string | Promise<string>>(html: T, init?: ResponseInit): T extends string
+    ? Response
+    : Promise<Response>
 }
 
 /**


### PR DESCRIPTION
I had some issues with using `c.html` with a non-promise body that had the return-type `Response | Promise<Response>`. This should use correct return-type depending on the input.

### The author should do the following, if applicable

- [x] `bun run format:fix && bun run lint:fix` to format the code

