### PR TITLE
perf(jsx/dom): improve performance

### DIFF
--- a/src/jsx/dom/context.ts
+++ b/src/jsx/dom/context.ts
@@ -2,7 +2,7 @@ import type { Child } from '../base'
 import { DOM_ERROR_HANDLER } from '../constants'
 import type { Context } from '../context'
 import { globalContexts } from '../context'
-import { newJSXNode, setInternalTagFlag } from './utils'
+import { setInternalTagFlag } from './utils'
 
 export const createContextProviderFunction =
   <T>(values: T[]): Function =>
@@ -33,7 +33,7 @@ export const createContextProviderFunction =
       }),
       props: {},
     })
-    const res = newJSXNode({ tag: '', props })
+    const res = { tag: '', props, type: '' }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(res as any)[DOM_ERROR_HANDLER] = (err: unknown) => {
       values.pop()

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -736,6 +736,16 @@ describe('DOM', () => {
     })
   })
 
+  describe('dangerouslySetInnerHTML', () => {
+    it('string', () => {
+      const App = () => {
+        return <div dangerouslySetInnerHTML={{ __html: '<p>Hello</p>' }} />
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<div><p>Hello</p></div>')
+    })
+  })
+
   describe('Event', () => {
     it('bubbling phase', async () => {
       const clicked: string[] = []
@@ -883,6 +893,13 @@ describe('DOM', () => {
       const addEventListenerSpy = vi.spyOn(dom.window.Node.prototype, 'addEventListener')
       render(<App />, root)
       expect(addEventListenerSpy).not.toHaveBeenCalled()
+    })
+
+    it('invalid event handler value', async () => {
+      const App = () => {
+        return <div onClick={1 as unknown as () => void}></div>
+      }
+      expect(() => render(<App />, root)).toThrow()
     })
   })
 
@@ -1874,6 +1891,16 @@ describe('DOM', () => {
       await Promise.resolve()
       expect(root.innerHTML).toBe('<div><p>1</p></div>')
     })
+
+    it('title', async () => {
+      const App = () => {
+        return <div>{createElement('title', {}, 'Hello')}</div>
+      }
+      const app = <App />
+      render(app, root)
+      expect(document.head.innerHTML).toBe('<title>Hello</title>')
+      expect(root.innerHTML).toBe('<div></div>')
+    })
   })
 
   describe('dom-specific createElement', () => {
@@ -1888,6 +1915,16 @@ describe('DOM', () => {
       root.querySelector('p')?.click()
       await Promise.resolve()
       expect(root.innerHTML).toBe('<div><p>1</p></div>')
+    })
+
+    it('title', async () => {
+      const App = () => {
+        return <div>{createElementForDom('title', {}, 'Hello')}</div>
+      }
+      const app = <App />
+      render(app, root)
+      expect(document.head.innerHTML).toBe('<title>Hello</title>')
+      expect(root.innerHTML).toBe('<div></div>')
     })
   })
 

--- a/src/jsx/dom/intrinsic-element/components.test.tsx
+++ b/src/jsx/dom/intrinsic-element/components.test.tsx
@@ -524,7 +524,7 @@ describe('intrinsic element', () => {
         )
       })
 
-      it('should be ordered by precedence attribute', () => {
+      it('should ignore precedence attribute', () => {
         const App = () => {
           return (
             <div>

--- a/src/jsx/dom/intrinsic-element/components.ts
+++ b/src/jsx/dom/intrinsic-element/components.ts
@@ -1,6 +1,5 @@
 import type { Props } from '../../base'
 import type { FC, JSXNode, PropsWithChildren, RefObject } from '../../types'
-import { newJSXNode } from '../utils'
 import { createPortal, getNameSpaceContext } from '../render'
 import type { PreserveNodeType } from '../render'
 import { useContext } from '../../context'
@@ -58,10 +57,12 @@ const documentMetadataTag = (
   supportBlocking: boolean
 ) => {
   if (props?.itemProp) {
-    return newJSXNode({
+    return {
       tag,
       props,
-    })
+      type: tag,
+      ref: props.ref,
+    }
   }
 
   const head = document.head
@@ -192,13 +193,15 @@ const documentMetadataTag = (
     }
   }
 
-  const jsxNode = newJSXNode({
+  const jsxNode = {
     tag,
+    type: tag,
     props: {
       ...restProps,
       ref,
     },
-  }) as JSXNode & { e?: HTMLElement; p?: PreserveNodeType }
+    ref,
+  } as unknown as JSXNode & { e?: HTMLElement; p?: PreserveNodeType }
 
   jsxNode.p = preserveNodeType // preserve for unmounting
   if (element) {
@@ -215,30 +218,37 @@ export const title: FC<PropsWithChildren> = (props) => {
   const nameSpaceContext = getNameSpaceContext()
   const ns = nameSpaceContext && useContext(nameSpaceContext)
   if (ns?.endsWith('svg')) {
-    return newJSXNode({
+    return {
       tag: 'title',
       props,
-    })
+      type: 'title',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref: (props as any).ref,
+    } as unknown as JSXNode
   }
   return documentMetadataTag('title', props, undefined, false, false)
 }
 
 export const script: FC<PropsWithChildren<IntrinsicElements['script']>> = (props) => {
   if (!props || ['src', 'async'].some((k) => !props[k])) {
-    return newJSXNode({
+    return {
       tag: 'style',
       props,
-    })
+      type: 'style',
+      ref: props.ref,
+    } as unknown as JSXNode
   }
   return documentMetadataTag('script', props, 1, false, true)
 }
 
 export const style: FC<PropsWithChildren<IntrinsicElements['style']>> = (props) => {
   if (!props || !['href', 'precedence'].every((k) => k in props)) {
-    return newJSXNode({
+    return {
       tag: 'style',
       props,
-    })
+      type: 'style',
+      ref: props.ref,
+    } as unknown as JSXNode
   }
   props['data-href'] = props.href
   delete props.href
@@ -251,10 +261,12 @@ export const link: FC<PropsWithChildren<IntrinsicElements['link']>> = (props) =>
     ['onLoad', 'onError'].some((k) => k in props) ||
     (props.rel === 'stylesheet' && (!('precedence' in props) || 'disabled' in props))
   ) {
-    return newJSXNode({
+    return {
       tag: 'link',
       props,
-    })
+      type: 'link',
+      ref: props.ref,
+    } as unknown as JSXNode
   }
   return documentMetadataTag('link', props, 1, 'precedence' in props, true)
 }
@@ -309,7 +321,7 @@ export const form: FC<
 
   const [data, isDirty] = state
   state[1] = false
-  return newJSXNode({
+  return {
     tag: FormContext as unknown as Function,
     props: {
       value: {
@@ -318,17 +330,19 @@ export const form: FC<
         method: data ? 'post' : null,
         action: data ? action : null,
       },
-      children: newJSXNode({
+      children: {
         tag: 'form',
         props: {
           ...restProps,
           ref,
         },
-      }),
+        type: 'form',
+        ref,
+      },
     },
     f: isDirty,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any) as any
+  } as any
 }
 
 const formActionableElement = (
@@ -357,11 +371,13 @@ const formActionableElement = (
     })
   }
 
-  return newJSXNode({
+  return {
     tag,
     props,
+    type: tag,
+    ref: props.ref,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }) as any
+  } as any
 }
 
 export const input: FC<PropsWithChildren<IntrinsicElements['input']>> = (props) =>

--- a/src/jsx/dom/jsx-dev-runtime.ts
+++ b/src/jsx/dom/jsx-dev-runtime.ts
@@ -4,17 +4,19 @@
  */
 
 import type { JSXNode, Props } from '../base'
-import { newJSXNode } from './utils'
 import * as intrinsicElementTags from './intrinsic-element/components'
 
 export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXNode => {
-  return newJSXNode({
-    tag:
-      (typeof tag === 'string' && intrinsicElementTags[tag as keyof typeof intrinsicElementTags]) ||
-      tag,
+  if (typeof tag === 'string' && intrinsicElementTags[tag as keyof typeof intrinsicElementTags]) {
+    tag = intrinsicElementTags[tag as keyof typeof intrinsicElementTags]
+  }
+  return {
+    tag,
+    type: tag,
     props,
     key,
-  })
+    ref: props.ref,
+  } as JSXNode
 }
 
 export const Fragment = (props: Record<string, unknown>): JSXNode => jsxDEV('', props, undefined)

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -105,11 +105,22 @@ export const getNameSpaceContext = () => nameSpaceContext
 
 const isNodeString = (node: Node): node is NodeString => 't' in (node as NodeString)
 
+const eventCache: Record<string, [string, boolean]> = {
+  // pre-define events that are used very frequently
+  onClick: ['click', false],
+}
 const getEventSpec = (key: string): [string, boolean] | undefined => {
+  if (!key.startsWith('on')) {
+    return undefined
+  }
+  if (eventCache[key]) {
+    return eventCache[key]
+  }
+
   const match = key.match(/^on([A-Z][a-zA-Z]+?(?:PointerCapture)?)(Capture)?$/)
   if (match) {
     const [, eventName, capture] = match
-    return [(eventAliasMap[eventName] || eventName).toLowerCase(), !!capture]
+    return (eventCache[key] = [(eventAliasMap[eventName] || eventName).toLowerCase(), !!capture])
   }
   return undefined
 }

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -261,7 +261,9 @@ const getNextChildren = (
   childrenToRemove: Node[],
   callbacks: EffectData[]
 ): void => {
-  childrenToRemove.push(...node.vR)
+  if (node.vR?.length) {
+    childrenToRemove.push(...node.vR)
+  }
   if (typeof node.tag === 'function') {
     node[DOM_STASH][1][STASH_EFFECT]?.forEach((data: EffectData) => callbacks.push(data))
   }
@@ -274,7 +276,9 @@ const getNextChildren = (
         getNextChildren(child, container, nextChildren, childrenToRemove, callbacks)
       } else {
         nextChildren.push(child)
-        childrenToRemove.push(...child.vR)
+        if (child.vR?.length) {
+          childrenToRemove.push(...child.vR)
+        }
       }
     }
   })

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -40,7 +40,6 @@ export type NodeObject = {
   vC: Node[] // virtual dom children
   pC?: Node[] // previous virtual dom children
   vR: Node[] // virtual dom children to remove
-  s?: Node[] // shadow virtual dom children
   n?: string // namespace
   f?: boolean // force build
   c: Container | undefined // container
@@ -221,12 +220,6 @@ const applyProps = (
 }
 
 const invokeTag = (context: Context, node: NodeObject): Child[] => {
-  if (node.s) {
-    const res = node.s
-    node.s = undefined
-    return res as Child[]
-  }
-
   node[DOM_STASH][0] = 0
   buildDataStack.push([context, node])
   const func = (node.tag as HasRenderToDom)[DOM_RENDERER] || node.tag

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -263,6 +263,8 @@ const getNextChildren = (
 ): void => {
   if (node.vR?.length) {
     childrenToRemove.push(...node.vR)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (node as any).vR
   }
   if (typeof node.tag === 'function') {
     node[DOM_STASH][1][STASH_EFFECT]?.forEach((data: EffectData) => callbacks.push(data))
@@ -285,6 +287,8 @@ const getNextChildren = (
         nextChildren.push(child)
         if (child.vR?.length) {
           childrenToRemove.push(...child.vR)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (child as any).vR
         }
       }
     }
@@ -394,11 +398,6 @@ const applyNodeObject = (node: NodeObject, container: Container, isNew: boolean)
           : document.createElement(child.tag as string)
         applyProps(el as HTMLElement, child.props, child.pP)
         applyNodeObject(child, el as HTMLElement, isNewLocal)
-        if (child.vR.length) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          delete (child as any).vR
-          delete child.pP
-        }
       }
     }
     if (child.tag === HONO_PORTAL_ELEMENT) {
@@ -415,9 +414,6 @@ const applyNodeObject = (node: NodeObject, container: Container, isNew: boolean)
         container.insertBefore(el, childNodes[offset] || null)
       }
     }
-  }
-  if (node.vR.length) {
-    node.vR = []
   }
   if (node.pP) {
     delete node.pP

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -237,14 +237,16 @@ const invokeTag = (context: Context, node: NodeObject): Child[] => {
   node[DOM_STASH][0] = 0
   buildDataStack.push([context, node])
   const func = (node.tag as HasRenderToDom)[DOM_RENDERER] || node.tag
-  try {
-    return [
-      func.call(null, {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const props = (func as any).defaultProps
+    ? {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ...((func as any).defaultProps || {}),
+        ...(func as any).defaultProps,
         ...node.props,
-      }),
-    ]
+      }
+    : node.props
+  try {
+    return [func.call(null, props)]
   } finally {
     buildDataStack.pop()
   }

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -126,6 +126,7 @@ const getEventSpec = (key: string): [string, boolean] | undefined => {
 }
 
 const toAttributeName = (element: SupportedElement, key: string): string =>
+  nameSpaceContext &&
   element instanceof SVGElement &&
   /[A-Z]/.test(key) &&
   (key in element.style || // Presentation attributes are findable in style object. "clip-path", "font-size", "stroke-width", etc.

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -138,7 +138,8 @@ const applyProps = (
   oldAttributes?: Props
 ): void => {
   attributes ||= {}
-  for (let [key, value] of Object.entries(attributes)) {
+  for (let key in attributes) {
+    const value = attributes[key]
     if (key !== 'children' && (!oldAttributes || oldAttributes[key] !== value)) {
       key = normalizeIntrinsicElementKey(key)
       const eventSpec = getEventSpec(key)
@@ -215,7 +216,8 @@ const applyProps = (
     }
   }
   if (oldAttributes) {
-    for (let [key, value] of Object.entries(oldAttributes)) {
+    for (let key in oldAttributes) {
+      const value = oldAttributes[key]
       if (key !== 'children' && !(key in attributes)) {
         key = normalizeIntrinsicElementKey(key)
         const eventSpec = getEventSpec(key)

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -20,8 +20,6 @@ const nameSpaceMap: Record<string, string> = {
   math: '1998/Math/MathML',
 } as const
 
-const skipProps: Set<string> = new Set(['children'])
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type HasRenderToDom = FC<any> & { [DOM_RENDERER]: FC<any> }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -141,7 +139,7 @@ const applyProps = (
 ): void => {
   attributes ||= {}
   for (let [key, value] of Object.entries(attributes)) {
-    if (!skipProps.has(key) && (!oldAttributes || oldAttributes[key] !== value)) {
+    if (key !== 'children' && (!oldAttributes || oldAttributes[key] !== value)) {
       key = normalizeIntrinsicElementKey(key)
       const eventSpec = getEventSpec(key)
       if (eventSpec) {
@@ -218,7 +216,7 @@ const applyProps = (
   }
   if (oldAttributes) {
     for (let [key, value] of Object.entries(oldAttributes)) {
-      if (!skipProps.has(key) && !(key in attributes)) {
+      if (key !== 'children' && !(key in attributes)) {
         key = normalizeIntrinsicElementKey(key)
         const eventSpec = getEventSpec(key)
         if (eventSpec) {

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -263,11 +263,14 @@ const getNextChildren = (
 }
 
 const findInsertBefore = (node: Node | undefined): SupportedElement | Text | null => {
-  return !node
-    ? null
-    : node.tag === HONO_PORTAL_ELEMENT
-    ? findInsertBefore(node.nN)
-    : node.e || (node.vC && node.pP && findInsertBefore(node.vC[0])) || findInsertBefore(node.nN)
+  for (; ; node = node.tag === HONO_PORTAL_ELEMENT || !node.vC || !node.pP ? node.nN : node.vC[0]) {
+    if (!node) {
+      return null
+    }
+    if (node.tag !== HONO_PORTAL_ELEMENT && node.e) {
+      return node.e
+    }
+  }
 }
 
 const removeNode = (node: Node): void => {

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -7,7 +7,6 @@ import type { EffectData } from '../hooks'
 import { STASH_EFFECT } from '../hooks'
 import { normalizeIntrinsicElementKey, styleObjectForEach } from '../utils'
 import { createContext } from './context' // import dom-specific versions
-import { newJSXNode } from './utils'
 
 const HONO_PORTAL_ELEMENT = '_hp'
 
@@ -548,13 +547,15 @@ export const buildNode = (node: Child): Node | undefined => {
     return { t: node.toString(), d: true } as NodeString
   } else {
     if ('vR' in node) {
-      node = newJSXNode({
+      node = {
         tag: (node as NodeObject).tag,
         props: (node as NodeObject).props,
         key: (node as NodeObject).key,
         f: (node as NodeObject).f,
+        type: (node as NodeObject).tag,
+        ref: (node as NodeObject).props.ref,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any)
+      } as any
     }
     if (typeof (node as JSXNode).tag === 'function') {
       ;(node as NodeObject)[DOM_STASH] = [0, []]

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -178,8 +178,8 @@ const applyProps = (
           }
         }
       } else {
-        const nodeName = container.nodeName
         if (key === 'value') {
+          const nodeName = container.nodeName
           if (nodeName === 'INPUT' || nodeName === 'TEXTAREA' || nodeName === 'SELECT') {
             ;(container as unknown as HTMLInputElement).value =
               value === null || value === undefined || value === false ? null : value
@@ -195,8 +195,8 @@ const applyProps = (
             }
           }
         } else if (
-          (key === 'checked' && nodeName === 'INPUT') ||
-          (key === 'selected' && nodeName === 'OPTION')
+          (key === 'checked' && container.nodeName === 'INPUT') ||
+          (key === 'selected' && container.nodeName === 'OPTION')
         ) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ;(container as any)[key] = value

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -330,14 +330,6 @@ const apply = (node: NodeObject, container: Container, isNew: boolean): void => 
   applyNodeObject(node, container, isNew)
 }
 
-const applyNode = (node: Node, container: Container, isNew: boolean): void => {
-  if (isNodeString(node)) {
-    container.textContent = node.t
-  } else {
-    applyNodeObject(node, container, isNew)
-  }
-}
-
 const findChildNodeIndex = (
   childNodes: NodeListOf<ChildNode>,
   child: ChildNode | null | undefined
@@ -401,7 +393,7 @@ const applyNodeObject = (node: NodeObject, container: Container, isNew: boolean)
           ? (document.createElementNS(child.n, child.tag as string) as SVGElement | MathMLElement)
           : document.createElement(child.tag as string)
         applyProps(el as HTMLElement, child.props, child.pP)
-        applyNode(child, el as HTMLElement, isNewLocal)
+        applyNodeObject(child, el as HTMLElement, isNewLocal)
         if (child.vR.length) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           delete (child as any).vR

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -145,14 +145,16 @@ const applyProps = (
       key = normalizeIntrinsicElementKey(key)
       const eventSpec = getEventSpec(key)
       if (eventSpec) {
-        if (oldAttributes) {
-          container.removeEventListener(eventSpec[0], oldAttributes[key], eventSpec[1])
-        }
-        if (value != null) {
-          if (typeof value !== 'function') {
-            throw new Error(`Event handler for "${key}" is not a function`)
+        if (oldAttributes?.[key] !== value) {
+          if (oldAttributes) {
+            container.removeEventListener(eventSpec[0], oldAttributes[key], eventSpec[1])
           }
-          container.addEventListener(eventSpec[0], value, eventSpec[1])
+          if (value != null) {
+            if (typeof value !== 'function') {
+              throw new Error(`Event handler for "${key}" is not a function`)
+            }
+            container.addEventListener(eventSpec[0], value, eventSpec[1])
+          }
         }
       } else if (key === 'dangerouslySetInnerHTML' && value) {
         container.innerHTML = value.__html

--- a/src/jsx/dom/utils.ts
+++ b/src/jsx/dom/utils.ts
@@ -1,4 +1,3 @@
-import type { JSXNode, Props } from '../base'
 import { DOM_INTERNAL_TAG } from '../constants'
 
 export const setInternalTagFlag = (fn: Function): Function => {

--- a/src/jsx/dom/utils.ts
+++ b/src/jsx/dom/utils.ts
@@ -6,19 +6,3 @@ export const setInternalTagFlag = (fn: Function): Function => {
   ;(fn as any)[DOM_INTERNAL_TAG] = true
   return fn
 }
-
-const JSXNodeCompatPrototype = {
-  type: {
-    get(this: { tag: string | Function }): string | Function {
-      return this.tag
-    },
-  },
-  ref: {
-    get(this: { props?: { ref: unknown } }): unknown {
-      return this.props?.ref
-    },
-  },
-}
-
-export const newJSXNode = (obj: { tag: string | Function; props?: Props; key?: string }): JSXNode =>
-  Object.defineProperties(obj, JSXNodeCompatPrototype) as JSXNode

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -40,8 +40,11 @@ describe('Hooks', () => {
 
   describe('useReducer()', () => {
     it('simple', async () => {
+      const reducer = (state: number, action: number) => state + action
+      const functions: Function[] = []
       const App = () => {
-        const [state, dispatch] = useReducer((state: number, action: number) => state + action, 0)
+        const [state, dispatch] = useReducer(reducer, 0)
+        functions.push(dispatch)
         return (
           <div>
             <button onClick={() => dispatch(1)}>{state}</button>
@@ -53,6 +56,7 @@ describe('Hooks', () => {
       root.querySelector('button')?.click()
       await Promise.resolve()
       expect(root.innerHTML).toBe('<div><button>1</button></div>')
+      expect(functions[0]).toBe(functions[1])
     })
   })
 

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -247,13 +247,14 @@ export const useReducer = <T, A>(
   initialArg: T,
   init?: (initialState: T) => T
 ): [T, (action: A) => void] => {
-  const [state, setState] = useState(() => (init ? init(initialArg) : initialArg))
-  return [
-    state,
+  const handler = useCallback(
     (action: A) => {
       setState((state) => reducer(state, action))
     },
-  ]
+    [reducer]
+  )
+  const [state, setState] = useState(() => (init ? init(initialArg) : initialArg))
+  return [state, handler]
 }
 
 const useEffectCommon = (


### PR DESCRIPTION
#3264

### Key changes

#### use for-loop instead of recursion for `findInsertBefore` 0dadfbc26c44bff5c5789a34ee20184675648b57

As @ryuapp  pointed out in #3203, the implementation with recursive calls did not perform well and sometimes resulted in errors when there were a large number of elements, so it was modified so that recursive calls were not made.

#### assign type and ref to node object directly. `Object.defineProperties` is too slow 7fd73efa4ba42002eb335c2ba2e993e482edb55d

* `reactElement.type`
* `reactElement.ref`

https://github.com/honojs/hono/compare/main...usualoma:hono:perf/jsx-dom?expand=1#diff-c9b14c1b74662b399c25e6dc0c870408c466e1c96e39a1d429903b2a3d0db51fL11-L20

The code to make the following properties referential is for React compatibility, but the implementation using `Object.defineProperties` was very expensive. This change is not pretty, but it is an acceptable redundancy when considered as a trade-off for improved performance.

#### Reduce recalculation and reapplication when properties are unchanged

In some cases, DOM attributes were being reassigned even when there were no changes to the properties, so reassignment is no longer performed when it is unnecessary.



### benchmark

Based on this branch (thank you very much @aminya!),

https://github.com/aminya/js-framework-benchmark/tree/hono

The following changes were added and benchmarked in my environment.

```diff
diff --git a/frameworks/keyed/hono/src/index.tsx b/frameworks/keyed/hono/src/index.tsx
index 2628e205..998c4b0f 100644
--- a/frameworks/keyed/hono/src/index.tsx
+++ b/frameworks/keyed/hono/src/index.tsx
@@ -141,9 +141,8 @@ const App = () => {
     <table class="table table-hover table-striped test-data">
       <tbody>
         {data.map(item => {
-          console.log(item);
           return (
-            <Row item={item} selected={selected === item.id} dispatch={dispatch} />
+            <Row key={item.id} item={item} selected={selected === item.id} dispatch={dispatch} />
           );
         })}
       </tbody>
```

Performance for creation or update is roughly equivalent to React, with smaller file sizes and memory usage, which is an expected result since "hono/jsx" aims for "an implementation with a React-compatible API that is small enough to be practical with a small amount of code".

![jsx-dom-bench](https://github.com/user-attachments/assets/1cea9d83-01ac-4788-b830-654aba628db8)

### The author should do the following, if applicable

- [x] Add tests
    - Only a few tests have been added, but as most of the changes are internal refactoring with no external specification changes, no further additional tests are considered necessary. 
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
