### PR TITLE
test(types): broken test in future versions of typescript

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -2249,15 +2249,18 @@ describe('Returning type from `app.use(path, mw)`', () => {
   })
 })
 describe('generic typed variables', () => {
+  const okHelper = (c: Context) => {
+    return <TData>(data: TData) => c.json({ data })
+  }
   type Variables = {
-    ok: <TData>(data: TData) => TypedResponse<{ data: TData }>
+    ok: ReturnType<typeof okHelper>
   }
   const app = new Hono<{ Variables: Variables }>()
 
   it('Should set and get variables with correct types', async () => {
     const route = app
       .use('*', async (c, next) => {
-        c.set('ok', (data) => c.json({ data }))
+        c.set('ok', okHelper(c))
         await next()
       })
       .get('/', (c) => {


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Summary
Fixed a test that will fail with future TypeScript versions.

### Repro
Upgrade TypeScript to `5.6.0-dev.20240819` and run `bun run test`. You'll get this error.
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/8f770559-4130-4722-8740-4856b1321952">

### Detail
This is a long story, but in short, the test passes because of a bug of TypeScript. I reported the bug and it was fixed.
https://github.com/microsoft/TypeScript/issues/59450

The error was detected in https://github.com/microsoft/TypeScript/pull/59516#issuecomment-2265997355

#### Why
Why does the test pass? This is because the return type of the function passed to `set('ok', ...)` is `TypedResponse<never>`. For any type `T`, `never` is subtype of `T`, so type-checking passes.
<img width="817" alt="image" src="https://github.com/user-attachments/assets/165ec743-f55b-467f-9b24-1ef7fabe8599">

 I can say `{ data: TData }` is treated as `never` here. This is just a bug of TypeScript. Because of the bug, `SimplifyDeepArray<{ data: TData }> extends JSONValue` is always evaluated as `false`, while it should be `true` because it's a.
https://github.com/honojs/hono/blob/b0af71fbcc6dbe44140ea76f16d68dfdb32a99a0/src/context.ts#L183-L187

#### After the bug was fixed
Then, why does the test fail now? Now `SimplifyDeepArray<{ data: TData }> extends JSONValue` is evaluated as `true` and `JSONParsed<{ data: TData }>` is executed. 
https://github.com/honojs/hono/blob/b0af71fbcc6dbe44140ea76f16d68dfdb32a99a0/src/utils/types.ts#L65-L70
<img width="920" alt="image" src="https://github.com/user-attachments/assets/66cc2782-922d-49da-b7b0-03ce6ecba985">

`data` property is omitted through `IsInvalid<T[K]> extends true ? never : K`, while the expected type here has `data` property. That means that `TData` is a subtype of `InvalidJSONValue` here. I think **this may be another bug of TypeScript**, but we have to resolve this ourselves for now.

#### Why this change fixes the problem (my guess, not sure)
Before my change, `Variables['ok']` and the type of `(data) => c.json({ data })` are decided separately, which is possibly wrong. Now they share the source (`okHelper`) and have the same type.
