### PR TITLE
fix(client): Add Query Parameter Support to WebSocket Client in `hono/client`

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1050,7 +1050,6 @@ describe('WebSocket URL Protocol Translation with Query Parameters', () => {
     '/',
     upgradeWebSocket((c) => ({
       onMessage(event, ws) {
-        console.log(`Message from client: ${event.data}`)
         ws.send('Hello from server!')
       },
       onClose: () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -178,12 +178,16 @@ export const hc = <T extends Hono<any, any, any>>(
       return new URL(url)
     }
     if (method === 'ws') {
-      const targetUrl = replaceUrlProtocol(
+      const webSocketUrl = replaceUrlProtocol(
         opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
         'ws'
       )
+      const targetUrl = new URL(webSocketUrl)
+      for (const key in opts.args[0]?.query) {
+        targetUrl.searchParams.set(key, opts.args[0].query[key])
+      }
 
-      return new WebSocket(targetUrl)
+      return new WebSocket(targetUrl.toString())
     }
 
     const req = new ClientRequestImpl(url, method)


### PR DESCRIPTION
This pull request adds support for query parameters to the WebSocket client in `hono/client`. The enhancement allows the WebSocket client to include query parameters in the URL, enabling more dynamic and flexible WebSocket connections.

#### Key Changes:
- **Query Parameter Handling**: The WebSocket client can now accept and append query parameters to the WebSocket URL, allowing for more versatile and customized WebSocket connections.

#### Updated Code:
```typescript
if (method === 'ws') {
  const webSocketUrl = replaceUrlProtocol(
    opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
    'ws'
  );
  const targetUrl = new URL(webSocketUrl);
  for (const key in opts.args[0].query) {
    targetUrl.searchParams.set(key, opts.args[0].query[key]);
  }
  return new WebSocket(targetUrl.toString());
}
```

#### Motivation:
This change was motivated by the need to allow the WebSocket client to handle query parameters, providing greater flexibility for developers to customize WebSocket connections based on specific requirements.

#### Impact:
The added functionality has been tested to ensure that query parameters are correctly appended to the WebSocket URL, enhancing the WebSocket client's capabilities in `hono/client`.

These updates will improve the usability of the WebSocket client in `hono/client`, making it more adaptable to various networking needs by supporting query parameters in WebSocket URLs.


### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [X] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
