### PR TITLE
fix(jsx/dom): Fixed a bug that caused Script elements to turn into Style elements.

### DIFF
--- a/src/jsx/dom/intrinsic-element/components.test.tsx
+++ b/src/jsx/dom/intrinsic-element/components.test.tsx
@@ -750,6 +750,33 @@ describe('intrinsic element', () => {
         await Promise.resolve()
         expect(root.innerHTML).toBe('<div><div>Content</div><button>Show</button></div>')
       })
+
+      it('should be inserted into body if has no props', async () => {
+        const App = () => {
+          return (
+            <div>
+              <script>alert('Hello')</script>
+            </div>
+          )
+        }
+        render(<App />, root)
+        expect(document.head.innerHTML).toBe('')
+        // prettier-ignore
+        expect(root.innerHTML).toBe('<div><script>alert(\'Hello\')</script></div>')
+      })
+
+      it('should be inserted into body if has only src prop', async () => {
+        const App = () => {
+          return (
+            <div>
+              <script src='script.js'></script>
+            </div>
+          )
+        }
+        render(<App />, root)
+        expect(document.head.innerHTML).toBe('')
+        expect(root.innerHTML).toBe('<div><script src="script.js"></script></div>')
+      })
     })
 
     it('accept ref object', async () => {

--- a/src/jsx/dom/intrinsic-element/components.ts
+++ b/src/jsx/dom/intrinsic-element/components.ts
@@ -226,7 +226,7 @@ export const title: FC<PropsWithChildren> = (props) => {
 export const script: FC<PropsWithChildren<IntrinsicElements['script']>> = (props) => {
   if (!props || ['src', 'async'].some((k) => !props[k])) {
     return newJSXNode({
-      tag: 'style',
+      tag: 'script',
       props,
     })
   }


### PR DESCRIPTION
Script elements with empty props or only src were inserted as style elements by typo.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code