### PR TITLE
feat(jsx): allow to merge CSSProperties declaration

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -10,7 +10,9 @@
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {
   export type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
-  export interface CSSProperties { [propertyKey: string]: unknown }
+  export interface CSSProperties {
+    [propertyKey: string]: unknown
+  }
   type AnyAttributes = { [attributeName: string]: any }
 
   interface JSXAttributes {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -10,7 +10,7 @@
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {
   export type CrossOrigin = 'anonymous' | 'use-credentials' | '' | undefined
-  export type CSSProperties = {}
+  export interface CSSProperties { [propertyKey: string]: unknown }
   type AnyAttributes = { [attributeName: string]: any }
 
   interface JSXAttributes {
@@ -179,7 +179,7 @@ export namespace JSX {
     popover?: string | undefined
     slot?: string | undefined
     spellcheck?: boolean | undefined
-    style?: CSSProperties | undefined
+    style?: CSSProperties | string | undefined
     tabindex?: number | undefined
     title?: string | undefined
     translate?: 'yes' | 'no' | undefined


### PR DESCRIPTION
Type declarations don't allow to merge, so [overriding type declaration](https://hono.dev/docs/guides/jsx#override-type-definitions) from docs doesn't work for CSSProperties.


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
