### PR TITLE
feat(cloudflare-pages): enable `c.env.eventContext` in `handleMiddleware`

### DIFF
--- a/src/adapter/cloudflare-pages/handler.test.ts
+++ b/src/adapter/cloudflare-pages/handler.test.ts
@@ -230,6 +230,18 @@ describe('Middleware adapter for Cloudflare Pages', () => {
     await expect(handler(eventContext)).rejects.toThrowError('Something went wrong')
     expect(next).not.toHaveBeenCalled()
   })
+
+  it('Should set the data in eventContext.data', async () => {
+    const next = vi.fn()
+    const eventContext = createEventContext({ next })
+    const handler = handleMiddleware(async (c, next) => {
+      c.env.eventContext.data.user = 'Joe'
+      await next()
+    })
+    expect(eventContext.data.user).toBeUndefined()
+    await handler(eventContext)
+    expect(eventContext.data.user).toBe('Joe')
+  })
 })
 
 describe('serveStatic()', () => {

--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -9,7 +9,7 @@ import type { BlankSchema, Env, Input, MiddlewareHandler, Schema } from '../../t
 type Params<P extends string = any> = Record<P, string | string[]>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type EventContext<Env = {}, P extends string = any, Data = {}> = {
+export type EventContext<Env = {}, P extends string = any, Data = Record<string, unknown>> = {
   request: Request
   functionPath: string
   waitUntil: (promise: Promise<unknown>) => void
@@ -43,12 +43,20 @@ export const handle =
   }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function handleMiddleware<E extends Env = any, P extends string = any, I extends Input = {}>(
-  middleware: MiddlewareHandler<E, P, I>
+export function handleMiddleware<E extends Env = {}, P extends string = any, I extends Input = {}>(
+  middleware: MiddlewareHandler<
+    E & {
+      Bindings: {
+        eventContext: EventContext
+      }
+    },
+    P,
+    I
+  >
 ): PagesFunction<E['Bindings']> {
   return async (executionCtx) => {
     const context = new Context(executionCtx.request, {
-      env: executionCtx.env,
+      env: { ...executionCtx.env, eventContext: executionCtx },
       executionCtx,
     })
 


### PR DESCRIPTION
Fixes #3320

This is for the Cloudflare Pages adapter. With this PR, you can access `EventContext` object in `hanldeMiddleware` via `c.env`.

```ts
// functions/_middleware.ts
import { handleMiddleware } from 'hono/cloudflare-pages'

export const onRequest = [
  handleMiddleware(async (c, next) => {
    c.env.eventContext.data.user = 'Joe'
    await next()
  }),
]
```

Then, you can access the data value in the handler:

```ts
// functions/api/[[route]].ts
import { Hono } from 'hono'
import type { EventContext } from 'hono/cloudflare-pages'
import { handle } from 'hono/cloudflare-pages'

type Env = {
  Bindings: {
    eventContext: EventContext
  }
}

const app = new Hono<Env>().basePath('/api')

const routes = app.get('/hello', (c) => {
  return c.json({
    message: `Hello, ${c.env.eventContext.data.user}!`, // 'Joe'
  })
})

export const onRequest = handle(routes)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
