### PR TITLE
fix(type): degradation of generic type handling

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -180,7 +180,7 @@ type JSONRespondReturn<
       ? JSONValue extends SimplifyDeepArray<T>
         ? never
         : JSONParsed<T>
-      : JSONParsed<T>,
+      : never,
     U,
     'json'
   >

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -2240,3 +2240,24 @@ describe('Returning type from `app.use(path, mw)`', () => {
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
+describe('generic typed variables', () => {
+  type Variables = {
+    ok: <TData>(data: TData) => TypedResponse<{ data: TData }>
+  }
+  const app = new Hono<{ Variables: Variables }>()
+
+  it('Should set and get variables with correct types', async () => {
+    const route = app
+      .use('*', async (c, next) => {
+        c.set('ok', (data) => c.json({ data }))
+        await next()
+      })
+      .get('/', (c) => {
+        const ok = c.get('ok')
+        return ok('Hello')
+      })
+    type Actual = ExtractSchema<typeof route>['/']['$get']['output']
+    type Expected = { data: string }
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+})

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,9 @@ export type IfAnyThenEmptyObject<T> = 0 extends 1 & T ? {} : T
 
 export type JSONPrimitive = string | boolean | number | null
 export type JSONArray = (JSONPrimitive | JSONObject | JSONArray)[]
-export type JSONObject = { [key: string]: JSONPrimitive | JSONArray | JSONObject | object }
+export type JSONObject = {
+  [key: string]: JSONPrimitive | JSONArray | JSONObject | object | InvalidJSONValue
+}
 export type InvalidJSONValue = undefined | symbol | ((...args: unknown[]) => unknown)
 
 type InvalidToNull<T> = T extends InvalidJSONValue ? null : T


### PR DESCRIPTION
### The author should do the following, if applicable
fix #3135 

This works in the use case of the reported issue, I'm not 100% sure why this works though

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
