### PR TITLE
fix(jsx): redefine scope attribute as enum type

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -580,7 +580,7 @@ export namespace JSX {
     colspan?: number | undefined
     headers?: string | undefined
     rowspan?: number | undefined
-    scope?: string | undefined
+    scope?: 'row' | 'col' | 'rowgroup' | 'colgroup' | string | undefined
     abbr?: string | undefined
   }
 


### PR DESCRIPTION
The scope attribute of the `th` element is defined as an enumerated type in the HTML spec.

[Reference](https://html.spec.whatwg.org/multipage/tables.html#attr-th-scope:~:text=The%20scope%20attribute%20is%20an%20enumerated%20attribute%20with%20the%20following%20keywords%20and%20states%3A)

So I redefined it. 
(To avoid destructive changes, the definition as a string type is retained.)

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
