### PR TITLE
test(helper/dev): fix typo of test case name

### DIFF
--- a/src/helper/dev/index.test.ts
+++ b/src/helper/dev/index.test.ts
@@ -171,7 +171,7 @@ describe('showRoutes() in NO_COLOR', () => {
   })
 })
 
-describe('geRouterName()', () => {
+describe('getRouterName()', () => {
   it('Should return the correct router name', async () => {
     const app = new Hono({
       router: new RegExpRouter(),


### PR DESCRIPTION
I found a typo in the test case.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
