### PR TITLE
feat(types): improve JSONParsed

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -11,7 +11,13 @@ import type {
 } from './types'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { RedirectStatusCode, StatusCode } from './utils/http-status'
-import type { IsAny, JSONParsed, JSONValue, SimplifyDeepArray } from './utils/types'
+import type {
+  InvalidJSONValue,
+  IsAny,
+  JSONParsed,
+  JSONValue,
+  SimplifyDeepArray,
+} from './utils/types'
 
 type HeaderRecord = Record<string, string | string[]>
 
@@ -142,12 +148,18 @@ interface TextRespond {
  * @returns {JSONRespondReturn<T, U>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
 interface JSONRespond {
-  <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode = StatusCode>(
+  <
+    T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
+    U extends StatusCode = StatusCode
+  >(
     object: T,
     status?: U,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U>
-  <T extends JSONValue | SimplifyDeepArray<unknown>, U extends StatusCode = StatusCode>(
+  <
+    T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
+    U extends StatusCode = StatusCode
+  >(
     object: T,
     init?: ResponseInit
   ): JSONRespondReturn<T, U>
@@ -160,7 +172,7 @@ interface JSONRespond {
  * @returns {Response & TypedResponse<SimplifyDeepArray<T> extends JSONValue ? (JSONValue extends SimplifyDeepArray<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
 type JSONRespondReturn<
-  T extends JSONValue | SimplifyDeepArray<unknown>,
+  T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
   U extends StatusCode
 > = Response &
   TypedResponse<
@@ -168,7 +180,7 @@ type JSONRespondReturn<
       ? JSONValue extends SimplifyDeepArray<T>
         ? never
         : JSONParsed<T>
-      : never,
+      : JSONParsed<T>,
     U,
     'json'
   >
@@ -692,7 +704,7 @@ export class Context<
    * ```
    */
   json: JSONRespond = <
-    T extends JSONValue | SimplifyDeepArray<unknown>,
+    T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
     U extends StatusCode = StatusCode
   >(
     object: T,

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -375,7 +375,7 @@ describe('Support c.json(undefined)', () => {
       '/this/is/a/test': {
         $get: {
           input: {}
-          output: undefined
+          output: never
           outputFormat: 'json'
           status: StatusCode
         }
@@ -528,7 +528,7 @@ describe('Path parameters', () => {
       type Output = T['/api/:a/:b?']['$get']['output']
       type Expected = {
         a: string
-        b: string | undefined
+        b?: string | undefined
       }
       type verify = Expect<Equal<Expected, Output>>
     })

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -528,7 +528,7 @@ describe('Path parameters', () => {
       type Output = T['/api/:a/:b?']['$get']['output']
       type Expected = {
         a: string
-        b?: string | undefined
+        b: string | undefined
       }
       type verify = Expect<Equal<Expected, Output>>
     })

--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -137,9 +137,14 @@ describe('JSONParsed', () => {
       type Expected = { a: number }
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
-    it('should convert T | undefined to optional', () => {
+    it('should convert T | undefined to T | undefined', () => {
       type Actual = JSONParsed<{ a: number; b: number | undefined }>
-      type Expected = { a: number; b?: number | undefined }
+      type Expected = { a: number; b: number | undefined }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should omit keys with invalid union', () => {
+      type Actual = JSONParsed<{ a: number; b: undefined | symbol }>
+      type Expected = { a: number }
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
   })

--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -21,6 +21,142 @@ describe('JSONParsed', () => {
     someMeta: Meta
   }
 
+  describe('primitives', () => {
+    it('should convert number type to number', () => {
+      type Actual = JSONParsed<number>
+      type Expected = number
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert string type to string', () => {
+      type Actual = JSONParsed<string>
+      type Expected = string
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert boolean type to boolean', () => {
+      type Actual = JSONParsed<boolean>
+      type Expected = boolean
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert null type to null', () => {
+      type Actual = JSONParsed<null>
+      type Expected = null
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
+  describe('toJSON', () => {
+    it('should convert { toJSON() => T } to T', () => {
+      type Actual = JSONParsed<{ toJSON(): number }>
+      type Expected = number
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('toJSON is not called recursively', () => {
+      type Actual = JSONParsed<{ toJSON(): { toJSON(): number } }>
+      type Expected = {}
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert { a: { toJSON() => T } } to { a: T }', () => {
+      type Actual = JSONParsed<{ a: { toJSON(): number } }>
+      type Expected = { a: number }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
+  describe('invalid types', () => {
+    it('should convert undefined type to never', () => {
+      type Actual = JSONParsed<undefined>
+      type Expected = never
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert symbol type to never', () => {
+      type Actual = JSONParsed<symbol>
+      type Expected = never
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert function type to never', () => {
+      type Actual = JSONParsed<() => void>
+      type Expected = never
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
+  describe('array', () => {
+    it('should convert undefined[] type to null[]', () => {
+      type Actual = JSONParsed<undefined[]>
+      type Expected = null[]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert Function[] type to null[]', () => {
+      type Actual = JSONParsed<(() => void)[]>
+      type Expected = null[]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert symbol[] type to null[]', () => {
+      type Actual = JSONParsed<symbol[]>
+      type Expected = null[]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert (T | undefined)[] type to JSONParsedT | null>[]', () => {
+      type Actual = JSONParsed<(number | undefined)[]>
+      type Expected = (number | null)[]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
+  describe('tuple', () => {
+    it('should convert [T, S] type to [T, S]', () => {
+      type Actual = JSONParsed<[number, string]>
+      type Expected = [number, string]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert [T, undefined] type to [T, null]', () => {
+      type Actual = JSONParsed<[number, undefined]>
+      type Expected = [number, null]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
+  describe('object', () => {
+    it('should omit keys with undefined value', () => {
+      type Actual = JSONParsed<{ a: number; b: undefined }>
+      type Expected = { a: number }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should omit keys with symbol value', () => {
+      type Actual = JSONParsed<{ a: number; b: symbol }>
+      type Expected = { a: number }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should omit keys with function value', () => {
+      type Actual = JSONParsed<{ a: number; b: () => void }>
+      type Expected = { a: number }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should omit symbol keys', () => {
+      type Actual = JSONParsed<{ a: number; [x: symbol]: number }>
+      type Expected = { a: number }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert T | undefined to optional', () => {
+      type Actual = JSONParsed<{ a: number; b: number | undefined }>
+      type Expected = { a: number; b?: number | undefined }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
+  describe('Set/Map', () => {
+    it('should convert Set to empty object', () => {
+      type Actual = JSONParsed<Set<number>>
+      type Expected = {}
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert Map to empty object', () => {
+      type Actual = JSONParsed<Map<number, number>>
+      type Expected = {}
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
   it('Should parse a complex type', () => {
     const sample: JSONParsed<SampleType> = {
       someMeta: {


### PR DESCRIPTION
I've improved `JSONParsed` in order to follow the spec of `JSON.stringify` as much as possible.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description

Here is major improvement:
- support tuple type
- handle undefined, symbol, and function type correctly(in array or object). For example
  - convert undefined to null in an array
  - drop keys whose value is undefined 

You can see some actual behaviour in [TS playground](https://www.typescriptlang.org/play/?#code/MYewdgziA2CmB00QHMAUByAZgVzMALgJbgBc6ANAAQBSAygPIBy8E+AToWMoZgJ6qoAlJQC8APkoBvAL6DhAenmVcAE1iZOsFQChQkGAiRp0EXgFsARjDJU6TFu07c+qWuavR4mEG1QAiCD85BSVVdU0dPSg4RBQMU0sYSgBrWF4AbRALACtYAgBdChoGZlYOLh5+SUp0t0TPb18AoPySSgBGWRDKPxk-XXBowzj0MI0wLUycvPxC2xKHcucqygBDNrGIyi7KRR6+gf0Yo3j3JIA3VehsWCncgqK7UscKl2r1yjqPLx9-QMEdntetJ+lEDLFjDg8ERwJRLtdbll7rNHgsyk5Kqh3m0hKIJDJAUpgaDBuCTqMwGpxpNVmw2KteHNivZ0a9+OlNhMVPk5LsiekwNhoNB8iSjsNjAkPOlafTGaiWS9lqhamcGr9moIed0-AKhSKxUMIRgoQRiGAZXSGUynosMS50rjxFJpNq+T09cLRYcjeSJqwtJR8CAngrnktMZJg08ccJnVigyGSrG8R1tsJCfsQUA)

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
