### PR TITLE
fix: factory inherit basePath types

### DIFF
--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from '../../hono'
-import type { Env, H, HandlerResponse, Input, MiddlewareHandler } from '../../types'
+import type { BlankEnv, Env, H, HandlerResponse, Input, MiddlewareHandler } from '../../types'
 
 type InitApp<E extends Env = Env> = (app: Hono<E>) => void
 
@@ -217,7 +217,7 @@ export class Factory<E extends Env = any, P extends string = any> {
     this.initApp = init?.initApp
   }
 
-  createApp = (): Hono<E> => {
+  createApp = (): Hono<E, BlankEnv, P> => {
     const app = new Hono<E>()
     if (this.initApp) {
       this.initApp(app)


### PR DESCRIPTION
factory don't inherit types of BasePath.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
