### PR TITLE
feat(jsx): add popover api attributes

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -181,7 +181,8 @@ export namespace JSX {
     lang?: string | undefined
     nonce?: string | undefined
     placeholder?: string | undefined
-    popover?: string | undefined
+    /** @see https://developer.mozilla.org/en-US/docs/Web/API/Popover_API */
+    popover?: boolean | 'auto' | 'manual' | undefined
     slot?: string | undefined
     spellcheck?: boolean | undefined
     style?: CSSProperties | string | undefined
@@ -238,6 +239,9 @@ export namespace JSX {
     cite?: string | undefined
   }
 
+  /** @see https://developer.mozilla.org/en-US/docs/Web/API/Popover_API */
+  type HTMLAttributePopoverTargetAction = 'show' | 'hide' | 'toggle'
+
   interface ButtonHTMLAttributes extends HTMLAttributes {
     disabled?: boolean | undefined
     form?: string | undefined
@@ -248,6 +252,8 @@ export namespace JSX {
     name?: string | undefined
     type?: 'submit' | 'reset' | 'button' | undefined
     value?: string | ReadonlyArray<string> | number | undefined
+    popovertarget?: string | undefined
+    popovertargetaction?: HTMLAttributePopoverTargetAction | undefined
 
     // React 19 compatibility
     formAction?: string | Function | undefined
@@ -462,6 +468,8 @@ export namespace JSX {
     type?: HTMLInputTypeAttribute | undefined
     value?: string | ReadonlyArray<string> | number | undefined
     width?: number | string | undefined
+    popovertarget?: string | undefined
+    popovertargetaction?: HTMLAttributePopoverTargetAction | undefined
 
     // React 19 compatibility
     formAction?: string | Function | undefined


### PR DESCRIPTION
I added attribute types for the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API).

![image](https://github.com/user-attachments/assets/9f83c307-6778-4d4f-b2cd-480f5110ef5b)


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
