### PR TITLE
refactor: pull out `.length` from for loop

### DIFF
--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -21,7 +21,7 @@ export class LinearRouter<T> implements Router<T> {
   match(method: string, path: string): Result<T> {
     const handlers: [T, Params][] = []
     const routesLength = this.routes.length
-    ROUTES_LOOP: for (let i = 0, len = routesLength; i < len; i++) {
+    ROUTES_LOOP: for (let i = 0; i < routesLength; i++) {
       const [routeMethod, routePath, handler] = this.routes[i]
       if (routeMethod !== method && routeMethod !== METHOD_NAME_ALL) {
         continue

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -20,7 +20,8 @@ export class LinearRouter<T> implements Router<T> {
 
   match(method: string, path: string): Result<T> {
     const handlers: [T, Params][] = []
-    ROUTES_LOOP: for (let i = 0, len = this.routes.length; i < len; i++) {
+    const routesLength = this.routes.length
+    ROUTES_LOOP: for (let i = 0, len = routesLength; i < len; i++) {
       const [routeMethod, routePath, handler] = this.routes[i]
       if (routeMethod !== method && routeMethod !== METHOD_NAME_ALL) {
         continue


### PR DESCRIPTION
On something like the router, the smallest improvement makes a difference.

https://dev.to/siddiqus/which-for-loop-is-the-fastest-in-javascript-4hdf