### PR TITLE
perf(utils/buffer): use promise all for better performance

### DIFF
--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -35,8 +35,7 @@ export const timingSafeEqual = async (
     hashFunction = sha256
   }
 
-  const sa = await hashFunction(a)
-  const sb = await hashFunction(b)
+  const [sa, sb] = await Promise.all([hashFunction(a), hashFunction(b)])
 
   if (!sa || !sb) {
     return false


### PR DESCRIPTION
Changed to use Promise.all in the `timignSafeEqual` function to improve performance.

## Measurement Results and Discussion

Here we share benchmark results for `timingSafeEqual` and (using Promise.all) `timingSafeEqual2` .

https://github.com/yasuaki640/timingSafeEqual-bench/actions/runs/9646432337/job/26602824121
(Click on the Run Benchmarks section to see the benchmark results )

We observed a 1.6 ~ 2x performance improvement (except for the last case) for the test cases present in [buffer.test.ts.](https://github.com/honojs/hono/blob/main/src/utils/buffer.test.ts)

The only performance degradation was in the following case

https://github.com/honojs/hono/blob/a9d5313a5a3b23dee963b765bda0a95f7b94bec7/src/utils/buffer.test.ts#L72

(The timingSafeEqual-bench repository has the following measurements)

https://github.com/yasuaki640/timingSafeEqual-bench/blob/ab3f59b0edc28e1607bbea139490023e88cdb2f1/timingSafeEqual.bench.ts#L232-L242

Probably due to the overhead of Promise.all itself.

However, to begin with, the mean execution time of this case is two orders of magnitude smaller than the other cases, and we are passing a (extremely short processing time) test function such as `() => undefined.`

Therefore, we believe that using Promise.all is more beneficial than the degradation of this case, noting the performance improvement in all other cases.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
