### PR TITLE
refactor: remove unnecessary async keyword from router tests

### DIFF
--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -27,7 +27,7 @@ describe('LinearRouter', () => {
         router.add('GET', '/entry/:id/:action', 'action')
       })
 
-      it('GET /entry/123/show', async () => {
+      it('GET /entry/123/show', () => {
         expect(() => {
           router.match('GET', '/entry/123/show')
         }).toThrowError(UnsupportedPathError)

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -23,7 +23,7 @@ describe('RegExpRouter', () => {
   })
 
   describe('Return value type', () => {
-    it('Should return [[T, ParamIndexMap][], ParamStash]', async () => {
+    it('Should return [[T, ParamIndexMap][], ParamStash]', () => {
       const router = new RegExpRouter<string>()
       router.add('GET', '/posts/:id', 'get post')
 
@@ -42,7 +42,7 @@ describe('RegExpRouter', () => {
       router.add('GET', '/entry/:name', 'get entry')
       router.add('POST', '/entry', 'create entry')
 
-      it('GET /entry/entries', async () => {
+      it('GET /entry/entries', () => {
         expect(() => {
           router.match('GET', '/entry/entries')
         }).toThrowError(UnsupportedPathError)
@@ -56,7 +56,7 @@ describe('RegExpRouter', () => {
       router.add('GET', '/:class/:id', ':class')
       router.add('GET', '/:model/:id', ':model')
 
-      it('GET /entry/123', async () => {
+      it('GET /entry/123', () => {
         expect(() => {
           router.match('GET', '/entry/123')
         }).toThrowError(UnsupportedPathError)


### PR DESCRIPTION
I was looking at the router tests and removed an async keyword that I thought was unnecessary.
I apologize if this was intended in any way.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
