### PR TITLE
feat(jsx/dom): improve performance of `findInsertBefore`

### DIFF
--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -273,22 +273,29 @@ const getNextChildren = (
 const findInsertBefore = (node: Node | undefined): SupportedElement | Text | null => {
   if (!node) {
     return null
-  } else if (node.tag === HONO_PORTAL_ELEMENT) {
-    return findInsertBefore(node.nN)
-  } else if (node.e) {
-    return node.e
   }
 
-  if (node.vC) {
-    for (let i = 0, len = node.vC.length; i < len; i++) {
-      const e = findInsertBefore(node.vC[i])
-      if (e) {
-        return e
+  const stack: (Node | undefined)[] = [node]
+
+  while (stack.length > 0) {
+    const currentNode = stack.pop()
+
+    if (!currentNode) {
+      continue
+    }
+
+    if (currentNode.tag === HONO_PORTAL_ELEMENT) {
+      stack.push(currentNode.nN)
+    } else if (currentNode.e) {
+      return currentNode.e
+    } else if (currentNode.vC) {
+      for (let i = currentNode.vC.length - 1; i >= 0; i--) {
+        stack.push(currentNode.vC[i])
       }
     }
   }
 
-  return findInsertBefore(node.nN)
+  return null
 }
 
 const removeNode = (node: Node): void => {


### PR DESCRIPTION
Fix #3201

I honestly don't know much about it, but eliminating recursive calls improves performance.
We may need accurate benchmarks or tests.

I tried with the following example:
https://github.com/ryuapp/hono-vite-template
At least increasing the issue example didn't slow it down.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
