### PR TITLE
chore: update outdated links in JSDoc

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -242,7 +242,7 @@ export class Context<
   /**
    * `.env` can get bindings (environment variables, secrets, KV namespaces, D1 database, R2 bucket etc.) in Cloudflare Workers.
    *
-   * @see {@link https://hono.dev/api/context#env}
+   * @see {@link https://hono.dev/docs/api/context#env}
    *
    * @example
    * ```ts
@@ -258,7 +258,7 @@ export class Context<
   /**
    * `.error` can get the error object from the middleware if the Handler throws an error.
    *
-   * @see {@link https://hono.dev/api/context#error}
+   * @see {@link https://hono.dev/docs/api/context#error}
    *
    * @example
    * ```ts
@@ -311,7 +311,7 @@ export class Context<
   }
 
   /**
-   * @see {@link https://hono.dev/api/context#event}
+   * @see {@link https://hono.dev/docs/api/context#event}
    * The FetchEvent associated with the current request.
    *
    * @throws Will throw an error if the context does not have a FetchEvent.
@@ -325,7 +325,7 @@ export class Context<
   }
 
   /**
-   * @see {@link https://hono.dev/api/context#executionctx}
+   * @see {@link https://hono.dev/docs/api/context#executionctx}
    * The ExecutionContext associated with the current request.
    *
    * @throws Will throw an error if the context does not have an ExecutionContext.
@@ -339,7 +339,7 @@ export class Context<
   }
 
   /**
-   * @see {@link https://hono.dev/api/context#res}
+   * @see {@link https://hono.dev/docs/api/context#res}
    * The Response object for the current request.
    */
   get res(): Response {
@@ -375,7 +375,7 @@ export class Context<
   /**
    * `.render()` can create a response within a layout.
    *
-   * @see {@link https://hono.dev/api/context#render-setrenderer}
+   * @see {@link https://hono.dev/docs/api/context#render-setrenderer}
    *
    * @example
    * ```ts
@@ -413,7 +413,7 @@ export class Context<
   /**
    * `.setRenderer()` can set the layout in the custom middleware.
    *
-   * @see {@link https://hono.dev/api/context#render-setrenderer}
+   * @see {@link https://hono.dev/docs/api/context#render-setrenderer}
    *
    * @example
    * ```tsx
@@ -438,7 +438,7 @@ export class Context<
   /**
    * `.header()` can set headers.
    *
-   * @see {@link https://hono.dev/api/context#body}
+   * @see {@link https://hono.dev/docs/api/context#body}
    *
    * @example
    * ```ts
@@ -498,7 +498,7 @@ export class Context<
   /**
    * `.set()` can set the value specified by the key.
    *
-   * @see {@link https://hono.dev/api/context#set-get}
+   * @see {@link https://hono.dev/docs/api/context#set-get}
    *
    * @example
    * ```ts
@@ -517,7 +517,7 @@ export class Context<
   /**
    * `.get()` can use the value specified by the key.
    *
-   * @see {@link https://hono.dev/api/context#set-get}
+   * @see {@link https://hono.dev/docs/api/context#set-get}
    *
    * @example
    * ```ts
@@ -534,7 +534,7 @@ export class Context<
   /**
    * `.var` can access the value of a variable.
    *
-   * @see {@link https://hono.dev/api/context#var}
+   * @see {@link https://hono.dev/docs/api/context#var}
    *
    * @example
    * ```ts
@@ -620,7 +620,7 @@ export class Context<
    * You can set headers with `.header()` and set HTTP status code with `.status`.
    * This can also be set in `.text()`, `.json()` and so on.
    *
-   * @see {@link https://hono.dev/api/context#body}
+   * @see {@link https://hono.dev/docs/api/context#body}
    *
    * @example
    * ```ts
@@ -649,7 +649,7 @@ export class Context<
   /**
    * `.text()` can render text as `Content-Type:text/plain`.
    *
-   * @see {@link https://hono.dev/api/context#text}
+   * @see {@link https://hono.dev/docs/api/context#text}
    *
    * @example
    * ```ts
@@ -682,7 +682,7 @@ export class Context<
   /**
    * `.json()` can render JSON as `Content-Type:application/json`.
    *
-   * @see {@link https://hono.dev/api/context#json}
+   * @see {@link https://hono.dev/docs/api/context#json}
    *
    * @example
    * ```ts
@@ -739,7 +739,7 @@ export class Context<
   /**
    * `.redirect()` can Redirect, default status code is 302.
    *
-   * @see {@link https://hono.dev/api/context#redirect}
+   * @see {@link https://hono.dev/docs/api/context#redirect}
    *
    * @example
    * ```ts
@@ -763,7 +763,7 @@ export class Context<
   /**
    * `.notFound()` can return the Not Found Response.
    *
-   * @see {@link https://hono.dev/api/context#notfound}
+   * @see {@link https://hono.dev/docs/api/context#notfound}
    *
    * @example
    * ```ts

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -51,7 +51,7 @@ export type HonoOptions<E extends Env> = {
   /**
    * `strict` option specifies whether to distinguish whether the last path is a directory or not.
    *
-   * @see {@link https://hono.dev/api/hono#strict-mode}
+   * @see {@link https://hono.dev/docs/api/hono#strict-mode}
    *
    * @default true
    */
@@ -59,7 +59,7 @@ export type HonoOptions<E extends Env> = {
   /**
    * `router` option specifices which router to use.
    *
-   * @see {@link https://hono.dev/api/hono#router-option}
+   * @see {@link https://hono.dev/docs/api/hono#router-option}
    *
    * @example
    * ```ts
@@ -70,7 +70,7 @@ export type HonoOptions<E extends Env> = {
   /**
    * `getPath` can handle the host header value.
    *
-   * @see {@link https://hono.dev/api/routing#routing-with-host-header-value}
+   * @see {@link https://hono.dev/docs/api/routing#routing-with-host-header-value}
    *
    * @example
    * ```ts
@@ -189,7 +189,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.route()` allows grouping other Hono instance in routes.
    *
-   * @see {@link https://hono.dev/api/routing#grouping}
+   * @see {@link https://hono.dev/docs/api/routing#grouping}
    *
    * @param {string} path - base Path
    * @param {Hono} app - other Hono instance
@@ -232,7 +232,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.basePath()` allows base paths to be specified.
    *
-   * @see {@link https://hono.dev/api/routing#base-path}
+   * @see {@link https://hono.dev/docs/api/routing#base-path}
    *
    * @param {string} path - base Path
    * @returns {Hono} changed Hono instance
@@ -251,7 +251,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.onError()` handles an error and returns a customized Response.
    *
-   * @see {@link https://hono.dev/api/hono#error-handling}
+   * @see {@link https://hono.dev/docs/api/hono#error-handling}
    *
    * @param {ErrorHandler} handler - request Handler for error
    * @returns {Hono} changed Hono instance
@@ -272,7 +272,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.notFound()` allows you to customize a Not Found Response.
    *
-   * @see {@link https://hono.dev/api/hono#not-found}
+   * @see {@link https://hono.dev/docs/api/hono#not-found}
    *
    * @param {NotFoundHandler} handler - request handler for not-found
    * @returns {Hono} changed Hono instance
@@ -292,7 +292,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.mount()` allows you to mount applications built with other frameworks into your Hono application.
    *
-   * @see {@link https://hono.dev/api/hono#mount}
+   * @see {@link https://hono.dev/docs/api/hono#mount}
    *
    * @param {string} path - base Path
    * @param {Function} applicationHandler - other Request Handler
@@ -458,7 +458,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.fetch()` will be entry point of your app.
    *
-   * @see {@link https://hono.dev/api/hono#fetch}
+   * @see {@link https://hono.dev/docs/api/hono#fetch}
    *
    * @param {Request} request - request Object of request
    * @param {Env} Env - env Object
@@ -484,7 +484,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    *   expect(res.status).toBe(200)
    * })
    * ```
-   * @see https://hono.dev/api/hono#request
+   * @see https://hono.dev/docs/api/hono#request
    */
   request = (
     input: RequestInfo | URL,
@@ -507,7 +507,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   /**
    * `.fire()` automatically adds a global fetch event listener.
    * This can be useful for environments that adhere to the Service Worker API, such as non-ES module Cloudflare Workers.
-   * @see https://hono.dev/api/hono#fire
+   * @see https://hono.dev/docs/api/hono#fire
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
    * @see https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/
    */

--- a/src/http-exception.ts
+++ b/src/http-exception.ts
@@ -20,7 +20,7 @@ type HTTPExceptionOptions = {
 /**
  * `HTTPException` must be used when a fatal error such as authentication failure occurs.
  *
- * @see {@link https://hono.dev/api/exception}
+ * @see {@link https://hono.dev/docs/api/exception}
  *
  * @param {StatusCode} status - status code of HTTPException
  * @param {HTTPExceptionOptions} options - options of HTTPException

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -48,7 +48,7 @@ type BasicAuthOptions =
 /**
  * Basic Auth Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/basic-auth}
+ * @see {@link https://hono.dev/docs/middleware/builtin/basic-auth}
  *
  * @param {BasicAuthOptions} options - The options for the basic authentication middleware.
  * @param {string} options.username - The username for authentication.

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -31,7 +31,7 @@ type BearerAuthOptions =
 /**
  * Bearer Auth Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/bearer-auth}
+ * @see {@link https://hono.dev/docs/middleware/builtin/bearer-auth}
  *
  * @param {BearerAuthOptions} options - The options for the bearer authentication middleware.
  * @param {string | string[]} [options.token] - The string or array of strings to validate the incoming bearer token against.

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -25,7 +25,7 @@ class BodyLimitError extends Error {
 /**
  * Body Limit Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/body-limit}
+ * @see {@link https://hono.dev/docs/middleware/builtin/body-limit}
  *
  * @param {BodyLimitOptions} options - The options for the body limit middleware.
  * @param {number} options.maxSize - The maximum body size allowed.

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -9,7 +9,7 @@ import type { MiddlewareHandler } from '../../types'
 /**
  * Cache Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/cache}
+ * @see {@link https://hono.dev/docs/middleware/builtin/cache}
  *
  * @param {Object} options - The options for the cache middleware.
  * @param {string | Function} options.cacheName - The name of the cache. Can be used to store multiple caches with different identifiers.

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -14,7 +14,7 @@ interface CompressionOptions {
 /**
  * Compress Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/compress}
+ * @see {@link https://hono.dev/docs/middleware/builtin/compress}
  *
  * @param {CompressionOptions} [options] - The options for the compress middleware.
  * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -18,7 +18,7 @@ type CORSOptions = {
 /**
  * CORS Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/cors}
+ * @see {@link https://hono.dev/docs/middleware/builtin/cors}
  *
  * @param {CORSOptions} [options] - The options for the CORS middleware.
  * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.

--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -19,7 +19,7 @@ const isRequestedByFormElementRe =
 /**
  * CSRF Protection Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/csrf}
+ * @see {@link https://hono.dev/docs/middleware/builtin/csrf}
  *
  * @param {CSRFOptions} [options] - The options for the CSRF protection middleware.
  * @param {string|string[]|(origin: string, context: Context) => boolean} [options.origin] - Specify origins.

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -33,7 +33,7 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
 /**
  * ETag Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/etag}
+ * @see {@link https://hono.dev/docs/middleware/builtin/etag}
  *
  * @param {ETagOptions} [options] - The options for the ETag middleware.
  * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -74,7 +74,7 @@ const createRenderer =
 /**
  * JSX Renderer Middleware for hono.
  *
- * @see {@link{https://hono.dev/middleware/builtin/jsx-renderer}}
+ * @see {@link{https://hono.dev/docs/middleware/builtin/jsx-renderer}}
  *
  * @param {ComponentWithChildren} [component] - The component to render, which can accept children and props.
  * @param {RendererOptions} [options] - The options for the JSX renderer middleware.

--- a/src/middleware/jwt/jwt.ts
+++ b/src/middleware/jwt/jwt.ts
@@ -19,7 +19,7 @@ export type JwtVariables = {
 /**
  * JWT Auth Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/jwt}
+ * @see {@link https://hono.dev/docs/middleware/builtin/jwt}
  *
  * @param {object} options - The options for the JWT middleware.
  * @param {string} [options.secret] - A value of your secret key.

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -63,7 +63,7 @@ function log(
 /**
  * Logger Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/logger}
+ * @see {@link https://hono.dev/docs/middleware/builtin/logger}
  *
  * @param {PrintFunc} [fn=console.log] - Optional function for customized logging behavior.
  * @returns {MiddlewareHandler} The middleware handler function.

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -35,7 +35,7 @@ const DEFAULT_METHOD_FORM_NAME = '_method'
 /**
  * Method Override Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/method-override}
+ * @see {@link https://hono.dev/docs/middleware/builtin/method-override}
  *
  * @param {MethodOverrideOptions} options - The options for the method override middleware.
  * @param {Hono} options.app - The instance of Hono is used in your application.

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -12,7 +12,7 @@ type prettyOptions = {
 /**
  * Pretty JSON Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/pretty-json}
+ * @see {@link https://hono.dev/docs/middleware/builtin/pretty-json}
  *
  * @param {prettyOptions} [options] - The options for the pretty JSON middleware.
  * @param {number} [options.space=2] - Number of spaces for indentation.

--- a/src/middleware/secure-headers/secure-headers.ts
+++ b/src/middleware/secure-headers/secure-headers.ts
@@ -133,7 +133,7 @@ export const NONCE: ContentSecurityPolicyOptionHandler = (ctx) => {
 /**
  * Secure Headers Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/secure-headers}
+ * @see {@link https://hono.dev/docs/middleware/builtin/secure-headers}
  *
  * @param {Partial<SecureHeadersOptions>} [customOptions] - The options for the secure headers middleware.
  * @param {ContentSecurityPolicyOptions} [customOptions.contentSecurityPolicy] - Settings for the Content-Security-Policy header.

--- a/src/middleware/timing/timing.ts
+++ b/src/middleware/timing/timing.ts
@@ -37,7 +37,7 @@ const getTime = (): number => {
 /**
  * Server-Timing Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/timing}
+ * @see {@link https://hono.dev/docs/middleware/builtin/timing}
  *
  * @param {TimingOptions} [config] - The options for the timing middleware.
  * @param {boolean} [config.total=true] - Show the total response time.

--- a/src/middleware/trailing-slash/index.ts
+++ b/src/middleware/trailing-slash/index.ts
@@ -8,7 +8,7 @@ import type { MiddlewareHandler } from '../../types'
 /**
  * Trailing Slash Middleware for Hono.
  *
- * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ * @see {@link https://hono.dev/docs/middleware/builtin/trailing-slash}
  *
  * @returns {MiddlewareHandler} The middleware handler function.
  *
@@ -42,7 +42,7 @@ export const trimTrailingSlash = (): MiddlewareHandler => {
  * Append trailing slash middleware for Hono.
  * Append a trailing slash to the URL if it doesn't have one. For example, `/path/to/page` will be redirected to `/path/to/page/`.
  *
- * @see {@link https://hono.dev/middleware/builtin/trailing-slash}
+ * @see {@link https://hono.dev/docs/middleware/builtin/trailing-slash}
  *
  * @returns {MiddlewareHandler} The middleware handler function.
  *

--- a/src/request.ts
+++ b/src/request.ts
@@ -27,7 +27,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.raw` can get the raw Request object.
    *
-   * @see {@link https://hono.dev/api/request#raw}
+   * @see {@link https://hono.dev/docs/api/request#raw}
    *
    * @example
    * ```ts
@@ -46,7 +46,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.path` can get the pathname of the request.
    *
-   * @see {@link https://hono.dev/api/request#path}
+   * @see {@link https://hono.dev/docs/api/request#path}
    *
    * @example
    * ```ts
@@ -72,7 +72,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.req.param()` gets the path parameters.
    *
-   * @see {@link https://hono.dev/api/routing#path-parameter}
+   * @see {@link https://hono.dev/docs/api/routing#path-parameter}
    *
    * @example
    * ```ts
@@ -119,7 +119,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.query()` can get querystring parameters.
    *
-   * @see {@link https://hono.dev/api/request#query}
+   * @see {@link https://hono.dev/docs/api/request#query}
    *
    * @example
    * ```ts
@@ -143,7 +143,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.queries()` can get multiple querystring parameter values, e.g. /search?tags=A&tags=B
    *
-   * @see {@link https://hono.dev/api/request#queries}
+   * @see {@link https://hono.dev/docs/api/request#queries}
    *
    * @example
    * ```ts
@@ -162,7 +162,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.header()` can get the request header value.
    *
-   * @see {@link https://hono.dev/api/request#header}
+   * @see {@link https://hono.dev/docs/api/request#header}
    *
    * @example
    * ```ts
@@ -188,7 +188,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.parseBody()` can parse Request body of type `multipart/form-data` or `application/x-www-form-urlencoded`
    *
-   * @see {@link https://hono.dev/api/request#parsebody}
+   * @see {@link https://hono.dev/docs/api/request#parsebody}
    *
    * @example
    * ```ts
@@ -229,7 +229,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.json()` can parse Request body of type `application/json`
    *
-   * @see {@link https://hono.dev/api/request#json}
+   * @see {@link https://hono.dev/docs/api/request#json}
    *
    * @example
    * ```ts
@@ -245,7 +245,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.text()` can parse Request body of type `text/plain`
    *
-   * @see {@link https://hono.dev/api/request#text}
+   * @see {@link https://hono.dev/docs/api/request#text}
    *
    * @example
    * ```ts
@@ -261,7 +261,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.arrayBuffer()` parse Request body as an `ArrayBuffer`
    *
-   * @see {@link https://hono.dev/api/request#arraybuffer}
+   * @see {@link https://hono.dev/docs/api/request#arraybuffer}
    *
    * @example
    * ```ts
@@ -282,7 +282,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    *   const body = await c.req.blob();
    * });
    * ```
-   * @see https://hono.dev/api/request#blob
+   * @see https://hono.dev/docs/api/request#blob
    */
   blob(): Promise<Blob> {
     return this.cachedBody('blob')
@@ -296,7 +296,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    *   const body = await c.req.formData();
    * });
    * ```
-   * @see https://hono.dev/api/request#formdata
+   * @see https://hono.dev/docs/api/request#formdata
    */
   formData(): Promise<FormData> {
     return this.cachedBody('formData')
@@ -318,7 +318,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @param target - The target of the validation.
    * @returns The validated data.
    *
-   * @see https://hono.dev/api/request#valid
+   * @see https://hono.dev/docs/api/request#valid
    */
   valid<T extends keyof I & keyof ValidationTargets>(target: T): InputToDataByTarget<I, T>
   valid(target: keyof ValidationTargets) {
@@ -328,7 +328,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.url()` can get the request url strings.
    *
-   * @see {@link https://hono.dev/api/request#url}
+   * @see {@link https://hono.dev/docs/api/request#url}
    *
    * @example
    * ```ts
@@ -345,7 +345,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.method()` can get the method name of the request.
    *
-   * @see {@link https://hono.dev/api/request#method}
+   * @see {@link https://hono.dev/docs/api/request#method}
    *
    * @example
    * ```ts
@@ -361,7 +361,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `.matchedRoutes()` can return a matched route in the handler
    *
-   * @see {@link https://hono.dev/api/request#matchedroutes}
+   * @see {@link https://hono.dev/docs/api/request#matchedroutes}
    *
    * @example
    * ```ts
@@ -388,7 +388,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
    * `routePath()` can retrieve the path registered within the handler
    *
-   * @see {@link https://hono.dev/api/request#routepath}
+   * @see {@link https://hono.dev/docs/api/request#routepath}
    *
    * @example
    * ```ts


### PR DESCRIPTION
Since directory structures of `hono.dev` has changed due to https://github.com/honojs/website/pull/357, and update the links in JSDoc.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
