### PR TITLE
fix(types): `param` in `ValidationTargets` supports optional param

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1808,7 +1808,7 @@ type ChangePathOfSchema<S extends Schema, Path extends string> = keyof S extends
   : { [K in keyof S as Path]: S[K] }
 
 export type Endpoint = {
-  input: Partial<ValidationTargets>
+  input: any
   output: any
   outputFormat: ResponseFormat
   status: StatusCode
@@ -1930,11 +1930,11 @@ type MergeTypedResponse<T> = T extends Promise<infer T2>
 export type FormValue = string | Blob
 export type ParsedFormValue = string | File
 
-export type ValidationTargets<T extends FormValue = ParsedFormValue> = {
+export type ValidationTargets<T extends FormValue = ParsedFormValue, P extends string = string> = {
   json: any
   form: Record<string, T | T[]>
   query: Record<string, string | string[]>
-  param: Record<string, string> | Record<string, string | undefined>
+  param: Record<P, P extends `${infer _}?` ? string | undefined : string>
   header: Record<string, string>
   cookie: Record<string, string>
 }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -833,6 +833,11 @@ it('With path parameters', () => {
 
   const route = app.put(
     '/posts/:id',
+    validator('param', () => {
+      return {
+        id: '123',
+      }
+    }),
     validator('form', () => {
       return {
         title: 'Foo',


### PR DESCRIPTION
Fixes #3227

In the current branch, `param` will be `Record<string, string> | Record<string, string | undefined>` regardless of whether the value of path param is optional or not. With this PR, the value type will be `string` by default, but it will be `string | undefined` if it is optional.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
