### PR TITLE
feat(jsx): improve `target` and `formtarget` attribute types

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -226,12 +226,12 @@ export namespace JSX {
     media?: string | undefined
     referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
     shape?: string | undefined
-    target?: string | undefined
+    target?: HTMLAttributeAnchorTarget | undefined
   }
 
   interface BaseHTMLAttributes extends HTMLAttributes {
     href?: string | undefined
-    target?: string | undefined
+    target?: HTMLAttributeAnchorTarget | undefined
   }
 
   interface BlockquoteHTMLAttributes extends HTMLAttributes {
@@ -244,7 +244,7 @@ export namespace JSX {
     formenctype?: string | undefined
     formmethod?: string | undefined
     formnovalidate?: boolean | undefined
-    formtarget?: string | undefined
+    formtarget?: HTMLAttributeAnchorTarget | undefined
     name?: string | undefined
     type?: 'submit' | 'reset' | 'button' | undefined
     value?: string | ReadonlyArray<string> | number | undefined
@@ -304,7 +304,7 @@ export namespace JSX {
     method?: string | undefined
     name?: string | undefined
     novalidate?: boolean | undefined
-    target?: string | undefined
+    target?: HTMLAttributeAnchorTarget | undefined
 
     // React 19 compatibility
     action?: string | Function | undefined
@@ -383,7 +383,7 @@ export namespace JSX {
     formenctype?: string | undefined
     formmethod?: string | undefined
     formnovalidate?: boolean | undefined
-    formtarget?: string | undefined
+    formtarget?: HTMLAttributeAnchorTarget | undefined
     height?: number | string | undefined
     list?: string | undefined
     max?: number | string | undefined


### PR DESCRIPTION
Improve `target` and `formtarget` types.

* area/target https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area#target
* base/target https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#target
* button/formtarget https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#formtarget
* form/target https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#target
* input/formtarget https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#formtarget

Should I rename `HTMLAttributeAnchorTarget` ?

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
