### PR TITLE
Adding support to absolute path. Tested on Bun.

### DIFF
--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -9,13 +9,13 @@ export const serveStatic = <E extends Env = Env>(
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {
-      path = `./${path}`
+      path = path.startsWith('/') ? path : `./${path}`
       // @ts-ignore
       const file = Bun.file(path)
       return (await file.exists()) ? file : null
     }
     const pathResolve = (path: string) => {
-      return `./${path}`
+      return path.startsWith('/') ? path : `./${path}`
     }
     const isDir = async (path: string) => {
       let isDir

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -9,12 +9,14 @@ export const serveStatic = <E extends Env = Env>(
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {
+      // let absolute path be, otherwise add './'
       path = path.startsWith('/') ? path : `./${path}`
       // @ts-ignore
       const file = Bun.file(path)
       return (await file.exists()) ? file : null
     }
     const pathResolve = (path: string) => {
+      // let absolute path be, otherwise add './'
       return path.startsWith('/') ? path : `./${path}`
     }
     const isDir = async (path: string) => {

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -40,7 +40,7 @@ export const getFilePathWithoutDefaultDocument = (
   }
 
   // /foo.html => foo.html
-  filename = filename.replace(/^\.?[\/\\]/, '')
+  filename = filename.replace(/^\.[\/\\]/, '')
 
   // foo\bar.txt => foo/bar.txt
   filename = filename.replace(/\\/, '/')
@@ -50,7 +50,8 @@ export const getFilePathWithoutDefaultDocument = (
 
   // ./assets/foo.html => assets/foo.html
   let path = root ? root + '/' + filename : filename
-  path = path.replace(/^\.?\//, '')
+
+  path = path.replace(/^\.\//, '')
 
   return path
 }

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -39,7 +39,8 @@ export const getFilePathWithoutDefaultDocument = (
     return
   }
 
-  // /foo.html => foo.html
+  // ./foo.html => foo.html
+  // ignore /foo.html as it's intentionally absolute path
   filename = filename.replace(/^\.[\/\\]/, '')
 
   // foo\bar.txt => foo/bar.txt
@@ -51,6 +52,7 @@ export const getFilePathWithoutDefaultDocument = (
   // ./assets/foo.html => assets/foo.html
   let path = root ? root + '/' + filename : filename
 
+  // ignore absolute path e.g. /assets/foo.css
   path = path.replace(/^\.\//, '')
 
   return path


### PR DESCRIPTION
### The author should do the following, if applicable

- [X] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
