### PR TITLE
ci: use `env` for codecov GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
         with:
           fail_ci_if_error: true
           directory: ./coverage
-          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   main:
     name: 'Main'


### PR DESCRIPTION
May fixes #3009