### PR TITLE
fix(jsx): handle async component error explicitly and throw the error in the response

### DIFF
--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -56,14 +56,15 @@ export const stringBufferToString = async (
 ): Promise<HtmlEscapedString> => {
   let str = ''
   callbacks ||= []
-  for (let i = buffer.length - 1; ; i--) {
-    str += buffer[i]
+  const resolvedBuffer = await Promise.all(buffer)
+  for (let i = resolvedBuffer.length - 1; ; i--) {
+    str += resolvedBuffer[i]
     i--
     if (i < 0) {
       break
     }
 
-    let r = await buffer[i]
+    let r = resolvedBuffer[i]
     if (typeof r === 'object') {
       callbacks.push(...((r as HtmlEscapedString).callbacks || []))
     }


### PR DESCRIPTION
fixes #3252

`Uncaught (in promise)` was occurring and the app was crashing under the following conditions.

* There are multiple asynchronous components.
* While waiting for the first Promise to be resolved, an error occurred in the subsequent Promise.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
