### PR TITLE
feat(context): added (optional) message argument to notFound() handler

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -899,8 +899,8 @@ export class Context<
    * })
    * ```
    */
-  notFound = (): Response | Promise<Response> => {
+  notFound = (message?: string | object): Response | Promise<Response> => {
     this.#notFoundHandler ??= () => new Response()
-    return this.#notFoundHandler(this)
+    return this.#notFoundHandler(this, message)
   }
 }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -33,8 +33,15 @@ import { getPath, getPathNoStrict, mergePath } from './utils/url'
  */
 export const COMPOSED_HANDLER = Symbol('composedHandler')
 
-const notFoundHandler = (c: Context) => {
-  return c.text('404 Not Found', 404)
+const notFoundHandler = (c: Context, message?: string | object) => {
+  if (!message) {
+    message = '404 Not Found'
+  }
+  const status = 404
+  if (typeof message === 'string') {
+    return c.text(message, status)
+  }
+  return c.json(message, 404)
 }
 
 const errorHandler = (err: Error | HTTPResponseError, c: Context) => {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1365,6 +1365,46 @@ describe('Not Found', () => {
       expect(await res.text()).toBe('Custom NotFound')
     })
   })
+
+  describe('Not Found message as string', () => {
+    const app = new Hono()
+
+    app.get('/not-found', (c) => c.notFound('Custom not found message string'))
+
+    it('Custom 404 Not Found message as string', async () => {
+      const res = await app.request('http://localhost/not-found')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe('Custom not found message string')
+    })
+  })
+
+  describe('Not Found message as object', () => {
+    const app = new Hono()
+
+    app.get('/not-found', (c) => c.notFound({ message: 'Custom not found message object' }))
+
+    it('Custom 404 Not Found message as object', async () => {
+      const res = await app.request('http://localhost/not-found')
+      expect(res.status).toBe(404)
+      expect(res.headers.get('Content-Type')).toMatch('application/json; charset=UTF-8')
+      expect(await res.text()).toBe('{"message":"Custom not found message object"}')
+    })
+  })
+
+  describe('Custom 404 Not Found handler with message', () => {
+    const app = new Hono()
+    app.notFound((c, message) => {
+      return c.text(message as string, 404)
+    })
+
+    app.get('/not-found', (c) => c.notFound('Custom not found handler and message'))
+
+    it('Custom 404 Not Found handler and message', async () => {
+      const res = await app.request('http://localhost/not-found')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe('Custom not found handler and message')
+    })
+  })
 })
 
 describe('Redirect', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,10 @@ export type H<
   R extends HandlerResponse<any> = any
 > = Handler<E, P, I, R> | MiddlewareHandler<E, P, I>
 
-export type NotFoundHandler<E extends Env = any> = (c: Context<E>) => Response | Promise<Response>
+export type NotFoundHandler<E extends Env = any> = (
+  c: Context<E>,
+  message?: string | object
+) => Response | Promise<Response>
 
 export interface HTTPResponseError extends Error {
   getResponse: () => Response


### PR DESCRIPTION
This PR adds an optional message argument (either `string` or `object`) to the `notFound()` handler.

E.g. this allows users to do:

```
app.get('/notfound', (c) => {
  return c.notFound('Customer not found.')
})
```

or even:

```
app.get('/notfound', (c) => {
  return c.notFound({ message: 'Customer not found.' })
})
```

The latter option (when an `object` is provided) will automatically result in a json response.

Of course the default behavior is still applied:

```
app.get('/notfound', (c) => {
  return c.notFound()
})
```

will just return in a text response containing `404 Not Found`.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
