### PR TITLE
feat(jsx): improve a-tag types with well known values

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { StringLiteralUnion } from '../utils/types'
+
 /**
  * This code is based on React.
  * https://github.com/facebook/react
@@ -467,11 +469,6 @@ export namespace JSX {
   }
 
   /**
-   * String literal types with auto-completion
-   * @see https://github.com/Microsoft/TypeScript/issues/29729
-   */
-  type LiteralUnion<T> = T | (string & Record<never, never>)
-  /**
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv
    */
   type MetaHttpEquiv =
@@ -519,15 +516,15 @@ export namespace JSX {
     | 'og:image:height'
     | 'og:image:alt'
   interface MetaHTMLAttributes extends HTMLAttributes {
-    charset?: LiteralUnion<'utf-8'> | undefined
-    'http-equiv'?: LiteralUnion<MetaHttpEquiv> | undefined
-    name?: LiteralUnion<MetaName> | undefined
+    charset?: StringLiteralUnion<'utf-8'> | undefined
+    'http-equiv'?: StringLiteralUnion<MetaHttpEquiv> | undefined
+    name?: StringLiteralUnion<MetaName> | undefined
     media?: string | undefined
     content?: string | undefined
-    property?: LiteralUnion<MetaProperty> | undefined
+    property?: StringLiteralUnion<MetaProperty> | undefined
 
     // React 19 compatibility
-    httpEquiv?: LiteralUnion<MetaHttpEquiv> | undefined
+    httpEquiv?: StringLiteralUnion<MetaHttpEquiv> | undefined
   }
 
   interface MeterHTMLAttributes extends HTMLAttributes {

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { BaseMime } from '../utils/mime'
 import type { StringLiteralUnion } from '../utils/types'
 
 /**
@@ -201,7 +202,7 @@ export namespace JSX {
     | 'strict-origin-when-cross-origin'
     | 'unsafe-url'
 
-  type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | string
+  type HTMLAttributeAnchorTarget = StringLiteralUnion<'_self' | '_blank' | '_parent' | '_top'>
 
   interface AnchorHTMLAttributes extends HTMLAttributes {
     download?: string | boolean | undefined
@@ -210,7 +211,7 @@ export namespace JSX {
     media?: string | undefined
     ping?: string | undefined
     target?: HTMLAttributeAnchorTarget | undefined
-    type?: string | undefined
+    type?: StringLiteralUnion<BaseMime> | undefined
     referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -97,3 +97,9 @@ export type HasRequiredKeys<BaseType extends object> = RequiredKeysOf<BaseType> 
   : true
 
 export type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false
+
+/**
+ * String literal types with auto-completion
+ * @see https://github.com/Microsoft/TypeScript/issues/29729
+ */
+export type StringLiteralUnion<T> = T | (string & Record<never, never>)


### PR DESCRIPTION
ref. #3276

* Refactor `LiteralUnion` type. It moves to utils directory and renamed to `StringLiteralUnion`.
* Improve a-tag types with well known values like meta-tag(#3276).

![image](https://github.com/user-attachments/assets/b09c0275-5451-43c0-8f82-6025aafd5a72)
![image](https://github.com/user-attachments/assets/a4d2e9bf-f64c-4bdb-a94b-deea12ce0599)


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
