### PR TITLE
feat(helper/streaming): Support Promise<string> or (async) JSX.Element in streamSSE

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -844,18 +844,11 @@ export class Context<
     this.#preparedHeaders['content-type'] = 'text/html; charset=UTF-8'
 
     if (typeof html === 'object') {
-      if (!(html instanceof Promise)) {
-        html = (html as string).toString() // HtmlEscapedString object to string
-      }
-      if ((html as string | Promise<string>) instanceof Promise) {
-        return (html as unknown as Promise<string>)
-          .then((html) => resolveCallback(html, HtmlEscapedCallbackPhase.Stringify, false, {}))
-          .then((html) => {
-            return typeof arg === 'number'
-              ? this.newResponse(html, arg, headers)
-              : this.newResponse(html, arg)
-          })
-      }
+      return resolveCallback(html, HtmlEscapedCallbackPhase.Stringify, false, {}).then((html) => {
+        return typeof arg === 'number'
+          ? this.newResponse(html, arg, headers)
+          : this.newResponse(html, arg)
+      })
     }
 
     return typeof arg === 'number'

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -15,16 +15,7 @@ export class SSEStreamingApi extends StreamingApi {
   }
 
   async writeSSE(message: SSEMessage) {
-    let data = message.data
-    if (typeof data === 'object') {
-      if (!(data instanceof Promise)) {
-        data = (data as string).toString() // HtmlEscapedString object to string
-      }
-      if ((data as string | Promise<string>) instanceof Promise) {
-        data = await resolveCallback(await data, HtmlEscapedCallbackPhase.Stringify, false, {})
-      }
-    }
-
+    const data = await resolveCallback(message.data, HtmlEscapedCallbackPhase.Stringify, false, {})
     const dataLines = (data as string)
       .split('\n')
       .map((line) => {


### PR DESCRIPTION
#3319

This change allows you to use "hono/jsx" to write the following in streamSSE. I don't think there are many use cases, but the changes on the `helper/streaming/sse.ts` side are also small and could be added to the implementation.

```tsx
streamSSE(c, async (stream) => {
  await stream.writeSSE({ data: <div>Hello</div> })
})
```

```tsx
streamSSE(c, async (stream) => {
  await stream.writeSSE({
    data: (
      <ErrorBoundary fallback={<div>Error</div>}>
        <AsyncComponent />
      </ErrorBoundary>
    ),
  })
})
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
