### PR TITLE
feat(jsx): improve meta-tag types with well known values

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -466,15 +466,73 @@ export namespace JSX {
     src?: string | undefined
   }
 
+  /**
+   * String literal types with auto-complition
+   * @see https://github.com/Microsoft/TypeScript/issues/29729
+   */
+  type LiteralUnion<T> = T | (string & Record<never, never>)
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv
+   */
+  type MetaHttpEquiv =
+    | LiteralUnion<
+        'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh'
+      >
+    | undefined
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name
+   */
+  type MetaName =
+    | LiteralUnion<
+        | 'application-name'
+        | 'author'
+        | 'description'
+        | 'generator'
+        | 'keywords'
+        | 'referrer'
+        | 'theme-color'
+        | 'color-scheme'
+        | 'viewport'
+        | 'creator'
+        | 'googlebot'
+        | 'publisher'
+        | 'robots'
+      >
+    | undefined
+  /**
+   * @see https://ogp.me/
+   */
+  type MetaProperty =
+    | LiteralUnion<
+        | 'og:title'
+        | 'og:type'
+        | 'og:image'
+        | 'og:url'
+        | 'og:audio'
+        | 'og:description'
+        | 'og:determiner'
+        | 'og:locale'
+        | 'og:locale:alternate'
+        | 'og:site_name'
+        | 'og:video'
+        | 'og:image:url'
+        | 'og:image:secure_url'
+        | 'og:image:type'
+        | 'og:image:width'
+        | 'og:image:height'
+        | 'og:image:alt'
+      >
+    | undefined
   interface MetaHTMLAttributes extends HTMLAttributes {
-    charset?: string | undefined
-    'http-equiv'?: string | undefined
-    name?: string | undefined
+    charset?: LiteralUnion<'utf-8'> | undefined
+    'http-equiv'?: MetaHttpEquiv
+    name?: MetaName
     media?: string | undefined
     content?: string | undefined
+    property?: MetaProperty
 
     // React 19 compatibility
-    httpEquiv?: string | undefined
+    httpEquiv?: MetaHttpEquiv
   }
 
   interface MeterHTMLAttributes extends HTMLAttributes {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -467,7 +467,7 @@ export namespace JSX {
   }
 
   /**
-   * String literal types with auto-complition
+   * String literal types with auto-completion
    * @see https://github.com/Microsoft/TypeScript/issues/29729
    */
   type LiteralUnion<T> = T | (string & Record<never, never>)
@@ -475,64 +475,59 @@ export namespace JSX {
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv
    */
   type MetaHttpEquiv =
-    | LiteralUnion<
-        'content-security-policy' | 'content-type' | 'default-style' | 'x-ua-compatible' | 'refresh'
-      >
-    | undefined
+    | 'content-security-policy'
+    | 'content-type'
+    | 'default-style'
+    | 'x-ua-compatible'
+    | 'refresh'
   /**
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name
    */
   type MetaName =
-    | LiteralUnion<
-        | 'application-name'
-        | 'author'
-        | 'description'
-        | 'generator'
-        | 'keywords'
-        | 'referrer'
-        | 'theme-color'
-        | 'color-scheme'
-        | 'viewport'
-        | 'creator'
-        | 'googlebot'
-        | 'publisher'
-        | 'robots'
-      >
-    | undefined
+    | 'application-name'
+    | 'author'
+    | 'description'
+    | 'generator'
+    | 'keywords'
+    | 'referrer'
+    | 'theme-color'
+    | 'color-scheme'
+    | 'viewport'
+    | 'creator'
+    | 'googlebot'
+    | 'publisher'
+    | 'robots'
   /**
    * @see https://ogp.me/
    */
   type MetaProperty =
-    | LiteralUnion<
-        | 'og:title'
-        | 'og:type'
-        | 'og:image'
-        | 'og:url'
-        | 'og:audio'
-        | 'og:description'
-        | 'og:determiner'
-        | 'og:locale'
-        | 'og:locale:alternate'
-        | 'og:site_name'
-        | 'og:video'
-        | 'og:image:url'
-        | 'og:image:secure_url'
-        | 'og:image:type'
-        | 'og:image:width'
-        | 'og:image:height'
-        | 'og:image:alt'
-      >
-    | undefined
+    | 'og:title'
+    | 'og:type'
+    | 'og:image'
+    | 'og:url'
+    | 'og:audio'
+    | 'og:description'
+    | 'og:determiner'
+    | 'og:locale'
+    | 'og:locale:alternate'
+    | 'og:site_name'
+    | 'og:video'
+    | 'og:image:url'
+    | 'og:image:secure_url'
+    | 'og:image:type'
+    | 'og:image:width'
+    | 'og:image:height'
+    | 'og:image:alt'
   interface MetaHTMLAttributes extends HTMLAttributes {
     charset?: LiteralUnion<'utf-8'> | undefined
-    'http-equiv'?: MetaHttpEquiv
-    name?: MetaName
+    'http-equiv'?: LiteralUnion<MetaHttpEquiv> | undefined
+    name?: LiteralUnion<MetaName> | undefined
     media?: string | undefined
     content?: string | undefined
-    property?: MetaProperty
+    property?: LiteralUnion<MetaProperty> | undefined
 
     // React 19 compatibility
-    httpEquiv?: MetaHttpEquiv
+    httpEquiv?: LiteralUnion<MetaHttpEquiv> | undefined
   }
 
   interface MeterHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
Improve meta-tag types with well known values like `c.header` (#3221) .

Now, we can use auto-completion in JSX:
![image](https://github.com/user-attachments/assets/1ac634f9-90b4-4620-83ac-2a35510eb3d2)


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

