### PR TITLE
feat(serveStatic): add `precompressed` option

### DIFF
--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -29,6 +29,7 @@ describe('Serve Static Middleware', () => {
   it('Should return 200 response - /static/hello.html', async () => {
     const res = await app.request('/static/hello.html')
     expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Encoding')).toBeNull()
     expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
     expect(await res.text()).toBe('Hello in ./static/hello.html')
   })
@@ -57,12 +58,15 @@ describe('Serve Static Middleware', () => {
   it('Should decode URI strings - /static/%E7%82%8E.txt', async () => {
     const res = await app.request('/static/%E7%82%8E.txt')
     expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
     expect(await res.text()).toBe('Hello in ./static/炎.txt')
   })
 
-  it('Should return 404 response - /static/not-found', async () => {
+  it('Should return 404 response - /static/not-found.txt', async () => {
     const res = await app.request('/static/not-found.txt')
     expect(res.status).toBe(404)
+    expect(res.headers.get('Content-Encoding')).toBeNull()
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
     expect(await res.text()).toBe('404 Not Found')
     expect(getContent).toBeCalledTimes(1)
   })
@@ -73,10 +77,11 @@ describe('Serve Static Middleware', () => {
       url: 'http://localhost/static/%2e%2e/static/hello.html',
     } as Request)
     expect(res.status).toBe(404)
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
     expect(await res.text()).toBe('404 Not Found')
   })
 
-  it('Should return pre-compressed response - /static/hello.html', async () => {
+  it('Should return a pre-compressed zstd response - /static/hello.html', async () => {
     const app = new Hono().use(
       '*',
       baseServeStatic({
@@ -86,35 +91,72 @@ describe('Serve Static Middleware', () => {
     )
 
     const res = await app.request('/static/hello.html', {
-      headers: { 'Accept-Encoding': 'gzip, deflate, br' },
+      headers: { 'Accept-Encoding': 'zstd' },
     })
 
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Encoding')).toBe('br')
+    expect(res.headers.get('Content-Encoding')).toBe('zstd')
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding')
     expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
-    expect(await res.text()).toBe('Hello in static/hello.html.br')
+    expect(await res.text()).toBe('Hello in static/hello.html.zst')
   })
 
-  it('Should not return pre-compressed response - /static/hello.html', async () => {
+  it('Should return a pre-compressed brotli response - /static/hello.html', async () => {
     const app = new Hono().use(
       '*',
       baseServeStatic({
-        getContent: vi.fn(async (path) => {
-          if (/\.(br|zst|gz)$/.test(path)) {
-            return null
-          }
-          return `Hello in ${path}`
-        }),
+        getContent,
         precompressed: true,
       })
     )
 
     const res = await app.request('/static/hello.html', {
-      headers: { 'Accept-Encoding': 'gzip, deflate, br' },
+      headers: { 'Accept-Encoding': 'wompwomp, gzip, br, deflate, zstd' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Encoding')).toBe('br')
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
+    expect(await res.text()).toBe('Hello in static/hello.html.br')
+  })
+
+  it('Should not return a pre-compressed response - /static/not-found.txt', async () => {
+    const app = new Hono().use(
+      '*',
+      baseServeStatic({
+        getContent,
+        precompressed: true,
+      })
+    )
+
+    const res = await app.request('/static/not-found.txt', {
+      headers: { 'Accept-Encoding': 'gzip, zstd, br' },
+    })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get('Content-Encoding')).toBeNull()
+    expect(res.headers.get('Vary')).toBeNull()
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/plain/)
+    expect(await res.text()).toBe('404 Not Found')
+  })
+
+  it('Should not return a pre-compressed response - /static/hello.html', async () => {
+    const app = new Hono().use(
+      '*',
+      baseServeStatic({
+        getContent,
+        precompressed: true,
+      })
+    )
+
+    const res = await app.request('/static/hello.html', {
+      headers: { 'Accept-Encoding': 'wompwomp, unknown' },
     })
 
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toBeNull()
+    expect(res.headers.get('Vary')).toBeNull()
     expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
     expect(await res.text()).toBe('Hello in static/hello.html')
   })

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -73,10 +73,6 @@ export const serveStatic = <E extends Env = Env>(
     path = pathResolve(path)
     let content = await getContent(path, c)
 
-    if (content instanceof Response) {
-      return c.newResponse(content.body, content)
-    }
-
     if (!content) {
       let pathWithoutDefaultDocument = getFilePathWithoutDefaultDocument({
         filename,
@@ -88,11 +84,15 @@ export const serveStatic = <E extends Env = Env>(
       pathWithoutDefaultDocument = pathResolve(pathWithoutDefaultDocument)
 
       if (pathWithoutDefaultDocument !== path) {
-        content = (await getContent(pathWithoutDefaultDocument, c)) as Data | null
+        content = await getContent(pathWithoutDefaultDocument, c)
         if (content) {
           path = pathWithoutDefaultDocument
         }
       }
+    }
+
+    if (content instanceof Response) {
+      return c.newResponse(content.body, content)
     }
 
     const mimeType = options.mimes

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -54,7 +54,7 @@ export const serveStatic = <E extends Env = Env>(
         root,
       })
       if (path && (await options.isDir(path))) {
-        filename = filename + '/'
+        filename += '/'
       }
     }
 
@@ -107,19 +107,19 @@ export const serveStatic = <E extends Env = Env>(
     let content = await getContent(path, c)
 
     if (!content) {
-      let pathWithOutDefaultDocument = getFilePathWithoutDefaultDocument({
+      let pathWithoutDefaultDocument = getFilePathWithoutDefaultDocument({
         filename,
         root,
       })
-      if (!pathWithOutDefaultDocument) {
+      if (!pathWithoutDefaultDocument) {
         return await next()
       }
-      pathWithOutDefaultDocument = pathResolve(pathWithOutDefaultDocument)
+      pathWithoutDefaultDocument = pathResolve(pathWithoutDefaultDocument)
 
-      if (pathWithOutDefaultDocument !== path) {
-        content = await getContent(pathWithOutDefaultDocument, c)
+      if (pathWithoutDefaultDocument !== path) {
+        content = await getContent(pathWithoutDefaultDocument, c)
         if (content) {
-          path = pathWithOutDefaultDocument
+          path = pathWithoutDefaultDocument
         }
       }
     }

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -103,31 +103,32 @@ export const serveStatic = <E extends Env = Env>(
       c.header('Content-Type', mimeType)
     }
 
-    if (options.precompressed) {
-      const acceptEncodings =
-        c.req
-          .header('Accept-Encoding')
-          ?.split(',')
-          .map((encoding) => encoding.trim())
-          .filter((encoding): encoding is keyof typeof ENCODINGS =>
-            Object.hasOwn(ENCODINGS, encoding)
-          )
-          .sort((a, b) => Object.keys(ENCODINGS).indexOf(a) - Object.keys(ENCODINGS).indexOf(b)) ||
-        []
+    if (content) {
+      if (options.precompressed) {
+        const acceptEncodings =
+          c.req
+            .header('Accept-Encoding')
+            ?.split(',')
+            .map((encoding) => encoding.trim())
+            .filter((encoding): encoding is keyof typeof ENCODINGS =>
+              Object.hasOwn(ENCODINGS, encoding)
+            )
+            .sort(
+              (a, b) => Object.keys(ENCODINGS).indexOf(a) - Object.keys(ENCODINGS).indexOf(b)
+            ) ?? []
 
-      for (const encoding of acceptEncodings) {
-        const compressedContent = (await getContent(path + ENCODINGS[encoding], c)) as Data | null
+        for (const encoding of acceptEncodings) {
+          const compressedContent = (await getContent(path + ENCODINGS[encoding], c)) as Data | null
 
-        if (compressedContent) {
-          content = compressedContent
-          c.header('Content-Encoding', encoding)
-          c.header('Vary', 'Accept-Encoding', { append: true })
-          break
+          if (compressedContent) {
+            content = compressedContent
+            c.header('Content-Encoding', encoding)
+            c.header('Vary', 'Accept-Encoding', { append: true })
+            break
+          }
         }
       }
-    }
 
-    if (content) {
       return c.body(content)
     }
 


### PR DESCRIPTION
Closes #3363 

Allows to serve all compatible pre-compressed files transparently to the client, otherwise fallback to serve the *original* file.

![Screenshot from 2024-09-03 15-03-44](https://github.com/user-attachments/assets/a466e62c-27f4-4fe7-9e2c-07ef5eb9c259)

In case there are several files with various encodings (e.g., *.gz* and *.br*), it has priority to use brotli, then zstd and finally gzip.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
