### PR TITLE
fix(vercel): remove deprecated address type

### DIFF
--- a/src/adapter/vercel/conninfo.ts
+++ b/src/adapter/vercel/conninfo.ts
@@ -4,6 +4,5 @@ export const getConnInfo: GetConnInfo = (c) => ({
   remote: {
     // https://github.com/vercel/vercel/blob/b70bfb5fbf28a4650d4042ce68ca5c636d37cf44/packages/edge/src/edge-headers.ts#L10-L12C32
     address: c.req.header('x-real-ip'),
-    addressType: 'unknown',
   },
 })


### PR DESCRIPTION
In #2958, we plan to remove an unnecessary address type.
So this PR removes it from vercel adapter.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
