### PR TITLE
Revert "fix(helper/adapter): don't check `navigator` is `undefined`

### DIFF
--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -47,12 +47,8 @@ export const getRuntimeKey = (): Runtime => {
   const global = globalThis as any
 
   // check if the current runtime supports navigator.userAgent
-  let userAgentSupported = false
-  // In Cloudflare Pages, navigator is undefined in the production environment.
-  // Therefore, it only check navigator.userAgent.
-  try {
-    userAgentSupported = typeof navigator.userAgent === 'string'
-  } catch {}
+  const userAgentSupported =
+    typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string'
 
   // if supported, check the user agent
   if (userAgentSupported) {


### PR DESCRIPTION
This reverts commit a285c4b3b4bc7a9c162ec24669c9890b16f91f63.
Related to #3158

I thought `navigator` would be `undefined` in the production of Cloudflare Pages. But it will not be `undefined` if we set `compatibility_date` correctly. So the commit is not necessary. We should keep the code clean.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
