### PR TITLE
fix(client): set Path as the default of Original

### DIFF
--- a/src/client/types.test.ts
+++ b/src/client/types.test.ts
@@ -23,3 +23,37 @@ describe('WebSockets', () => {
     >().toEqualTypeOf(true)
   })
 })
+
+describe('without the leading slash', () => {
+  const app = new Hono()
+    .get('foo', (c) => c.json({}))
+    .get('foo/bar', (c) => c.json({}))
+    .get('foo/:id/baz', (c) => c.json({}))
+  const client = hc<typeof app>('')
+  it('`foo` should have `$get`', () => {
+    expectTypeOf(client.foo).toHaveProperty('$get')
+  })
+  it('`foo.bar` should not have `$get`', () => {
+    expectTypeOf(client.foo.bar).toHaveProperty('$get')
+  })
+  it('`foo[":id"].baz` should have `$get`', () => {
+    expectTypeOf(client.foo[':id'].baz).toHaveProperty('$get')
+  })
+})
+
+describe('with the leading slash', () => {
+  const app = new Hono()
+    .get('/foo', (c) => c.json({}))
+    .get('/foo/bar', (c) => c.json({}))
+    .get('/foo/:id/baz', (c) => c.json({}))
+  const client = hc<typeof app>('')
+  it('`foo` should have `$get`', () => {
+    expectTypeOf(client.foo).toHaveProperty('$get')
+  })
+  it('`foo.bar` should not have `$get`', () => {
+    expectTypeOf(client.foo.bar).toHaveProperty('$get')
+  })
+  it('`foo[":id"].baz` should have `$get`', () => {
+    expectTypeOf(client.foo[':id'].baz).toHaveProperty('$get')
+  })
+})

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -146,7 +146,7 @@ export type InferRequestOptionsType<T> = T extends (
 type PathToChain<
   Path extends string,
   E extends Schema,
-  Original extends string = ''
+  Original extends string = Path
 > = Path extends `/${infer P}`
   ? PathToChain<P, E, Path>
   : Path extends `${infer P}/${infer R}`


### PR DESCRIPTION
Routings without the leading slash like `app.get('foo', ...)` works well, but it seems like `hc` fails to extract its type correctly.
You can't access `hc<typeof app>('/').foo.$get`, which works on runtime though.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] ~Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code~ not needed, I guess
