### PR TITLE
feat(middleware): introduce Request ID middleware

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -47,6 +47,7 @@
     "./method-override": "./src/middleware/method-override/index.ts",
     "./powered-by": "./src/middleware/powered-by/index.ts",
     "./pretty-json": "./src/middleware/pretty-json/index.ts",
+    "./request-id": "./src/middleware/request-id/request-id.ts",
     "./secure-headers": "./src/middleware/secure-headers/secure-headers.ts",
     "./ssg": "./src/helper/ssg/index.ts",
     "./streaming": "./src/helper/streaming/index.ts",

--- a/package.json
+++ b/package.json
@@ -213,6 +213,11 @@
       "import": "./dist/middleware/pretty-json/index.js",
       "require": "./dist/cjs/middleware/pretty-json/index.js"
     },
+    "./request-id": {
+      "types": "./dist/types/middleware/request-id/index.d.ts",
+      "import": "./dist/middleware/request-id/index.js",
+      "require": "./dist/cjs/middleware/request-id/index.js"
+    },
     "./secure-headers": {
       "types": "./dist/types/middleware/secure-headers/index.d.ts",
       "import": "./dist/middleware/secure-headers/index.js",

--- a/package.json
+++ b/package.json
@@ -460,6 +460,9 @@
       "pretty-json": [
         "./dist/types/middleware/pretty-json"
       ],
+      "request-id": [
+        "./dist/types/middleware/request-id"
+      ],
       "streaming": [
         "./dist/types/helper/streaming"
       ],

--- a/src/middleware/request-id/index.test.ts
+++ b/src/middleware/request-id/index.test.ts
@@ -1,12 +1,12 @@
 import { Hono } from '../../hono'
-import { requestID } from '.'
+import { requestId } from '.'
 
 const regexUUIDv4 = /([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})/
 
 describe('Request ID Middleware', () => {
   const app = new Hono()
-  app.use('*', requestID())
-  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+  app.use('*', requestId())
+  app.get('/requestId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
 
   it('Should return random request id', async () => {
     const res = await app.request('http://localhost/requestId')
@@ -46,8 +46,8 @@ describe('Request ID Middleware with custom generator', () => {
     return 'HonoHonoHono'
   }
   const app = new Hono()
-  app.use('*', requestID({ generator: generateWord }))
-  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+  app.use('*', requestId({ generator: generateWord }))
+  app.get('/requestId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
 
   it('Should return custom request id', async () => {
     const res = await app.request('http://localhost/requestId')
@@ -60,10 +60,10 @@ describe('Request ID Middleware with custom generator', () => {
 
 describe('Request ID Middleware with custom max length', () => {
   const app = new Hono()
-  app.use('/requestId', requestID({ limitLength: 9 }))
-  app.use('/zeroId', requestID({ limitLength: 0 }))
-  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
-  app.get('/zeroId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+  app.use('/requestId', requestId({ limitLength: 9 }))
+  app.use('/zeroId', requestId({ limitLength: 0 }))
+  app.get('/requestId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
+  app.get('/zeroId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
 
   it('Should return cut custom request id', async () => {
     const res = await app.request('http://localhost/requestId', {
@@ -93,10 +93,10 @@ describe('Request ID Middleware with custom max length', () => {
 
 describe('Request ID Middleware with custom header', () => {
   const app = new Hono()
-  app.use('/requestId', requestID({ headerName: 'Hono-Request-Id' }))
-  app.get('/emptyId', requestID({ headerName: '' }))
-  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
-  app.get('/emptyId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+  app.use('/requestId', requestId({ headerName: 'Hono-Request-Id' }))
+  app.get('/emptyId', requestId({ headerName: '' }))
+  app.get('/requestId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
+  app.get('/emptyId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
 
   it('Should return custom request id', async () => {
     const res = await app.request('http://localhost/requestId', {

--- a/src/middleware/request-id/index.test.ts
+++ b/src/middleware/request-id/index.test.ts
@@ -81,35 +81,48 @@ describe('Request ID Middleware with custom generator', () => {
   })
 })
 
-describe('Request ID Middleware with custom max length', () => {
-  const characterOf255 = 'h'.repeat(255)
-  const characterOf256 = 'h'.repeat(256)
+describe('Request ID Middleware with limit length', () => {
+  const charactersOf255 = 'h'.repeat(255)
+  const charactersOf256 = 'h'.repeat(256)
 
   const app = new Hono()
   app.use('/requestId', requestId())
+  app.use('/limit256', requestId({ limitLength: 256 }))
   app.get('/requestId', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
+  app.get('/limit256', (c) => c.text(c.get('requestId') ?? 'No Request ID'))
 
   it('Should return custom request id', async () => {
     const res = await app.request('http://localhost/requestId', {
       headers: {
-        'X-Request-Id': characterOf255,
+        'X-Request-Id': charactersOf255,
       },
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    expect(res.headers.get('X-Request-Id')).toBe(characterOf255)
-    expect(await res.text()).toBe(characterOf255)
+    expect(res.headers.get('X-Request-Id')).toBe(charactersOf255)
+    expect(await res.text()).toBe(charactersOf255)
   })
   it('Should return random request id without using request header', async () => {
     const res = await app.request('http://localhost/requestId', {
       headers: {
-        'X-Request-Id': characterOf256,
+        'X-Request-Id': charactersOf256,
       },
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('X-Request-Id')).toMatch(regexUUIDv4)
     expect(await res.text()).toMatch(regexUUIDv4)
+  })
+  it('Should return custom request id with 256 characters', async () => {
+    const res = await app.request('http://localhost/limit256', {
+      headers: {
+        'X-Request-Id': charactersOf256,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe(charactersOf256)
+    expect(await res.text()).toBe(charactersOf256)
   })
 })
 

--- a/src/middleware/request-id/index.test.ts
+++ b/src/middleware/request-id/index.test.ts
@@ -1,0 +1,119 @@
+import { Hono } from '../../hono'
+import { requestID } from '.'
+
+const regexUUIDv4 = /([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})/
+
+describe('Request ID Middleware', () => {
+  const app = new Hono()
+  app.use('*', requestID())
+  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+
+  it('Should return random request id', async () => {
+    const res = await app.request('http://localhost/requestId')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toMatch(regexUUIDv4)
+    expect(await res.text()).match(regexUUIDv4)
+  })
+
+  it('Should return custom request id', async () => {
+    const res = await app.request('http://localhost/requestId', {
+      headers: {
+        'X-Request-Id': 'hono-is-cool',
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe('hono-is-cool')
+    expect(await res.text()).toBe('hono-is-cool')
+  })
+
+  it('Should return sanitized custom request id', async () => {
+    const res = await app.request('http://localhost/requestId', {
+      headers: {
+        'X-Request-Id': 'Hello!12345-@*^',
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe('Hello12345-')
+    expect(await res.text()).toBe('Hello12345-')
+  })
+})
+
+describe('Request ID Middleware with custom generator', () => {
+  function generateWord() {
+    return 'HonoHonoHono'
+  }
+  const app = new Hono()
+  app.use('*', requestID({ generator: generateWord }))
+  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+
+  it('Should return custom request id', async () => {
+    const res = await app.request('http://localhost/requestId')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe('HonoHonoHono')
+    expect(await res.text()).toBe('HonoHonoHono')
+  })
+})
+
+describe('Request ID Middleware with custom max length', () => {
+  const app = new Hono()
+  app.use('/requestId', requestID({ limitLength: 9 }))
+  app.use('/zeroId', requestID({ limitLength: 0 }))
+  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+  app.get('/zeroId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+
+  it('Should return cut custom request id', async () => {
+    const res = await app.request('http://localhost/requestId', {
+      headers: {
+        'X-Request-Id': '12345678910',
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe('123456789')
+    expect(await res.text()).toBe('123456789')
+  })
+
+  it('Should return uncut request id', async () => {
+    const characterOf260 = 'h'.repeat(260)
+    const res = await app.request('http://localhost/zeroId', {
+      headers: {
+        'X-Request-Id': characterOf260,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe(characterOf260)
+    expect(await res.text()).toBe(characterOf260)
+  })
+})
+
+describe('Request ID Middleware with custom header', () => {
+  const app = new Hono()
+  app.use('/requestId', requestID({ headerName: 'Hono-Request-Id' }))
+  app.get('/emptyId', requestID({ headerName: '' }))
+  app.get('/requestId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+  app.get('/emptyId', (c) => c.text(c.get('requestID') ?? 'No Request ID'))
+
+  it('Should return custom request id', async () => {
+    const res = await app.request('http://localhost/requestId', {
+      headers: {
+        'Hono-Request-Id': 'hono-is-cool',
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Hono-Request-Id')).toBe('hono-is-cool')
+    expect(await res.text()).toBe('hono-is-cool')
+  })
+
+  it('Should return default random request id', async () => {
+    const res = await app.request('http://localhost/requestId')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toMatch(regexUUIDv4)
+  })
+})

--- a/src/middleware/request-id/index.test.ts
+++ b/src/middleware/request-id/index.test.ts
@@ -110,10 +110,11 @@ describe('Request ID Middleware with custom header', () => {
     expect(await res.text()).toBe('hono-is-cool')
   })
 
-  it('Should return default random request id', async () => {
-    const res = await app.request('http://localhost/requestId')
+  it('Should not return request id', async () => {
+    const res = await app.request('http://localhost/emptyId')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBeNull()
     expect(await res.text()).toMatch(regexUUIDv4)
   })
 })

--- a/src/middleware/request-id/index.ts
+++ b/src/middleware/request-id/index.ts
@@ -1,8 +1,8 @@
-import type { RequestIDVariables } from './request-id'
-export type { RequestIDVariables }
-export { requestID } from './request-id'
+import type { RequestIdVariables } from './request-id'
+export type { RequestIdVariables }
+export { requestId } from './request-id'
 import type {} from '../..'
 
 declare module '../..' {
-  interface ContextVariableMap extends RequestIDVariables {}
+  interface ContextVariableMap extends RequestIdVariables {}
 }

--- a/src/middleware/request-id/index.ts
+++ b/src/middleware/request-id/index.ts
@@ -1,0 +1,8 @@
+import type { RequestIDVariables } from './request-id'
+export type { RequestIDVariables }
+export { requestID } from './request-id'
+import type {} from '../..'
+
+declare module '../..' {
+  interface ContextVariableMap extends RequestIDVariables {}
+}

--- a/src/middleware/request-id/request-id.ts
+++ b/src/middleware/request-id/request-id.ts
@@ -10,7 +10,7 @@ export type RequestIdVariables = {
   requestId: string
 }
 
-export type RequesIdOptions = {
+export type RequestIdOptions = {
   limitLength?: number
   headerName?: string
   generator?: (c: Context) => string
@@ -43,7 +43,7 @@ export const requestId = ({
   limitLength = 255,
   headerName = 'X-Request-Id',
   generator = () => crypto.randomUUID(),
-}: RequesIdOptions = {}): MiddlewareHandler => {
+}: RequestIdOptions = {}): MiddlewareHandler => {
   return async function requestId(c, next) {
     // If `headerName` is empty string, req.header will return the object
     let reqId = headerName ? c.req.header(headerName) : undefined

--- a/src/middleware/request-id/request-id.ts
+++ b/src/middleware/request-id/request-id.ts
@@ -1,0 +1,60 @@
+/**
+ * @module
+ * Request ID Middleware for Hono.
+ */
+
+import type { MiddlewareHandler } from '../../types'
+
+export type RequestIDVariables = {
+  requestID: string
+}
+
+export type RequesIDOptions = {
+  limitLength?: number
+  headerName?: string
+  generator?: () => string
+}
+
+/**
+ * Request ID Middleware for Hono.
+ *
+ * @param {object} options - Options for Request ID middleware.
+ * @param {number} [options.limitLength=255] - The maximum length of request id.
+ * If positive truncates the request id at the specified length.
+ * @param {string} [options.headerName=X-Request-Id] - The header name used in request id.
+ * @param {generator} [options.generator=crypto.randomUUID()] - The request id generation function.
+ *
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * type Variables = RequestIDVariables
+ * const app = new Hono<{Variables: Variables}>()
+ *
+ * app.use(requestID())
+ * app.get('/', (c) => {
+ *   console.log(c.get('requestID')) // Debug
+ *   return c.text('Hello World!')
+ * })
+ * ```
+ */
+export const requestID = (options?: RequesIDOptions): MiddlewareHandler => {
+  const limitLength = options?.limitLength ?? 255
+  const headerName = options?.headerName ?? 'X-Request-Id'
+
+  return async function requestID(c, next) {
+    let requestId = c.req.header(headerName)
+    if (requestId) {
+      requestId = requestId.replace(/[^\w\-]/g, '')
+      requestId = limitLength > 0 ? requestId.substring(0, limitLength) : requestId
+    } else {
+      requestId = options?.generator?.() ?? crypto.randomUUID()
+    }
+
+    c.set('requestID', requestId)
+    if (headerName) {
+      c.header(headerName, requestId)
+    }
+    await next()
+  }
+}

--- a/src/middleware/request-id/request-id.ts
+++ b/src/middleware/request-id/request-id.ts
@@ -43,7 +43,9 @@ export const requestID = (options?: RequesIDOptions): MiddlewareHandler => {
   const headerName = options?.headerName ?? 'X-Request-Id'
 
   return async function requestID(c, next) {
-    let requestId = c.req.header(headerName)
+    // If `headerName` is empty string, req.header will return the object
+    let requestId = headerName ? c.req.header(headerName) : undefined
+
     if (requestId) {
       requestId = requestId.replace(/[^\w\-]/g, '')
       requestId = limitLength > 0 ? requestId.substring(0, limitLength) : requestId

--- a/src/middleware/request-id/request-id.ts
+++ b/src/middleware/request-id/request-id.ts
@@ -21,7 +21,6 @@ export type RequestIdOptions = {
  *
  * @param {object} options - Options for Request ID middleware.
  * @param {number} [options.limitLength=255] - The maximum length of request id.
- * If positive truncates the request id at the specified length.
  * @param {string} [options.headerName=X-Request-Id] - The header name used in request id.
  * @param {generator} [options.generator=() => crypto.randomUUID()] - The request id generation function.
  *
@@ -47,11 +46,7 @@ export const requestId = ({
   return async function requestId(c, next) {
     // If `headerName` is empty string, req.header will return the object
     let reqId = headerName ? c.req.header(headerName) : undefined
-
-    if (reqId) {
-      reqId = reqId.replace(/[^\w\-]/g, '')
-      reqId = limitLength > 0 ? reqId.substring(0, limitLength) : reqId
-    } else {
+    if (!reqId || reqId.length > limitLength || /[^\w\-]/.test(reqId)) {
       reqId = generator(c)
     }
 

--- a/src/middleware/request-id/request-id.ts
+++ b/src/middleware/request-id/request-id.ts
@@ -5,11 +5,11 @@
 
 import type { MiddlewareHandler } from '../../types'
 
-export type RequestIDVariables = {
-  requestID: string
+export type RequestIdVariables = {
+  requestId: string
 }
 
-export type RequesIDOptions = {
+export type RequesIdOptions = {
   limitLength?: number
   headerName?: string
   generator?: () => string
@@ -28,34 +28,34 @@ export type RequesIDOptions = {
  *
  * @example
  * ```ts
- * type Variables = RequestIDVariables
+ * type Variables = RequestIdVariables
  * const app = new Hono<{Variables: Variables}>()
  *
- * app.use(requestID())
+ * app.use(requestId())
  * app.get('/', (c) => {
- *   console.log(c.get('requestID')) // Debug
+ *   console.log(c.get('requestId')) // Debug
  *   return c.text('Hello World!')
  * })
  * ```
  */
-export const requestID = (options?: RequesIDOptions): MiddlewareHandler => {
+export const requestId = (options?: RequesIdOptions): MiddlewareHandler => {
   const limitLength = options?.limitLength ?? 255
   const headerName = options?.headerName ?? 'X-Request-Id'
 
-  return async function requestID(c, next) {
+  return async function requestId(c, next) {
     // If `headerName` is empty string, req.header will return the object
-    let requestId = headerName ? c.req.header(headerName) : undefined
+    let reqId = headerName ? c.req.header(headerName) : undefined
 
-    if (requestId) {
-      requestId = requestId.replace(/[^\w\-]/g, '')
-      requestId = limitLength > 0 ? requestId.substring(0, limitLength) : requestId
+    if (reqId) {
+      reqId = reqId.replace(/[^\w\-]/g, '')
+      reqId = limitLength > 0 ? reqId.substring(0, limitLength) : reqId
     } else {
-      requestId = options?.generator?.() ?? crypto.randomUUID()
+      reqId = options?.generator?.() ?? crypto.randomUUID()
     }
 
-    c.set('requestID', requestId)
+    c.set('requestId', reqId)
     if (headerName) {
-      c.header(headerName, requestId)
+      c.header(headerName, reqId)
     }
     await next()
   }


### PR DESCRIPTION
Request ID middleware generates a unique id for a request.
The unique request id can be used to trace a request end-to-end.
```ts
const app = new Hono()

app.use(requestId())
app.get('/', (c) => {
    console.log(c.get('requestId'))
    return c.text('Hello World!')
})
```

It is also easily customizable with several options.

```ts
type RequesIdOptions = {
  // The maximum length of request id.
  // The default value is 255. 
  limitLength?: number
  // The header name used in request id.
  // The default value is 'X-Request-Id'.
  headerName?: string
  // The request id generation function.
  // The default value is 'crypto.randomUUID()'.
  generator?: (c: Context) => string
}
```


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
