### PR TITLE
Fixes #3150 - BunJS not crashing when using Bun.build and then consume the client.

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -342,7 +342,6 @@ describe('Form - Multiple Values', () => {
   const client = hc('http://localhost/')
 
   it('Should get 200 response - query', async () => {
-    // @ts-expect-error `client['multiple-values'].$post` is not typed
     const res = await client['multiple-values'].$post({
       form: {
         key: ['foo', 'bar'],

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -39,9 +39,9 @@ function clientRequestImpl(baseUrl: string, method: string) {
   return {
     fetch: async (
       args?: ValidationTargets<FormValue> & {
-        param?: Record<string, string>;
+        param?: Record<string, string>
       },
-      opt?: ClientRequestOptions,
+      opt?: ClientRequestOptions
     ) => {
       if (args) {
         if (args.query) {
@@ -92,8 +92,8 @@ function clientRequestImpl(baseUrl: string, method: string) {
         ...(typeof opt?.headers === 'function'
           ? await opt.headers()
           : opt?.headers
-            ? opt.headers
-            : {}),
+          ? opt.headers
+          : {}),
       }
 
       if (args?.cookie) {
@@ -134,7 +134,7 @@ function clientRequestImpl(baseUrl: string, method: string) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const hc = <T extends Hono<any, Schema, string>>(
   baseUrl: string,
-  options?: ClientRequestOptions,
+  options?: ClientRequestOptions
 ) =>
   createProxy(function proxyCallback(opts) {
     const parts = [...opts.path]
@@ -177,7 +177,7 @@ export const hc = <T extends Hono<any, Schema, string>>(
     if (method === 'ws') {
       const webSocketUrl = replaceUrlProtocol(
         opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
-        'ws',
+        'ws'
       )
       const targetUrl = new URL(webSocketUrl)
       for (const key in opts.args[0]?.query ?? []) {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -186,7 +186,7 @@ export const hc = <T extends Hono<any, Schema, string>>(
       const targetUrl = new URL(webSocketUrl)
       for (const key in opts.args[0]?.query ?? []) {
         const value = opts.args[0].query[key]
-        targetUrl.searchParams.set(key, Array.isArray(value) ? value.join(',') : value)
+        targetUrl.searchParams.set(key, Array.isArray(value) ? value.toString() : value)
       }
 
       return new WebSocket(targetUrl.toString())

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,5 @@
 import type { Hono } from '../hono'
-import type { FormValue, ValidationTargets } from '../types'
+import type { FormValue, Schema, ValidationTargets } from '../types'
 import { serialize } from '../utils/cookie'
 import type { UnionToIntersection } from '../utils/types'
 import type { Callback, Client, ClientRequestOptions } from './types'
@@ -11,133 +11,130 @@ import {
   replaceUrlProtocol,
 } from './utils'
 
-const createProxy = (callback: Callback, path: string[]) => {
-  const proxy: unknown = new Proxy(() => {}, {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createProxy<T extends Hono<any, Schema, string>>(callback: Callback, path: string[]) {
+  const proxy = new Proxy(() => {}, {
     get(_obj, key) {
       if (typeof key !== 'string' || key === 'then') {
         return undefined
       }
       return createProxy(callback, [...path, key])
     },
-    apply(_1, _2, args) {
+    apply(_1, _2, args: (ValidationTargets & { param: Record<string, string> })[]) {
       return callback({
         path,
         args,
       })
     },
-  })
+  }) as UnionToIntersection<Client<T>>
   return proxy
 }
 
-class ClientRequestImpl {
-  private url: string
-  private method: string
-  private queryParams: URLSearchParams | undefined = undefined
-  private pathParams: Record<string, string> = {}
-  private rBody: BodyInit | undefined
-  private cType: string | undefined = undefined
+function clientRequestImpl(baseUrl: string, method: string) {
+  let queryParams: URLSearchParams | undefined = undefined
+  let pathParams: Record<string, string> = {}
+  let rBody: BodyInit | undefined = undefined
+  let cType: string | undefined = undefined
 
-  constructor(url: string, method: string) {
-    this.url = url
-    this.method = method
-  }
-  fetch = async (
-    args?: ValidationTargets<FormValue> & {
-      param?: Record<string, string>
+  return {
+    fetch: async (
+      args?: ValidationTargets<FormValue> & {
+        param?: Record<string, string>;
+      },
+      opt?: ClientRequestOptions,
+    ) => {
+      if (args) {
+        if (args.query) {
+          for (const [k, v] of Object.entries(args.query)) {
+            if (v === undefined) {
+              continue
+            }
+
+            queryParams ||= new URLSearchParams()
+            if (Array.isArray(v)) {
+              for (const v2 of v) {
+                queryParams.append(k, v2)
+              }
+            } else {
+              queryParams.set(k, v)
+            }
+          }
+        }
+
+        if (args.form) {
+          const form = new FormData()
+          for (const [k, v] of Object.entries(args.form)) {
+            if (Array.isArray(v)) {
+              for (const v2 of v) {
+                form.append(k, v2)
+              }
+            } else {
+              form.append(k, v)
+            }
+          }
+          rBody = form
+        }
+
+        if (args.json) {
+          rBody = JSON.stringify(args.json)
+          cType = 'application/json'
+        }
+
+        if (args.param) {
+          pathParams = args.param
+        }
+      }
+
+      let methodUpperCase = method.toUpperCase()
+
+      const headerValues: Record<string, string> = {
+        ...(args?.header ?? {}),
+        ...(typeof opt?.headers === 'function'
+          ? await opt.headers()
+          : opt?.headers
+            ? opt.headers
+            : {}),
+      }
+
+      if (args?.cookie) {
+        const cookies: string[] = []
+        for (const [key, value] of Object.entries(args.cookie)) {
+          cookies.push(serialize(key, value, { path: '/' }))
+        }
+        headerValues.Cookie = cookies.join(',')
+      }
+
+      if (cType) {
+        headerValues['Content-Type'] = cType
+      }
+
+      const headers = new Headers(headerValues ?? undefined)
+      let url = baseUrl
+
+      url = removeIndexString(url)
+      url = replaceUrlParam(url, pathParams)
+
+      if (queryParams) {
+        url = url + '?' + queryParams.toString()
+      }
+      methodUpperCase = method.toUpperCase()
+      const setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
+
+      // Pass URL string to 1st arg for testing with MSW and node-fetch
+      return (opt?.fetch ?? fetch)(url, {
+        body: setBody ? rBody : undefined,
+        method: methodUpperCase,
+        headers: headers,
+        ...opt?.init,
+      })
     },
-    opt?: ClientRequestOptions
-  ) => {
-    if (args) {
-      if (args.query) {
-        for (const [k, v] of Object.entries(args.query)) {
-          if (v === undefined) {
-            continue
-          }
-
-          this.queryParams ||= new URLSearchParams()
-          if (Array.isArray(v)) {
-            for (const v2 of v) {
-              this.queryParams.append(k, v2)
-            }
-          } else {
-            this.queryParams.set(k, v)
-          }
-        }
-      }
-
-      if (args.form) {
-        const form = new FormData()
-        for (const [k, v] of Object.entries(args.form)) {
-          if (Array.isArray(v)) {
-            for (const v2 of v) {
-              form.append(k, v2)
-            }
-          } else {
-            form.append(k, v)
-          }
-        }
-        this.rBody = form
-      }
-
-      if (args.json) {
-        this.rBody = JSON.stringify(args.json)
-        this.cType = 'application/json'
-      }
-
-      if (args.param) {
-        this.pathParams = args.param
-      }
-    }
-
-    let methodUpperCase = this.method.toUpperCase()
-
-    const headerValues: Record<string, string> = {
-      ...(args?.header ?? {}),
-      ...(typeof opt?.headers === 'function'
-        ? await opt.headers()
-        : opt?.headers
-        ? opt.headers
-        : {}),
-    }
-
-    if (args?.cookie) {
-      const cookies: string[] = []
-      for (const [key, value] of Object.entries(args.cookie)) {
-        cookies.push(serialize(key, value, { path: '/' }))
-      }
-      headerValues['Cookie'] = cookies.join(',')
-    }
-
-    if (this.cType) {
-      headerValues['Content-Type'] = this.cType
-    }
-
-    const headers = new Headers(headerValues ?? undefined)
-    let url = this.url
-
-    url = removeIndexString(url)
-    url = replaceUrlParam(url, this.pathParams)
-
-    if (this.queryParams) {
-      url = url + '?' + this.queryParams.toString()
-    }
-    methodUpperCase = this.method.toUpperCase()
-    const setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
-
-    // Pass URL string to 1st arg for testing with MSW and node-fetch
-    return (opt?.fetch || fetch)(url, {
-      body: setBody ? this.rBody : undefined,
-      method: methodUpperCase,
-      headers: headers,
-      ...opt?.init,
-    })
   }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>>(
+export const hc = <T extends Hono<any, Schema, string>>(
   baseUrl: string,
-  options?: ClientRequestOptions
+  options?: ClientRequestOptions,
 ) =>
   createProxy(function proxyCallback(opts) {
     const parts = [...opts.path]
@@ -180,17 +177,18 @@ export const hc = <T extends Hono<any, any, any>>(
     if (method === 'ws') {
       const webSocketUrl = replaceUrlProtocol(
         opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
-        'ws'
+        'ws',
       )
       const targetUrl = new URL(webSocketUrl)
-      for (const key in opts.args[0]?.query) {
-        targetUrl.searchParams.set(key, opts.args[0].query[key])
+      for (const key in opts.args[0]?.query ?? []) {
+        const value = opts.args[0].query[key]
+        targetUrl.searchParams.set(key, Array.isArray(value) ? value.join(',') : value)
       }
 
       return new WebSocket(targetUrl.toString())
     }
 
-    const req = new ClientRequestImpl(url, method)
+    const req = clientRequestImpl(url, method)
     if (method) {
       options ??= {}
       const args = deepMerge<ClientRequestOptions>(options, { ...(opts.args[1] ?? {}) })

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -30,104 +30,108 @@ function createProxy<T extends Hono<any, Schema, string>>(callback: Callback, pa
   return proxy
 }
 
-function clientRequestImpl(baseUrl: string, method: string) {
-  let queryParams: URLSearchParams | undefined = undefined
-  let pathParams: Record<string, string> = {}
-  let rBody: BodyInit | undefined = undefined
-  let cType: string | undefined = undefined
+class ClientRequestImpl {
+  private url: string
+  private method: string
+  private queryParams: URLSearchParams | undefined = undefined
+  private pathParams: Record<string, string> = {}
+  private rBody: BodyInit | undefined
+  private cType: string | undefined = undefined
 
-  return {
-    fetch: async (
-      args?: ValidationTargets<FormValue> & {
-        param?: Record<string, string>
-      },
-      opt?: ClientRequestOptions
-    ) => {
-      if (args) {
-        if (args.query) {
-          for (const [k, v] of Object.entries(args.query)) {
-            if (v === undefined) {
-              continue
-            }
-
-            queryParams ||= new URLSearchParams()
-            if (Array.isArray(v)) {
-              for (const v2 of v) {
-                queryParams.append(k, v2)
-              }
-            } else {
-              queryParams.set(k, v)
-            }
-          }
-        }
-
-        if (args.form) {
-          const form = new FormData()
-          for (const [k, v] of Object.entries(args.form)) {
-            if (Array.isArray(v)) {
-              for (const v2 of v) {
-                form.append(k, v2)
-              }
-            } else {
-              form.append(k, v)
-            }
-          }
-          rBody = form
-        }
-
-        if (args.json) {
-          rBody = JSON.stringify(args.json)
-          cType = 'application/json'
-        }
-
-        if (args.param) {
-          pathParams = args.param
-        }
-      }
-
-      let methodUpperCase = method.toUpperCase()
-
-      const headerValues: Record<string, string> = {
-        ...(args?.header ?? {}),
-        ...(typeof opt?.headers === 'function'
-          ? await opt.headers()
-          : opt?.headers
-          ? opt.headers
-          : {}),
-      }
-
-      if (args?.cookie) {
-        const cookies: string[] = []
-        for (const [key, value] of Object.entries(args.cookie)) {
-          cookies.push(serialize(key, value, { path: '/' }))
-        }
-        headerValues.Cookie = cookies.join(',')
-      }
-
-      if (cType) {
-        headerValues['Content-Type'] = cType
-      }
-
-      const headers = new Headers(headerValues ?? undefined)
-      let url = baseUrl
-
-      url = removeIndexString(url)
-      url = replaceUrlParam(url, pathParams)
-
-      if (queryParams) {
-        url = url + '?' + queryParams.toString()
-      }
-      methodUpperCase = method.toUpperCase()
-      const setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
-
-      // Pass URL string to 1st arg for testing with MSW and node-fetch
-      return (opt?.fetch ?? fetch)(url, {
-        body: setBody ? rBody : undefined,
-        method: methodUpperCase,
-        headers: headers,
-        ...opt?.init,
-      })
+  constructor(url: string, method: string) {
+    this.url = url
+    this.method = method
+  }
+  fetch = async (
+    args?: ValidationTargets<FormValue> & {
+      param?: Record<string, string>
     },
+    opt?: ClientRequestOptions
+  ) => {
+    if (args) {
+      if (args.query) {
+        for (const [k, v] of Object.entries(args.query)) {
+          if (v === undefined) {
+            continue
+          }
+
+          this.queryParams ||= new URLSearchParams()
+          if (Array.isArray(v)) {
+            for (const v2 of v) {
+              this.queryParams.append(k, v2)
+            }
+          } else {
+            this.queryParams.set(k, v)
+          }
+        }
+      }
+
+      if (args.form) {
+        const form = new FormData()
+        for (const [k, v] of Object.entries(args.form)) {
+          if (Array.isArray(v)) {
+            for (const v2 of v) {
+              form.append(k, v2)
+            }
+          } else {
+            form.append(k, v)
+          }
+        }
+        this.rBody = form
+      }
+
+      if (args.json) {
+        this.rBody = JSON.stringify(args.json)
+        this.cType = 'application/json'
+      }
+
+      if (args.param) {
+        this.pathParams = args.param
+      }
+    }
+
+    let methodUpperCase = this.method.toUpperCase()
+
+    const headerValues: Record<string, string> = {
+      ...(args?.header ?? {}),
+      ...(typeof opt?.headers === 'function'
+        ? await opt.headers()
+        : opt?.headers
+        ? opt.headers
+        : {}),
+    }
+
+    if (args?.cookie) {
+      const cookies: string[] = []
+      for (const [key, value] of Object.entries(args.cookie)) {
+        cookies.push(serialize(key, value, { path: '/' }))
+      }
+      headerValues['Cookie'] = cookies.join(',')
+    }
+
+    if (this.cType) {
+      headerValues['Content-Type'] = this.cType
+    }
+
+    const headers = new Headers(headerValues ?? undefined)
+    let url = this.url
+
+    url = removeIndexString(url)
+    url = replaceUrlParam(url, this.pathParams)
+
+    if (this.queryParams) {
+      url = url + '?' + this.queryParams.toString()
+    }
+    methodUpperCase = this.method.toUpperCase()
+    const setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
+
+    // Pass URL string to 1st arg for testing with MSW and node-fetch
+    return (opt?.fetch || fetch)(url, {
+      body: setBody ? this.rBody : undefined,
+      method: methodUpperCase,
+      headers: headers,
+      ...opt?.init,
+    })
   }
 }
 
@@ -188,7 +192,7 @@ export const hc = <T extends Hono<any, Schema, string>>(
       return new WebSocket(targetUrl.toString())
     }
 
-    const req = clientRequestImpl(url, method)
+    const req = new ClientRequestImpl(url, method)
     if (method) {
       options ??= {}
       const args = deepMerge<ClientRequestOptions>(options, { ...(opts.args[1] ?? {}) })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,5 @@
 import type { Hono } from '../hono'
-import type { Endpoint, ResponseFormat, Schema } from '../types'
+import type { Endpoint, FormValue, ResponseFormat, Schema, ValidationTargets } from '../types'
 import type { StatusCode, SuccessStatusCode } from '../utils/http-status'
 import type { HasRequiredKeys } from '../utils/types'
 
@@ -170,8 +170,9 @@ export type Callback = (opts: CallbackOptions) => unknown
 
 interface CallbackOptions {
   path: string[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any[]
+  args: (ValidationTargets<FormValue> & {
+    param?: Record<string, string>
+  })[]
 }
 
 export type ObjectType<T = unknown> = {


### PR DESCRIPTION
### The author should do the following, if applicable

- [❌] Add tests
- [✔️] Run tests
- [✔️] `bun run format:fix && bun run lint:fix` to format the code
- [❌] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

While we could wait for BunJS to fix it, we could move the client to use functions instead of a class. This should not change the behavior of the client. Also, I took advantage to improve a bit further the types.