### PR TITLE
Export Client type

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,4 +11,5 @@ export type {
   ClientRequestOptions,
   ClientRequest,
   ClientResponse,
+  Client
 } from './types'


### PR DESCRIPTION
This PR exports the Client type so that it can be used in consuming projects. Without this, it is difficult to work with the RPC feature and build a custom API client. This small change will unblocks a big headache for me.
