### PR TITLE
chore(test): cover jsx attributes

### DIFF
--- a/src/jsx/jsx-runtime.test.tsx
+++ b/src/jsx/jsx-runtime.test.tsx
@@ -11,12 +11,16 @@ describe('jsx-runtime', () => {
 
   it('Should render HTML strings', async () => {
     app.get('/', (c) => {
-      return c.html(<h1>Hello</h1>)
+      return c.html(
+        <h1 class='hello' style={{ margin: '1px', padding: '1px' }}>
+          Hello
+        </h1>
+      )
     })
     const res = await app.request('http://localhost/')
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('text/html; charset=UTF-8')
-    expect(await res.text()).toBe('<h1>Hello</h1>')
+    expect(await res.text()).toBe('<h1 class="hello" style="margin:1px;padding:1px">Hello</h1>')
   })
 
   // https://en.reactjs.org/docs/jsx-in-depth.html#booleans-null-and-undefined-are-ignored


### PR DESCRIPTION

This PR is going to cover `jsx-runtime.ts` file which is covered 0% now.

https://app.codecov.io/github/honojs/hono/blob/main/src%2Fjsx%2Fjsx-runtime.ts
![image](https://github.com/user-attachments/assets/5a4964c9-3829-4eba-a6f9-26a131851d0a)


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
