### PR TITLE
chore: fix typo in JSDoc

### DIFF
--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -74,7 +74,7 @@ const createRenderer =
 /**
  * JSX Renderer Middleware for hono.
  *
- * @see {@link{https://hono.dev/docs/middleware/builtin/jsx-renderer}}
+ * @see {@link https://hono.dev/docs/middleware/builtin/jsx-renderer}
  *
  * @param {ComponentWithChildren} [component] - The component to render, which can accept children and props.
  * @param {RendererOptions} [options] - The options for the JSX renderer middleware.


### PR DESCRIPTION
### The author should do the following, if applicable
The following does not apply

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
