### PR TITLE
feat(vercel): add `getConnInfo` for vercel adapter

### DIFF
--- a/src/adapter/vercel/conninfo.test.ts
+++ b/src/adapter/vercel/conninfo.test.ts
@@ -1,0 +1,18 @@
+import { Context } from '../../context'
+import { getConnInfo } from './conninfo'
+
+describe('getConnInfo', () => {
+  it('Should getConnInfo works', () => {
+    const address = Math.random().toString()
+    const req = new Request('http://localhost/', {
+      headers: {
+        'x-real-ip': address,
+      },
+    })
+    const c = new Context(req)
+
+    const info = getConnInfo(c)
+
+    expect(info.remote.address).toBe(address)
+  })
+})

--- a/src/adapter/vercel/conninfo.ts
+++ b/src/adapter/vercel/conninfo.ts
@@ -1,0 +1,9 @@
+import type { GetConnInfo } from '../../helper/conninfo'
+
+export const getConnInfo: GetConnInfo = (c) => ({
+  remote: {
+    // https://github.com/vercel/vercel/blob/b70bfb5fbf28a4650d4042ce68ca5c636d37cf44/packages/edge/src/edge-headers.ts#L10-L12C32
+    address: c.req.header('x-real-ip'),
+    addressType: 'unknown',
+  },
+})

--- a/src/adapter/vercel/index.ts
+++ b/src/adapter/vercel/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { handle } from './handler'
+export { getConnInfo } from './conninfo'


### PR DESCRIPTION
This pr adds `getConnInfo` for vercel adapter based on https://github.com/vercel/vercel/blob/b70bfb5fbf28a4650d4042ce68ca5c636d37cf44/packages/edge/src/edge-headers.ts#L10-L12C32


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
