### PR TITLE
chore: Fix typos in JSDoc

### DIFF
--- a/src/helper/conninfo/types.ts
+++ b/src/helper/conninfo/types.ts
@@ -30,11 +30,11 @@ export type NetAddrInfo = {
 )
 
 /**
- * HTTP Connection infomation
+ * HTTP Connection information
  */
 export interface ConnInfo {
   /**
-   * Remote infomation
+   * Remote information
    */
   remote: NetAddrInfo
 }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -194,7 +194,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    *
    * @param {string} path - base Path
    * @param {Hono} app - other Hono instance
-   * @returns {Hono} routed Hono instnace
+   * @returns {Hono} routed Hono instance
    *
    * @example
    * ```ts
@@ -459,7 +459,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    *
    * @see {@link https://hono.dev/api/hono#fetch}
    *
-   * @param {Request} request - reuqest Object of request
+   * @param {Request} request - request Object of request
    * @param {Env} Env - env Object
    * @param {ExecutionContext} - context of execution
    * @returns {Response | Promise<Response>} response of request


### PR DESCRIPTION
### The author should do the following, if applicable

The following does not apply
- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
