### PR TITLE
fix(types): correct inferring env when routes channing

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1348,11 +1348,12 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
         return c.json(0)
       })
-
     new Hono<Env>()
       .get('/', mw1, mw2, (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
@@ -1366,13 +1367,16 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
         return c.json(0)
       })
-
     new Hono<Env>()
       .get('/', mw1, mw2, mw3, (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
@@ -1388,15 +1392,20 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
         return c.json(0)
       })
-
     new Hono<Env>()
       .get('/', mw1, mw2, mw3, mw4, (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
@@ -1414,13 +1423,21 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
+        // @ts-expect-error foo4 is not typed
         c.get('foo4')
+        // @ts-expect-error foo4 is not typed
         c.var.foo4
         return c.json(0)
       })
@@ -1444,19 +1461,28 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
+        // @ts-expect-error foo4 is not typed
         c.get('foo4')
+        // @ts-expect-error foo4 is not typed
         c.var.foo4
+        // @ts-expect-error foo5 is not typed
         c.get('foo5')
+        // @ts-expect-error foo5 is not typed
         c.var.foo5
         return c.json(0)
       })
-
     new Hono<Env>()
       .get('/', mw1, mw2, mw3, mw4, mw5, mw6, (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
@@ -1478,22 +1504,32 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
+        // @ts-expect-error foo4 is not typed
         c.get('foo4')
+        // @ts-expect-error foo4 is not typed
         c.var.foo4
+        // @ts-expect-error foo5 is not typed
         c.get('foo5')
+        // @ts-expect-error foo5 is not typed
         c.var.foo5
+        // @ts-expect-error foo6 is not typed
         c.get('foo6')
-
+        // @ts-expect-error foo6 is not typed
         c.var.foo6
         return c.json(0)
       })
-
     new Hono<Env>()
       .get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7, (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
@@ -1517,23 +1553,36 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
+        // @ts-expect-error foo4 is not typed
         c.get('foo4')
+        // @ts-expect-error foo4 is not typed
         c.var.foo4
+        // @ts-expect-error foo5 is not typed
         c.get('foo5')
+        // @ts-expect-error foo5 is not typed
         c.var.foo5
+        // @ts-expect-error foo6 is not typed
         c.get('foo6')
+        // @ts-expect-error foo6 is not typed
         c.var.foo6
+        // @ts-expect-error foo7 is not typed
         c.get('foo7')
+        // @ts-expect-error foo7 is not typed
         c.var.foo7
         return c.json(0)
       })
-
     new Hono<Env>()
       .get('/', mw1, mw2, mw3, mw4, mw5, mw6, mw7, mw8, (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
@@ -1559,21 +1608,37 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
+        // @ts-expect-error foo4 is not typed
         c.get('foo4')
+        // @ts-expect-error foo4 is not typed
         c.var.foo4
+        // @ts-expect-error foo5 is not typed
         c.get('foo5')
+        // @ts-expect-error foo5 is not typed
         c.var.foo5
+        // @ts-expect-error foo6 is not typed
         c.get('foo6')
+        // @ts-expect-error foo6 is not typed
         c.var.foo6
+        // @ts-expect-error foo7 is not typed
         c.get('foo7')
+        // @ts-expect-error foo7 is not typed
         c.var.foo7
+        // @ts-expect-error foo8 is not typed
         c.get('foo8')
+        // @ts-expect-error foo8 is not typed
         c.var.foo8
         return c.json(0)
       })
@@ -1605,23 +1670,41 @@ describe('c.var with chaining - test only types', () => {
       .get('/', (c) => {
         expectTypeOf(c.get('init')).toEqualTypeOf<number>()
         expectTypeOf(c.var.init).toEqualTypeOf<number>()
+        // @ts-expect-error foo1 is not typed
         c.get('foo1')
+        // @ts-expect-error foo1 is not typed
         c.var.foo1
+        // @ts-expect-error foo2 is not typed
         c.get('foo2')
+        // @ts-expect-error foo2 is not typed
         c.var.foo2
+        // @ts-expect-error foo3 is not typed
         c.get('foo3')
+        // @ts-expect-error foo3 is not typed
         c.var.foo3
+        // @ts-expect-error foo4 is not typed
         c.get('foo4')
+        // @ts-expect-error foo4 is not typed
         c.var.foo4
+        // @ts-expect-error foo5 is not typed
         c.get('foo5')
+        // @ts-expect-error foo5 is not typed
         c.var.foo5
+        // @ts-expect-error foo6 is not typed
         c.get('foo6')
+        // @ts-expect-error foo6 is not typed
         c.var.foo6
+        // @ts-expect-error foo7 is not typed
         c.get('foo7')
+        // @ts-expect-error foo7 is not typed
         c.var.foo7
+        // @ts-expect-error foo8 is not typed
         c.get('foo8')
+        // @ts-expect-error foo8 is not typed
         c.var.foo8
+        // @ts-expect-error foo9 is not typed
         c.get('foo9')
+        // @ts-expect-error foo9 is not typed
         c.var.foo9
         return c.json(0)
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,11 +131,7 @@ export interface HandlerInterface<
   >(
     path: P,
     handler: H<E2, MergedPath, I, R>
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x2)
   <
@@ -165,11 +161,7 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 3)
   <
@@ -203,11 +195,7 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 4)
   <
@@ -250,11 +238,7 @@ export interface HandlerInterface<
       H<E4, MergedPath, I3>,
       H<E5, MergedPath, I4, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 5)
   <
@@ -302,11 +286,7 @@ export interface HandlerInterface<
       H<E5, MergedPath, I4>,
       H<E6, MergedPath, I5, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 6)
   <
@@ -366,11 +346,7 @@ export interface HandlerInterface<
       H<E6, MergedPath, I5>,
       H<E7, MergedPath, I6, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 7)
   <
@@ -436,11 +412,7 @@ export interface HandlerInterface<
       H<E7, MergedPath, I6>,
       H<E8, MergedPath, I7, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 8)
   <
@@ -512,11 +484,7 @@ export interface HandlerInterface<
       H<E8, MergedPath, I7>,
       H<E9, MergedPath, I8, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 9)
   <
@@ -594,11 +562,7 @@ export interface HandlerInterface<
       H<E9, MergedPath, I8>,
       H<E10, MergedPath, I9, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 10)
   <
@@ -682,11 +646,7 @@ export interface HandlerInterface<
       H<E10, MergedPath, I9>,
       H<E11, MergedPath, I10, R>
     ]
-  ): Hono<
-    IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>, BasePath>
 
   // app.get(...handlers[])
   <


### PR DESCRIPTION
Fixes the regression bug (#2046) caused by #2412

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
