### PR TITLE
fix(types): handle readonly array correctly

### DIFF
--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -101,6 +101,11 @@ describe('JSONParsed', () => {
       type Expected = (number | null)[]
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
+    it('should convert { key: readonly T[]} correctly', () => {
+      type Actual = JSONParsed<{ key: readonly number[] }>
+      type Expected = { key: readonly number[] }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
   })
 
   describe('tuple', () => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -56,6 +56,8 @@ export type JSONParsed<T> = T extends { toJSON(): infer J }
   ? [JSONParsed<InvalidToNull<R>>, ...JSONParsed<U>]
   : T extends Array<infer U>
   ? Array<JSONParsed<InvalidToNull<U>>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<JSONParsed<InvalidToNull<U>>>
   : T extends Set<unknown> | Map<unknown, unknown>
   ? {}
   : T extends object


### PR DESCRIPTION
### The author should do the following, if applicable
My apologies that `JSONParsed` didn't convert `ReadonlyArray` type correctly. Types of methods disappeared
![image](https://github.com/user-attachments/assets/0d5a0d33-b772-4c44-b952-da44b0bff84b)

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
