### PR TITLE
feat(jsx): improve `type` (MIME) attribute types

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -287,7 +287,7 @@ export namespace JSX {
   interface EmbedHTMLAttributes extends HTMLAttributes {
     height?: number | string | undefined
     src?: string | undefined
-    type?: string | undefined
+    type?: StringLiteralUnion<BaseMime> | undefined
     width?: number | string | undefined
   }
 
@@ -495,7 +495,7 @@ export namespace JSX {
     imagesizes?: string | undefined
     referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
     sizes?: string | undefined
-    type?: string | undefined
+    type?: StringLiteralUnion<BaseMime> | undefined
     charSet?: string | undefined
 
     // React 19 compatibility
@@ -607,7 +607,7 @@ export namespace JSX {
     form?: string | undefined
     height?: number | string | undefined
     name?: string | undefined
-    type?: string | undefined
+    type?: StringLiteralUnion<BaseMime> | undefined
     usemap?: string | undefined
     width?: number | string | undefined
   }
@@ -658,7 +658,10 @@ export namespace JSX {
     nomodule?: boolean | undefined
     referrerpolicy?: HTMLAttributeReferrerPolicy | undefined
     src?: string | undefined
-    type?: string | undefined
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type
+     */
+    type?: StringLiteralUnion<'' | 'text/javascript' | 'importmap' | 'module'> | undefined
 
     // React 19 compatibility
     crossOrigin?: CrossOrigin
@@ -687,14 +690,17 @@ export namespace JSX {
     sizes?: string | undefined
     src?: string | undefined
     srcset?: string | undefined
-    type?: string | undefined
+    type?: StringLiteralUnion<BaseMime> | undefined
     width?: number | string | undefined
   }
 
   interface StyleHTMLAttributes extends HTMLAttributes {
     media?: string | undefined
     scoped?: boolean | undefined
-    type?: string | undefined
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#type
+     */
+    type?: '' | 'text/css' | undefined
 
     // React 19 compatibility
     href?: string | undefined

--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -684,13 +684,14 @@ export namespace JSX {
     value?: string | ReadonlyArray<string> | number | undefined
   }
 
+  type MediaMime = BaseMime & (`image/${string}` | `audio/${string}` | `video/${string}`)
   interface SourceHTMLAttributes extends HTMLAttributes {
     height?: number | string | undefined
     media?: string | undefined
     sizes?: string | undefined
     src?: string | undefined
     srcset?: string | undefined
-    type?: StringLiteralUnion<BaseMime> | undefined
+    type?: StringLiteralUnion<MediaMime> | undefined
     width?: number | string | undefined
   }
 


### PR DESCRIPTION
embed, link, object, script, source, and style elements

![embed](https://github.com/user-attachments/assets/5f2f9ace-3523-45ad-a172-2d7a4891cb38)
![link](https://github.com/user-attachments/assets/dc920f00-ad10-4775-b525-25367e80901c)
![object](https://github.com/user-attachments/assets/18c012df-4ae0-41dc-b830-d1d53ed65e76)

I did NOT add BaseMime to either source, script or style element. Should I do this?

![source](https://github.com/user-attachments/assets/788f091b-1f68-4dfd-bfe7-fb89c5675808)
![script](https://github.com/user-attachments/assets/1b158d2f-aa80-4649-9777-0b8534ba3f15)
![style](https://github.com/user-attachments/assets/e5d65913-f7f6-45a6-834a-a9d6037c9fc5)

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
