### PR TITLE
fix(client): support array values for `query` in `ws`

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1079,9 +1079,10 @@ describe('WebSocket URL Protocol Translation with Query Parameters', () => {
       query: {
         id: '123',
         type: 'test',
+        tag: ['a', 'b'],
       },
     })
-    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index?id=123&type=test')
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index?id=123&type=test&tag=a&tag=b')
   })
 
   it('Translates HTTPS to wss and includes query parameters', async () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -183,8 +183,16 @@ export const hc = <T extends Hono<any, any, any>>(
         'ws'
       )
       const targetUrl = new URL(webSocketUrl)
-      for (const key in opts.args[0]?.query) {
-        targetUrl.searchParams.set(key, opts.args[0].query[key])
+
+      const queryParams: Record<string, string | string[]> | undefined = opts.args[0]?.query
+      if (queryParams) {
+        Object.entries(queryParams).forEach(([key, value]) => {
+          if (Array.isArray(value)) {
+            value.forEach((item) => targetUrl.searchParams.append(key, item))
+          } else {
+            targetUrl.searchParams.set(key, value)
+          }
+        })
       }
 
       return new WebSocket(targetUrl.toString())


### PR DESCRIPTION
Related to #3151

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
