### PR TITLE
feat(jsx/precompile): Normalization and stringification of attribute values as `renderToString`

### DIFF
--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -111,9 +111,24 @@ Deno.test('JSX: css', async () => {
   )
 })
 
-Deno.test('JSX: className', async () => {
-  const html = <div className='foo'></div>
-  assertEquals(html.toString(), '<div class="foo"></div>')
+Deno.test('JSX: normalize key', async () => {
+  const className = <div className='foo'></div>
+  const htmlFor = <div htmlFor='foo'></div>
+  const crossOrigin = <div crossOrigin='foo'></div>
+  const httpEquiv = <div httpEquiv='foo'></div>
+  const itemProp = <div itemProp='foo'></div>
+  const fetchPriority = <div fetchPriority='foo'></div>
+  const noModule = <div noModule='foo'></div>
+  const formAction = <div formAction='foo'></div>
+
+  assertEquals(className.toString(), '<div class="foo"></div>')
+  assertEquals(htmlFor.toString(), '<div for="foo"></div>')
+  assertEquals(crossOrigin.toString(), '<div crossorigin="foo"></div>')
+  assertEquals(httpEquiv.toString(), '<div http-equiv="foo"></div>')
+  assertEquals(itemProp.toString(), '<div itemprop="foo"></div>')
+  assertEquals(fetchPriority.toString(), '<div fetchpriority="foo"></div>')
+  assertEquals(noModule.toString(), '<div nomodule="foo"></div>')
+  assertEquals(formAction.toString(), '<div formaction="foo"></div>')
 })
 
 Deno.test('JSX: null or undefined', async () => {

--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -110,3 +110,35 @@ Deno.test('JSX: css', async () => {
     '<html><head><style id="hono-css">.css-3142110215{color:red}</style></head><body><div class="css-3142110215"></div></body></html>'
   )
 })
+
+Deno.test('JSX: className', async () => {
+  const html = <div className='foo'></div>
+  assertEquals(html.toString(), '<div class="foo"></div>')
+})
+
+Deno.test('JSX: null or undefined', async () => {
+  const nullHtml = <div className={null}></div>
+  const undefinedHtml = <div className={undefined}></div>
+
+  assertEquals(nullHtml.toString(), '<div ></div>')
+  assertEquals(undefinedHtml.toString(), '<div ></div>')
+})
+
+Deno.test('JSX: boolean attributes', async () => {
+  const trueHtml = <div disabled={true}></div>
+  const falseHtml = <div disabled={false}></div>
+
+  assertEquals(trueHtml.toString(), '<div disabled></div>')
+  assertEquals(falseHtml.toString(), '<div></div>')
+})
+
+Deno.test('JSX: number', async () => {
+  const html = <div tabIndex={1}></div>
+
+  assertEquals(html.toString(), '<div tabindex="1"></div>')
+})
+
+Deno.test('JSX: style', async () => {
+  const html = <div style={{ fontSize: '12px', color: null }}></div>
+  assertEquals(html.toString(), '<div style="font-size:12px"></div>')
+})

--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -120,20 +120,27 @@ Deno.test('JSX: null or undefined', async () => {
   const nullHtml = <div className={null}></div>
   const undefinedHtml = <div className={undefined}></div>
 
-  assertEquals(nullHtml.toString(), '<div ></div>')
-  assertEquals(undefinedHtml.toString(), '<div ></div>')
+  // react-jsx : <div>
+  // precompile : <div > // Extra whitespace is allowed because it is a specification.
+
+  assertEquals(nullHtml.toString().replace(/\s+/g, ''), '<div></div>')
+  assertEquals(undefinedHtml.toString().replace(/\s+/g, ''), '<div></div>')
 })
 
 Deno.test('JSX: boolean attributes', async () => {
   const trueHtml = <div disabled={true}></div>
   const falseHtml = <div disabled={false}></div>
 
-  assertEquals(trueHtml.toString(), '<div disabled></div>')
+  // output is different, but semantics as HTML is the same, so both are OK
+  // react-jsx : <div disabled="">
+  // precompile : <div disabled>
+
+  assertEquals(trueHtml.toString().replace('=""', ''), '<div disabled></div>')
   assertEquals(falseHtml.toString(), '<div></div>')
 })
 
 Deno.test('JSX: number', async () => {
-  const html = <div tabIndex={1}></div>
+  const html = <div tabindex={1}></div>
 
   assertEquals(html.toString(), '<div tabindex="1"></div>')
 })

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -62,7 +62,7 @@ const emptyTags = [
   'track',
   'wbr',
 ]
-const booleanAttributes = [
+export const booleanAttributes = [
   'allowfullscreen',
   'async',
   'autofocus',

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -9,7 +9,6 @@ export type { JSX } from './jsx-dev-runtime'
 import { html, raw } from '../helper/html'
 import type { HtmlEscapedString, StringBuffer, HtmlEscaped } from '../utils/html'
 import { escapeToBuffer, stringBufferToString } from '../utils/html'
-import { booleanAttributes } from './base'
 import { normalizeIntrinsicElementKey, styleObjectForEach } from './utils'
 
 export { html as jsxTemplate }

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -6,13 +6,51 @@
 export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
 export { jsxDEV as jsxs } from './jsx-dev-runtime'
 export type { JSX } from './jsx-dev-runtime'
-
 import { html, raw } from '../helper/html'
-import type { HtmlEscapedString } from '../utils/html'
+import type { HtmlEscapedString, StringBuffer, HtmlEscaped } from '../utils/html'
+import { escapeToBuffer, stringBufferToString } from '../utils/html'
+import { booleanAttributes } from './base'
+import { normalizeIntrinsicElementKey, styleObjectForEach } from './utils'
+
 export { html as jsxTemplate }
+
 export const jsxAttr = (
-  name: string,
-  value: string | Promise<string>
-): HtmlEscapedString | Promise<HtmlEscapedString> =>
-  typeof value === 'string' ? raw(name + '="' + html`${value}` + '"') : html`${name}="${value}"`
+  key: string,
+  v: string | Promise<string> | Record<string, string | number | null | undefined | boolean>
+): HtmlEscapedString | Promise<HtmlEscapedString> => {
+  key = normalizeIntrinsicElementKey(key)
+  const buffer: StringBuffer = [`${key}="`] as StringBuffer
+  if (key === 'style' && typeof v === 'object') {
+    // object to style strings
+    let styleStr = ''
+    styleObjectForEach(v as Record<string, string | number>, (property, value) => {
+      if (value != null) {
+        styleStr += `${styleStr ? ';' : ''}${property}:${value}`
+      }
+    })
+    escapeToBuffer(styleStr, buffer)
+    buffer[0] += '"'
+  } else if (typeof v === 'string') {
+    escapeToBuffer(v, buffer)
+    buffer[0] += '"'
+  } else if (v === null || v === undefined) {
+    return raw('')
+  } else if (typeof v === 'number' || (v as unknown as HtmlEscaped).isEscaped) {
+    buffer[0] += `${v}"`
+  } else if (typeof v === 'boolean' && booleanAttributes.includes(key)) {
+    if (v) {
+      buffer[0] += '"'
+    } else {
+      return raw('')
+    }
+  } else if (v instanceof Promise) {
+    buffer.unshift('"', v)
+  } else {
+    escapeToBuffer(v.toString(), buffer)
+    buffer[0] += '"'
+  }
+
+  return buffer.length === 1 ? raw(buffer[0]) : stringBufferToString(buffer, undefined)
+}
+
 export const jsxEscape = (value: string) => value

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -37,12 +37,6 @@ export const jsxAttr = (
     return raw('')
   } else if (typeof v === 'number' || (v as unknown as HtmlEscaped).isEscaped) {
     buffer[0] += `${v}"`
-  } else if (typeof v === 'boolean' && booleanAttributes.includes(key)) {
-    if (v) {
-      buffer[0] += '"'
-    } else {
-      return raw('')
-    }
   } else if (v instanceof Promise) {
     buffer.unshift('"', v)
   } else {

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -9,7 +9,7 @@ export type { JSX } from './jsx-dev-runtime'
 import { html, raw } from '../helper/html'
 import type { HtmlEscapedString, StringBuffer, HtmlEscaped } from '../utils/html'
 import { escapeToBuffer, stringBufferToString } from '../utils/html'
-import { normalizeIntrinsicElementKey, styleObjectForEach } from './utils'
+import { styleObjectForEach } from './utils'
 
 export { html as jsxTemplate }
 
@@ -17,7 +17,6 @@ export const jsxAttr = (
   key: string,
   v: string | Promise<string> | Record<string, string | number | null | undefined | boolean>
 ): HtmlEscapedString | Promise<HtmlEscapedString> => {
-  key = normalizeIntrinsicElementKey(key)
   const buffer: StringBuffer = [`${key}="`] as StringBuffer
   if (key === 'style' && typeof v === 'object') {
     // object to style strings


### PR DESCRIPTION
fix #3427

The “precompile” process converts attribute values in the same way as the normal `renderToString` process.
https://github.com/usualoma/hono/blob/fd80df6a0f03876cf6ac2b12b4b7b812c19ca616/src/jsx/base.ts#L180-L227

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
