### PR TITLE
fix(types): useSyncExternalStore type

### DIFF
--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -396,7 +396,7 @@ export const useImperativeHandle = <T>(
 }
 
 export const useSyncExternalStore = <T>(
-  subscribe: (callback: (value: T) => void) => () => void,
+  subscribe: (callback: () => void) => () => void,
   getSnapshot: () => T,
   getServerSnapshot?: () => T
 ): T => {


### PR DESCRIPTION
Align with react
note: the parameter is not used in function body

### The author should do the following, if applicable

- [ ] Add tests (I don't how to add type-only test)
- [x] Run tests (some unrelated test failed)
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
