### PR TITLE
fix(stream): Fixed a problem that onAbort() is called even if request is normally closed in deno

### DIFF
--- a/runtime_tests/bun/index.test.tsx
+++ b/runtime_tests/bun/index.test.tsx
@@ -333,6 +333,14 @@ describe('streaming', () => {
       })
     })
   })
+  app.get('/streamHello', (c) => {
+    return stream(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.write('Hello')
+    })
+  })
   app.get('/streamSSE', (c) => {
     return streamSSE(c, async (stream) => {
       stream.onAbort(() => {
@@ -341,6 +349,14 @@ describe('streaming', () => {
       return new Promise<void>((resolve) => {
         stream.onAbort(resolve)
       })
+    })
+  })
+  app.get('/streamSSEHello', (c) => {
+    return streamSSE(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.write('Hello')
     })
   })
 
@@ -369,6 +385,13 @@ describe('streaming', () => {
       }
       expect(aborted).toBe(true)
     })
+
+    it('Should not be called onAbort if already closed', async () => {
+      expect(aborted).toBe(false)
+      const res = await fetch(`http://localhost:${server.port}/streamHello`)
+      expect(await res.text()).toBe('Hello')
+      expect(aborted).toBe(false)
+    })
   })
 
   describe('streamSSE', () => {
@@ -385,6 +408,13 @@ describe('streaming', () => {
         await new Promise((resolve) => setTimeout(resolve))
       }
       expect(aborted).toBe(true)
+    })
+
+    it('Should not be called onAbort if already closed', async () => {
+      expect(aborted).toBe(false)
+      const res = await fetch(`http://localhost:${server.port}/streamSSEHello`)
+      expect(await res.text()).toBe('Hello')
+      expect(aborted).toBe(false)
     })
   })
 })

--- a/runtime_tests/deno/stream.test.ts
+++ b/runtime_tests/deno/stream.test.ts
@@ -35,6 +35,26 @@ Deno.test('Shuld call onAbort via stream', async () => {
   await server.shutdown()
 })
 
+Deno.test('Shuld not call onAbort via stream if already closed', async () => {
+  const app = new Hono()
+  let aborted = false
+  app.get('/stream', (c) => {
+    return stream(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.write('Hello')
+    })
+  })
+
+  const server = Deno.serve({ port: 0 }, app.fetch)
+  assertEquals(aborted, false)
+  const res = await fetch(`http://localhost:${server.addr.port}/stream`)
+  assertEquals(await res.text(), 'Hello')
+  assertEquals(aborted, false)
+  await server.shutdown()
+})
+
 Deno.test('Shuld call onAbort via streamSSE', async () => {
   const app = new Hono()
   let aborted = false
@@ -65,5 +85,25 @@ Deno.test('Shuld call onAbort via streamSSE', async () => {
   }
   assertEquals(aborted, true)
 
+  await server.shutdown()
+})
+
+Deno.test('Shuld not call onAbort via streamSSE if already closed', async () => {
+  const app = new Hono()
+  let aborted = false
+  app.get('/stream', (c) => {
+    return streamSSE(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.write('Hello')
+    })
+  })
+
+  const server = Deno.serve({ port: 0 }, app.fetch)
+  assertEquals(aborted, false)
+  const res = await fetch(`http://localhost:${server.addr.port}/stream`)
+  assertEquals(await res.text(), 'Hello')
+  assertEquals(aborted, false)
   await server.shutdown()
 })

--- a/runtime_tests/node/index.test.ts
+++ b/runtime_tests/node/index.test.ts
@@ -113,6 +113,14 @@ describe('stream', () => {
       })
     })
   })
+  app.get('/streamHello', (c) => {
+    return stream(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.write('Hello')
+    })
+  })
 
   const server = createAdaptorServer(app)
 
@@ -128,6 +136,14 @@ describe('stream', () => {
       await new Promise((resolve) => setTimeout(resolve))
     }
     expect(aborted).toBe(true)
+  })
+
+  it('Should not be called onAbort if already closed', async () => {
+    expect(aborted).toBe(false)
+    const res = await request(server).get('/streamHello')
+    expect(res.status).toBe(200)
+    expect(res.text).toBe('Hello')
+    expect(aborted).toBe(false)
   })
 })
 
@@ -146,6 +162,14 @@ describe('streamSSE', () => {
       })
     })
   })
+  app.get('/streamHello', (c) => {
+    return streamSSE(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.write('Hello')
+    })
+  })
 
   const server = createAdaptorServer(app)
 
@@ -161,5 +185,13 @@ describe('streamSSE', () => {
       await new Promise((resolve) => setTimeout(resolve))
     }
     expect(aborted).toBe(true)
+  })
+
+  it('Should not be called onAbort if already closed', async () => {
+    expect(aborted).toBe(false)
+    const res = await request(server).get('/streamHello')
+    expect(res.status).toBe(200)
+    expect(res.text).toBe('Hello')
+    expect(aborted).toBe(false)
   })
 })

--- a/runtime_tests/node/index.test.ts
+++ b/runtime_tests/node/index.test.ts
@@ -124,6 +124,10 @@ describe('stream', () => {
 
   const server = createAdaptorServer(app)
 
+  beforeEach(() => {
+    aborted = false
+  })
+
   it('Should call onAbort', async () => {
     const req = request(server)
       .get('/stream')
@@ -172,6 +176,10 @@ describe('streamSSE', () => {
   })
 
   const server = createAdaptorServer(app)
+
+  beforeEach(() => {
+    aborted = false
+  })
 
   it('Should call onAbort', async () => {
     const req = request(server)

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -69,7 +69,9 @@ export const streamSSE = (
 
   // bun does not cancel response stream when request is canceled, so detect abort by signal
   c.req.raw.signal.addEventListener('abort', () => {
-    stream.abort()
+    if (!stream.closed) {
+      stream.abort()
+    }
   })
   // in bun, `c` is destroyed when the request is returned, so hold it until the end of streaming
   contextStash.set(stream.responseReadable, c)

--- a/src/helper/streaming/stream.ts
+++ b/src/helper/streaming/stream.ts
@@ -12,7 +12,9 @@ export const stream = (
 
   // bun does not cancel response stream when request is canceled, so detect abort by signal
   c.req.raw.signal.addEventListener('abort', () => {
-    stream.abort()
+    if (!stream.closed) {
+      stream.abort()
+    }
   })
   // in bun, `c` is destroyed when the request is returned, so hold it until the end of streaming
   contextStash.set(stream.responseReadable, c)

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -13,6 +13,10 @@ export class StreamingApi {
    * Whether the stream has been aborted.
    */
   aborted: boolean = false
+  /**
+   * Whether the stream has been closed normally.
+   */
+  closed: boolean = false
 
   constructor(writable: WritableStream, _readable: ReadableStream) {
     this.writable = writable
@@ -66,6 +70,7 @@ export class StreamingApi {
     } catch (e) {
       // Do nothing. If you want to handle errors, create a stream by yourself.
     }
+    this.closed = true
   }
 
   async pipe(body: ReadableStream) {


### PR DESCRIPTION
#3042 fixed the problem in bun, but in deno, `onAbort()` was being called after a successful exit.

In deno, an "abort" event is fired for `req.signal` even if it exits successfully.

In this pull request, fix so that `onAbort()` is not called when stream finishes successfully.

```ts
import { Hono } from 'hono'

const app = new Hono()
app.get('/stream', (c) => {
  return stream(c, async (stream) => {
    stream.onAbort(() => {
      console.log('Aborted!')
    })
    await stream.write('Hello')
  })
})

export default app
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
