### PR TITLE
refactor(src/utils): refactor some function signatures in src/utils

### DIFF
--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -29,12 +29,8 @@ export const equal = (a: ArrayBuffer, b: ArrayBuffer): boolean => {
 export const timingSafeEqual = async (
   a: string | object | boolean,
   b: string | object | boolean,
-  hashFunction?: Function
+  hashFunction: Function = sha256
 ): Promise<boolean> => {
-  if (!hashFunction) {
-    hashFunction = sha256
-  }
-
   const [sa, sb] = await Promise.all([hashFunction(a), hashFunction(b)])
 
   if (!sa || !sb) {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -290,13 +290,12 @@ const _getQueryParam = (
   return key ? results[key] : results
 }
 
-export const getQueryParam: (
+export const getQueryParam = (
   url: string,
   key?: string
-) => string | undefined | Record<string, string> = _getQueryParam as (
-  url: string,
-  key?: string
-) => string | undefined | Record<string, string>
+): string | undefined | Record<string, string> => {
+  return _getQueryParam(url, key) as string | undefined | Record<string, string>
+}
 
 export const getQueryParams = (
   url: string,


### PR DESCRIPTION
### The author should do the following, if applicable

 src/utils/buffer.ts
 changed to default argument because it seemed redundant to handle cases where a hash function was not passed as an argument.

src/utils/url.ts
changed signatures like getQueryParams 

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code