### PR TITLE
fix(client): replace optional params to url correctly

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -815,7 +815,9 @@ describe('Infer the response type with different status codes', () => {
 })
 
 describe('$url() with a param option', () => {
-  const app = new Hono().get('/posts/:id/comments', (c) => c.json({ ok: true }))
+  const app = new Hono()
+    .get('/posts/:id/comments', (c) => c.json({ ok: true }))
+    .get('/something/:firstId/:secondId/:version?', (c) => c.json({ ok: true }))
   type AppType = typeof app
   const client = hc<AppType>('http://localhost')
 
@@ -831,6 +833,17 @@ describe('$url() with a param option', () => {
   it('Should return the correct path - /posts/:id/comments', async () => {
     const url = client.posts[':id'].comments.$url()
     expect(url.pathname).toBe('/posts/:id/comments')
+  })
+
+  it('Should return the correct path - /something/123/456', async () => {
+    const url = client.something[':firstId'][':secondId'][':version?'].$url({
+      param: {
+        firstId: '123',
+        secondId: '456',
+        version: undefined,
+      },
+    })
+    expect(url.pathname).toBe('/something/123/456')
   })
 })
 

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -46,6 +46,17 @@ describe('replaceUrlParams', () => {
     const replacedUrl = replaceUrlParam(url, params)
     expect(replacedUrl).toBe('http://localhost/year/2024/month/2')
   })
+
+  it('Should replace correctly when it has optional parameters', () => {
+    const url = 'http://localhost/something/:firstId/:secondId/:version?'
+    const params = {
+      firstId: '123',
+      secondId: '456',
+      version: undefined,
+    }
+    const replacedUrl = replaceUrlParam(url, params)
+    expect(replacedUrl).toBe('http://localhost/something/123/456')
+  })
 })
 
 describe('replaceUrlProtocol', () => {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -7,10 +7,10 @@ export const mergePath = (base: string, path: string) => {
   return base + path
 }
 
-export const replaceUrlParam = (urlString: string, params: Record<string, string>) => {
+export const replaceUrlParam = (urlString: string, params: Record<string, string | undefined>) => {
   for (const [k, v] of Object.entries(params)) {
-    const reg = new RegExp('/:' + k + '(?:{[^/]+})?')
-    urlString = urlString.replace(reg, `/${v}`)
+    const reg = new RegExp('/:' + k + '(?:{[^/]+})?\\??')
+    urlString = urlString.replace(reg, v ? `/${v}` : '')
   }
   return urlString
 }


### PR DESCRIPTION
Fixes #3303

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
