### PR TITLE
fix(validator): don't return a FormData if formData is cached

### DIFF
--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -948,6 +948,7 @@ describe('Clone Request object', () => {
       })
       const res = await app.request(req)
       expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ foo: 'bar' })
     })
   })
 })

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -917,9 +917,8 @@ describe('Clone Request object', () => {
         await next()
       },
       validator('form', (value) => {
-        // the value should not be a FormData
         if (value instanceof FormData) {
-          throw new Error('value should be FormData')
+          throw new Error('The value should not be a FormData')
         }
         return value
       }),


### PR DESCRIPTION
Fixes #3039

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
