### PR TITLE
feat(lambda-edge): add `getConnInfo` helper for Lambda@Edge

### DIFF
--- a/src/adapter/lambda-edge/conninfo.test.ts
+++ b/src/adapter/lambda-edge/conninfo.test.ts
@@ -1,0 +1,27 @@
+import { Context } from '../../context'
+import type { CloudFrontEdgeEvent } from './handler'
+import { getConnInfo } from './conninfo'
+
+describe('getConnInfo', () => {
+  it('Should info is valid', () => {
+    const clientIp = Math.random().toString()
+    const env = {
+      event: {
+        Records: [
+          {
+            cf: {
+              request: {
+                clientIp,
+              },
+            },
+          },
+        ],
+      } as CloudFrontEdgeEvent,
+    }
+
+    const c = new Context(new Request('http://localhost/'), { env })
+    const info = getConnInfo(c)
+
+    expect(info.remote.address).toBe(clientIp)
+  })
+})

--- a/src/adapter/lambda-edge/conninfo.ts
+++ b/src/adapter/lambda-edge/conninfo.ts
@@ -1,0 +1,15 @@
+import type { GetConnInfo } from '../../helper/conninfo'
+import type { CloudFrontEdgeEvent } from './handler'
+import type { Context } from '../../context'
+
+type Env = {
+  Bindings: {
+    event: CloudFrontEdgeEvent
+  }
+}
+
+export const getConnInfo: GetConnInfo = (c: Context<Env>) => ({
+  remote: {
+    address: c.env.event.Records[0].cf.request.clientIp,
+  },
+})

--- a/src/adapter/lambda-edge/index.ts
+++ b/src/adapter/lambda-edge/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { handle } from './handler'
+export { getConnInfo } from './conninfo'
 export type {
   Callback,
   CloudFrontConfig,


### PR DESCRIPTION
Added `getConnInfo` for AWS Lambda@Edge.

Here is the code tested in the actual AWS environment.

https://github.com/yasuaki640/hono-lambda-edge-conninfo-20240705/blob/main/lambda/index_edge.ts

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
