### PR TITLE
feat(streaming): add `Identity` as Content-Encoding for `streamText()`

### DIFF
--- a/src/helper/streaming/text.test.ts
+++ b/src/helper/streaming/text.test.ts
@@ -20,6 +20,7 @@ describe('Text Streaming Helper', () => {
     expect(res.headers.get('content-type')).toMatch(/^text\/plain/)
     expect(res.headers.get('x-content-type-options')).toBe('nosniff')
     expect(res.headers.get('transfer-encoding')).toBe('chunked')
+    expect(res.headers.get('content-encoding')).toBe('identity')
 
     if (!res.body) {
       throw new Error('Body is null')

--- a/src/helper/streaming/text.ts
+++ b/src/helper/streaming/text.ts
@@ -11,5 +11,6 @@ export const streamText = (
   c.header('Content-Type', TEXT_PLAIN)
   c.header('X-Content-Type-Options', 'nosniff')
   c.header('Transfer-Encoding', 'chunked')
+  c.header('Content-Encoding', 'identity')
   return stream(c, cb, onError)
 }


### PR DESCRIPTION


Closes #3449

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
