### PR TITLE
feat(context): added application json constant

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -328,6 +328,8 @@ interface ResponseInit {
 
 export const TEXT_PLAIN = 'text/plain; charset=UTF-8'
 
+export const APPLICATION_JSON = 'application/json; charset=UTF-8'
+
 /**
  * Sets the headers of a response.
  *
@@ -828,7 +830,7 @@ export class Context<
   ): JSONRespondReturn<T, U> => {
     const body = JSON.stringify(object)
     this.#preparedHeaders ??= {}
-    this.#preparedHeaders['content-type'] = 'application/json; charset=UTF-8'
+    this.#preparedHeaders['content-type'] = APPLICATION_JSON
     /* eslint-disable @typescript-eslint/no-explicit-any */
     return (
       typeof arg === 'number' ? this.newResponse(body, arg, headers) : this.newResponse(body, arg)


### PR DESCRIPTION
This adds the `APPLICATION_JSON = 'application/json; charset=UTF-8'` constant which is used in the `.json()` helper (and now can be re-used).

Note: this is similar as the existing `TEXT_PLAIN = 'text/plain; charset=UTF-8'` constant already present.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
