### PR TITLE
perf: parseAccept without spread operator

### DIFF
--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -27,27 +27,27 @@ export interface acceptsOptions extends acceptsConfig {
 
 export const parseAccept = (acceptHeader: string): Accept[] => {
   // Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
-  const accepts = acceptHeader.split(',');
-    return accepts.map((accept) => {
-      const parts = accept.trim().split(';'); // ['text/html', 'q=0.9', 'image/webp']
-      const type = parts[0]; // text/html
-      const params = parts.slice(1); // ['q=0.9', 'image/webp']
-      const q = params.find((param) => param.startsWith('q='));
-  
-      const paramsObject = params.reduce((acc, param) => {
-        const keyValue = param.split('=');
-        const key = keyValue[0].trim();
-        const value = keyValue[1].trim();
-        acc[key] = value;
-        return acc;
-      }, {} as { [key: string]: string });
-  
-      return {
-        type: type,
-        params: paramsObject,
-        q: q ? parseFloat(q.split('=')[1]) : 1,
-      };
-    });
+  const accepts = acceptHeader.split(',')
+  return accepts.map((accept) => {
+    const parts = accept.trim().split(';') // ['text/html', 'q=0.9', 'image/webp']
+    const type = parts[0] // text/html
+    const params = parts.slice(1) // ['q=0.9', 'image/webp']
+    const q = params.find((param) => param.startsWith('q='))
+
+    const paramsObject = params.reduce((acc, param) => {
+      const keyValue = param.split('=')
+      const key = keyValue[0].trim()
+      const value = keyValue[1].trim()
+      acc[key] = value
+      return acc
+    }, {} as { [key: string]: string })
+
+    return {
+      type: type,
+      params: paramsObject,
+      q: q ? parseFloat(q.split('=')[1]) : 1,
+    }
+  })
 }
 
 export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -27,19 +27,27 @@ export interface acceptsOptions extends acceptsConfig {
 
 export const parseAccept = (acceptHeader: string): Accept[] => {
   // Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
-  const accepts = acceptHeader.split(',') // ['text/html', 'application/xhtml+xml', 'application/xml;q=0.9', 'image/webp', '*/*;q=0.8']
-  return accepts.map((accept) => {
-    const [type, ...params] = accept.trim().split(';') // ['application/xml', 'q=0.9']
-    const q = params.find((param) => param.startsWith('q=')) // 'q=0.9'
-    return {
-      type,
-      params: params.reduce((acc, param) => {
-        const [key, value] = param.split('=')
-        return { ...acc, [key.trim()]: value.trim() }
-      }, {}),
-      q: q ? parseFloat(q.split('=')[1]) : 1,
-    }
-  })
+  const accepts = acceptHeader.split(',');
+    return accepts.map((accept) => {
+      const parts = accept.trim().split(';'); // ['text/html', 'q=0.9', 'image/webp']
+      const type = parts[0]; // text/html
+      const params = parts.slice(1); // ['q=0.9', 'image/webp']
+      const q = params.find((param) => param.startsWith('q='));
+  
+      const paramsObject = params.reduce((acc, param) => {
+        const keyValue = param.split('=');
+        const key = keyValue[0].trim();
+        const value = keyValue[1].trim();
+        acc[key] = value;
+        return acc;
+      }, {} as { [key: string]: string });
+  
+      return {
+        type: type,
+        params: paramsObject,
+        q: q ? parseFloat(q.split('=')[1]) : 1,
+      };
+    });
 }
 
 export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -27,7 +27,7 @@ export interface acceptsOptions extends acceptsConfig {
 
 export const parseAccept = (acceptHeader: string): Accept[] => {
   // Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
-  const accepts = acceptHeader.split(',')
+  const accepts = acceptHeader.split(',') // ['text/html', 'application/xhtml+xml', 'application/xml;q=0.9', 'image/webp', '*/*;q=0.8']
   return accepts.map((accept) => {
     const parts = accept.trim().split(';') // ['text/html', 'q=0.9', 'image/webp']
     const type = parts[0] // text/html


### PR DESCRIPTION
Hello, small perf improvements by removing spread operator.

source : https://prateeksurana.me/blog/why-using-object-spread-with-reduce-bad-idea/

I made a little repo to bench the function without spread operator, we can notice a small improvement  : https://github.com/Jayllyz/parseHeader-bench

<img width="875" alt="image" src="https://github.com/honojs/hono/assets/16305216/6f23dc0b-b2cc-41b2-8141-bfd4a48907c8">


### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
