### PR TITLE
feat(serve-static): "206 Partial Content" support

### DIFF
--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -31,6 +31,7 @@ export const serveStatic = <E extends Env = Env>(
           : undefined,
       })
     }
+    // partialContentSupport is not implemented since this middleware is deprecated
     return baseServeStatic({
       ...options,
       getContent,

--- a/src/adapter/deno/deno.d.ts
+++ b/src/adapter/deno/deno.d.ts
@@ -8,6 +8,11 @@ declare namespace Deno {
    */
   export function mkdir(path: string, options?: { recursive?: boolean }): Promise<void>
 
+  export function lstatSync(path: string): {
+    isDirectory: boolean
+    size: number
+  }
+
   /**
    * Write a new file, with the specified path and data.
    *
@@ -24,5 +29,20 @@ declare namespace Deno {
   ): {
     response: Response
     socket: WebSocket
+  }
+
+  export function open(path: string): Promise<FsFile>
+
+  export enum SeekMode {
+    Start = 0,
+  }
+
+  export function seekSync(rid: number, offset: number, whence: SeekMode): number
+  export function readSync(rid: number, buffer: Uint8Array): number
+
+  export type FsFile = {
+    rid: number
+    readable: ReadableStream<Uint8Array>
+    close(): void
   }
 }

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -7,7 +7,7 @@ import type { Context, Data } from '../../context'
 import type { Env, MiddlewareHandler } from '../../types'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
 import { getFilePath, getFilePathWithoutDefaultDocument } from '../../utils/filepath'
-import { getMimeType } from '../../utils/mime'
+import { getMimeType, mimes } from '../../utils/mime'
 
 export type ServeStaticOptions<E extends Env = Env> = {
   root?: string
@@ -29,12 +29,65 @@ const ENCODINGS_ORDERED_KEYS = Object.keys(ENCODINGS) as (keyof typeof ENCODINGS
 const DEFAULT_DOCUMENT = 'index.html'
 const defaultPathResolve = (path: string) => path
 
+const PARTIAL_CONTENT_BOUNDARY = 'PARTIAL_CONTENT_BOUNDARY'
+
+export type PartialContent = { start: number; end: number; data: Data }
+
+const formatRangeSize = (start: number, end: number, size: number | undefined): string => {
+  return `bytes ${start}-${end}/${size ?? '*'}`
+}
+
+export type RangeRequest =
+  | { type: 'range'; start: number; end: number | undefined }
+  | { type: 'last'; last: number }
+  | { type: 'ranges'; ranges: Array<{ start: number; end: number }> }
+
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
+const decodeRangeRequestHeader = (raw: string | undefined): RangeRequest | undefined => {
+  const bytes = raw?.match(/^bytes=(.+)$/)
+  if (bytes) {
+    const bytesContent = bytes[1].trim()
+    const last = bytesContent.match(/^-(\d+)$/)
+    if (last) {
+      return { type: 'last', last: parseInt(last[1]) }
+    }
+
+    const single = bytesContent.match(/^(\d+)-(\d+)?$/)
+    if (single) {
+      return {
+        type: 'range',
+        start: parseInt(single[1]),
+        end: single[2] ? parseInt(single[2]) : undefined,
+      }
+    }
+
+    const multiple = bytesContent.match(/^(\d+-\d+(?:,\s*\d+-\d+)+)$/)
+    if (multiple) {
+      const ranges = multiple[1].split(',').map((range) => {
+        const [start, end] = range.split('-').map((n) => parseInt(n.trim()))
+        return { start, end }
+      })
+      return { type: 'ranges', ranges }
+    }
+  }
+
+  // RFC 9110 https://www.rfc-editor.org/rfc/rfc9110#field.range
+  // - An origin server MUST ignore a Range header field that contains a range unit it does not understand.
+  // - A server that supports range requests MAY ignore or reject a Range header field that contains an invalid ranges-specifier.
+  return undefined
+}
+
 /**
  * This middleware is not directly used by the user. Create a wrapper specifying `getContent()` by the environment such as Deno or Bun.
  */
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
     getContent: (path: string, c: Context<E>) => Promise<Data | Response | null>
+    partialContentSupport?: (path: string) => Promise<{
+      size: number
+      getPartialContent: (start: number, end: number) => PartialContent
+      close: () => void
+    }>
     pathResolve?: (path: string) => string
     isDir?: (path: string) => boolean | undefined | Promise<boolean | undefined>
   }
@@ -84,6 +137,97 @@ export const serveStatic = <E extends Env = Env>(
 
     if (isAbsoluteRoot) {
       path = '/' + path
+    }
+
+    // TODO: Cache control for partial contents with If-Range, Date, Cache-Control, ETag, Expires, Content-Location, and Vary.
+    const rangeRequest = decodeRangeRequestHeader(c.req.header('Range'))
+    if (rangeRequest) {
+      if (!options.partialContentSupport) {
+        // Fallbacks to getContent since getPartialContents is not provided
+      } else {
+        let partialContentSupport
+        try {
+          partialContentSupport = await options.partialContentSupport(path)
+        } catch {
+          await options.onNotFound?.(path, c)
+          await next()
+          return
+        }
+
+        const { size, getPartialContent, close } = partialContentSupport
+        const offsetSize = size - 1
+        let contents: Array<PartialContent>
+        switch (rangeRequest.type) {
+          case 'last':
+            contents = [getPartialContent(size - rangeRequest.last, offsetSize)]
+            break
+          case 'range':
+            contents = [
+              getPartialContent(
+                rangeRequest.start,
+                Math.min(rangeRequest.end ?? offsetSize, offsetSize)
+              ),
+            ]
+            break
+          case 'ranges':
+            if (rangeRequest.ranges.length > 10) {
+              c.header('Content-Length', String(size))
+              return c.text('', 416)
+            }
+
+            contents = rangeRequest.ranges.map((range) =>
+              getPartialContent(range.start, Math.min(range.end, offsetSize))
+            )
+            break
+        }
+        close()
+
+        const contentLength = contents.reduce((acc, { start, end }) => acc + (end - start + 1), 0)
+        c.header('Content-Length', String(contentLength))
+        c.header('Accept-Ranges', 'bytes')
+
+        const mimeType = getMimeType(path, options.mimes ?? mimes) ?? 'application/octet-stream'
+        let responseBody: Data
+
+        if (contents.length === 1) {
+          c.header('Content-Type', mimeType)
+          const part = contents[0]
+          const contentRange = formatRangeSize(part.start, part.end, size)
+          c.header('Content-Range', contentRange)
+          responseBody = part.data
+        } else {
+          c.header('Content-Type', `multipart/byteranges; boundary=${PARTIAL_CONTENT_BOUNDARY}`)
+          responseBody = new ReadableStream({
+            async start(controller) {
+              const encoder = new TextEncoder()
+              while (contents.length) {
+                const part = contents.shift()!
+                const contentRange = formatRangeSize(part.start, part.end, size)
+                controller.enqueue(
+                  encoder.encode(
+                    `--${PARTIAL_CONTENT_BOUNDARY}\r\nContent-Type: ${mimeType}\r\nContent-Range: ${contentRange}\r\n\r\n`
+                  )
+                )
+                if (typeof part.data === 'string') {
+                  controller.enqueue(encoder.encode(part.data))
+                } else if (part.data instanceof ReadableStream) {
+                  const reader = part.data.getReader()
+                  const readResult = await reader.read()
+                  controller.enqueue(readResult.value)
+                } else {
+                  controller.enqueue(part.data)
+                }
+                controller.enqueue(encoder.encode('\r\n'))
+              }
+              controller.enqueue(encoder.encode(`--${PARTIAL_CONTENT_BOUNDARY}--\r\n`))
+              controller.close()
+            },
+          })
+        }
+
+        await options.onFound?.(path, c)
+        return c.body(responseBody, 206)
+      }
     }
 
     const getContent = options.getContent

--- a/src/request.ts
+++ b/src/request.ts
@@ -175,11 +175,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   header(): Record<string, string>
   header(name?: string) {
     if (name) {
-      return this.raw.headers.get(name.toLowerCase()) ?? undefined
+      return this.raw.headers?.get(name.toLowerCase()) ?? undefined
     }
 
     const headerData: Record<string, string | undefined> = {}
-    this.raw.headers.forEach((value, key) => {
+    this.raw.headers?.forEach((value, key) => {
       headerData[key] = value
     })
     return headerData


### PR DESCRIPTION
Closes #3324 

This implements [206 Partial Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206)(also called as range requests) support in `serve-static` middleware.
It will be useful specially for seeking a video file. 

`serve-static` base implementation now accepts an optional function:
```typescript
partialContentSupport?: (path: string) => Promise<{
      size: number
      getPartialContent: (start: number, end: number) => PartialContent
      close: () => void
}>
```
If `partialContentSupport` is provided and HTTP header includes valid `Range`, `serve-static` returns  subsets of content.
`getPartialContent` function encapsulates a file handle to avoid opening and closing file multiple times.
`close` function is invoked when all ranges are read, to teardown the file handle.

### 416 Range Not Satisfiable
The implementation also returns [416 Range Not Satisfiable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/416) if `Range` headers contains many range requests (more than 10), that is potentially DoS (Denial of Service) attack.
This limitation (`10`) is just a clueless number.
The number may be changed when we understand it is too small/too big.


### Not included
- Cache-control via `If-Range`, `ETag` and so on. I think this feature is useful without having cache-control, which needs a lot work.
- Node.js implementation. Because Node.js does not share `serverStatic` implementation 😭 It is solely implemented here: https://github.com/honojs/node-server/blob/74e86a28f375e5acd52e342519ff2b1110a95c16/src/serve-static.ts#L59 
- Deno coverage is 0%: #3456 will fix it

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code



