### PR TITLE
fix(build): improve addExtension esbuild plugin

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -41,7 +41,11 @@ const addExtension = (extension: string = '.js', fileExtension: string = '.ts'):
         } else {
           tsPath = path.join(args.resolveDir, args.path, `index${fileExtension}`)
           if (fs.existsSync(tsPath)) {
-            importPath = `${args.path}/index${extension}`
+            if (args.path.endsWith('/')) {
+              importPath = `${args.path}index${extension}`
+            } else {
+              importPath = `${args.path}/index${extension}`
+            }
           }
         }
         return { path: importPath, external: true }


### PR DESCRIPTION
This PR improves the extension handling (in esm build) in `build.ts`.

Currently in `addExtension` esbuild plugin, we create the import path like `${args.path}/index${extension}` when the ts path of the form `path.join(args.resolveDir, args.path, "index.ts")` exists. However this has an issue when the original import path ends with `/` (like [this one](https://github.com/honojs/hono/blob/73ff6c0e82d66468e28ed439481220f56ab03882/src/helper/streaming/text.ts#L4)). In that case the resulted import path becomes something like `.//index.js`. This import path seems confusing some runtimes (ex. Deno https://github.com/denoland/deno/issues/25532 ).

This PR checks whether the original path ends with `/` or not, and creates more appropriate path.

By this change, for example, the build result of `src/helpers/streaming/text.ts` changes from:

```js
// src/helper/streaming/text.ts
import { TEXT_PLAIN } from "../../context.js";
import { stream } from ".//index.js";
var streamText = (c, cb, onError) => {
  c.header("Content-Type", TEXT_PLAIN);
  c.header("X-Content-Type-Options", "nosniff");
  c.header("Transfer-Encoding", "chunked");
  return stream(c, cb, onError);
};
export {
  streamText
};
```

to:
```js
// src/helper/streaming/text.ts
import { TEXT_PLAIN } from "../../context.js";
import { stream } from "./index.js";
var streamText = (c, cb, onError) => {
  c.header("Content-Type", TEXT_PLAIN);
  c.header("X-Content-Type-Options", "nosniff");
  c.header("Transfer-Encoding", "chunked");
  return stream(c, cb, onError);
};
export {
  streamText
};
```





### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
