### PR TITLE
feat(logger): improve automatic color support detection

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -3,14 +3,22 @@
  * Color utility.
  */
 
+import { hasTTY, isCI, isWindows } from './flags'
+
 export function getColorEnabled(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { process, Deno } = globalThis as any
 
+  // It is put as a function instead of a constant to only to run as needed in the ternary operator.
+  const isColorSupported = () =>
+    !globalThis.process?.env?.NO_COLOR &&
+    (Boolean(globalThis.process?.env?.FORCE_COLOR) ||
+      ((hasTTY || isWindows) && globalThis.process?.env?.TERM !== 'dumb') ||
+      isCI)
+
   const isNoColor =
     typeof process !== 'undefined'
-      ? // eslint-disable-next-line no-unsafe-optional-chaining
-        'NO_COLOR' in process?.env
+      ? !isColorSupported()
       : typeof Deno?.noColor === 'boolean'
       ? (Deno.noColor as boolean)
       : false

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -1,0 +1,24 @@
+/**
+ * @module flags
+ * Some common flags about the environment.
+ *
+ * @credit unjs/std-env
+ */
+
+/** Value of process.platform */
+export const platform = globalThis.process?.platform || ''
+
+/** Detect if `CI` environment variable is set */
+export const isCI = Boolean(globalThis.process?.env?.CI)
+
+/** Detect if stdout.TTY is available */
+export const hasTTY = Boolean(globalThis.process?.stdout && globalThis.process?.stdout.isTTY)
+
+/** Detect if process.platform is Windows */
+export const isWindows = /^win/i.test(platform)
+
+/** Detect if process.platform is Linux */
+export const isLinux = /^linux/i.test(platform)
+
+/** Detect if process.platform is macOS (darwin kernel) */
+export const isMacOS = /^darwin/i.test(platform)


### PR DESCRIPTION
The current color detection is not great and the log message in CloudWatch logs is hard to read.
![image](https://github.com/honojs/hono/assets/23612546/da269f52-2bf9-4ec7-99b0-64b1e9a7f3af)


The PR adds `utils/flags.ts` and improve `getColorEnabled()` ~~using `isColorSupported` flag~~ _The flag have been moved to inline of the function to align with the current test cases_.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

