### PR TITLE
fix(serve-static): use application/octet-stream if the mime type is not detected

### DIFF
--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -143,6 +143,7 @@ describe('Serve Static Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toBe('br')
     expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
     expect(await res.text()).toBe('Hello in static/hello.unknown.br')
   })
 

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -99,13 +99,8 @@ export const serveStatic = <E extends Env = Env>(
     }
 
     if (content) {
-      const mimeType = options.mimes
-        ? getMimeType(path, options.mimes) ?? getMimeType(path)
-        : getMimeType(path)
-
-      if (mimeType) {
-        c.header('Content-Type', mimeType)
-      }
+      const mimeType = (options.mimes && getMimeType(path, options.mimes)) || getMimeType(path)
+      c.header('Content-Type', mimeType || 'application/octet-stream')
 
       if (options.precompressed && (!mimeType || COMPRESSIBLE_CONTENT_TYPE_REGEX.test(mimeType))) {
         const acceptEncodingSet = new Set(


### PR DESCRIPTION
Currently, if the `mimeType` could not be detected, the `Content-Type` is not set, so it falls back to “text/plain”. There may be cases where “text/plain” is acceptable, but I don't think it is appropriate for binary data to be returned as "text/plain", so I think it should be "application/octet-stream”. Even on general web servers, the default is "application/octet-stream" for files that cannot be detected from the file extension.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
