### PR TITLE
feat(websocket): Add generics type to `WSContext`

### DIFF
--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -29,7 +29,9 @@ export interface BunWebSocketData {
   protocol: string
 }
 
-const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext<BunServerWebSocket<BunWebSocketData>> => {
+const createWSContext = (
+  ws: BunServerWebSocket<BunWebSocketData>
+): WSContext<BunServerWebSocket<BunWebSocketData>> => {
   return {
     send: (source, options) => {
       const sendingData =
@@ -50,6 +52,7 @@ const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext<Bu
 export const createBunWebSocket = <T>(): CreateWebSocket<T> => {
   const websocketConns: WSEvents[] = []
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const upgradeWebSocket: UpgradeWebSocket<any> = (createEvents) => {
     return async (c, next) => {
       const server = getBunServer(c)

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -29,9 +29,7 @@ export interface BunWebSocketData {
   protocol: string
 }
 
-const createWSContext = (
-  ws: BunServerWebSocket<BunWebSocketData>
-): WSContext => {
+const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext => {
   return {
     send: (source, options) => {
       const sendingData =

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -19,11 +19,9 @@ interface BunWebSocketHandler<T> {
   close(ws: BunServerWebSocket<T>, code?: number, reason?: string): void
   message(ws: BunServerWebSocket<T>, message: string | Uint8Array): void
 }
-interface CreateWebSocket {
-  (): {
-    upgradeWebSocket: UpgradeWebSocket
-    websocket: BunWebSocketHandler<BunWebSocketData>
-  }
+interface CreateWebSocket<T> {
+  upgradeWebSocket: UpgradeWebSocket<T>
+  websocket: BunWebSocketHandler<BunWebSocketData>
 }
 export interface BunWebSocketData {
   connId: number
@@ -49,10 +47,10 @@ const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext<Bu
   }
 }
 
-export const createBunWebSocket: CreateWebSocket = () => {
+export const createBunWebSocket = <T>(): CreateWebSocket<T> => {
   const websocketConns: WSEvents[] = []
 
-  const upgradeWebSocket: UpgradeWebSocket = (createEvents) => {
+  const upgradeWebSocket: UpgradeWebSocket<any> = (createEvents) => {
     return async (c, next) => {
       const server = getBunServer(c)
       if (!server) {

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -31,7 +31,7 @@ export interface BunWebSocketData {
 
 const createWSContext = (
   ws: BunServerWebSocket<BunWebSocketData>
-): WSContext<BunServerWebSocket<BunWebSocketData>> => {
+): WSContext => {
   return {
     send: (source, options) => {
       const sendingData =

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -31,7 +31,7 @@ export interface BunWebSocketData {
   protocol: string
 }
 
-const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext => {
+const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext<BunServerWebSocket<BunWebSocketData>> => {
   return {
     send: (source, options) => {
       const sendingData =

--- a/src/adapter/cloudflare-workers/websocket.ts
+++ b/src/adapter/cloudflare-workers/websocket.ts
@@ -14,7 +14,7 @@ export const upgradeWebSocket: UpgradeWebSocket = (createEvents) => async (c, ne
   const client: WebSocket = webSocketPair[0]
   const server: WebSocket = webSocketPair[1]
 
-  const wsContext: WSContext = {
+  const wsContext: WSContext<WebSocket> = {
     binaryType: 'arraybuffer',
     close: (code, reason) => server.close(code, reason),
     get protocol() {

--- a/src/adapter/cloudflare-workers/websocket.ts
+++ b/src/adapter/cloudflare-workers/websocket.ts
@@ -1,7 +1,7 @@
 import type { UpgradeWebSocket, WSContext, WSReadyState } from '../../helper/websocket'
 
 // Based on https://github.com/honojs/hono/issues/1153#issuecomment-1767321332
-export const upgradeWebSocket: UpgradeWebSocket = (createEvents) => async (c, next) => {
+export const upgradeWebSocket: UpgradeWebSocket<WebSocket> = (createEvents) => async (c, next) => {
   const events = await createEvents(c)
 
   const upgradeHeader = c.req.header('Upgrade')

--- a/src/adapter/deno/websocket.ts
+++ b/src/adapter/deno/websocket.ts
@@ -20,7 +20,7 @@ export interface UpgradeWebSocketOptions {
   idleTimeout?: number
 }
 
-export const upgradeWebSocket: UpgradeWebSocket<UpgradeWebSocketOptions> =
+export const upgradeWebSocket: UpgradeWebSocket<WebSocket, UpgradeWebSocketOptions> =
   (createEvents, options) => async (c, next) => {
     if (c.req.header('upgrade') !== 'websocket') {
       return await next()

--- a/src/adapter/deno/websocket.ts
+++ b/src/adapter/deno/websocket.ts
@@ -29,7 +29,7 @@ export const upgradeWebSocket: UpgradeWebSocket<UpgradeWebSocketOptions> =
     const events = await createEvents(c)
     const { response, socket } = Deno.upgradeWebSocket(c.req.raw, options || {})
 
-    const wsContext: WSContext = {
+    const wsContext: WSContext<WebSocket> = {
       binaryType: 'arraybuffer',
       close: (code, reason) => socket.close(code, reason),
       get protocol() {

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -33,14 +33,14 @@ export type UpgradeWebSocket<T = any> = (
 
 export type WSReadyState = 0 | 1 | 2 | 3
 
-export type WSContext = {
+export type WSContext<T = unknown> = {
   send(
     source: string | ArrayBuffer | Uint8Array,
     options?: {
       compress: boolean
     }
   ): void
-  raw?: unknown
+  raw?: T
   binaryType: BinaryType
   readyState: WSReadyState
   url: URL | null

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -10,19 +10,19 @@ import type { MiddlewareHandler } from '../../types'
 /**
  * WebSocket Event Listeners type
  */
-export interface WSEvents {
-  onOpen?: (evt: Event, ws: WSContext) => void
-  onMessage?: (evt: MessageEvent<WSMessageReceive>, ws: WSContext) => void
-  onClose?: (evt: CloseEvent, ws: WSContext) => void
-  onError?: (evt: Event, ws: WSContext) => void
+export interface WSEvents<T = unknown> {
+  onOpen?: (evt: Event, ws: WSContext<T>) => void
+  onMessage?: (evt: MessageEvent<WSMessageReceive>, ws: WSContext<T>) => void
+  onClose?: (evt: CloseEvent, ws: WSContext<T>) => void
+  onError?: (evt: Event, ws: WSContext<T>) => void
 }
 
 /**
  * Upgrade WebSocket Type
  */
-export type UpgradeWebSocket<T = any> = (
-  createEvents: (c: Context) => WSEvents | Promise<WSEvents>,
-  options?: T
+export type UpgradeWebSocket<T = unknown,U = any> = (
+  createEvents: (c: Context) => WSEvents<T> | Promise<WSEvents<T>>,
+  options?: U
 ) => MiddlewareHandler<
   any,
   string,

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -20,7 +20,7 @@ export interface WSEvents<T = unknown> {
 /**
  * Upgrade WebSocket Type
  */
-export type UpgradeWebSocket<T = unknown,U = any> = (
+export type UpgradeWebSocket<T = unknown, U = any> = (
   createEvents: (c: Context) => WSEvents<T> | Promise<WSEvents<T>>,
   options?: U
 ) => MiddlewareHandler<


### PR DESCRIPTION
Fix #3327 

## Description

In this pull request, you can set `ws.raw` type as `ServerWebSocket` on Bun.
So, you can now use Bun own WebSocket API, including Pub/Sub feature!

```typescript
import { Hono } from 'hono'
import { createBunWebSocket } from 'hono/bun'
import type { ServerWebSocket } from 'bun'

const app = new Hono()

const { upgradeWebSocket, websocket } = createBunWebSocket<ServerWebSocket>()

app.get(
  '/ws',
  upgradeWebSocket((c) => {
    return {
      onMessage(event, ws) {
        ws.raw.subscribe('chat-test') // ws.raw type is unknown now, but we will be able to set ServerWebSocket.
      },
    }
  })
)
```


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
