### PR TITLE
feat(serve-static): add `onFound` option

### DIFF
--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -18,6 +18,11 @@ describe('Serve Static Middleware', () => {
     isDir: (path) => {
       return path === 'static/hello.world'
     },
+    onFound: (path, c) => {
+      if (path.endsWith('hello.html')) {
+        c.header('X-Custom', `Found the file at ${path}`)
+      }
+    },
   })
 
   app.get('/static/*', serveStatic)
@@ -31,6 +36,7 @@ describe('Serve Static Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
     expect(await res.text()).toBe('Hello in ./static/hello.html')
+    expect(res.headers.get('X-Custom')).toBe('Found the file at ./static/hello.html')
   })
 
   it('Should return 200 response - /static/sub', async () => {

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -13,6 +13,7 @@ export type ServeStaticOptions<E extends Env = Env> = {
   path?: string
   mimes?: Record<string, string>
   rewriteRequestPath?: (path: string) => string
+  onFound?: (path: string, c: Context<E>) => void | Promise<void>
   onNotFound?: (path: string, c: Context<E>) => void | Promise<void>
 }
 
@@ -99,6 +100,7 @@ export const serveStatic = <E extends Env = Env>(
       if (mimeType) {
         c.header('Content-Type', mimeType)
       }
+      await options.onFound?.(path, c)
       return c.body(content)
     }
 


### PR DESCRIPTION
This PR introduces the `onFound` option for Serve Static Middleware.

If you want to add a custom header to found files, you can write the following:

```ts
app.get(
  '/static/*',
  serveStatic({
    // ... 
    onFound: (_path, c) => {
      c.header('Cache-Control', `public, immutable, max-age=31536000`)
    },
  })
)
```

Related to #3395 https://github.com/honojs/node-server/pull/195

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
