### PR TITLE
feat(jsx): add global attributes to interface definition

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -146,17 +146,37 @@ export namespace JSX {
 
   export interface HTMLAttributes extends JSXAttributes, EventAttributes, AnyAttributes {
     accesskey?: string | undefined
+    autocapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters' | undefined
     autofocus?: boolean | undefined
     class?: string | Promise<string> | undefined
     contenteditable?: boolean | 'inherit' | undefined
     contextmenu?: string | undefined
     dir?: string | undefined
     draggable?: boolean | undefined
+    enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
     hidden?: boolean | undefined
     id?: string | undefined
+    inert?: boolean | undefined
+    inputmode?:
+      | 'none'
+      | 'text'
+      | 'tel'
+      | 'url'
+      | 'email'
+      | 'numeric'
+      | 'decimal'
+      | 'search'
+      | undefined
+    is?: string | undefined
+    itemid?: string | undefined
+    itemprop?: string | undefined
+    itemref?: string | undefined
+    itemscope?: boolean | undefined
+    itemtype?: string | undefined
     lang?: string | undefined
     nonce?: string | undefined
     placeholder?: string | undefined
+    popover?: string | undefined
     slot?: string | undefined
     spellcheck?: boolean | undefined
     style?: CSSProperties | undefined
@@ -347,7 +367,6 @@ export namespace JSX {
     capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
     checked?: boolean | undefined
     disabled?: boolean | undefined
-    enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
     form?: string | undefined
     formenctype?: string | undefined
     formmethod?: string | undefined


### PR DESCRIPTION
The definition of the global attribute was added with reference to the [html specification](https://html.spec.whatwg.org/multipage/dom.html#global-attributes).

In my opinion, this PR will make hobo/jsx more user-friendly, though.
(It is debatable to what extent we should follow the HTML specification, so this PR will be closed if it is not necessary.)

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
