### PR TITLE
fix(validator): Fixed a bug in hono/validator where URL Encoded Data could not be validated if the Content-Type included charset.

### DIFF
--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -247,6 +247,22 @@ describe('FormData', () => {
     })
   })
 
+  it('Should validate if Content-Type is a application/x-www-form-urlencoded with a charset', async () => {
+    const params = new URLSearchParams()
+    params.append('foo', 'bar')
+    const res = await app.request('/post', {
+      method: 'POST',
+      body: params,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      foo: 'bar',
+    })
+  })
+
   it('Should return `foo[]` as an array', async () => {
     const form = new FormData()
     form.append('foo[]', 'bar1')

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -25,7 +25,7 @@ type ExcludeResponseType<T> = T extends Response & TypedResponse<any> ? never : 
 
 const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
 const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
-const urlencodedRegex = /^application\/x-www-form-urlencoded$/
+const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
 
 export const validator = <
   InputType,


### PR DESCRIPTION
Fix #3296 

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
