### PR TITLE
test: test uncovered return statement

### DIFF
--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -97,7 +97,7 @@ describe('removeIndexString', () => {
 describe('deepMerge', () => {
   it('should return the source object if the target object is not an object', () => {
     const target = null
-    const source = { a: 1 }
+    const source = 'not an object' as unknown as Record<string, unknown>
     const result = deepMerge(target, source)
     expect(result).toEqual(source)
   })


### PR DESCRIPTION
close #2980 

Adjusted the value passed as the second argument to improve coverage.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code


