### PR TITLE
fix(types): add key to IntrinsicAttributes

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -30,6 +30,9 @@ export namespace JSX {
   export interface IntrinsicElements extends IntrinsicElementsDefined {
     [tagName: string]: Props
   }
+  export interface IntrinsicAttributes {
+      key?: string | number | bigint | null | undefined;
+  }
 }
 
 let nameSpaceContext: Context<string> | undefined = undefined

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -31,7 +31,7 @@ export namespace JSX {
     [tagName: string]: Props
   }
   export interface IntrinsicAttributes {
-      key?: string | number | bigint | null | undefined;
+    key?: string | number | bigint | null | undefined
   }
 }
 


### PR DESCRIPTION
make `arr.map(x => <CustomComponent key={x.id} />)` not emit type error

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
