### PR TITLE
feat(adapter/node): add conninfo adapter for Node.js

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -65,6 +65,7 @@
     "./cloudflare-pages": "./src/adapter/cloudflare-pages/index.ts",
     "./deno": "./src/adapter/deno/index.ts",
     "./bun": "./src/adapter/bun/index.ts",
+    "./node": "./src/adapter/node/index.ts",
     "./aws-lambda": "./src/adapter/aws-lambda/index.ts",
     "./vercel": "./src/adapter/vercel/index.ts",
     "./netlify": "./src/adapter/netlify/index.ts",

--- a/package.json
+++ b/package.json
@@ -313,6 +313,11 @@
       "import": "./dist/adapter/bun/index.js",
       "require": "./dist/cjs/adapter/bun/index.js"
     },
+    "./node": {
+      "types": "./dist/types/adapter/node/index.d.ts",
+      "import": "./dist/adapter/node/index.js",
+      "require": "./dist/cjs/adapter/node/index.js"
+    },
     "./aws-lambda": {
       "types": "./dist/types/adapter/aws-lambda/index.d.ts",
       "import": "./dist/adapter/aws-lambda/index.js",
@@ -514,6 +519,9 @@
       ],
       "bun": [
         "./dist/types/adapter/bun"
+      ],
+      "node": [
+        "./dist/types/adapter/node"
       ],
       "nextjs": [
         "./dist/types/adapter/nextjs"

--- a/src/adapter/node/conninfo.ts
+++ b/src/adapter/node/conninfo.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from 'node:http'
-import type { GetConnInfo, AddressType } from '../../helper/conninfo'
+import type { AddressType, GetConnInfo } from '../../helper/conninfo'
 
 /**
  * Get conninfo with Node.js

--- a/src/adapter/node/conninfo.ts
+++ b/src/adapter/node/conninfo.ts
@@ -1,0 +1,22 @@
+import type { IncomingMessage } from 'node:http'
+import type { GetConnInfo, AddressType } from '../../helper/conninfo'
+
+/**
+ * Get conninfo with Node.js
+ * Assuming @hono/node-server, but if incoming is in c.env, it will work correctly on other servers.
+ * @param c Context
+ * @returns ConnInfo
+ */
+export const getConnInfo: GetConnInfo = (c) => {
+  const { incoming } = c.env as { incoming: IncomingMessage }
+  if (!incoming?.socket) {
+    throw new Error('No socket available')
+  }
+  return {
+    remote: {
+      address: incoming.socket.remoteAddress,
+      port: incoming.socket.remotePort,
+      addressType: incoming.socket.remoteFamily as AddressType,
+    },
+  }
+}

--- a/src/adapter/node/index.test.ts
+++ b/src/adapter/node/index.test.ts
@@ -1,4 +1,4 @@
-import { getConnInfo } from './conninfo'
+import { getConnInfo } from '.'
 
 describe('ConnInfo', () => {
   it('Should be re-exported', () => {

--- a/src/adapter/node/index.test.ts
+++ b/src/adapter/node/index.test.ts
@@ -1,0 +1,7 @@
+import { getConnInfo } from './conninfo'
+
+describe('ConnInfo', () => {
+  it('Should be re-exported', () => {
+    expect(getConnInfo).toBeDefined()
+  })
+})

--- a/src/adapter/node/index.ts
+++ b/src/adapter/node/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @module
+ * @hono/node-server Adapter for Hono.
+ */
+
+export { getConnInfo } from './conninfo'


### PR DESCRIPTION
Since "@hono/node-server" is assumed, the name "adapter/node" may or may not be appropriate, but "adapter/node-server" would also be confusing, so I boldly chose "adapter/node".

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
