### PR TITLE
refactor(utils/basic-auth):  Moved Internal function to utils 

### DIFF
--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -75,7 +75,7 @@ export const basicAuth = (
   }
 
   return async function basicAuth(ctx, next) {
-    const requestUser = auth(ctx.req)
+    const requestUser = auth(ctx.req.raw)
     if (requestUser) {
       if (verifyUserInOptions) {
         if (await options.verifyUser(requestUser.username, requestUser.password, ctx)) {

--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -5,32 +5,9 @@
 
 import type { Context } from '../../context'
 import { HTTPException } from '../../http-exception'
-import type { HonoRequest } from '../../request'
 import type { MiddlewareHandler } from '../../types'
+import { auth } from '../../utils/basic-auth'
 import { timingSafeEqual } from '../../utils/buffer'
-import { decodeBase64 } from '../../utils/encode'
-
-const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
-const USER_PASS_REGEXP = /^([^:]*):(.*)$/
-const utf8Decoder = new TextDecoder()
-const auth = (req: HonoRequest) => {
-  const match = CREDENTIALS_REGEXP.exec(req.header('Authorization') || '')
-  if (!match) {
-    return undefined
-  }
-
-  let userPass = undefined
-  // If an invalid string is passed to atob(), it throws a `DOMException`.
-  try {
-    userPass = USER_PASS_REGEXP.exec(utf8Decoder.decode(decodeBase64(match[1])))
-  } catch {} // Do nothing
-
-  if (!userPass) {
-    return undefined
-  }
-
-  return { username: userPass[1], password: userPass[2] }
-}
 
 type BasicAuthOptions =
   | {

--- a/src/utils/basic-auth.test.ts
+++ b/src/utils/basic-auth.test.ts
@@ -3,61 +3,55 @@ import { auth } from './basic-auth'
 
 describe('auth', () => {
   it('auth() - not include Authorization Header', () => {
-    const req = new HonoRequest(new Request('http://localhost/auth'))
-    const res = auth(req)
+    const res = auth(new Request('http://localhost/auth'))
     expect(res).toBeUndefined()
   })
 
   it('auth() - invalid Authorization Header format', () => {
-    const req = new HonoRequest(
+    const res = auth(
       new Request('http://localhost/auth', {
         headers: { Authorization: 'InvalidAuthHeader' },
       })
     )
-    const res = auth(req)
     expect(res).toBeUndefined()
   })
 
   it('auth() - invalid Base64 string in Authorization Header', () => {
-    const req = new HonoRequest(
+    const res = auth(
       new Request('http://localhost/auth', {
         headers: { Authorization: 'Basic InvalidBase64' },
       })
     )
-    const res = auth(req)
     expect(res).toBeUndefined()
   })
 
   it('auth() - valid Authorization Header', () => {
     const validBase64 = btoa('username:password')
-    const req = new HonoRequest(
+    const res = auth(
       new Request('http://localhost/auth', {
         headers: { Authorization: `Basic ${validBase64}` },
       })
     )
-    const res = auth(req)
     expect(res).toEqual({ username: 'username', password: 'password' })
   })
 
   it('auth() - empty username', () => {
     const validBase64 = btoa(':password')
-    const req = new HonoRequest(
+    const res = auth(
       new Request('http://localhost/auth', {
         headers: { Authorization: `Basic ${validBase64}` },
       })
     )
-    const res = auth(req)
     expect(res).toEqual({ username: '', password: 'password' })
   })
 
   it('auth() - empty password', () => {
     const validBase64 = btoa('username:')
-    const req = new HonoRequest(
+    const res = auth(
       new Request('http://localhost/auth', {
         headers: { Authorization: `Basic ${validBase64}` },
       })
     )
-    const res = auth(req)
     expect(res).toEqual({ username: 'username', password: '' })
   })
 })

--- a/src/utils/basic-auth.test.ts
+++ b/src/utils/basic-auth.test.ts
@@ -1,0 +1,63 @@
+import { HonoRequest } from '../request'
+import { auth } from './basic-auth'
+
+describe('auth', () => {
+  it('auth() - not include Authorization Header', () => {
+    const req = new HonoRequest(new Request('http://localhost/auth'))
+    const res = auth(req)
+    expect(res).toBeUndefined()
+  })
+
+  it('auth() - invalid Authorization Header format', () => {
+    const req = new HonoRequest(
+      new Request('http://localhost/auth', {
+        headers: { Authorization: 'InvalidAuthHeader' },
+      })
+    )
+    const res = auth(req)
+    expect(res).toBeUndefined()
+  })
+
+  it('auth() - invalid Base64 string in Authorization Header', () => {
+    const req = new HonoRequest(
+      new Request('http://localhost/auth', {
+        headers: { Authorization: 'Basic InvalidBase64' },
+      })
+    )
+    const res = auth(req)
+    expect(res).toBeUndefined()
+  })
+
+  it('auth() - valid Authorization Header', () => {
+    const validBase64 = btoa('username:password')
+    const req = new HonoRequest(
+      new Request('http://localhost/auth', {
+        headers: { Authorization: `Basic ${validBase64}` },
+      })
+    )
+    const res = auth(req)
+    expect(res).toEqual({ username: 'username', password: 'password' })
+  })
+
+  it('auth() - empty username', () => {
+    const validBase64 = btoa(':password')
+    const req = new HonoRequest(
+      new Request('http://localhost/auth', {
+        headers: { Authorization: `Basic ${validBase64}` },
+      })
+    )
+    const res = auth(req)
+    expect(res).toEqual({ username: '', password: 'password' })
+  })
+
+  it('auth() - empty password', () => {
+    const validBase64 = btoa('username:')
+    const req = new HonoRequest(
+      new Request('http://localhost/auth', {
+        headers: { Authorization: `Basic ${validBase64}` },
+      })
+    )
+    const res = auth(req)
+    expect(res).toEqual({ username: 'username', password: '' })
+  })
+})

--- a/src/utils/basic-auth.ts
+++ b/src/utils/basic-auth.ts
@@ -1,0 +1,27 @@
+import type { HonoRequest } from '../request'
+import { decodeBase64 } from './encode'
+
+const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
+const USER_PASS_REGEXP = /^([^:]*):(.*)$/
+const utf8Decoder = new TextDecoder()
+
+export type Auth = (req: HonoRequest) => { username: string; password: string } | undefined
+
+export const auth: Auth = (req: HonoRequest) => {
+  const match = CREDENTIALS_REGEXP.exec(req.header('Authorization') || '')
+  if (!match) {
+    return undefined
+  }
+
+  let userPass = undefined
+  // If an invalid string is passed to atob(), it throws a `DOMException`.
+  try {
+    userPass = USER_PASS_REGEXP.exec(utf8Decoder.decode(decodeBase64(match[1])))
+  } catch {} // Do nothing
+
+  if (!userPass) {
+    return undefined
+  }
+
+  return { username: userPass[1], password: userPass[2] }
+}

--- a/src/utils/basic-auth.ts
+++ b/src/utils/basic-auth.ts
@@ -1,14 +1,13 @@
-import type { HonoRequest } from '../request'
 import { decodeBase64 } from './encode'
 
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/
 const utf8Decoder = new TextDecoder()
 
-export type Auth = (req: HonoRequest) => { username: string; password: string } | undefined
+export type Auth = (req: Request) => { username: string; password: string } | undefined
 
-export const auth: Auth = (req: HonoRequest) => {
-  const match = CREDENTIALS_REGEXP.exec(req.header('Authorization') || '')
+export const auth: Auth = (req: Request) => {
+  const match = CREDENTIALS_REGEXP.exec(req.headers.get('Authorization') || '')
   if (!match) {
     return undefined
   }


### PR DESCRIPTION
I have moved the functions used internally in the Basic Auth Middleware to the utils directory. Additionally, I have added tests.

For the background on this refactor, please refer to the following: https://github.com/honojs/middleware/pull/676#issuecomment-2323178685

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
