### PR TITLE
fix(jsx): fix draggable type to accept boolean

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -154,7 +154,7 @@ export namespace JSX {
     contenteditable?: boolean | 'inherit' | undefined
     contextmenu?: string | undefined
     dir?: string | undefined
-    draggable?: 'true' | 'false' | undefined
+    draggable?: 'true' | 'false' | boolean | undefined
     enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined
     hidden?: boolean | undefined
     id?: string | undefined


### PR DESCRIPTION
React accepts a boolean for the draggable attribute, so I adapted the behavior.
Incidentally, other [Boolianish values](https://github.com/facebook/react/blob/ba6a9e94edf0db3ad96432804f9931ce9dc89fec/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L649-L654) also render a 'true' or 'false' string when they receive a boolean, so this type definition should be less confusing to the user.

An example of the code is as follows

```tsx
  it('test draggable', () => {
    const template = <div draggable={true}>draggable</div>
    expect(template.toString()).toBe('<div draggable="true">draggable</div>')
  })

  // other booleanish value
  it('test spellcheck', () => {
    const template = <div spellcheck={true}>spellcheck</div>
    expect(template.toString()).toBe('<div spellcheck="true">spellcheck</div>')
  })
```

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
