### PR TITLE
fix(combine/every): make `every` middleware work with short-circuiting middlewares

### DIFF
--- a/src/middleware/combine/index.test.ts
+++ b/src/middleware/combine/index.test.ts
@@ -150,6 +150,22 @@ describe('every', () => {
     expect(await res.text()).toBe('oops')
     expect(middleware2).not.toBeCalled()
   })
+
+  it('Should return the same response a middleware returns if it short-circuits the chain', async () => {
+    const middleware1: MiddlewareHandler = async (c) => {
+      return c.text('Hello Middleware 1')
+    }
+    const middleware2 = vi.fn(nextMiddleware)
+
+    app.use('/', every(middleware1, middleware2))
+    app.get('/', (c) => {
+      return c.text('Hello World')
+    })
+    const res = await app.request('http://localhost/')
+
+    expect(await res.text()).toBe('Hello Middleware 1')
+    expect(middleware2).not.toBeCalled()
+  })
 })
 
 describe('except', () => {

--- a/src/middleware/combine/index.ts
+++ b/src/middleware/combine/index.ts
@@ -94,6 +94,7 @@ export const every = (...middleware: (MiddlewareHandler | Condition)[]): Middlew
     if (res === false) {
       throw new Error('Unmet condition')
     }
+    return res
   })
 
   const handler = async (c: Context, next: Next) =>


### PR DESCRIPTION
When using `every` middleware to compose middlewares that short-circuits the chain (i.e. return a `Response` object, like e.g. `zod-validator`, but I had also issues with e.g. `cors` with OPTIONS requests) and, as a result, don't call `next()`, it was throwing an error `Error: Context is not finalized. Did you forget to return a Response object or await next()?`. This fixes the issue and makes it possible to use it with (probably?) any middleware.

As a side note, I attempted to simplify the `compose`'s middleware signature (and I did) as it could easily accept an array of functions/handlers and simplify the code. But I think the signature is so complicated because of the usage in `dispatch` method of the `Hono` class and that would require mapping to an array of handlers which would probably slightly worsen the overall performance (not sure how to measure that but presumably 0 `Array.prototype.map`s is better than 1) and that method seems to be rather critical. If you think it's worth considering I'll submit another PR, but it's probably not worth it.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
