### PR TITLE
chore: upload bun test coverage to CodeCov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: '20.x'
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: '1.0.25'
+          bun-version: '1.1.16'
       - run: bun install
       - run: bun run format
       - run: bun run lint
@@ -92,9 +92,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: '1.0.25'
+          bun-version: '1.1.16'
       - run: bun run test:bun
-
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-bun
+          path: coverage/
   fastly:
     name: 'Fastly Compute'
     runs-on: ubuntu-latest

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,7 @@
 [install.lockfile]
 print = "yarn"
+
+[test]
+coverage = true
+coverageReporter = ["text", "lcov"]
+coverageDir = "coverage/raw/bun"


### PR DESCRIPTION
https://bun.sh/blog/bun-v1.1.16
Bun is now able to generate statement coverage in LCOV format, which can be uploaded to CodeCov.
This improves coverage by 0.92%!
```diff
##             main    #3022      +/-   ##
==========================================
+ Coverage   94.76%   95.68%   +0.92%     
==========================================
  Files         136      137       +1     
  Lines       13361    13391      +30     
  Branches     2276     2252      -24     
==========================================
+ Hits        12661    12813     +152     
+ Misses        700      578     -122     
```

> [!note]
> Currently, some types of "unexecutable" lines are marked as uncovered, but better than nothing.
> It will be improved in Bun someday.
> <img width="610" alt="image" src="https://github.com/honojs/hono/assets/127635/5ff593ba-fd1f-4858-9507-48bbb75908e9">


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
