### PR TITLE
fix:(csrf) fix typo of csrf middleware

### DIFF
--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -73,7 +73,7 @@ export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
     return handler(origin, c)
   }
 
-  return async function cors(c, next) {
+  return async function csrf(c, next) {
     if (
       !isSafeMethodRe.test(c.req.method) &&
       isRequestedByFormElementRe.test(c.req.header('content-type') || '') &&


### PR DESCRIPTION
There was a section that appeared to be a naming discrepancy, which has been corrected.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
