### PR TITLE
feat(jsx-renderer): set `Content-Encoding` when `stream` is `true`

### DIFF
--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -238,6 +238,7 @@ describe('JSX renderer', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Transfer-Encoding')).toEqual('chunked')
     expect(res.headers.get('Content-Type')).toEqual('text/html; charset=UTF-8')
+    expect(res.headers.get('Content-Encoding')).toEqual('Identity')
 
     if (!res.body) {
       throw new Error('Body is null')

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -60,6 +60,7 @@ const createRenderer =
       if (options.stream === true) {
         c.header('Transfer-Encoding', 'chunked')
         c.header('Content-Type', 'text/html; charset=UTF-8')
+        c.header('Content-Encoding', 'Identity')
       } else {
         for (const [key, value] of Object.entries(options.stream)) {
           c.header(key, value)


### PR DESCRIPTION
With this PR, if the `stream` is `true,` it will set `Content-Encoding` as `Identity`. This is needed to correct the behavior of `Suspense` when the content is encoded like `gzip.`

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
