### PR TITLE
PoC: Introduce File System Access API Helper / Adapter

### DIFF
--- a/src/adapter/deno/deno.d.ts
+++ b/src/adapter/deno/deno.d.ts
@@ -25,4 +25,6 @@ declare namespace Deno {
     response: Response
     socket: WebSocket
   }
+
+  export function cwd(): string
 }

--- a/src/adapter/deno/deno.d.ts
+++ b/src/adapter/deno/deno.d.ts
@@ -17,6 +17,23 @@ declare namespace Deno {
    */
   export function writeFile(path: string, data: Uint8Array): Promise<void>
 
+  export function remove(path: string, options?: {
+    recursive?: boolean
+  }): Promise<void>
+
+  export function readDir(path: string): AsyncIterable<{
+    name: string
+    isFile: boolean
+    isDirectory: boolean
+    isSymlink: boolean
+  }>
+
+  export interface FileInfo {
+    isDirectory: boolean
+  }
+
+  export function stat(path: string): Promise<FileInfo>
+
   export function upgradeWebSocket(
     req: Request,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/adapter/deno/deno.d.ts
+++ b/src/adapter/deno/deno.d.ts
@@ -34,6 +34,32 @@ declare namespace Deno {
 
   export function stat(path: string): Promise<FileInfo>
 
+  export interface OpenOptions {
+    read?: boolean
+    write?: boolean
+    append?: boolean
+    truncate?: boolean
+    create?: boolean
+    createNew?: boolean
+    mode?: number
+  }
+
+  export type SeekMode = 0 | 1 | 2
+  export interface FsFile {
+    readonly readable: ReadableStream<Uint8Array>
+    readonly writable: WritableStream<Uint8Array>
+
+    close(): void
+    seek(offset: number, whence?: SeekMode): Promise<void>
+    truncate(len?: number): Promise<void>
+
+    write(p: Uint8Array): Promise<number>
+  }
+  export function open(
+    path: string | URL,
+    options?: OpenOptions,
+  ): Promise<FsFile> 
+
   export function upgradeWebSocket(
     req: Request,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/adapter/deno/fs.ts
+++ b/src/adapter/deno/fs.ts
@@ -1,0 +1,25 @@
+/**
+ * FS Adapter for Deno.
+ * @module
+ */
+
+import { basename } from '../../helper/fs'
+import type { CreateFS } from '../../helper/fs'
+import { joinPaths } from '../../utils/filepath/join'
+
+export const resolve = (path: string) => {
+  const cwd = Deno.cwd()
+
+  return joinPaths(cwd, path)
+}
+
+export const createFS: CreateFS = async (basePath: string) => {
+  return {
+    name: basename(basePath),
+    kind: 'directory',
+    isSameEntry(other) {
+
+      return other.kind === 'directory' && 
+    },
+  }
+}

--- a/src/adapter/deno/fs.ts
+++ b/src/adapter/deno/fs.ts
@@ -3,9 +3,10 @@
  * @module
  */
 
-import { basename } from '../../helper/fs'
-import type { ExtendedFileSystemDirectoryHandle, OpenDir, OpenFile } from '../../helper/fs'
+import { basename, isWriteParams } from '../../helper/fs/utils'
+import type { ExtendedFileSystemDirectoryHandle, ExtendedFileSystemFileHandle, ExtendedFileSystemHandle, OpenDir, OpenFile } from '../../helper/fs'
 import { joinPaths } from '../../utils/filepath/join'
+import { relative } from '../../utils/filepath/relative'
 
 export const resolve = (path: string) => {
   const cwd = Deno.cwd()
@@ -13,8 +14,159 @@ export const resolve = (path: string) => {
   return joinPaths(cwd, path)
 }
 
-export const openFile: OpenFile = async (path) => {
-  // TODO
+const chunkTypeToUint8Array = async (chunk?: Exclude<FileSystemWriteChunkType, WriteParams>) => {
+  if (!chunk) {
+    return
+  }
+  if (typeof chunk === 'string') {
+    return new TextEncoder().encode(chunk)
+  }
+  if (chunk instanceof Blob) {
+    return new Uint8Array(await chunk.arrayBuffer())
+  }
+  if (chunk instanceof ArrayBuffer) {
+    return new Uint8Array(chunk)
+  }
+  return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+}
+
+class DenoFileSystemWritableFileStream extends WritableStream<FileSystemWriteChunkType> implements FileSystemWritableFileStream {
+  #file: Deno.FsFile
+  constructor(file: Deno.FsFile) {
+    super({
+      write: async (chunk) => {
+        this.#writeToDeno(chunk)
+      }
+    })
+    this.#file = file
+  }
+  async seek(position: number): Promise<void> {
+    await this.#file.seek(position)
+  }
+  async truncate(size: number): Promise<void> {
+    await this.#file.truncate(size)
+  }
+  async write(data: FileSystemWriteChunkType): Promise<void> {
+    this.#writeToDeno(data)
+  }
+  async #writeToDeno(inputData: FileSystemWriteChunkType) {
+    if (isWriteParams(inputData)) {
+      switch (inputData.type) {
+        case 'write': {
+          const data = await chunkTypeToUint8Array(inputData.data ?? void 0)
+          inputData.position && await this.seek(inputData.position)
+
+          data && await this.#file.write(data)
+          break
+        }
+        case 'seek': {
+          inputData.position && await this.seek(inputData.position)
+        }
+        case 'truncate': {
+          inputData.size && await this.truncate(inputData.size)
+        }
+      }
+    } else {
+
+    }
+  }
+}
+
+class DenoFileSystemFileHandle implements ExtendedFileSystemFileHandle {
+  readonly name: string
+  readonly path: string
+  readonly kind = 'file'
+  constructor(resolvedPath: string) {
+    this.name = basename(resolvedPath)
+    this.path = resolvedPath
+  }
+  async isSameEntry(other: ExtendedFileSystemHandle) {
+    return other.kind === 'file' && this.path === other.path
+  }
+  remove(options: FileSystemRemoveOptions): Promise<void> {
+    return Deno.remove(this.path, options)
+  }
+  async createWritable(options?: FileSystemCreateWritableOptions): Promise<FileSystemWritableFileStream> {
+    const file = await Deno.open(this.path, {
+      write: true,
+      truncate: !options?.keepExistingData
+    })
+    return 
+  }
+}
+
+export const openFile: OpenFile = async (filePath, options) => {
+  let stat: Deno.FileInfo | null = null
+  try {
+    stat = await Deno.stat(filePath)
+  } catch (_e) {
+    if (options?.create) {
+      await Deno.writeFile(filePath, new Uint8Array(0))
+    } else {
+      throw new DOMException('File is not found.', 'NotFoundError')
+    }
+  }
+  if (stat && !stat.isDirectory) {
+    throw new DOMException('Target type is not a file.', 'TypeMismatchError')
+  }
+
+  return new DenoFileSystemFileHandle(filePath)
+}
+
+class DenoFileSystemDirectoryHandle implements ExtendedFileSystemDirectoryHandle {
+  readonly name: string
+  readonly path: string
+  readonly kind = 'directory'
+
+  constructor(resolvedPath: string) {
+    this.name = basename(resolvedPath)
+    this.path = resolvedPath
+  }
+  async isSameEntry(other: ExtendedFileSystemDirectoryHandle) {
+    return other.kind === 'directory' && this.path === other.path
+  }
+  async remove(options: FileSystemRemoveOptions) {
+    await Deno.remove(this.path, options)
+  }
+  async removeEntry(name: string, options: FileSystemRemoveOptions) {
+    const removeTarget = joinPaths(this.path, name)
+    await Deno.remove(removeTarget, options)
+  }
+  async getDirectoryHandle(name: string, options: FileSystemGetDirectoryOptions) {
+    return openDir(joinPaths(this.path, name), options)
+  }
+  async getFileHandle(name: string, options: FileSystemGetFileOptions) {
+    return openFile(joinPaths(this.path, name), options)
+  }
+  async resolve(possibleDescendant: ExtendedFileSystemHandle) {
+    if ('path' in possibleDescendant) {
+      const relativePath = relative(this.path, possibleDescendant.path)
+      return [relativePath]
+    }
+    return null
+  }
+
+  async *entries(): FileSystemDirectoryHandleAsyncIterator<[string, ExtendedFileSystemHandle]> {
+    for await (const { name, isFile } of Deno.readDir(this.path)) {
+      const childPath = joinPaths(this.path, name)
+      const entry: [string, ExtendedFileSystemHandle] = [
+        name,
+        await (isFile ? openFile : openDir)(childPath)
+      ]
+      yield entry
+    }
+  }
+  [Symbol.asyncIterator] = () => this.entries()
+  async * keys(): FileSystemDirectoryHandleAsyncIterator<string> {
+    for await (const { name } of Deno.readDir(this.path)) {
+      yield name
+    }
+  }
+  async * values(): FileSystemDirectoryHandleAsyncIterator<ExtendedFileSystemHandle> {
+    for await (const [, value] of this.entries()) {
+      yield value
+    }
+  }
 }
 
 export const openDir: OpenDir = async (basePath, options) => {
@@ -32,30 +184,5 @@ export const openDir: OpenDir = async (basePath, options) => {
     throw new DOMException('Target type is not a directiry.', 'TypeMismatchError')
   }
 
-  const handle: ExtendedFileSystemDirectoryHandle = {
-    name: basename(basePath),
-    kind: 'directory',
-    path: resolve(basePath),
-    async isSameEntry(other) {
-      const otherPath = 'path' in other ? other.path : ''
-      return other.kind === 'directory' && this.path === otherPath
-    },
-    async remove(options) {
-      await Deno.remove(this.path, options)
-    },
-    async removeEntry(name, options) {
-      const removeTarget = joinPaths(this.path, name)
-      await Deno.remove(removeTarget, options)
-    },
-    async getDirectoryHandle(name, options) {
-      return openDir(joinPaths(this.path, name), options)
-    },
-    async getFileHandle(name, options) {
-      return openFile(joinPaths(this.path, name), options)
-    },
-    async resolve(possibleDescendant) {
-      // TODO
-    },
-  }
-  return handle
+  return new DenoFileSystemDirectoryHandle(resolve(basePath))
 }

--- a/src/adapter/deno/fs.ts
+++ b/src/adapter/deno/fs.ts
@@ -4,7 +4,7 @@
  */
 
 import { basename } from '../../helper/fs'
-import type { CreateFS } from '../../helper/fs'
+import type { ExtendedFileSystemDirectoryHandle, OpenDir, OpenFile } from '../../helper/fs'
 import { joinPaths } from '../../utils/filepath/join'
 
 export const resolve = (path: string) => {
@@ -13,13 +13,49 @@ export const resolve = (path: string) => {
   return joinPaths(cwd, path)
 }
 
-export const createFS: CreateFS = async (basePath: string) => {
-  return {
+export const openFile: OpenFile = async (path) => {
+  // TODO
+}
+
+export const openDir: OpenDir = async (basePath, options) => {
+  let stat: Deno.FileInfo | null = null
+  try {
+    stat = await Deno.stat(basePath)
+  } catch (_e) {
+    if (options?.create) {
+      await Deno.mkdir(basePath, { recursive: true })
+    } else {
+      throw new DOMException('Directory is not found.', 'NotFoundError')
+    }
+  }
+  if (stat && !stat.isDirectory) {
+    throw new DOMException('Target type is not a directiry.', 'TypeMismatchError')
+  }
+
+  const handle: ExtendedFileSystemDirectoryHandle = {
     name: basename(basePath),
     kind: 'directory',
-    isSameEntry(other) {
-
-      return other.kind === 'directory' && 
+    path: resolve(basePath),
+    async isSameEntry(other) {
+      const otherPath = 'path' in other ? other.path : ''
+      return other.kind === 'directory' && this.path === otherPath
+    },
+    async remove(options) {
+      await Deno.remove(this.path, options)
+    },
+    async removeEntry(name, options) {
+      const removeTarget = joinPaths(this.path, name)
+      await Deno.remove(removeTarget, options)
+    },
+    async getDirectoryHandle(name, options) {
+      return openDir(joinPaths(this.path, name), options)
+    },
+    async getFileHandle(name, options) {
+      return openFile(joinPaths(this.path, name), options)
+    },
+    async resolve(possibleDescendant) {
+      // TODO
     },
   }
+  return handle
 }

--- a/src/helper/fs/index.ts
+++ b/src/helper/fs/index.ts
@@ -1,0 +1,21 @@
+/**
+ * FS Helper for Hono.
+ * @module
+ */
+
+
+/**
+ * Create a FileSystemDirectoryHandle factory function.
+ *
+ * @param basePath - The base path of the file system directory.
+ * @return FileSystemDirectoryHandle.
+ */
+export type CreateFS = (basePath: string) => Promise<FileSystemDirectoryHandle>
+
+/**
+ * Returns the last component of a file path.
+ *
+ * @param path - The file path.
+ * @return The last component of the file path.
+ */
+export const basename = (path: string): string => path.split(/[\/\\]/).at(-1) ?? ''

--- a/src/helper/fs/index.ts
+++ b/src/helper/fs/index.ts
@@ -3,14 +3,43 @@
  * @module
  */
 
+/**
+ * Extended FileSystemHandle
+ */
+export interface ExtendedFileSystemHandle extends FileSystemHandle {
+  /**
+   * A path of file.
+   */
+  path: string
+
+  isSameEntry(handle: ExtendedFileSystemHandle): Promise<boolean>
+
+  /**
+   * Remove Handle
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/remove)
+   * @param options remove options
+   */
+  remove(options: {
+    recursive: boolean
+  }): Promise<void>
+}
+
+export type ExtendedFileSystemDirectoryHandle = ExtendedFileSystemHandle & FileSystemDirectoryHandle & {
+  getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<ExtendedFileSystemDirectoryHandle>
+  getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<ExtendedFileSystemFileHandle>
+}
+
+export type ExtendedFileSystemFileHandle = ExtendedFileSystemHandle & FileSystemFileHandle
 
 /**
- * Create a FileSystemDirectoryHandle factory function.
+ * Create a FileSystemDirectoryHandle
  *
  * @param basePath - The base path of the file system directory.
- * @return FileSystemDirectoryHandle.
+ * @return ExtendedFileSystemDirectoryHandle.
  */
-export type CreateFS = (basePath: string) => Promise<FileSystemDirectoryHandle>
+export type OpenDir = (basePath: string, options?: FileSystemGetDirectoryOptions) => Promise<ExtendedFileSystemDirectoryHandle>
+
+export type OpenFile = (targetPath: string, options?: FileSystemGetFileOptions) => Promise<ExtendedFileSystemFileHandle>
 
 /**
  * Returns the last component of a file path.

--- a/src/helper/fs/index.ts
+++ b/src/helper/fs/index.ts
@@ -3,48 +3,9 @@
  * @module
  */
 
-/**
- * Extended FileSystemHandle
- */
-export interface ExtendedFileSystemHandle extends FileSystemHandle {
-  /**
-   * A path of file.
-   */
-  path: string
+export {
+  basename,
+  isWriteParams
+} from './utils'
 
-  isSameEntry(handle: ExtendedFileSystemHandle): Promise<boolean>
-
-  /**
-   * Remove Handle
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/remove)
-   * @param options remove options
-   */
-  remove(options: {
-    recursive: boolean
-  }): Promise<void>
-}
-
-export type ExtendedFileSystemDirectoryHandle = ExtendedFileSystemHandle & FileSystemDirectoryHandle & {
-  getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<ExtendedFileSystemDirectoryHandle>
-  getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<ExtendedFileSystemFileHandle>
-}
-
-export type ExtendedFileSystemFileHandle = ExtendedFileSystemHandle & FileSystemFileHandle
-
-/**
- * Create a FileSystemDirectoryHandle
- *
- * @param basePath - The base path of the file system directory.
- * @return ExtendedFileSystemDirectoryHandle.
- */
-export type OpenDir = (basePath: string, options?: FileSystemGetDirectoryOptions) => Promise<ExtendedFileSystemDirectoryHandle>
-
-export type OpenFile = (targetPath: string, options?: FileSystemGetFileOptions) => Promise<ExtendedFileSystemFileHandle>
-
-/**
- * Returns the last component of a file path.
- *
- * @param path - The file path.
- * @return The last component of the file path.
- */
-export const basename = (path: string): string => path.split(/[\/\\]/).at(-1) ?? ''
+export type * from './types'

--- a/src/helper/fs/types.ts
+++ b/src/helper/fs/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Extended FileSystemHandle
+ */
+export interface ExtendedFileSystemHandle extends FileSystemHandle {
+  /**
+   * A path of file.
+   */
+  path: string
+
+  isSameEntry(handle: ExtendedFileSystemHandle): Promise<boolean>
+
+  /**
+   * Remove Handle
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/remove)
+   * @param options remove options
+   */
+  remove(options: FileSystemRemoveOptions): Promise<void>
+}
+
+export type ExtendedFileSystemDirectoryHandle = ExtendedFileSystemHandle & FileSystemDirectoryHandle & {
+  getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<ExtendedFileSystemDirectoryHandle>
+  getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<ExtendedFileSystemFileHandle>
+  resolve(possibleDescendant: ExtendedFileSystemHandle): Promise<string[] | null>
+
+  entries(): FileSystemDirectoryHandleAsyncIterator<[string, ExtendedFileSystemHandle]>
+  values(): FileSystemDirectoryHandleAsyncIterator<ExtendedFileSystemHandle>
+}
+
+export type ExtendedFileSystemFileHandle = ExtendedFileSystemHandle & FileSystemFileHandle
+
+/**
+ * Create a FileSystemDirectoryHandle
+ *
+ * @param basePath - The base path of the file system directory.
+ * @return ExtendedFileSystemDirectoryHandle.
+ */
+export type OpenDir = (basePath: string, options?: FileSystemGetDirectoryOptions) => Promise<ExtendedFileSystemDirectoryHandle>
+
+export type OpenFile = (targetPath: string, options?: FileSystemGetFileOptions) => Promise<ExtendedFileSystemFileHandle>

--- a/src/helper/fs/utils.ts
+++ b/src/helper/fs/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Utility functions for defining filesystem adapters.
+ * @module
+ */
+
+/**
+ * Returns the last component of a file path.
+ *
+ * @param path - The file path.
+ * @return The last component of the file path.
+ */
+export const basename = (path: string): string => path.split(/[\/\\]/).at(-1) ?? ''
+
+
+/**
+ * Checks if the provided data object is of type `WriteParams`.
+ *
+ * @param data - The data object to check.
+ * @returns `true` if the object is of type `WriteParams`, `false` otherwise.
+ */
+export const isWriteParams = (data: FileSystemWriteChunkType): data is WriteParams => {
+  // Determine if `type` exists
+  // Additionally, `Blob` has a `type`, so return early
+  // Also in string, can't use `in`
+  if (data instanceof Blob || typeof data === 'string') {
+    return true
+  }
+
+  return 'type' in data
+}

--- a/src/helper/ssg/utils.test.ts
+++ b/src/helper/ssg/utils.test.ts
@@ -1,32 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { dirname, joinPaths } from './utils'
+import { dirname } from './utils'
 
-describe('joinPath', () => {
-  it('Should joined path is valid.', () => {
-    expect(joinPaths('test')).toBe('test') //single
-    expect(joinPaths('.test')).toBe('.test') //single with dot
-    expect(joinPaths('/.test')).toBe('/.test') //single with dot with root
-    expect(joinPaths('test', 'test2')).toBe('test/test2') // single and single
-    expect(joinPaths('test', 'test2', '../test3')).toBe('test/test3') // single and single and single with parent
-    expect(joinPaths('.', '../')).toBe('..') // dot and parent
-    expect(joinPaths('test/', 'test2/')).toBe('test/test2') // trailing slashes
-    expect(joinPaths('./test', './test2')).toBe('test/test2') // dot and slash
-    expect(joinPaths('', 'test')).toBe('test') // empty path
-    expect(joinPaths('/test', '/test2')).toBe('/test/test2') // root path
-    expect(joinPaths('../', 'test')).toBe('../test') // parent and single
-    expect(joinPaths('test', '..', 'test2')).toBe('test2') // single triple dot and single
-    expect(joinPaths('test', '...', 'test2')).toBe('test/.../test2') // single triple dot and single
-    expect(joinPaths('test', './test2', '.test3.')).toBe('test/test2/.test3.') // single and single with slash and single with dot
-    expect(joinPaths('test', '../', '.test2')).toBe('.test2') // single and parent and single with dot
-    expect(joinPaths('..', '..', 'test')).toBe('../../test') // parent and parent and single
-    expect(joinPaths('..', '..')).toBe('../..') // parent and parent
-    expect(joinPaths('.test../test2/../')).toBe('.test..') //shuffle
-    expect(joinPaths('.test./.test2/../')).toBe('.test.') //shuffle2
-  })
-  it('Should windows path is valid.', () => {
-    expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')
-  })
-})
 describe('dirname', () => {
   it('Should dirname is valid.', () => {
     expect(dirname('parent/child')).toBe('parent')

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -13,47 +13,6 @@ export const dirname = (path: string): string => {
   return splittedPath.slice(0, -1).join('/') // Windows supports slash path
 }
 
-const normalizePath = (path: string): string => {
-  return path.replace(/(\\)/g, '/').replace(/\/$/g, '')
-}
-
-const handleParent = (resultPaths: string[], beforeParentFlag: boolean): void => {
-  if (resultPaths.length === 0 || beforeParentFlag) {
-    resultPaths.push('..')
-  } else {
-    resultPaths.pop()
-  }
-}
-
-const handleNonDot = (path: string, resultPaths: string[]): void => {
-  path = path.replace(/^\.(?!.)/, '')
-  if (path !== '') {
-    resultPaths.push(path)
-  }
-}
-
-const handleSegments = (paths: string[], resultPaths: string[]): void => {
-  let beforeParentFlag = false
-  for (const path of paths) {
-    // Handle `..`
-    if (path === '..') {
-      handleParent(resultPaths, beforeParentFlag)
-      beforeParentFlag = true
-    } else {
-      // Handle `.` or `abc`
-      handleNonDot(path, resultPaths)
-      beforeParentFlag = false
-    }
-  }
-}
-
-export const joinPaths = (...paths: string[]): string => {
-  paths = paths.map(normalizePath)
-  const resultPaths: string[] = []
-  handleSegments(paths.join('/').split('/'), resultPaths)
-  return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
-}
-
 interface FilterStaticGenerateRouteData {
   path: string
 }

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -5,7 +5,7 @@
 
 import type { Context, Data } from '../../context'
 import type { Env, MiddlewareHandler } from '../../types'
-import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath'
+import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath/getFilePath'
 import { getMimeType } from '../../utils/mime'
 
 export type ServeStaticOptions<E extends Env = Env> = {

--- a/src/utils/filepath/getFilePath.test.ts
+++ b/src/utils/filepath/getFilePath.test.ts
@@ -1,4 +1,4 @@
-import { getFilePath, getFilePathWithoutDefaultDocument } from './filepath'
+import { getFilePath, getFilePathWithoutDefaultDocument } from './getFilePath'
 
 describe('getFilePathWithoutDefaultDocument', () => {
   it('Should return file path correctly', async () => {

--- a/src/utils/filepath/getFilePath.ts
+++ b/src/utils/filepath/getFilePath.ts
@@ -1,6 +1,6 @@
 /**
  * @module
- * FilePath utility.
+ * getFilePath utility.
  */
 
 type FilePathOptions = {

--- a/src/utils/filepath/index.ts
+++ b/src/utils/filepath/index.ts
@@ -1,0 +1,5 @@
+/**
+ * FilePath utility.
+ * @module
+ */
+export { getFilePath, getFilePathWithoutDefaultDocument } from './getFilePath'

--- a/src/utils/filepath/index.ts
+++ b/src/utils/filepath/index.ts
@@ -3,3 +3,5 @@
  * @module
  */
 export { getFilePath, getFilePathWithoutDefaultDocument } from './getFilePath'
+export { joinPaths } from './join'
+export { relative } from './relative'

--- a/src/utils/filepath/join.test.ts
+++ b/src/utils/filepath/join.test.ts
@@ -1,0 +1,28 @@
+import { joinPaths } from './join'
+
+describe('joinPath', () => {
+  it('Should joined path is valid.', () => {
+    expect(joinPaths('test')).toBe('test') //single
+    expect(joinPaths('.test')).toBe('.test') //single with dot
+    expect(joinPaths('/.test')).toBe('/.test') //single with dot with root
+    expect(joinPaths('test', 'test2')).toBe('test/test2') // single and single
+    expect(joinPaths('test', 'test2', '../test3')).toBe('test/test3') // single and single and single with parent
+    expect(joinPaths('.', '../')).toBe('..') // dot and parent
+    expect(joinPaths('test/', 'test2/')).toBe('test/test2') // trailing slashes
+    expect(joinPaths('./test', './test2')).toBe('test/test2') // dot and slash
+    expect(joinPaths('', 'test')).toBe('test') // empty path
+    expect(joinPaths('/test', '/test2')).toBe('/test/test2') // root path
+    expect(joinPaths('../', 'test')).toBe('../test') // parent and single
+    expect(joinPaths('test', '..', 'test2')).toBe('test2') // single triple dot and single
+    expect(joinPaths('test', '...', 'test2')).toBe('test/.../test2') // single triple dot and single
+    expect(joinPaths('test', './test2', '.test3.')).toBe('test/test2/.test3.') // single and single with slash and single with dot
+    expect(joinPaths('test', '../', '.test2')).toBe('.test2') // single and parent and single with dot
+    expect(joinPaths('..', '..', 'test')).toBe('../../test') // parent and parent and single
+    expect(joinPaths('..', '..')).toBe('../..') // parent and parent
+    expect(joinPaths('.test../test2/../')).toBe('.test..') //shuffle
+    expect(joinPaths('.test./.test2/../')).toBe('.test.') //shuffle2
+  })
+  it('Should windows path is valid.', () => {
+    expect(joinPaths('a\\b\\c', 'd\\e')).toBe('a/b/c/d/e')
+  })
+})

--- a/src/utils/filepath/join.ts
+++ b/src/utils/filepath/join.ts
@@ -1,0 +1,56 @@
+/**
+ * Utility for joining paths.
+ * @module
+ */
+
+const normalizePath = (path: string): string => {
+  return path.replace(/(\\)/g, '/').replace(/\/$/g, '')
+}
+
+const handleParent = (resultPaths: string[], beforeParentFlag: boolean): void => {
+  if (resultPaths.length === 0 || beforeParentFlag) {
+    resultPaths.push('..')
+  } else {
+    resultPaths.pop()
+  }
+}
+
+
+const handleNonDot = (path: string, resultPaths: string[]): void => {
+  path = path.replace(/^\.(?!.)/, '')
+  if (path !== '') {
+    resultPaths.push(path)
+  }
+}
+
+
+const handleSegments = (paths: string[], resultPaths: string[]): void => {
+  let beforeParentFlag = false
+  for (const path of paths) {
+    // Handle `..`
+    if (path === '..') {
+      handleParent(resultPaths, beforeParentFlag)
+      beforeParentFlag = true
+    } else {
+      // Handle `.` or `abc`
+      handleNonDot(path, resultPaths)
+      beforeParentFlag = false
+    }
+  }
+}
+
+/**
+ * Joins multiple paths into one path.
+ *
+ * It normalizes all paths by removing duplicate slashes and
+ * removes empty segments.
+ *
+ * @param paths Paths to join.
+ * @returns Joined path.
+ */
+export const joinPaths = (...paths: string[]): string => {
+  paths = paths.map(normalizePath)
+  const resultPaths: string[] = []
+  handleSegments(paths.join('/').split('/'), resultPaths)
+  return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
+}

--- a/src/utils/filepath/relative.test.ts
+++ b/src/utils/filepath/relative.test.ts
@@ -1,0 +1,23 @@
+import { relative } from './relative'
+
+const relativeTestCases: [string, string, string][] = [
+  ['/a/b/c', '/a/b/d/e', '../d/e'],
+  ['/a/b/c', '/a/b/c/d/e/f/g', 'd/e/f/g'],
+  ['/a/b/c', '/a/c/d/e/f/g', '../../c/d/e/f/g'],
+  ['/a/b/c', '/a/c/d/e', '../../c/d/e'],
+  ['/a/b/c', '/a/c', '../../c'],
+  ['/a/b/c', '/d/e/f/g', '../../../d/e/f/g'],
+  ['/a/b/c', '/d/e', '../../../d/e'],
+  ['/a/b/c', '/d', '../../../d'],
+  ['/a/b/c', '/a/b/c', ''],
+  ['/a/b/c', '/a/b/c/', ''],
+  ['/a/b/c', '/a/b/c/d/e/f/g', 'd/e/f/g'],
+]
+
+describe('relative', () => {
+  it('Should return relative path', () => {
+    for (const [from, to, expected] of relativeTestCases) {
+      expect(relative(from, to)).toBe(expected)
+    }
+  })
+})

--- a/src/utils/filepath/relative.ts
+++ b/src/utils/filepath/relative.ts
@@ -1,0 +1,42 @@
+/**
+ * Relative path
+ * @module
+ */
+
+import { joinPaths } from './join'
+
+/**
+ * Resolve relative path from `from` to `to`.
+ * @param from - The path from which you want to resolve.
+ * @param to - The path you want to resolve.
+ * @returns A relative path from `from` to `to`.
+ * @example
+ * ```ts
+ * import { relative } from 'hono/utils/filepath'
+ *
+ * relative('/a/b/c', '/a/b/d/e') // => '../d/e'
+ * ```
+ */
+export const relative = (from: string, to: string): string => {
+  const normalizedFrom = joinPaths(from)
+  const normalizedTo = joinPaths(to)
+
+  const fromSegments = normalizedFrom.split('/')
+  const toSegments = normalizedTo.split('/')
+
+  const commonSegments: string[] = []
+
+  for (let i = 0; i < Math.min(fromSegments.length, toSegments.length); i++) {
+    if (fromSegments[i] !== toSegments[i]) {
+      break
+    }
+    commonSegments.push(fromSegments[i])
+  }
+
+  const resultSegments = [
+    ...Array(fromSegments.length - commonSegments.length).fill('..'),
+    ...toSegments.slice(commonSegments.length),
+  ]
+
+  return resultSegments.join('/')
+}


### PR DESCRIPTION
**It is work in progress.**

I'll propose unified FS APIs. I'm trying implementing.

### Motivation

JavaScript runtimes have different APIs to access file system. So Hono has wrapper in `serveStatic` and SSG Helper. They should be merged I think. Therefore I'll propose it.

Hono is just Web application framework but I'm sure that middleware creators can create more powerful middleware.

### Web Standard

Hono follows Web Standard APIs. This PR will use WHATWG File System Access API ([Spec](https://fs.spec.whatwg.org), [MDN](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API)).

However File System API is formulated for browsers, features for using local filesystem is sometimes missing. (e.g., Get absolute path from entry) So I'm going to extend API interface.

### API Plans/Ideas
Open dir/file:
```ts
import { openDir, openFile } from 'hono/deno'

const dir = openDir('./public') // It's FileSystemDirectoryHandle but extended
const dir = openFile('./public/example.txt') // It's FileSystemFileHandle but extended
```
Serve static:
```ts
import { openDir, openFile } from 'hono/deno'
import { serveStatic } from 'hono/serve-static'

app.use('*', serveStatic({
  root: openDir('./public')
})
app.get('/favicon.ico', serveStatic({
  file: openFile('./assets/favicon.ico')
})
```
SSG:
```ts
import { toSSG } from 'hono/ssg'
import { openDir } from 'hono/deno'

toSSG(app, openDir('./dist'))
```

### Progress
Currently it's almost an idea.

#### Runtimes
- [ ] Deno
  - [x] readDir (without file access)
  - [ ] readFile
- [ ] Bun
- [ ] Node.js

#### Features
- [ ] SSG
- [ ] Serve-Static

I want forward compatibility.
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
