### PR TITLE
fix(aws-lambda): set cookies with comma is bugged

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -258,7 +258,10 @@ abstract class EventProcessor<E extends LambdaEvent> {
 
   setCookies(event: E, res: Response, result: APIGatewayProxyResult) {
     if (res.headers.has('set-cookie')) {
-      const cookies = res.headers.get('set-cookie')?.split(', ')
+      const cookies = res.headers.getSetCookie
+        ? res.headers.getSetCookie()
+        : Array.from(res.headers.entries()).filter(([k]) => k === 'set-cookie').map(([, v]) => v)
+
       if (Array.isArray(cookies)) {
         this.setCookiesToResult(event, result, cookies)
         res.headers.delete('set-cookie')

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -260,7 +260,9 @@ abstract class EventProcessor<E extends LambdaEvent> {
     if (res.headers.has('set-cookie')) {
       const cookies = res.headers.getSetCookie
         ? res.headers.getSetCookie()
-        : Array.from(res.headers.entries()).filter(([k]) => k === 'set-cookie').map(([, v]) => v)
+        : Array.from(res.headers.entries())
+            .filter(([k]) => k === 'set-cookie')
+            .map(([, v]) => v)
 
       if (Array.isArray(cookies)) {
         this.setCookiesToResult(event, result, cookies)


### PR DESCRIPTION
Currently it is bugged if the cookie have comma: "," in it's value/key.  
Example: cookie with an `Expires`:  
![image](https://github.com/honojs/hono/assets/23612546/ffc559b8-4fb2-42ac-88da-fb50b4ea8eff)

The PR fixes this by using the newer `Header`.getSetCookie() if possible (it's still relatively new), with safe falling iterating the `Header` and extracting the set-cookie values.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
