### PR TITLE
feat(WebSocket): Add Pub/Sub feature

### DIFF
--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -12,6 +12,8 @@ interface BunServerWebSocket<T> {
   close(code?: number, reason?: string): void
   data: T
   readyState: 0 | 1 | 2 | 3
+  subscribe(channel: string): void
+  unsubscribe(channel: string): void
 }
 
 interface BunWebSocketHandler<T> {
@@ -44,6 +46,12 @@ const createWSContext = (ws: BunServerWebSocket<BunWebSocketData>): WSContext =>
     close(code, reason) {
       ws.close(code, reason)
     },
+    subscribe(channel) {
+      ws.subscribe(channel)
+    },
+    unsubscribe(channel) {
+      ws.unsubscribe(channel)
+    }
   }
 }
 

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -46,6 +46,8 @@ export type WSContext<T = unknown> = {
   url: URL | null
   protocol: string | null
   close(code?: number, reason?: string): void
+  subscribe?(channel: string): void
+  unsubscribe?(channel: string): void
 }
 
 export type WSMessageReceive = string | Blob | ArrayBufferLike

--- a/src/helper/websocket/pubsub.ts
+++ b/src/helper/websocket/pubsub.ts
@@ -1,0 +1,17 @@
+export class WSPubSub<T extends WebSocket = WebSocket> {
+    _topics: {[key in string]: Set<T>}
+    constructor() {
+        this._topics = {}
+    }
+    subscribe(topic: string, ws: T):void {
+        this._topics[topic].add(ws)
+    }
+    unsubscribe(topic: string, ws: T): void {
+        this._topics[topic].delete(ws)
+    }
+    publish(topic: string, message: string | ArrayBufferLike | ArrayBufferView) {
+        for (const ws of this._topics[topic]) {
+            ws.send(message)
+        }
+    }
+}


### PR DESCRIPTION
relate to #3230 

## Desctiption

This PR will allow us to use Publish/Subscribe messaging model on WebSocket like [Bun can do](https://bun.sh/guides/websocket/pubsub) natively.

## Demo

### Bun

Bun has own Pub/Sub API.

```typescript
import { Hono } from 'hono'
import { createBunWebSocket } from 'hono/bun'
import type { ServerWebSocket } from 'bun'

const app = new Hono()
const { upgradeWebSocket, websocket } =
  createBunWebSocket<ServerWebSocket>()

app.get(
  '/ws',
  upgradeWebSocket((c) => {
    return {
      onMessage(event, ws) {
        ws.subscribe('chatroom')
        server.publish('Hello!')
      }
    }
  })
)

const server = Bun.serve({
  fetch: app.fetch,
  websocket,
})
```

### Other runtimes

Other runtimes such as Deno will get minimal PubSub class.

```typescript
import { Hono } from 'hono'
import { upgradeWebSocket } from 'hono/deno'
import { WSPubSub } from 'hono/websocket'

const app = new Hono()
const pubsub = new WSPubSub()

app.get(
  '/ws',
  upgradeWebSocket(pubsub, (c) => {
    return {
      onMessage(event, ws) {
        ws.subscribe('chatroom')
        pubsub.publish('Hello!')
      }
    }
  })
)
```

I don't know this method of implementation will accept all people. So if you have the opinion, please comment.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
