### PR TITLE
fix(validator): support `application/json` with a charset as JSON

### DIFF
--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -136,6 +136,18 @@ describe('JSON', () => {
     expect(res.status).toBe(200)
   })
 
+  it('Should validate if Content-Type is a application/json with a charset', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf8',
+      },
+      body: JSON.stringify({ foo: 'bar' }),
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ foo: 'bar' })
+  })
+
   it('Should validate if Content-Type is a subtype like application/merge-patch+json', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -23,8 +23,8 @@ export type ValidationFunction<
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExcludeResponseType<T> = T extends Response & TypedResponse<any> ? never : T
 
-const jsonRegex = /^application\/([a-z-\.]+\+)?json$/
-const multipartRegex = /^multipart\/form-data(; boundary=[A-Za-z0-9'"()+_,\-./:=?]+)?$/
+const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+const multipartRegex = /^multipart\/form-data(; boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
 const urlencodedRegex = /^application\/x-www-form-urlencoded$/
 
 export const validator = <


### PR DESCRIPTION
Fixes #3194

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
