### PR TITLE
fix(secure-headers): optimize getPermissionsPolicyDirectives function

### DIFF
--- a/src/middleware/secure-headers/index.test.ts
+++ b/src/middleware/secure-headers/index.test.ts
@@ -160,7 +160,7 @@ describe('Secure Headers Middleware', () => {
     expect(res.headers.get('X-XSS-Protection')).toEqual('1')
   })
 
-  it('should set Permission-Policy header', async () => {
+  it('should set Permission-Policy header correctly', async () => {
     const app = new Hono()
     app.use(
       '/test',
@@ -173,13 +173,20 @@ describe('Secure Headers Middleware', () => {
           camera: false,
           microphone: true,
           geolocation: ['*'],
+          usb: ['self', 'https://a.example.com', 'https://b.example.com'],
+          accelerometer: ['https://*.example.com'],
+          gyroscope: ['src'],
+          magnetometer: ['https://a.example.com', 'https://b.example.com'],
         },
       })
     )
 
     const res = await app.request('/test')
     expect(res.headers.get('Permissions-Policy')).toEqual(
-      'fullscreen=(self), bluetooth=(none), payment=(self example.com), sync-xhr=(), camera=none, microphone=(), geolocation=(*)'
+      'fullscreen=(self), bluetooth=none, payment=(self "example.com"), sync-xhr=(), camera=none, microphone=*, ' +
+        'geolocation=*, usb=(self "https://a.example.com" "https://b.example.com"), ' +
+        'accelerometer=("https://*.example.com"), gyroscope=(src), ' +
+        'magnetometer=("https://a.example.com" "https://b.example.com")'
     )
   })
   it('CSP Setting', async () => {

--- a/src/middleware/secure-headers/secure-headers.ts
+++ b/src/middleware/secure-headers/secure-headers.ts
@@ -278,12 +278,18 @@ function getPermissionsPolicyDirectives(policy: PermissionsPolicyOptions): strin
       const kebabDirective = camelToKebab(directive)
 
       if (typeof value === 'boolean') {
-        return `${kebabDirective}=${value ? '()' : 'none'}`
+        return `${kebabDirective}=${value ? '*' : 'none'}`
       }
 
       if (Array.isArray(value)) {
-        const allowlist = value.length === 0 ? '()' : `(${value.join(' ')})`
-        return `${kebabDirective}=${allowlist}`
+        if (value.length === 0) {
+          return `${kebabDirective}=()`
+        }
+        if (value.length === 1 && (value[0] === '*' || value[0] === 'none')) {
+          return `${kebabDirective}=${value[0]}`
+        }
+        const allowlist = value.map((item) => (['self', 'src'].includes(item) ? item : `"${item}"`))
+        return `${kebabDirective}=(${allowlist.join(' ')})`
       }
 
       return ''


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code


I am very sorry.
I found a bug (wrong specification) and fixed it.

- When specified with `{delective}: true`, `true` means “allowed at all origins” and should be represented as `*` in the header. However, an empty parenthesis () is printed, implying a restriction.

Please let me know if there is a problem, because I don't know if I should direct the PR to the `next` branch.