### PR TITLE
fix(jsx): allow null, undefined, and boolean to be returned from function component

### DIFF
--- a/runtime_tests/deno-jsx/jsx.test.tsx
+++ b/runtime_tests/deno-jsx/jsx.test.tsx
@@ -28,6 +28,12 @@ Deno.test('JSX: Fragment', () => {
   assertEquals(fragment.toString(), '<p>1</p><p>2</p>')
 })
 
+Deno.test('JSX: Empty Fragment', () => {
+  const Component = () => <></>
+  const html = <Component />
+  assertEquals(html.toString(), '')
+})
+
 Deno.test('JSX: Async Component', async () => {
   const Component = async ({ name }: { name: string }) =>
     new Promise<HtmlEscapedString>((resolve) => setTimeout(() => resolve(<span>{name}</span>), 10))

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -247,7 +247,10 @@ class JSXFunctionNode extends JSXNode {
       children: children.length <= 1 ? children[0] : children,
     })
 
-    if (res instanceof Promise) {
+    if (typeof res === 'boolean' || res == null) {
+      // boolean or null or undefined
+      return
+    } else if (res instanceof Promise) {
       if (globalContexts.length === 0) {
         buffer.unshift('', res)
       } else {

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -15,7 +15,7 @@ import { domRenderers } from './intrinsic-element/common'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Props = Record<string, any>
 export type FC<P = Props> = {
-  (props: P): HtmlEscapedString | Promise<HtmlEscapedString>
+  (props: P): HtmlEscapedString | Promise<HtmlEscapedString> | null
   defaultProps?: Partial<P> | undefined
   displayName?: string | undefined
 }
@@ -374,11 +374,11 @@ export const memo = <T>(
   component: FC<T>,
   propsAreEqual: (prevProps: Readonly<T>, nextProps: Readonly<T>) => boolean = shallowEqual
 ): FC<T> => {
-  let computed: HtmlEscapedString | Promise<HtmlEscapedString> | undefined = undefined
+  let computed: ReturnType<FC<T>> = null
   let prevProps: T | undefined = undefined
-  return ((props: T & { children?: Child }): HtmlEscapedString | Promise<HtmlEscapedString> => {
+  return ((props) => {
     if (prevProps && !propsAreEqual(prevProps, props)) {
-      computed = undefined
+      computed = null
     }
     prevProps = props
     return (computed ||= component(props))

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -383,6 +383,24 @@ describe('render to string', () => {
         '<html><head><title>Home page</title></head><body><h1>Hono</h1><p>Hono is great</p></body></html>'
       )
     })
+
+    describe('Booleans, Null, and Undefined Are Ignored', () => {
+      it.each([true, false, undefined, null])('%s', (item) => {
+        const Component: FC = (() => {
+          return item
+        }) as FC
+        const template = <Component />
+        expect(template.toString()).toBe('')
+      })
+
+      it('falsy value', () => {
+        const Component: FC = (() => {
+          return 0
+        }) as unknown as FC
+        const template = <Component />
+        expect(template.toString()).toBe('0')
+      })
+    })
   })
 
   describe('style attribute', () => {


### PR DESCRIPTION
fixes #3235
The deno converts an empty `Fragment` to `null` when the value of the "jsx" entry is "precompile", but "hono/jsx" was not able to handle the function component returning `null`, which caused the problem #3235.

### What should be the returned value of an `FC` type?

In the current React type definition, `FunctionComponent` returns the `ReactNode`, and since `ReactNode` also includes `boolean` and `undefined`, it would be preferable if Hono's `FC` also included these (`boolean` and `undefined`). 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1114-L1122
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L478-L489

However, the changes to add `undefined` and `boolean` have a considerable impact on existing code, so I have chosen not to do so in this pull request. I would like to discuss this at another time.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
