### PR TITLE
feat(client): Add WebSocket Provider Integration Tests and Enhance WebSocket Initialization

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1250,7 +1250,7 @@ describe('WebSocket Provider Integration', () => {
         console.log(`Message from client: ${event.data}`)
         ws.send('Hello from server!')
       },
-      onClose: () => {
+      onClose() {
         console.log('Connection closed')
       },
     }))

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1240,3 +1240,80 @@ describe('Redirect response - only types', () => {
     }
   })
 })
+
+describe('WebSocket Provider Integration', () => {
+  const app = new Hono()
+  const route = app.get(
+    '/',
+    upgradeWebSocket((c) => ({
+      onMessage(event, ws) {
+        console.log(`Message from client: ${event.data}`)
+        ws.send('Hello from server!')
+      },
+      onClose: () => {
+        console.log('Connection closed')
+      },
+    }))
+  )
+
+  type AppType = typeof route
+
+  const server = setupServer()
+  beforeAll(() => server.listen())
+  afterEach(() => {
+    vi.clearAllMocks()
+    server.resetHandlers()
+  })
+  afterAll(() => server.close())
+
+  it.each([
+    {
+      description: 'should initialize the WebSocket provider correctly',
+      url: 'http://localhost',
+      query: undefined,
+      expectedUrl: 'ws://localhost/index',
+    },
+    {
+      description: 'should correctly add query parameters to the WebSocket URL',
+      url: 'http://localhost',
+      query: { id: '123', type: 'test', tag: ['a', 'b'] },
+      expectedUrl: 'ws://localhost/index?id=123&type=test&tag=a&tag=b',
+    },
+  ])('$description', ({ url, expectedUrl, query }) => {
+    const webSocketMock = vi.fn()
+    const client = hc<AppType>(url, {
+      webSocket(url, options) {
+        return webSocketMock(url, options)
+      },
+    })
+    client.index.$ws({ query })
+    expect(webSocketMock).toHaveBeenCalledWith(expectedUrl, undefined)
+  })
+
+  it.each([
+    {
+      description: 'should use the default WebSocket URL when no query parameters are provided',
+      url: 'http://localhost',
+      query: undefined,
+      expectedUrl: 'ws://localhost/index',
+    },
+    {
+      description: 'should correctly add query parameters in the WebSocket URL',
+      url: 'http://localhost',
+      query: { id: '123', type: 'test', tag: ['a', 'b'] },
+      expectedUrl: 'ws://localhost/index?id=123&type=test&tag=a&tag=b',
+    },
+  ])('$description', ({ url, expectedUrl, query }) => {
+    const webSocketMock = vi.fn()
+    const client = hc<AppType>(url)
+    client.index.$ws(
+      { query },
+      {
+        webSocket(url, options) {
+          return webSocketMock(url, options)
+        },
+      }
+    )
+    expect(webSocketMock).toHaveBeenCalledWith(expectedUrl, undefined)
+  })
+})

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1247,7 +1247,6 @@ describe('WebSocket Provider Integration', () => {
     '/',
     upgradeWebSocket((c) => ({
       onMessage(event, ws) {
-        console.log(`Message from client: ${event.data}`)
         ws.send('Hello from server!')
       },
       onClose() {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1289,31 +1289,4 @@ describe('WebSocket Provider Integration', () => {
     client.index.$ws({ query })
     expect(webSocketMock).toHaveBeenCalledWith(expectedUrl, undefined)
   })
-
-  it.each([
-    {
-      description: 'should use the default WebSocket URL when no query parameters are provided',
-      url: 'http://localhost',
-      query: undefined,
-      expectedUrl: 'ws://localhost/index',
-    },
-    {
-      description: 'should correctly add query parameters in the WebSocket URL',
-      url: 'http://localhost',
-      query: { id: '123', type: 'test', tag: ['a', 'b'] },
-      expectedUrl: 'ws://localhost/index?id=123&type=test&tag=a&tag=b',
-    },
-  ])('$description', ({ url, expectedUrl, query }) => {
-    const webSocketMock = vi.fn()
-    const client = hc<AppType>(url)
-    client.index.$ws(
-      { query },
-      {
-        webSocket(url, options) {
-          return webSocketMock(url, options)
-        },
-      }
-    )
-    expect(webSocketMock).toHaveBeenCalledWith(expectedUrl, undefined)
-  })
 })

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -195,9 +195,6 @@ export const hc = <T extends Hono<any, any, any>>(
         })
       }
       const establishWebSocket = (...args: ConstructorParameters<typeof WebSocket>) => {
-        if (opts.args[1] !== undefined && typeof opts.args[1].webSocket === 'function') {
-          return opts.args[1].webSocket(...args)
-        }
         if (options?.webSocket !== undefined && typeof options.webSocket === 'function') {
           return options.webSocket(...args)
         }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -194,8 +194,17 @@ export const hc = <T extends Hono<any, any, any>>(
           }
         })
       }
+      const establishWebSocket = (...args: ConstructorParameters<typeof WebSocket>) => {
+        if (opts.args[1] !== undefined && typeof opts.args[1].webSocket === 'function') {
+          return opts.args[1].webSocket(...args)
+        }
+        if (options?.webSocket !== undefined && typeof options.webSocket === 'function') {
+          return options.webSocket(...args)
+        }
+        return new WebSocket(...args)
+      }
 
-      return new WebSocket(targetUrl.toString())
+      return establishWebSocket(targetUrl.toString())
     }
 
     const req = new ClientRequestImpl(url, method)

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -7,6 +7,7 @@ type HonoRequest = (typeof Hono.prototype)['request']
 
 export type ClientRequestOptions<T = unknown> = {
   fetch?: typeof fetch | HonoRequest
+  webSocket?: (...args: ConstructorParameters<typeof WebSocket>) => WebSocket
   /**
    * Standard `RequestInit`, caution that this take highest priority
    * and could be used to overwrite things that Hono sets for you, like `body | method | headers`.
@@ -43,7 +44,7 @@ export type ClientRequest<S extends Schema> = {
 } & (S['$get'] extends { outputFormat: 'ws' }
     ? S['$get'] extends { input: infer I }
       ? {
-          $ws: (args?: I) => WebSocket
+          $ws: (args?: I, options?: Pick<ClientRequestOptions, 'webSocket'>) => WebSocket
         }
       : {}
     : {})

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -44,7 +44,7 @@ export type ClientRequest<S extends Schema> = {
 } & (S['$get'] extends { outputFormat: 'ws' }
     ? S['$get'] extends { input: infer I }
       ? {
-          $ws: (args?: I, options?: Pick<ClientRequestOptions, 'webSocket'>) => WebSocket
+          $ws: (args?: I) => WebSocket
         }
       : {}
     : {})


### PR DESCRIPTION
## Background
I use hono/client and wanted to reconnect websockets. However, the $ws method in hono/client internally creates a new WebSocket, so in order to use a websocket client with reconnection, it was necessary to define the url directly. This would lose the type safety of Hono RPC.

This change allows the use of clients that conform to WebSocket interfaces with reconnection, such as [reconnecting-websocket](https://github.com/pladaria/reconnecting-websocket), internally.

### example usage

```ts
import ReconnectingWebSocket from 'reconnecting-websocket';

const client = hc<AppType>(url, {
  webSocket(url, options) {
    return new ReconnectingWebSocket(url, options)
  },
})
client.index.$ws({ query })
```

## What was done

- Added new test cases for WebSocket provider integration to ensure correct initialization and handling of query parameters.
- Enhanced WebSocket initialization logic to support custom WebSocket implementations via client options.
- Updated `hc` function to use `establishWebSocket` method for flexible WebSocket creation.
- Modified `ClientRequestOptions` to include `webSocket` for custom WebSocket handling.

## How to Test

- Run the new and existing test suite to verify functionality and integration.
- Verify the correct inclusion and handling of query parameters in WebSocket URLs.

### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [X] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
