### PR TITLE
chore(test): replace deprecated vitest type

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -1,9 +1,9 @@
-import type { Suite } from 'vitest'
+import type { RunnerTestSuite } from 'vitest'
 import type { ParamIndexMap, Params, Router } from '../router'
 
-const getSuiteHierarchy = (suite?: Suite) => {
-  const res: Suite[] = []
-  let s: Suite | undefined = suite
+const getSuiteHierarchy = (suite?: RunnerTestSuite) => {
+  const res: RunnerTestSuite[] = []
+  let s: RunnerTestSuite | undefined = suite
   while (s) {
     res.unshift(s)
     s = s.suite


### PR DESCRIPTION
I forgot to replace the deprecated type in #3326 , so I replaced it.

[reference.](https://github.com/vitest-dev/vitest/blob/372a2c26a8e5ac2cfe6db961ed40529f09464e82/packages/vitest/src/public/index.ts#L130-L131)



### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
