### PR TITLE
refactor(http-status): remove unnecessary line of types and use common types

### DIFF
--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -67,4 +67,3 @@ export type StatusCode =
   | ClientErrorStatusCode
   | ServerErrorStatusCode
   | UnofficialStatusCode
-  | UnOfficalStatusCode

--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -55,7 +55,7 @@ export type UnofficialStatusCode = -1
  * @deprecated
  * Use `UnofficialStatusCode` instead.
  */
-export type UnOfficalStatusCode = -1
+export type UnOfficalStatusCode = UnofficialStatusCode
 
 /**
  * If you want to use an unofficial status, use `UnofficialStatusCode`.


### PR DESCRIPTION
I think each of `UnOfficalStatusCode` and `UnofficialStatusCode` are the same types (-1).
So, I can remove this line.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
