### PR TITLE
fix(types): allow `string[] | File[]` for RPC form value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1927,9 +1927,11 @@ type MergeTypedResponse<T> = T extends Promise<infer T2>
 //////                             /////
 ////////////////////////////////////////
 
+export type FormValue = string | File
+
 export type ValidationTargets = {
   json: any
-  form: Record<string, string | File>
+  form: Record<string, FormValue | FormValue[]>
   query: Record<string, string | string[]>
   param: Record<string, string> | Record<string, string | undefined>
   header: Record<string, string>

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -3,7 +3,13 @@ import type { ZodSchema } from 'zod'
 import { z } from 'zod'
 import { Hono } from '../hono'
 import { HTTPException } from '../http-exception'
-import type { ErrorHandler, ExtractSchema, MiddlewareHandler, ValidationTargets } from '../types'
+import type {
+  ErrorHandler,
+  ExtractSchema,
+  FormValue,
+  MiddlewareHandler,
+  ValidationTargets,
+} from '../types'
 import type { StatusCode } from '../utils/http-status'
 import type { Equal, Expect } from '../utils/types'
 import type { ValidationFunction } from './validator'
@@ -743,7 +749,7 @@ it('With path parameters', () => {
       $put: {
         input: {
           form: {
-            title: string | File
+            title: FormValue | FormValue[]
           }
         } & {
           param: {
@@ -789,7 +795,7 @@ it('`on`', () => {
       $purge: {
         input: {
           form: {
-            tag: string | File
+            tag: FormValue | FormValue[]
           }
         } & {
           query: {


### PR DESCRIPTION
Fixes #3116

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
