### PR TITLE
feat: initApp of factory support rpc

### DIFF
--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -204,7 +204,8 @@ describe('createHandler', () => {
 
 describe('createApp', () => {
   type Env = { Variables: { foo: string } }
-  const factory = createFactory<Env>({
+  const factory = createFactory<Env>()
+  const app = factory.createApp({
     initApp: (app) => {
       app.use((c, next) => {
         c.set('foo', 'bar')
@@ -212,7 +213,6 @@ describe('createApp', () => {
       })
     },
   })
-  const app = factory.createApp()
   it('Should set the correct type and initialize the app', async () => {
     app.get('/', (c) => {
       expectTypeOf(c.var.foo).toEqualTypeOf<string>()
@@ -221,6 +221,27 @@ describe('createApp', () => {
     const res = await app.request('/')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('bar')
+  })
+  
+  const app2 = factory.createApp({
+    initApp: (app) => {
+      return app.get("/", (c) => c.text("Hono is cool"))
+    }
+  })
+  it('Should set the correct type and initialize the app', async () => {
+    expectTypeOf(app2).toEqualTypeOf<Hono<Env, {
+      "/": {
+          $get: {
+              input: {};
+              output: "Hono is cool";
+              outputFormat: "text";
+              status: StatusCode;
+          };
+      };
+  }, "/">>()
+    const res = await app2.request('/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Hono is cool')
   })
 })
 

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -222,23 +222,29 @@ describe('createApp', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('bar')
   })
-  
+
   const app2 = factory.createApp({
     initApp: (app) => {
-      return app.get("/", (c) => c.text("Hono is cool"))
-    }
+      return app.get('/', (c) => c.text('Hono is cool'))
+    },
   })
   it('Should set the correct type and initialize the app', async () => {
-    expectTypeOf(app2).toEqualTypeOf<Hono<Env, {
-      "/": {
-          $get: {
-              input: {};
-              output: "Hono is cool";
-              outputFormat: "text";
-              status: StatusCode;
-          };
-      };
-  }, "/">>()
+    expectTypeOf(app2).toEqualTypeOf<
+      Hono<
+        Env,
+        {
+          '/': {
+            $get: {
+              input: {}
+              output: 'Hono is cool'
+              outputFormat: 'text'
+              status: StatusCode
+            }
+          }
+        },
+        '/'
+      >
+    >()
     const res = await app2.request('/')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('Hono is cool')

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from '../../hono'
-import type { BlankEnv, BlankSchema, Env, H, HandlerResponse, Input, MergePath, MiddlewareHandler } from '../../types'
+import type { BlankSchema, Env, H, HandlerResponse, Input, MiddlewareHandler } from '../../types'
 
 type InitApp<E extends Env = Env> = (app: Hono<E>) => Hono<E> | void
 
@@ -210,7 +210,7 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
   ]
 }
 
-export class Factory<E extends Env = any, P extends string = "/"> {
+export class Factory<E extends Env = any, P extends string = '/'> {
   private initApp?: InitApp<E>
 
   constructor(init?: { initApp?: InitApp<E> }) {
@@ -230,7 +230,7 @@ export class Factory<E extends Env = any, P extends string = "/"> {
     if (this.initApp) {
       this.initApp(app)
     }
-    return app as ReturnType<A> extends void ? Hono<E, BlankSchema> : ReturnType<A>;
+    return app as ReturnType<A> extends void ? Hono<E, BlankSchema> : ReturnType<A>
   }
 
   createMiddleware = <I extends Input = {}>(middleware: MiddlewareHandler<E, P, I>) => middleware
@@ -241,15 +241,13 @@ export class Factory<E extends Env = any, P extends string = "/"> {
   }
 }
 
-export const createFactory = <E extends Env = any, P extends string = any>(
-  init?: {
-    /**
-      * @deprecated
-      * use `factory.createApp({ initApp })` instead of `createFactory({ initApp })` 
-      */
-    initApp?: InitApp<E>
-  }
-): Factory<E, P> => new Factory<E, P>(init)
+export const createFactory = <E extends Env = any, P extends string = any>(init?: {
+  /**
+   * @deprecated
+   * use `factory.createApp({ initApp })` instead of `createFactory({ initApp })`
+   */
+  initApp?: InitApp<E>
+}): Factory<E, P> => new Factory<E, P>(init)
 
 export const createMiddleware = <
   E extends Env = any,

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -221,7 +221,7 @@ export class Factory<E extends Env = any, P extends string = '/'> {
    * @experimental
    * `createApp` is an experimental feature.
    */
-  createApp = <A extends InitApp<E>>(init?: { initApp?: A }) => {
+  createApp = <A extends InitApp<E>>(init?: { initApp?: A }): ReturnType<A> extends void ? Hono<E, BlankSchema> : ReturnType<A> => {
     if (init?.initApp) {
       this.initApp = init?.initApp
     }

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -221,7 +221,9 @@ export class Factory<E extends Env = any, P extends string = '/'> {
    * @experimental
    * `createApp` is an experimental feature.
    */
-  createApp = <A extends InitApp<E>>(init?: { initApp?: A }): ReturnType<A> extends void ? Hono<E, BlankSchema> : ReturnType<A> => {
+  createApp = <A extends InitApp<E>>(init?: {
+    initApp?: A
+  }): ReturnType<A> extends void ? Hono<E, BlankSchema> : ReturnType<A> => {
     if (init?.initApp) {
       this.initApp = init?.initApp
     }


### PR DESCRIPTION
The purpose of this PR is to add the route declared in `initApp` to `Schema` so that it can be used from RPC.  

Also, since `initApp` is only used in createApp and specifying the types in the factory constructor makes the types more circuitous,
The previous method is marked as deprecated.  

We can remove the `deprecated` and make `initApp` a `createApp` only property.

```ts
// typed
const app = factory.createApp({
  initApp: app => app.get("/factory", (c) => c.text("Hono and Factory is cool")).use(middleware)
})
```

However, since this would not achieve the objective of avoiding redundancy by the factory, we are actually considering the following approach.

```ts
const factory = createFactory().initApp(app => app...)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Related
https://github.com/honojs/hono/issues/3159