### PR TITLE
PoC: feat(jsx/dom): introduce jsx/dom/tiny. Some features are omit in this runtime, but the size is very small.

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,11 @@
       "import": "./dist/jsx/dom/jsx-dev-runtime.js",
       "require": "./dist/cjs/jsx/dom/jsx-dev-runtime.js"
     },
+    "./jsx/dom/jsx-dev-runtime/tiny": {
+      "types": "./dist/types/jsx/dom/tiny/jsx-dev-runtime.d.ts",
+      "import": "./dist/jsx/dom/tiny/jsx-dev-runtime.js",
+      "require": "./dist/cjs/jsx/dom/tiny/jsx-dev-runtime.js"
+    },
     "./jsx/dom/jsx-runtime": {
       "types": "./dist/types/jsx/dom/jsx-runtime.d.ts",
       "import": "./dist/jsx/dom/jsx-runtime.js",

--- a/src/jsx/dom/components.test.tsx
+++ b/src/jsx/dom/components.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource ../ */
 import { JSDOM } from 'jsdom'
+import './feat/intrinsic-element'
 import { ErrorBoundary as ErrorBoundaryCommon, Suspense as SuspenseCommon } from '..' // for common
 // run tests by old style jsx default
 // hono/jsx/jsx-runtime and hono/jsx/dom/jsx-runtime are tested in their respective settings

--- a/src/jsx/dom/components.ts
+++ b/src/jsx/dom/components.ts
@@ -1,7 +1,7 @@
 import type { Child, FC, PropsWithChildren } from '../'
 import type { ErrorHandler, FallbackRender } from '../components'
 import { DOM_ERROR_HANDLER } from '../constants'
-import { Fragment } from './jsx-runtime'
+import { Fragment } from './tiny/jsx-runtime'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const ErrorBoundary: FC<

--- a/src/jsx/dom/context.test.tsx
+++ b/src/jsx/dom/context.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource ../ */
 import { JSDOM } from 'jsdom'
+import './feat/intrinsic-element'
 import {
   Suspense,
   createContext as createContextCommon,

--- a/src/jsx/dom/feat/intrinsic-element.ts
+++ b/src/jsx/dom/feat/intrinsic-element.ts
@@ -1,0 +1,12 @@
+/**
+ * @module
+ * This module install intrinsic-element features to `hono/jsx/dom`.
+ */
+
+import { intrinsicElementTags } from '../tiny/jsx-dev-runtime'
+import * as intrinsicElementTagsImplemented from '../intrinsic-element/components'
+
+for (const key in intrinsicElementTagsImplemented) {
+  intrinsicElementTags[key] =
+    intrinsicElementTagsImplemented[key as keyof typeof intrinsicElementTagsImplemented]
+}

--- a/src/jsx/dom/hooks/index.test.tsx
+++ b/src/jsx/dom/hooks/index.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource ../../ */
 import { JSDOM } from 'jsdom'
+import '../feat/intrinsic-element'
 import { render, useCallback, useState } from '..'
 import { useActionState, useFormStatus, useOptimistic } from '.'
 

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource ../ */
 import { JSDOM } from 'jsdom'
+import './feat/intrinsic-element'
 import type { Child, FC } from '..'
 // run tests by old style jsx default
 // hono/jsx/jsx-runtime and hono/jsx/dom/jsx-runtime are tested in their respective settings

--- a/src/jsx/dom/index.ts
+++ b/src/jsx/dom/index.ts
@@ -32,7 +32,7 @@ import {
 import { useActionState, useFormStatus, useOptimistic } from './hooks'
 import { ErrorBoundary, Suspense } from './components'
 import { createContext } from './context'
-import { Fragment, jsx } from './jsx-runtime'
+import { Fragment, jsx } from './tiny/jsx-runtime'
 import { createPortal, flushSync } from './render'
 
 export { render } from './render'

--- a/src/jsx/dom/jsx-dev-runtime.ts
+++ b/src/jsx/dom/jsx-dev-runtime.ts
@@ -3,20 +3,5 @@
  * This module provides the `hono/jsx/dom` dev runtime.
  */
 
-import type { JSXNode, Props } from '../base'
-import * as intrinsicElementTags from './intrinsic-element/components'
-
-export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXNode => {
-  if (typeof tag === 'string' && intrinsicElementTags[tag as keyof typeof intrinsicElementTags]) {
-    tag = intrinsicElementTags[tag as keyof typeof intrinsicElementTags]
-  }
-  return {
-    tag,
-    type: tag,
-    props,
-    key,
-    ref: props.ref,
-  } as JSXNode
-}
-
-export const Fragment = (props: Record<string, unknown>): JSXNode => jsxDEV('', props, undefined)
+import './feat/intrinsic-element'
+export { jsxDEV, Fragment } from './tiny/jsx-dev-runtime'

--- a/src/jsx/dom/tiny/jsx-dev-runtime.ts
+++ b/src/jsx/dom/tiny/jsx-dev-runtime.ts
@@ -1,0 +1,22 @@
+/**
+ * @module
+ * This module provides the `hono/jsx/dom` dev runtime.
+ */
+
+import type { JSXNode, Props } from '../../base'
+export const intrinsicElementTags: Record<string, Function> = {}
+
+export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXNode => {
+  if (typeof tag === 'string' && intrinsicElementTags[tag as keyof typeof intrinsicElementTags]) {
+    tag = intrinsicElementTags[tag as keyof typeof intrinsicElementTags]
+  }
+  return {
+    tag,
+    type: tag,
+    props,
+    key,
+    ref: props.ref,
+  } as JSXNode
+}
+
+export const Fragment = (props: Record<string, unknown>): JSXNode => jsxDEV('', props, undefined)

--- a/src/jsx/dom/tiny/jsx-runtime.ts
+++ b/src/jsx/dom/tiny/jsx-runtime.ts
@@ -1,0 +1,7 @@
+/**
+ * @module
+ * This module provides the `hono/jsx/dom/tiny` runtime.
+ */
+
+export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
+export { jsxDEV as jsxs } from './jsx-dev-runtime'

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource ../ */
 import { JSDOM } from 'jsdom'
+import '../dom/feat/intrinsic-element'
 // run tests by old style jsx default
 // hono/jsx/jsx-runtime and hono/jsx/dom/jsx-runtime are tested in their respective settings
 import { ErrorBoundary, Suspense, render } from '../dom'


### PR DESCRIPTION
There are currently no plans to include this, but it is a PoC to show that it is possible to reduce the size.

The size of "jsx/dom" has increased considerably with the changes in #2960. For apps that do not need the features of #2960, it is possible to provide a smaller sized runtime that omits those features.

### Usage

with full feature

```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "hono/jsx/dom",
  }
}
```

without title/script/style/meta elements feature https://react.dev/reference/react-dom/components

```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "hono/jsx/dom/tiny",
  }
}
```

### Result

Compared with the code used in js-framework-benchmark.

```
% ls -lSr solid/dist/main.js preact/dist/main.js react-hooks/dist/main.js hono/dist/index.js hono-tiny/dist/index.js | awk '{print $NF, $5}'
solid/dist/main.js 11288
hono-tiny/dist/index.js 11930
hono/dist/index.js 16108
preact/dist/main.js 16612
react-hooks/dist/main.js 145439
```

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
