### PR TITLE
test(hono): not found handled by sub

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1958,7 +1958,7 @@ describe('Hono with `app.route`', () => {
       const res = await app.request('https://example.com/sub/implicit-404')
       expect(res.status).toBe(404)
       expect(res.headers.get('explicit')).toBe(null)
-      expect(await res.text()).toBe('404 Not Found by app')
+      expect(await res.text()).toBe('404 Not Found by sub')
     })
   })
 })


### PR DESCRIPTION
Hi

I don't know if it's a typo but I expect a sub not found handler to take priority over the parent not found.

### Case : 

```ts
const app = new Hono()
const sub = new Hono()
app.notFound((c) => {
  return c.text('404 Not Found by app', 404)
})
sub.notFound((c) => {
  return c.text('404 Not Found by sub', 404)
})
app.route('/sub', sub)
```