### PR TITLE
perf(context): improve initializing `Context`

### DIFF
--- a/runtime_tests/deno/hono.test.ts
+++ b/runtime_tests/deno/hono.test.ts
@@ -1,7 +1,6 @@
 import { Context } from '../../src/context.ts'
 import { env, getRuntimeKey } from '../../src/helper/adapter/index.ts'
 import { Hono } from '../../src/hono.ts'
-import { HonoRequest } from '../../src/request.ts'
 import { assertEquals } from './deps.ts'
 
 // Test just only minimal patterns.

--- a/runtime_tests/deno/hono.test.ts
+++ b/runtime_tests/deno/hono.test.ts
@@ -29,7 +29,7 @@ Deno.test('runtime', () => {
 })
 
 Deno.test('environment variables', () => {
-  const c = new Context(new HonoRequest(new Request('http://localhost/')))
+  const c = new Context(new Request('http://localhost/'))
   const { NAME } = env<{ NAME: string }>(c)
   assertEquals(NAME, 'Deno')
 })

--- a/src/adapter/bun/conninfo.test.ts
+++ b/src/adapter/bun/conninfo.test.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { getConnInfo } from './conninfo'
 
 const createRandomBunServer = () => {
@@ -22,7 +21,7 @@ const createRandomBunServer = () => {
 describe('getConnInfo', () => {
   it('Should info is valid', () => {
     const { port, server, address } = createRandomBunServer()
-    const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: server })
+    const c = new Context(new Request('http://localhost/'), { env: server })
     const info = getConnInfo(c)
 
     expect(info.remote.port).toBe(port)
@@ -32,7 +31,7 @@ describe('getConnInfo', () => {
   })
   it('Should getConnInfo works when env is { server: server }', () => {
     const { port, server, address } = createRandomBunServer()
-    const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: { server } })
+    const c = new Context(new Request('http://localhost/'), { env: { server } })
 
     const info = getConnInfo(c)
 
@@ -42,12 +41,12 @@ describe('getConnInfo', () => {
     expect(info.remote.transport).toBeUndefined()
   })
   it('Should throw error when user did not give server', () => {
-    const c = new Context(new HonoRequest(new Request('http://localhost/')), { env: {} })
+    const c = new Context(new Request('http://localhost/'), { env: {} })
 
     expect(() => getConnInfo(c)).toThrowError(TypeError)
   })
   it('Should throw error when requestIP is not function', () => {
-    const c = new Context(new HonoRequest(new Request('http://localhost/')), {
+    const c = new Context(new Request('http://localhost/'), {
       env: {
         requestIP: 0,
       },

--- a/src/adapter/bun/server.test.ts
+++ b/src/adapter/bun/server.test.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { getBunServer } from './server'
 import type { BunServer } from './server'
 
@@ -7,13 +6,11 @@ describe('getBunServer', () => {
   it('Should success to pick Server', () => {
     const server = {} as BunServer
 
-    expect(
-      getBunServer(new Context(new HonoRequest(new Request('http://localhost/')), { env: server }))
-    ).toBe(server)
-    expect(
-      getBunServer(
-        new Context(new HonoRequest(new Request('http://localhost/')), { env: { server } })
-      )
-    ).toBe(server)
+    expect(getBunServer(new Context(new Request('http://localhost/'), { env: server }))).toBe(
+      server
+    )
+    expect(getBunServer(new Context(new Request('http://localhost/'), { env: { server } }))).toBe(
+      server
+    )
   })
 })

--- a/src/adapter/cloudflare-workers/conninfo.test.ts
+++ b/src/adapter/cloudflare-workers/conninfo.test.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { getConnInfo } from './conninfo'
 
 describe('getConnInfo', () => {
@@ -10,7 +9,7 @@ describe('getConnInfo', () => {
         'cf-connecting-ip': address,
       },
     })
-    const c = new Context(new HonoRequest(req))
+    const c = new Context(req)
 
     const info = getConnInfo(c)
 

--- a/src/adapter/deno/conninfo.test.ts
+++ b/src/adapter/deno/conninfo.test.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { getConnInfo } from './conninfo'
 
 describe('getConnInfo', () => {
@@ -7,7 +6,7 @@ describe('getConnInfo', () => {
     const transport = 'tcp'
     const address = Math.random().toString()
     const port = Math.floor(Math.random() * (65535 + 1))
-    const c = new Context(new HonoRequest(new Request('http://localhost/')), {
+    const c = new Context(new Request('http://localhost/'), {
       env: {
         remoteAddr: {
           transport,

--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -1,6 +1,5 @@
 import { compose } from './compose'
 import { Context } from './context'
-import { HonoRequest } from './request'
 import type { Params } from './router'
 
 type C = {
@@ -88,7 +87,7 @@ describe('compose with returning a promise, non-async function', () => {
 describe('Handler and middlewares', () => {
   const middleware: MiddlewareTuple[] = []
 
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
 
   const mHandlerFoo = async (c: Context, next: Function) => {
@@ -124,7 +123,7 @@ describe('Handler and middlewares', () => {
 describe('compose with Context - 200 success', () => {
   const middleware: MiddlewareTuple[] = []
 
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const handler = (c: Context) => {
     return c.text('Hello')
@@ -148,7 +147,7 @@ describe('compose with Context - 200 success', () => {
 describe('compose with Context - 404 not found', () => {
   const middleware: MiddlewareTuple[] = []
 
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const onNotFound = (c: Context) => {
     return c.text('onNotFound', 404)
   }
@@ -185,7 +184,7 @@ describe('compose with Context - 404 not found', () => {
 describe('compose with Context - 401 not authorized', () => {
   const middleware: MiddlewareTuple[] = []
 
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const handler = (c: Context) => {
     return c.text('Hello')
@@ -211,7 +210,7 @@ describe('compose with Context - 401 not authorized', () => {
 describe('compose with Context - next() below', () => {
   const middleware: MiddlewareTuple[] = []
 
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const handler = (c: Context) => {
     const message = c.req.header('x-custom') || 'blank'
@@ -238,7 +237,7 @@ describe('compose with Context - next() below', () => {
 describe('compose with Context - 500 error', () => {
   const middleware: MiddlewareTuple[] = []
 
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
 
   it('Error on handler', async () => {
@@ -303,7 +302,7 @@ describe('compose with Context - 500 error', () => {
   })
 })
 describe('compose with Context - not finalized', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   const c: Context = new Context(req)
   const onNotFound = (c: Context) => {
     return c.text('onNotFound', 404)

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,9 +1,8 @@
 import { Context } from './context'
 import { setCookie } from './helper/cookie'
-import { HonoRequest } from './request'
 
 describe('Context', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
 
   let c: Context
   beforeEach(() => {
@@ -214,7 +213,7 @@ describe('Context', () => {
   })
 
   it('Should be able read env', async () => {
-    const req = new HonoRequest(new Request('http://localhost/'))
+    const req = new Request('http://localhost/')
     const key = 'a-secret-key'
     const ctx = new Context(req, {
       env: {
@@ -244,7 +243,7 @@ describe('Context', () => {
 })
 
 describe('event and executionCtx', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
 
   it('Should return the event if accessing c.event', () => {
     const respondWith = vi.fn()
@@ -289,7 +288,7 @@ describe('event and executionCtx', () => {
 })
 
 describe('Context header', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)
@@ -357,7 +356,7 @@ describe('Context header', () => {
 })
 
 describe('Pass a ResponseInit to respond methods', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)
@@ -434,7 +433,7 @@ declare module './context' {
 }
 
 describe('c.render', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)

--- a/src/context.ts
+++ b/src/context.ts
@@ -408,7 +408,7 @@ export class Context<
    *
    * @returns The current layout function.
    */
-  getLayout = () => this.#layout
+  getLayout = (): Layout<PropsForRenderer & { Layout: Layout }> | undefined => this.#layout
 
   /**
    * `.setRenderer()` can set the layout in the custom middleware.

--- a/src/helper/streaming/sse.test.ts
+++ b/src/helper/streaming/sse.test.ts
@@ -1,9 +1,8 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { streamSSE } from '.'
 
 describe('SSE Streaming helper', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)

--- a/src/helper/streaming/stream.test.ts
+++ b/src/helper/streaming/stream.test.ts
@@ -3,7 +3,7 @@ import { HonoRequest } from '../../request'
 import { stream } from '.'
 
 describe('Basic Streaming Helper', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)

--- a/src/helper/streaming/stream.test.ts
+++ b/src/helper/streaming/stream.test.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { stream } from '.'
 
 describe('Basic Streaming Helper', () => {

--- a/src/helper/streaming/text.test.ts
+++ b/src/helper/streaming/text.test.ts
@@ -1,9 +1,8 @@
 import { Context } from '../../context'
-import { HonoRequest } from '../../request'
 import { streamText } from '.'
 
 describe('Text Streaming Helper', () => {
-  const req = new HonoRequest(new Request('http://localhost/'))
+  const req = new Request('http://localhost/')
   let c: Context
   beforeEach(() => {
     c = new Context(req)

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -7,7 +7,6 @@
 import { compose } from './compose'
 import { Context } from './context'
 import type { ExecutionContext } from './context'
-import { HonoRequest } from './request'
 import type { Router } from './router'
 import { METHODS, METHOD_NAME_ALL, METHOD_NAME_ALL_LOWERCASE } from './router'
 import type {
@@ -409,7 +408,9 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     const path = this.getPath(request, { env })
     const matchResult = this.matchRoute(method, path)
 
-    const c = new Context(new HonoRequest(request, path, matchResult), {
+    const c = new Context(request, {
+      path,
+      matchResult,
       env,
       executionCtx,
       notFoundHandler: this.notFoundHandler,


### PR DESCRIPTION
This PR improves the performance for initialization of `Context`:

* Delay initialization for variables as long as possible.
* Pass `Request` object instead of `HonoRequest` and make it later if `c.req` is called.
* Some tests have been changed. But I think it is not a problem because `Context` is used in the `hono` package internally, though a type of `Context` is exported.
* It's not related to performance, but use `#` for some private properties.

### Result

With this benchmark code:

```ts
import { bench, group, run } from 'mitata'
import { Hono as HonoNext } from '../../dist/index.js'
import { Hono } from 'hono'

const req = new Request('http://localhost/')
const app = new Hono().get('/', (c) => c.text('Hi'))
const appNext = new HonoNext().get('/', (c) => c.text('Hi'))

bench('noop', () => {})

group(() => {
  bench('4.4.8', async () => {
    await app.fetch(req)
  })
  bench('next', async () => {
    await appNext.fetch(req)
  })
})

run()
```

The performance is improved.

Bun:

```
benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
4.4.8         906 ns/iter     (850 ns … 1'490 ns)    892 ns  1'303 ns  1'490 ns
next          821 ns/iter     (772 ns … 1'145 ns)    822 ns  1'094 ns  1'145 ns

summary
  next
   1.1x faster than 4.4.8
```

Node.js:

```
benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
4.4.8       1'099 ns/iter   (1'012 ns … 2'116 ns)  1'101 ns  1'715 ns  2'116 ns
next        1'055 ns/iter     (987 ns … 1'317 ns)  1'075 ns  1'274 ns  1'317 ns

summary
  next
   1.04x faster than 4.4.8
```

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
