### PR TITLE
fix(jsx/dom): fix performance issue with adding many new node listings

### DIFF
--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -117,6 +117,24 @@ describe('DOM', () => {
     expect(root.innerHTML).toBe('Hello')
   })
 
+  describe('performance', () => {
+    it('should be O(N) for each additional element', () => {
+      const App = () => (
+        <>
+          {Array.from({ length: 1000 }, (_, i) => (
+            <div>
+              <span>{i}</span>
+            </div>
+          ))}
+        </>
+      )
+      render(<App />, root)
+      expect(root.innerHTML).toBe(
+        Array.from({ length: 1000 }, (_, i) => `<div><span>${i}</span></div>`).join('')
+      )
+    })
+  })
+
   describe('attribute', () => {
     it('simple', () => {
       const App = () => <div id='app' class='app' />

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -271,24 +271,11 @@ const getNextChildren = (
 }
 
 const findInsertBefore = (node: Node | undefined): SupportedElement | Text | null => {
-  if (!node) {
-    return null
-  } else if (node.tag === HONO_PORTAL_ELEMENT) {
-    return findInsertBefore(node.nN)
-  } else if (node.e) {
-    return node.e
-  }
-
-  if (node.vC) {
-    for (let i = 0, len = node.vC.length; i < len; i++) {
-      const e = findInsertBefore(node.vC[i])
-      if (e) {
-        return e
-      }
-    }
-  }
-
-  return findInsertBefore(node.nN)
+  return !node
+    ? null
+    : node.tag === HONO_PORTAL_ELEMENT
+    ? findInsertBefore(node.nN)
+    : node.e || (node.vC && node.pP && findInsertBefore(node.vC[0])) || findInsertBefore(node.nN)
 }
 
 const removeNode = (node: Node): void => {


### PR DESCRIPTION
fix #3201

* First time rendering does not need to look for elements from child nodes
** Avoid unnecessary checks with `node.pP`.
* Sibling elements are always searched, so there is no need for a for loop.
** Need only `findInsertBefore(node.vC[0])`

I have not added any additional tests as there is already sufficient testing on the expected rendering results.

For performance, although it is a simple test, I have added a test to check that I am not getting as much computation as n to the nth power.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
