### PR TITLE
feat: Introduce Service Worker Adapter

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -5,7 +5,8 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "deno.ns"
+      "deno.ns",
+      "webworker"
     ]
   },
   "unstable": [

--- a/jsr.json
+++ b/jsr.json
@@ -69,6 +69,7 @@
     "./vercel": "./src/adapter/vercel/index.ts",
     "./netlify": "./src/adapter/netlify/index.ts",
     "./lambda-edge": "./src/adapter/lambda-edge/index.ts",
+    "./service-worker": "./src/adapter/service-worker/index.ts",
     "./testing": "./src/helper/testing/index.ts",
     "./dev": "./src/helper/dev/index.ts",
     "./ws": "./src/helper/websocket/index.ts",

--- a/jsr.json
+++ b/jsr.json
@@ -5,8 +5,7 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "deno.ns",
-      "webworker"
+      "deno.ns"
     ]
   },
   "unstable": [

--- a/package.json
+++ b/package.json
@@ -333,6 +333,11 @@
       "import": "./dist/adapter/lambda-edge/index.js",
       "require": "./dist/cjs/adapter/lambda-edge/index.js"
     },
+    "./service-worker": {
+      "types": "./dist/types/adapter/service-worker/index.d.ts",
+      "import": "./dist/adapter/service-worker/index.js",
+      "require": "./dist/cjs/adapter/service-worker/index.js"
+    },
     "./testing": {
       "types": "./dist/types/helper/testing/index.d.ts",
       "import": "./dist/helper/testing/index.js",
@@ -526,6 +531,9 @@
       ],
       "lambda-edge": [
         "./dist/types/adapter/lambda-edge"
+      ],
+      "service-worker": [
+        "./dist/types/adapter/service-worker"
       ],
       "testing": [
         "./dist/types/helper/testing"

--- a/src/adapter/service-worker/handler.test.ts
+++ b/src/adapter/service-worker/handler.test.ts
@@ -38,10 +38,10 @@ describe('handle', () => {
   })
   it('Fallback 404 when app does not response Promise', async () => {
     const app = new Hono()
-    app.get('/', c => c.text('Not found', 404))
+    app.get('/', (c) => c.text('Not found', 404))
     const handler = handle(app)
     const result = handler({
-      request: new Request('https://localhost/')
+      request: new Request('https://localhost/'),
     } as FetchEventLike)
 
     expect(result).toBeUndefined()

--- a/src/adapter/service-worker/handler.test.ts
+++ b/src/adapter/service-worker/handler.test.ts
@@ -1,5 +1,4 @@
 import { Hono } from '../../hono'
-import type { FetchEventLike } from '../../types'
 import { handle } from './handler'
 
 describe('handle', () => {

--- a/src/adapter/service-worker/handler.test.ts
+++ b/src/adapter/service-worker/handler.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from '../../hono'
 import { handle } from './handler'
+import type { FetchEvent } from './types'
 
 describe('handle', () => {
   it('Success to fetch', async () => {

--- a/src/adapter/service-worker/handler.test.ts
+++ b/src/adapter/service-worker/handler.test.ts
@@ -15,7 +15,7 @@ describe('handle', () => {
         respondWith(res) {
           resolve(res)
         },
-      } as FetchEventLike)
+      } as FetchEvent)
     }).then((res) => res.json())
     expect(json).toStrictEqual({ hello: 'world' })
   })
@@ -32,18 +32,26 @@ describe('handle', () => {
         respondWith(res) {
           resolve(res)
         },
-      } as FetchEventLike)
+      } as FetchEvent)
     }).then((res) => res.text())
     expect(text).toBe('hello world')
   })
-  it('Fallback 404 when app does not response Promise', async () => {
+  it('Do not fallback 404 when fetch is undefined', async () => {
     const app = new Hono()
     app.get('/', (c) => c.text('Not found', 404))
-    const handler = handle(app)
-    const result = handler({
-      request: new Request('https://localhost/'),
-    } as FetchEventLike)
+    const handler = handle(app, {
+      fetch: undefined,
+    })
+    const result = await new Promise<Response>((resolve) =>
+      handler({
+        request: new Request('https://localhost/'),
+        respondWith(r) {
+          resolve(r)
+        },
+      } as FetchEvent)
+    )
 
-    expect(result).toBeUndefined()
+    expect(result.status).toBe(404)
+    expect(await result.text()).toBe('Not found')
   })
 })

--- a/src/adapter/service-worker/handler.test.ts
+++ b/src/adapter/service-worker/handler.test.ts
@@ -36,4 +36,14 @@ describe('handle', () => {
     }).then((res) => res.text())
     expect(text).toBe('hello world')
   })
+  it('Fallback 404 when app does not response Promise', async () => {
+    const app = new Hono()
+    app.get('/', c => c.text('Not found', 404))
+    const handler = handle(app)
+    const result = handler({
+      request: new Request('https://localhost/')
+    } as FetchEventLike)
+
+    expect(result).toBeUndefined()
+  })
 })

--- a/src/adapter/service-worker/handler.test.ts
+++ b/src/adapter/service-worker/handler.test.ts
@@ -1,0 +1,39 @@
+import { Hono } from '../../hono'
+import type { FetchEventLike } from '../../types'
+import { handle } from './handler'
+
+describe('handle', () => {
+  it('Success to fetch', async () => {
+    const app = new Hono()
+    app.get('/', (c) => {
+      return c.json({ hello: 'world' })
+    })
+    const handler = handle(app)
+    const json = await new Promise<Response>((resolve) => {
+      handler({
+        request: new Request('http://localhost/'),
+        respondWith(res) {
+          resolve(res)
+        },
+      } as FetchEventLike)
+    }).then((res) => res.json())
+    expect(json).toStrictEqual({ hello: 'world' })
+  })
+  it('Fallback 404', async () => {
+    const app = new Hono()
+    const handler = handle(app, {
+      async fetch() {
+        return new Response('hello world')
+      },
+    })
+    const text = await new Promise<Response>((resolve) => {
+      handler({
+        request: new Request('http://localhost/'),
+        respondWith(res) {
+          resolve(res)
+        },
+      } as FetchEventLike)
+    }).then((res) => res.text())
+    expect(text).toBe('hello world')
+  })
+})

--- a/src/adapter/service-worker/handler.ts
+++ b/src/adapter/service-worker/handler.ts
@@ -1,0 +1,37 @@
+/**
+ * Handler for Service Worker
+ * @module
+ */
+
+import type { Hono } from '../../hono'
+import type { FetchEventLike } from '../../types'
+
+type Handler = (evt: FetchEventLike) => void
+
+/**
+ * Adapter for Service Worker
+ */
+export const handle = (
+  app: Hono,
+  opts: {
+    fetch: (req: Request) => Promise<Response>
+  } = {
+    fetch: fetch,
+  }
+): Handler => {
+  return (evt) => {
+    const fetched = app.fetch(evt.request)
+    if (fetched instanceof Response && fetched.status === 404) {
+      return
+    }
+    evt.respondWith(
+      (async () => {
+        const res = await fetched
+        if (res.status === 404) {
+          return await opts.fetch(evt.request)
+        }
+        return res
+      })()
+    )
+  }
+}

--- a/src/adapter/service-worker/handler.ts
+++ b/src/adapter/service-worker/handler.ts
@@ -3,8 +3,6 @@
  * @module
  */
 
-/// <reference lib="webworker" />
-
 import type { Hono } from '../../hono'
 
 type Handler = (evt: FetchEvent) => void

--- a/src/adapter/service-worker/handler.ts
+++ b/src/adapter/service-worker/handler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Hono } from '../../hono'
+import type { FetchEvent } from './types'
 
 type Handler = (evt: FetchEvent) => void
 

--- a/src/adapter/service-worker/index.ts
+++ b/src/adapter/service-worker/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Cloudflare Workers Adapter for Hono.
+ * @module
+ */
+export { handle } from './handler'

--- a/src/adapter/service-worker/types.ts
+++ b/src/adapter/service-worker/types.ts
@@ -1,0 +1,14 @@
+interface ExtendableEvent extends Event {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  waitUntil(f: Promise<any>): void
+}
+
+export interface FetchEvent extends ExtendableEvent {
+  readonly clientId: string
+  readonly handled: Promise<undefined>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly preloadResponse: Promise<any>
+  readonly request: Request
+  readonly resultingClientId: string
+  respondWith(r: Response | PromiseLike<Response>): void
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["webworker"],
     "target": "ES2022",
     "declaration": true,
     "moduleResolution": "Bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "lib": ["webworker"],
     "target": "ES2022",
     "declaration": true,
     "moduleResolution": "Bundler",


### PR DESCRIPTION
I added adapter for Service Worker on browser.

I think that Hono is good for creating Service Worker.

In the PR, you can write code like that:
```ts
import { Hono } from 'hono'
import { handle } from 'hono/service-worker'

const app = new Hono()
app.get('/', c => c.text('Hello World'))

self.addEventListener('fetch', handle(app))
```

When app responses 404, adapter fetches the original server.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
