### PR TITLE
perf(utils/buffer): use promise all for performance

### DIFF
--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,5 +1,31 @@
 import { SHA256 as sha256CryptoJS } from 'crypto-js'
-import { bufferToFormData, bufferToString, timingSafeEqual } from './buffer'
+import { bufferToFormData, bufferToString, equal, timingSafeEqual } from './buffer'
+
+describe('equal', () => {
+  it('should return true for identical ArrayBuffers', () => {
+    const buffer1 = new ArrayBuffer(1)
+    const buffer2 = buffer1
+    expect(equal(buffer1, buffer2)).toBe(true)
+  })
+
+  it('should return false for ArrayBuffers of different lengths', () => {
+    const buffer1 = new ArrayBuffer(1)
+    const buffer2 = new ArrayBuffer(2)
+    expect(equal(buffer1, buffer2)).toBe(false)
+  })
+
+  it('should return false for ArrayBuffers with different content', () => {
+    const buffer1 = new Uint8Array([1, 2, 3, 4]).buffer
+    const buffer2 = new Uint8Array([2, 2, 3, 4]).buffer
+    expect(equal(buffer1, buffer2)).toBe(false)
+  })
+
+  it('should return true for ArrayBuffers with identical content', () => {
+    const buffer1 = new Uint8Array([1, 2, 3, 4]).buffer
+    const buffer2 = new Uint8Array([1, 2, 3, 4]).buffer
+    expect(equal(buffer1, buffer2)).toBe(true)
+  })
+})
 
 describe('buffer', () => {
   it('positive', async () => {

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,6 +1,5 @@
 import { SHA256 as sha256CryptoJS } from 'crypto-js'
 import { bufferToFormData, bufferToString, equal, timingSafeEqual } from './buffer'
-import { expect } from 'vitest'
 
 describe('equal', () => {
   it('should return true for identical ArrayBuffers', () => {

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,5 +1,6 @@
 import { SHA256 as sha256CryptoJS } from 'crypto-js'
 import { bufferToFormData, bufferToString, equal, timingSafeEqual } from './buffer'
+import { expect } from 'vitest'
 
 describe('equal', () => {
   it('should return true for identical ArrayBuffers', () => {
@@ -69,6 +70,7 @@ describe('buffer', () => {
     expect(await timingSafeEqual({ a: 1 }, { a: 2 })).toBe(false)
     expect(await timingSafeEqual([1, 2], [1, 2])).toBe(false)
     expect(await timingSafeEqual([1, 2], [1, 2, 3])).toBe(false)
+    expect(await timingSafeEqual('a', 'b', () => undefined)).toBe(false)
   })
 })
 
@@ -77,6 +79,10 @@ describe('bufferToString', () => {
     const bytes = [227, 129, 130, 227, 129, 132, 227, 129, 134, 227, 129, 136, 227, 129, 138]
     const buffer = Uint8Array.from(bytes).buffer
     expect(bufferToString(buffer)).toBe('あいうえお')
+  })
+  it('should return the passed arguments as is ', () => {
+    const notBuffer = 'あいうえお' as unknown as ArrayBuffer
+    expect(bufferToString(notBuffer)).toBe('あいうえお')
   })
 })
 

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -35,8 +35,7 @@ export const timingSafeEqual = async (
     hashFunction = sha256
   }
 
-  const sa = await hashFunction(a)
-  const sb = await hashFunction(b)
+  const [sa, sb] = await Promise.all([hashFunction(a), hashFunction(b)])
 
   if (!sa || !sb) {
     return false


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
