### PR TITLE
perf(types): replace intersection with union to get better perf

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -212,7 +212,11 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   >(
     path: SubPath,
     app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, ExcludeEmptyObject<MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> | S>, BasePath> {
+  ): Hono<
+    E,
+    ExcludeEmptyObject<MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> | S>,
+    BasePath
+  > {
     const subApp = this.basePath(path)
     app.routes.map((r) => {
       let handler
@@ -520,6 +524,5 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   }
 }
 export type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T
-
 
 export { Hono as HonoBase }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -26,6 +26,7 @@ import type {
   RouterRoute,
   Schema,
 } from './types'
+import type { ExcludeEmptyObject } from './utils/types'
 import { getPath, getPathNoStrict, mergePath } from './utils/url'
 
 /**
@@ -523,6 +524,5 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     })
   }
 }
-export type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T
 
 export { Hono as HonoBase }

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -212,7 +212,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   >(
     path: SubPath,
     app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> & S, BasePath> {
+  ): Hono<E, ExcludeEmptyObject<MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> | S>, BasePath> {
     const subApp = this.basePath(path)
     app.routes.map((r) => {
       let handler
@@ -519,5 +519,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     })
   }
 }
+export type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T
+
 
 export { Hono as HonoBase }

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,7 +148,7 @@ export interface HandlerInterface<
     handler: H<E2, MergedPath, I, R>
   ): Hono<
     E,
-    ExcludeEmptyObject<S | ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponse<R>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponse<R>>,
     BasePath
   >
 
@@ -1985,8 +1985,6 @@ type EnvOrEmpty<T> = T extends Env ? (Env extends T ? {} : T) : T
 type IntersectNonAnyTypes<T extends any[]> = T extends [infer Head, ...infer Rest]
   ? IfAnyThenEmptyObject<EnvOrEmpty<Head>> & IntersectNonAnyTypes<Rest>
   : {}
-
-type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T
 
 ////////////////////////////////////////
 //////                            //////

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,11 +146,7 @@ export interface HandlerInterface<
   >(
     path: P,
     handler: H<E2, MergedPath, I, R>
-  ): Hono<
-    E,
-    S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponse<R>>,
-    BasePath
-  >
+  ): Hono<E, S & ToSchema<M, MergePath<BasePath, P>, I, MergeTypedResponse<R>>, BasePath>
 
   // app.get(handler x 3)
   <
@@ -1822,13 +1818,15 @@ type ExtractParams<Path extends string> = string extends Path
 type FlattenIfIntersect<T> = T extends infer O ? { [K in keyof O]: O[K] } : never
 
 export type MergeSchemaPath<OrigSchema extends Schema, SubPath extends string> = {
-  [P in keyof OrigSchema as MergePath<SubPath, P & string>]:
-      [OrigSchema[P]] extends [Record<string, Endpoint>]
-      ? { [M in keyof OrigSchema[P]]: MergeEndpointParamsWithPath<OrigSchema[P][M], SubPath> }
-      : never
+  [P in keyof OrigSchema as MergePath<SubPath, P & string>]: [OrigSchema[P]] extends [
+    Record<string, Endpoint>
+  ]
+    ? { [M in keyof OrigSchema[P]]: MergeEndpointParamsWithPath<OrigSchema[P][M], SubPath> }
+    : never
 }
 
-type MergeEndpointParamsWithPath<T extends Endpoint, SubPath extends string> = T extends unknown ? {
+type MergeEndpointParamsWithPath<T extends Endpoint, SubPath extends string> = T extends unknown
+  ? {
       input: T['input'] extends { param: infer _ }
         ? ExtractParams<SubPath> extends never
           ? T['input']
@@ -1856,7 +1854,7 @@ type MergeEndpointParamsWithPath<T extends Endpoint, SubPath extends string> = T
       outputFormat: T['outputFormat']
       status: T['status']
     }
-    : never
+  : never
 export type AddParam<I, P extends string> = ParamKeys<P> extends never
   ? I
   : I extends { param: infer _ }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -97,3 +97,5 @@ export type IsAny<T> = boolean extends (T extends never ? true : false) ? true :
  * @see https://github.com/Microsoft/TypeScript/issues/29729
  */
 export type StringLiteralUnion<T> = T | (string & Record<never, never>)
+
+export type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### details
**This leads a breaking change**

I found that massive amount of intersection increase type instantiation.
So, I've tried replacing intersections to union and as a result, this has decreased type instantiation drastically, that is, by about 70%.
<img width="329" alt="image" src="https://github.com/user-attachments/assets/863e105e-041e-486b-9f69-d55733dfceb6">

However, union here is not intuitive and this may be a breaking change for users manipulating type of Hono somehow. I'm not certain how they do that, though

@yusukebe What's your thought on that? Do you think we should go for it this way?