### PR TITLE
perf(jsx): skip the special behavior when the element is in the head.

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -327,7 +327,7 @@ export const jsxFn = (
       props,
       children
     )
-  } else if (tag === 'svg') {
+  } else if (tag === 'svg' || tag === 'head') {
     nameSpaceContext ||= createContext('')
     return new JSXNode(tag, props, [
       new JSXFunctionNode(

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -470,6 +470,21 @@ describe('render to string', () => {
       expect(template.toString()).toBe('<span data-text="&lt;html-escaped-string&gt;">Hello</span>')
     })
   })
+
+  describe('head', () => {
+    it('Simple head elements should be rendered as is', () => {
+      const template = (
+        <head>
+          <title>Hono!</title>
+          <meta name='description' content='A description' />
+          <script src='script.js'></script>
+        </head>
+      )
+      expect(template.toString()).toBe(
+        '<head><title>Hono!</title><meta name="description" content="A description"/><script src="script.js"></script></head>'
+      )
+    })
+  })
 })
 
 describe('className', () => {

--- a/src/jsx/intrinsic-element/components.ts
+++ b/src/jsx/intrinsic-element/components.ts
@@ -106,8 +106,15 @@ const documentMetadataTag = (tag: string, children: Child, props: Props, sort: b
 
 export const title: FC<PropsWithChildren> = ({ children, ...props }) => {
   const nameSpaceContext = getNameSpaceContext()
-  if (nameSpaceContext && useContext(nameSpaceContext) === 'svg') {
-    new JSXNode('title', props, toArray(children ?? []) as Child[])
+  if (nameSpaceContext) {
+    const context = useContext(nameSpaceContext)
+    if (context === 'svg' || context === 'head') {
+      return new JSXNode(
+        'title',
+        props,
+        toArray(children ?? []) as Child[]
+      ) as unknown as HtmlEscapedString
+    }
   }
 
   return documentMetadataTag('title', children, props, false)
@@ -116,7 +123,11 @@ export const script: FC<PropsWithChildren<IntrinsicElements['script']>> = ({
   children,
   ...props
 }) => {
-  if (['src', 'async'].some((k) => !props[k])) {
+  const nameSpaceContext = getNameSpaceContext()
+  if (
+    ['src', 'async'].some((k) => !props[k]) ||
+    (nameSpaceContext && useContext(nameSpaceContext) === 'head')
+  ) {
     return returnWithoutSpecialBehavior('script', children, props)
   }
 
@@ -144,6 +155,10 @@ export const link: FC<PropsWithChildren<IntrinsicElements['link']>> = ({ childre
   return documentMetadataTag('link', children, props, 'precedence' in props)
 }
 export const meta: FC<PropsWithChildren> = ({ children, ...props }) => {
+  const nameSpaceContext = getNameSpaceContext()
+  if (nameSpaceContext && useContext(nameSpaceContext) === 'head') {
+    return returnWithoutSpecialBehavior('meta', children, props)
+  }
   return documentMetadataTag('meta', children, props, false)
 }
 


### PR DESCRIPTION
#3347

The following elements are no longer special behavior when they are already in the head element.

* title
* meta
* script

In my environment, the results were as follows

```
benchmark        time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------- -----------------------------
• Real World Scenario
--------------------------------------------------- -----------------------------
KitaJS/Html     426 µs/iter     (352 µs … 1'410 µs)    384 µs    856 µs  1'015 µs
Typed Html    1'644 µs/iter   (1'477 µs … 2'078 µs)  1'751 µs  1'960 µs  2'078 µs
VHtml         2'184 µs/iter   (2'051 µs … 2'730 µs)  2'248 µs  2'655 µs  2'730 µs
React JSX     5'673 µs/iter   (5'406 µs … 6'461 µs)  5'898 µs  6'422 µs  6'461 µs
Preact          793 µs/iter     (625 µs … 2'217 µs)    697 µs  1'750 µs  2'217 µs
React         5'645 µs/iter   (5'407 µs … 6'361 µs)  5'844 µs  6'331 µs  6'361 µs
Common Tags   2'941 µs/iter   (2'783 µs … 3'680 µs)  2'947 µs  3'589 µs  3'680 µs
Ghtml           201 µs/iter     (165 µs … 1'266 µs)    188 µs    910 µs  1'195 µs
JSXTE         3'686 µs/iter   (3'261 µs … 4'513 µs)  3'766 µs  4'314 µs  4'513 µs
hono/jsx      1'046 µs/iter   (1'002 µs … 1'231 µs)  1'060 µs  1'203 µs  1'231 µs

summary for Real World Scenario
  Ghtml
   2.12x faster than KitaJS/Html
   3.94x faster than Preact
   5.19x faster than hono/jsx
   8.16x faster than Typed Html
   10.84x faster than VHtml
   14.6x faster than Common Tags
   18.3x faster than JSXTE
   28.03x faster than React
   28.17x faster than React JSX
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code