### PR TITLE
 fix(jsx): changes behavior when `download` attribute is set to a boolean value.

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -56,6 +56,7 @@ const booleanAttributes = [
   'default',
   'defer',
   'disabled',
+  'download',
   'formnovalidate',
   'hidden',
   'inert',

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -297,6 +297,28 @@ describe('render to string', () => {
     })
   })
 
+  describe('download attribute', () => {
+    it('<a download={true}></a> should be rendered as <a download=""></a>', () => {
+      const template = <a download={true}></a>
+      expect(template.toString()).toBe('<a download=""></a>')
+    })
+
+    it('<a download={false}></a> should be rendered as <a></a>', () => {
+      const template = <a download={false}></a>
+      expect(template.toString()).toBe('<a></a>')
+    })
+
+    it('<a download></a> should be rendered as <a download=""></a>', () => {
+      const template = <a download></a>
+      expect(template.toString()).toBe('<a download=""></a>')
+    })
+
+    it('<a download="test"></a> should be rendered as <a download="test"></a>', () => {
+      const template = <a download='test'></a>
+      expect(template.toString()).toBe('<a download="test"></a>')
+    })
+  })
+
   describe('Function', () => {
     it('should be ignored used in on* props', () => {
       const onClick = () => {}

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -179,7 +179,7 @@ export namespace JSX {
   type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
 
   interface AnchorHTMLAttributes extends HTMLAttributes {
-    download?: any
+    download?: string | boolean | undefined
     href?: string | undefined
     hreflang?: string | undefined
     media?: string | undefined
@@ -194,7 +194,7 @@ export namespace JSX {
   interface AreaHTMLAttributes extends HTMLAttributes {
     alt?: string | undefined
     coords?: string | undefined
-    download?: any
+    download?: string | boolean | undefined
     href?: string | undefined
     hreflang?: string | undefined
     media?: string | undefined


### PR DESCRIPTION
Closes: #3093

This patch changes behavior when `download` attribute is set to a boolean value.

before:

```tsx
console.log(<a download></a>) // => <a download="true"></a>
console.log(<a download={ false }></a>) // => <a download="false"></a>
```

after:

```tsx
console.log(<a download></a>) // => <a download=""></a>
console.log(<a download={ false }></a>) // => <a></a>
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
