### PR TITLE
feat(client): improve handling status code types

### DIFF
--- a/src/client/types.test.ts
+++ b/src/client/types.test.ts
@@ -1,7 +1,12 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectTypeOf } from 'vitest'
 import { Hono } from '..'
 import { upgradeWebSocket } from '../adapter/deno/websocket'
 import { hc } from '.'
+import { HTTPException } from '../http-exception'
+import type { Equal, Expect } from '../utils/types'
+import { setupServer } from 'msw/node'
+import { HttpResponse, http } from 'msw'
 
 describe('WebSockets', () => {
   const app = new Hono()
@@ -55,5 +60,67 @@ describe('with the leading slash', () => {
   })
   it('`foo[":id"].baz` should have `$get`', () => {
     expectTypeOf(client.foo[':id'].baz).toHaveProperty('$get')
+  })
+})
+
+describe('Status Code - test only Types', () => {
+  const server = setupServer(
+    http.get('http://localhost/foo', async () => {
+      return HttpResponse.json({})
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  const app = new Hono()
+  const flag = {}
+
+  const routes = app.get('/foo', (c) => {
+    if (flag) {
+      throw new HTTPException(500, {
+        message: 'Server Error!',
+      })
+    }
+    if (flag) {
+      return c.json({ message: 'invalid!' }, 401)
+    }
+    if (flag) {
+      return c.redirect('/', 301)
+    }
+    return c.json({ ok: true }, 200)
+  })
+
+  const client = hc<typeof routes>('http://localhost')
+
+  it('Should handle different status codes', async () => {
+    const res = await client.foo.$get()
+
+    if (res.status === 500) {
+      const data = await res.json<{ errorMessage: string }>()
+      type Expected = { errorMessage: string }
+      type verify = Expect<Equal<Expected, typeof data>>
+    }
+
+    if (res.status === 401) {
+      const data = await res.json()
+      type Expected = { message: string }
+      type verify = Expect<Equal<Expected, typeof data>>
+    }
+
+    if (res.status === 200) {
+      const data = await res.json()
+      type Expected = { ok: boolean }
+      type verify = Expect<Equal<Expected, typeof data>>
+    }
+  })
+
+  it('Should infer union types', async () => {
+    const res = await client.foo.$get()
+
+    const data = await res.json()
+    type Expected = { message: string } | { ok: boolean }
+    type verify = Expect<Equal<Expected, typeof data>>
   })
 })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,6 +1,6 @@
 import type { Hono } from '../hono'
 import type { Endpoint, ResponseFormat, Schema } from '../types'
-import type { StatusCode, SuccessStatusCode } from '../utils/http-status'
+import type { RedirectStatusCode, StatusCode, SuccessStatusCode } from '../utils/http-status'
 import type { HasRequiredKeys } from '../utils/types'
 
 type HonoRequest = (typeof Hono.prototype)['request']
@@ -63,7 +63,15 @@ type ClientResponseOfEndpoint<T extends Endpoint = Endpoint> = T extends {
   outputFormat: infer F
   status: infer S
 }
-  ? ClientResponse<O, S extends number ? S : never, F extends ResponseFormat ? F : never>
+  ? F extends 'redirect'
+    ? ClientResponse<O, S extends RedirectStatusCode ? S : never, 'redirect'>
+    :
+        | ClientResponse<O, S extends StatusCode ? S : never, F extends ResponseFormat ? F : never>
+        | ClientResponse<
+            {},
+            S extends StatusCode ? Exclude<Exclude<StatusCode, RedirectStatusCode>, S> : never,
+            F extends ResponseFormat ? F : never
+          >
   : never
 
 export interface ClientResponse<
@@ -84,11 +92,13 @@ export interface ClientResponse<
   url: string
   redirect(url: string, status: number): Response
   clone(): Response
-  json(): F extends 'text'
+  json<JSONT>(): F extends 'text'
     ? Promise<never>
     : F extends 'json'
-    ? Promise<BlankRecordToNever<T>>
-    : Promise<unknown>
+    ? undefined extends JSONT
+      ? Promise<BlankRecordToNever<T>>
+      : Promise<JSONT>
+    : Promise<T & {}>
   text(): F extends 'text' ? (T extends string ? Promise<T> : Promise<never>) : Promise<string>
   blob(): Promise<Blob>
   formData(): Promise<FormData>
@@ -119,12 +129,14 @@ export type InferResponseType<T, U extends StatusCode = StatusCode> = InferRespo
   U
 >
 
+type WithoutEmptyObject<T> = T extends {} ? (keyof T extends never ? never : T) : T
+
 type InferResponseTypeFromEndpoint<T extends Endpoint, U extends StatusCode> = T extends {
   output: infer O
   status: infer S
 }
   ? S extends U
-    ? O
+    ? WithoutEmptyObject<O>
     : never
   : never
 


### PR DESCRIPTION
The PR will improve the handling of TypeScript types of status codes in the Response returned by the client.

Fixes #2719
Fixes #3170
Fixes https://github.com/honojs/middleware/issues/580

### Allowing `number` for `res.status`

Imagine the following application which throws the `HTTPException` in the handler:

```ts
import { HTTPException } from 'hono/http-exception'
import { Hono } from 'hono'

const app = new Hono()
const flag = {}

const routes = app.get('/foo', (c) => {
  if (flag) {
    throw new HTTPException(500, {
      message: 'Server Error!',
    })
  }
  return c.json({ ok: true }, 200)
})
```

You will create the client with the types:

```ts
import { hc } from 'hono/client'

const client = hc<typeof routes>('/')
const res = await client.foo.$get()
```

The current pain point is it can't infer the response having `500` status correctly.

```ts
if (res.status === 500) {
  const data = await res.json()
}
```

The error showing in your IDE:

![CleanShot 2024-08-18 at 18 34 22@2x](https://github.com/user-attachments/assets/9a176955-da53-4c16-aedb-ce0b246399ff)

It should be fixed. However, handling the response content and status with an `HTTPException`  or `Error`  object is impossible. So, I've found the solution to enable accepting `number` for `res.status`.

```ts
if (res.status === 500) { // res.status can be `number`. **No** error!
  const data = await res.json()
}
```

### Accept generics for `res.json()`

That solution solves the problem of the error of `res.status`, but the content returned from `res.json()` will not be typed:

```ts
if (res.status === 500) {
  const data = await res.json() // never. not typed
}
```

Also to set the correct types is impossible for it. So, I'll introduce `res.json()` accepting generrics. You can write the following:

```ts
if (res.status === 500) {
  const data = await res.json<{ message: string }>()
}
```

This method does not allow automatic inference, but it avoids type errors.

### Other improvements

I added some modifications since other tests failed with the changes.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
