### PR TITLE
chore(test): suppress no-unused-vars "'x' is assigned a value but only used as type"

### DIFF
--- a/src/client/types.test.ts
+++ b/src/client/types.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectTypeOf } from 'vitest'
 import { Hono } from '..'
 import { upgradeWebSocket } from '../adapter/deno/websocket'

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectTypeOf } from 'vitest'
 import { hc } from '../../client'
 import type { ClientRequest } from '../../client/types'

--- a/src/helper/ssg/ssg.test.tsx
+++ b/src/helper/ssg/ssg.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /** @jsxImportSource ../../jsx */
 import { Hono } from '../../hono'
 import { poweredBy } from '../../middleware/powered-by'


### PR DESCRIPTION
👇  Suppresses noisy false-positives on pull requests.
![image](https://github.com/user-attachments/assets/b1dc529d-8fe3-4628-92a9-ce9a799bf75b)


> [!note]
> Unfortunately, [there is no option to allow type-only usage and only available fix is to disable.](https://github.com/typescript-eslint/typescript-eslint/issues/9778#issuecomment-2282777895) 


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

