### PR TITLE
fix(types): env variables override ContextVariableMap

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -69,8 +69,8 @@ export type Layout<T = Record<string, any>> = (props: T) => any
  * @template E - Environment type.
  */
 interface Get<E extends Env> {
-  <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
   <Key extends keyof E['Variables']>(key: Key): E['Variables'][Key]
+  <Key extends keyof ContextVariableMap>(key: Key): ContextVariableMap[Key]
 }
 
 /**
@@ -79,8 +79,8 @@ interface Get<E extends Env> {
  * @template E - Environment type.
  */
 interface Set<E extends Env> {
-  <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
   <Key extends keyof E['Variables']>(key: Key, value: E['Variables'][Key]): void
+  <Key extends keyof ContextVariableMap>(key: Key, value: ContextVariableMap[Key]): void
 }
 
 /**

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1638,14 +1638,30 @@ declare module './context' {
   }
 }
 
-describe('c.var with ContextVariableMap - test only types', () => {
-  it('Should no throw a type error', () => {
+describe('ContextVariableMap type tests', () => {
+  it('Should not throw type errors with c.var', () => {
     new Hono().get((c) => {
       expectTypeOf(c.get('payload')).toEqualTypeOf<string>()
       return c.json(0)
     })
     new Hono().get((c) => {
       expectTypeOf(c.var.payload).toEqualTypeOf<string>()
+      return c.json(0)
+    })
+  })
+
+  it('Should override ContextVariableMap with env variables', () => {
+    const middleware = createMiddleware<{
+      Variables: {
+        payload: number
+      }
+    }>(async (c, next) => {
+      c.set('payload', 123)
+      await next()
+    })
+
+    new Hono().get(middleware, (c) => {
+      expectTypeOf(c.get('payload')).toEqualTypeOf<number>()
       return c.json(0)
     })
   })


### PR DESCRIPTION
```ts
declare module 'hono' {
  interface ContextVariableMap {
    test: 'root'
  }
}

const middleware = createMiddleware<{
  Variables: {
    test: 'override'
  }
}>(async (c, next) => {
  c.set('test', 'override')
  await next()
})

const router = new Hono()
  .get(
    '/test',
    middleware,
    async c => {
      const test = c.get('test')
      //    ^? "root"
      return c.text(test) // 'override', type doesn't match
    },
  )

const app = new Hono()
  .use(async (c, next) => {
    c.set('test', 'root')
    await next()
  })
  .route('/', router)
```