### PR TITLE
update HTMLRespond type

### DIFF
--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -21,6 +21,15 @@ export type HtmlEscaped = {
 export type HtmlEscapedString = string & HtmlEscaped
 
 /**
+ * Anything that has a `toString` method.
+ */
+type HasToString = {
+  toString(): string
+}
+
+export type HTMLInput = string | HtmlEscapedString | HasToString
+
+/**
  * StringBuffer contains string and Promise<string> alternately
  * The length of the array will be odd, the odd numbered element will be a string,
  * and the even numbered element will be a Promise<string>.
@@ -140,7 +149,7 @@ export const resolveCallbackSync = (str: string | HtmlEscapedString): string => 
 }
 
 export const resolveCallback = async (
-  str: string | HtmlEscapedString,
+  str: HTMLInput,
   phase: (typeof HtmlEscapedCallbackPhase)[keyof typeof HtmlEscapedCallbackPhase],
   preserveCallbacks: boolean,
   context: object,
@@ -148,12 +157,12 @@ export const resolveCallback = async (
 ): Promise<string> => {
   const callbacks = (str as HtmlEscapedString).callbacks as HtmlEscapedCallback[]
   if (!callbacks?.length) {
-    return Promise.resolve(str)
+    return Promise.resolve(str.toString())
   }
   if (buffer) {
     buffer[0] += str
   } else {
-    buffer = [str]
+    buffer = [str.toString()]
   }
 
   const resStr = Promise.all(callbacks.map((c) => c({ phase, buffer, context }))).then((res) =>


### PR DESCRIPTION
If you pass anything with a `toString` method into `c.html` it will return the result, but the types don't currently reflect this. 

This PR adds a `HasToString` type as an option for the first argument of `c.html`. 

This enables you to do things like this and not have TS errors. Right now this works but TS errors.

```ts
const app = new Hono();

app.get("/number", (c) => c.html(1));

const obj = { toString: () => "hello world" };

app.get("/hello", (c) => c.html(obj));
```

```txt
No overload matches this call.
  Overload 1 of 2, '(html: string | Promise<string>, status?: StatusCode | undefined, headers?: HeaderRecord | undefined): Response | Promise<Response>', gave the following error.
    Argument of type 'number' is not assignable to parameter of type 'string | Promise<string>'.
  Overload 2 of 2, '(html: string | Promise<string>, init?: ResponseInit | undefined): Response | Promise<Response>', gave the following error.
    Argument of type 'number' is not assignable to parameter of type 'string | Promise<string>'.ts(2769)
```

Thanks for the review, I'm not sure if there's a case I'm not considering here. 

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
