### PR TITLE
feat(jsx): improve input attribute types based on react

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -347,7 +347,7 @@ export namespace JSX {
     datetime?: string | undefined
   }
 
-  type HTMLInputTypeAttribute =
+  type HTMLInputTypeAttribute = StringLiteralUnion<
     | 'button'
     | 'checkbox'
     | 'color'
@@ -370,12 +370,72 @@ export namespace JSX {
     | 'time'
     | 'url'
     | 'week'
-    | string
+  >
+  type AutoFillAddressKind = 'billing' | 'shipping'
+  type AutoFillBase = '' | 'off' | 'on'
+  type AutoFillContactField =
+    | 'email'
+    | 'tel'
+    | 'tel-area-code'
+    | 'tel-country-code'
+    | 'tel-extension'
+    | 'tel-local'
+    | 'tel-local-prefix'
+    | 'tel-local-suffix'
+    | 'tel-national'
+  type AutoFillContactKind = 'home' | 'mobile' | 'work'
+  type AutoFillCredentialField = 'webauthn'
+  type AutoFillNormalField =
+    | 'additional-name'
+    | 'address-level1'
+    | 'address-level2'
+    | 'address-level3'
+    | 'address-level4'
+    | 'address-line1'
+    | 'address-line2'
+    | 'address-line3'
+    | 'bday-day'
+    | 'bday-month'
+    | 'bday-year'
+    | 'cc-csc'
+    | 'cc-exp'
+    | 'cc-exp-month'
+    | 'cc-exp-year'
+    | 'cc-family-name'
+    | 'cc-given-name'
+    | 'cc-name'
+    | 'cc-number'
+    | 'cc-type'
+    | 'country'
+    | 'country-name'
+    | 'current-password'
+    | 'family-name'
+    | 'given-name'
+    | 'honorific-prefix'
+    | 'honorific-suffix'
+    | 'name'
+    | 'new-password'
+    | 'one-time-code'
+    | 'organization'
+    | 'postal-code'
+    | 'street-address'
+    | 'transaction-amount'
+    | 'transaction-currency'
+    | 'username'
+  type OptionalPrefixToken<T extends string> = `${T} ` | ''
+  type OptionalPostfixToken<T extends string> = ` ${T}` | ''
+  type AutoFillField =
+    | AutoFillNormalField
+    | `${OptionalPrefixToken<AutoFillContactKind>}${AutoFillContactField}`
+  type AutoFillSection = `section-${string}`
+  type AutoFill =
+    | AutoFillBase
+    | `${OptionalPrefixToken<AutoFillSection>}${OptionalPrefixToken<AutoFillAddressKind>}${AutoFillField}${OptionalPostfixToken<AutoFillCredentialField>}`
 
   interface InputHTMLAttributes extends HTMLAttributes {
     accept?: string | undefined
     alt?: string | undefined
-    autocomplete?: string | undefined
+    autocomplete?: StringLiteralUnion<AutoFill> | undefined
     capture?: boolean | 'user' | 'environment' | undefined // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
     checked?: boolean | undefined
     disabled?: boolean | undefined


### PR DESCRIPTION
improve input attribute types based on react

ref. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/865051c6befe8d67f7ac2fdcac6cdf4922c1dc83/types/react/index.d.ts#L3263-L3389

![image](https://github.com/user-attachments/assets/a7c9d792-24ec-45be-bbd1-8032501e8a57)
![image](https://github.com/user-attachments/assets/9027b270-2dd1-4a6e-9ffc-b7a06b9c6232)

I think `autocomplete` is too complex 😅 
But I respect react types.


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
