### PR TITLE
perf(serve-static): performance optimization for precompressed feature

### DIFF
--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -4,11 +4,10 @@
  */
 
 import type { MiddlewareHandler } from '../../types'
+import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
 
 const ENCODING_TYPES = ['gzip', 'deflate'] as const
 const cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
-const compressibleContentTypeRegExp =
-  /^\s*(?:text\/[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-virtualbox-hdd|x-virtualbox-ova|x-virtualbox-ovf|x-virtualbox-vbox|x-virtualbox-vdi|x-virtualbox-vhd|x-virtualbox-vmdk|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
 
 interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
@@ -68,7 +67,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
 
 const shouldCompress = (res: Response) => {
   const type = res.headers.get('Content-Type')
-  return type && compressibleContentTypeRegExp.test(type)
+  return type && COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type)
 }
 
 const shouldTransform = (res: Response) => {

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -97,15 +97,15 @@ export const serveStatic = <E extends Env = Env>(
       return c.newResponse(content.body, content)
     }
 
-    const mimeType = options.mimes
-      ? getMimeType(path, options.mimes) ?? getMimeType(path)
-      : getMimeType(path)
-
-    if (mimeType) {
-      c.header('Content-Type', mimeType)
-    }
-
     if (content) {
+      const mimeType = options.mimes
+        ? getMimeType(path, options.mimes) ?? getMimeType(path)
+        : getMimeType(path)
+
+      if (mimeType) {
+        c.header('Content-Type', mimeType)
+      }
+
       if (options.precompressed) {
         const acceptEncodingSet = new Set(
           c.req

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -5,6 +5,7 @@
 
 import type { Context, Data } from '../../context'
 import type { Env, MiddlewareHandler } from '../../types'
+import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
 import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath'
 import { getMimeType } from '../../utils/mime'
 
@@ -106,7 +107,7 @@ export const serveStatic = <E extends Env = Env>(
         c.header('Content-Type', mimeType)
       }
 
-      if (options.precompressed) {
+      if (options.precompressed && (!mimeType || COMPRESSIBLE_CONTENT_TYPE_REGEX.test(mimeType))) {
         const acceptEncodingSet = new Set(
           c.req
             .header('Accept-Encoding')

--- a/src/utils/compress.ts
+++ b/src/utils/compress.ts
@@ -1,0 +1,10 @@
+/**
+ * @module
+ * Constants for compression.
+ */
+
+/**
+ * Match for compressible content type.
+ */
+export const COMPRESSIBLE_CONTENT_TYPE_REGEX =
+  /^\s*(?:text\/[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-virtualbox-hdd|x-virtualbox-ova|x-virtualbox-ovf|x-virtualbox-vbox|x-virtualbox-vdi|x-virtualbox-vhd|x-virtualbox-vmdk|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i


### PR DESCRIPTION
* 6a675c3e79877775c9815023a24f30acdcdeba9e : Replace with faster implementation
* 7f58d8f1aaa142b2f475d0bf0acb00bc2bcaf783 : "Content-Type" is appropriate to set only if the file is found
* 9aeb1cd2522522fc821f98c100f6a2f28ce484bb : As I wrote in https://github.com/honojs/node-server/pull/199#issuecomment-2351498366, if the file is not a compressible mime type, it is better not to find a compressed file

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
