### PR TITLE
fix(jsx): corrects the type of 'draggable' attribute in intrinsic-elements.ts

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -152,7 +152,7 @@ export namespace JSX {
     contenteditable?: boolean | 'inherit' | undefined
     contextmenu?: string | undefined
     dir?: string | undefined
-    draggable?: boolean | undefined
+    draggable?: 'true' | 'false' | undefined
     enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
     hidden?: boolean | undefined
     id?: string | undefined


### PR DESCRIPTION
closes #3223 

Since [the html specification defines the draggable attribute as an enum](https://html.spec.whatwg.org/multipage/dnd.html#the-draggable-attribute),
we have modified it to conform to that specification.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
