### PR TITLE
PoC: feat(middleware/hook): introduce hook middleware

### DIFF
--- a/src/middleware/hook/index.ts
+++ b/src/middleware/hook/index.ts
@@ -1,0 +1,53 @@
+import type { Context } from '../../context'
+import type { Env, Handler, MiddlewareHandler, Next } from '../../types'
+
+const isWrapped = Symbol()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Hook = (c: Context, handler: Handler, handlerContext: Record<string, any>) => void
+export const hook = <E extends Env = Env>(
+  options: {
+    before?: Hook
+    beforeNext?: Hook
+    afterNext?: Hook
+    after?: Hook
+  } = {}
+): MiddlewareHandler => {
+  function hook(c: Context<E>, next: Next) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(c.req.matchResult[0] as unknown as [[any]][]).forEach((routeData) => {
+      if (routeData[0][0][isWrapped]) {
+        return
+      }
+
+      const handler = routeData[0][0]
+      const name = handler.name || ''
+      routeData[0][0] = {
+        [name]: function (c: Context, next: Next) {
+          const handlerContext = Object.create(null)
+
+          if (options.before) {
+            options.before?.(c, handler, handlerContext)
+          }
+          const internalNext = () => {
+            options.beforeNext?.(c, handler, handlerContext)
+            const res = next()
+            res.finally(() => options.afterNext?.(c, handler, handlerContext))
+            return res
+          }
+          const res = handler(c, internalNext)
+          if (res instanceof Promise) {
+            res.finally(() => options.after?.(c, handler, handlerContext))
+          } else {
+            options.after?.(c, handler, handlerContext)
+          }
+          return res
+        },
+      }[name]
+      routeData[0][0][isWrapped] = true
+    })
+    return next()
+  }
+  hook[isWrapped] = true
+  return hook
+}

--- a/src/middleware/hook/index.ts
+++ b/src/middleware/hook/index.ts
@@ -3,8 +3,13 @@ import type { Env, Handler, MiddlewareHandler, Next } from '../../types'
 
 const isWrapped = Symbol()
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Hook = (c: Context, handler: Handler, handlerContext: Record<string, any>) => void
+export type Hook = (
+  c: Context,
+  handler: Handler,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handlerContext: Record<string, any>,
+  traceId: string
+) => void
 export const hook = <E extends Env = Env>(
   options: {
     before?: Hook
@@ -14,6 +19,9 @@ export const hook = <E extends Env = Env>(
   } = {}
 ): MiddlewareHandler => {
   function hook(c: Context<E>, next: Next) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    c.set('middleware-hook-trace-id' as any, Math.random().toString(16).slice(2))
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(c.req.matchResult[0] as unknown as [[any]][]).forEach((routeData) => {
       if (routeData[0][0][isWrapped]) {
@@ -25,21 +33,22 @@ export const hook = <E extends Env = Env>(
       routeData[0][0] = {
         [name]: function (c: Context, next: Next) {
           const handlerContext = Object.create(null)
+          const traceId = c.get('middleware-hook-trace-id')
 
           if (options.before) {
-            options.before?.(c, handler, handlerContext)
+            options.before?.(c, handler, handlerContext, traceId)
           }
           const internalNext = () => {
-            options.beforeNext?.(c, handler, handlerContext)
+            options.beforeNext?.(c, handler, handlerContext, traceId)
             const res = next()
-            res.finally(() => options.afterNext?.(c, handler, handlerContext))
+            res.finally(() => options.afterNext?.(c, handler, handlerContext, traceId))
             return res
           }
           const res = handler(c, internalNext)
           if (res instanceof Promise) {
-            res.finally(() => options.after?.(c, handler, handlerContext))
+            res.finally(() => options.after?.(c, handler, handlerContext, traceId))
           } else {
-            options.after?.(c, handler, handlerContext)
+            options.after?.(c, handler, handlerContext, traceId)
           }
           return res
         },

--- a/src/request.ts
+++ b/src/request.ts
@@ -358,6 +358,10 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return this.raw.method
   }
 
+  get matchResult(): Result<[unknown, RouterRoute]> {
+    return this.#matchResult
+  }
+
   /**
    * `.matchedRoutes()` can return a matched route in the handler
    *


### PR DESCRIPTION
### Usage

```ts
import { Hono } from 'hono'
import { hook } from 'hook'

const app = new Hono()
app.use(
  hook({
    before(c, handler, handlerContext, traceId) {
      console.log(traceId, 'before', handler.name)
      handlerContext['start'] = Date.now()
    },
    beforeNext(c, handler, _, traceId) {
      console.log(traceId, 'beforeNext', handler.name)
    },
    afterNext(c, handler, _, traceId) {
      console.log(traceId, 'afterNext', handler.name)
    },
    after(c, handler, handlerContext, traceId) {
      const elapsed = Date.now() - handlerContext['start']
      console.log(traceId, `after ${handler.name} ${elapsed}ms`, handler.name)
    },
  })
)

app.use(async function middlewareA(c, next) {
  await new Promise((resolve) => setTimeout(resolve, 100))
  await next()
})

app.use(async function middlewareB(c, next) {
  await new Promise((resolve) => setTimeout(resolve, 200))
  await next()
})

app.get('/', async function handler(c) {
  await new Promise((resolve) => setTimeout(resolve, 200))
  return c.text('Hello, World!')
})

export default app
```

### Output

```
c0934c4a53236 before middlewareA
c0934c4a53236 beforeNext middlewareA
c0934c4a53236 before middlewareB
c0934c4a53236 beforeNext middlewareB
c0934c4a53236 before handler
c0934c4a53236 after handler 203ms handler
c0934c4a53236 afterNext middlewareB
c0934c4a53236 after middlewareB 406ms middlewareB
c0934c4a53236 afterNext middlewareA
c0934c4a53236 after middlewareA 508ms middlewareA
```

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
