### PR TITLE
fix(utils/color): Deno does not require permission for `NO_COLOR`

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -3,16 +3,23 @@
  * Color utility.
  */
 
+/**
+ * Get whether color change on terminal is enabled or disabled.
+ * If `NO_COLOR` environment variable is set, this function returns `false`.
+ * @see {@link https://no-color.org/}
+ *
+ * @returns {boolean}
+ */
 export function getColorEnabled(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { process, Deno } = globalThis as any
 
   const isNoColor =
-    typeof process !== 'undefined'
+    typeof Deno?.noColor === 'boolean'
+      ? (Deno.noColor as boolean)
+      : typeof process !== 'undefined'
       ? // eslint-disable-next-line no-unsafe-optional-chaining
         'NO_COLOR' in process?.env
-      : typeof Deno?.noColor === 'boolean'
-      ? (Deno.noColor as boolean)
       : false
 
   return !isNoColor


### PR DESCRIPTION
If we run Hono with Deno in node-compat mode, permission to obtain `NO_COLOR` from env is required in logger and showRoutes.
This PR fixes that and add the Doc.

If you want to reproduce the current situation, try the following ways:

1. Make a directory and add Hono.
```sh
mkdir my-app
cd my-app
bun add hono
```
2. Run this script by Deno.
```ts
// deno run main.ts
import { getColorEnabled } from "hono/utils/color"
console.log(getColorEnabled())
```
3. Deno requests env access to "NO_COLOR".
```sh
┌ ⚠️  Deno requests env access to "NO_COLOR".
├ Run again with --allow-env to bypass this prompt.
└ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all env permissions) >
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
