### PR TITLE
fix(factory): relax Bindings and Variables for `createMiddleware`

### DIFF
--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -36,6 +36,35 @@ describe('createMiddleware', () => {
     const url = client.message.$url()
     expect(url.pathname).toBe('/message')
   })
+
+  describe('Relax types for Bindings and Variables', () => {
+    it('Should not throw a type error', () => {
+      type Bindings = {
+        MY_VAR_IN_BINDINGS: string
+      }
+
+      const app = new Hono<{ Bindings: Bindings }>()
+
+      type Variables = {
+        MY_VAR: string
+      }
+      const middleware = (_variable: string) =>
+        createMiddleware<{ Variables: Variables }>(async (c, next) => {
+          await next()
+        })
+
+      app.get(
+        '/',
+        createMiddleware<{ Bindings: Bindings }>(async (c, next) => {
+          const mw = middleware(c.env.MY_VAR_IN_BINDINGS)
+          await mw(c, next) // `c` does not throw an error
+        }),
+        (c) => {
+          return c.json({})
+        }
+      )
+    })
+  })
 })
 
 describe('createHandler', () => {

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -48,6 +48,7 @@ describe('createMiddleware', () => {
       type Variables = {
         MY_VAR: string
       }
+
       const middleware = (_variable: string) =>
         createMiddleware<{ Variables: Variables }>(async (c, next) => {
           await next()

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -6,6 +6,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from '../../hono'
 import type { Env, H, HandlerResponse, Input, MiddlewareHandler } from '../../types'
+import type { Simplify } from '../../utils/types'
 
 type InitApp<E extends Env = Env> = (app: Hono<E>) => void
 
@@ -237,10 +238,20 @@ export const createFactory = <E extends Env = any, P extends string = any>(init?
   initApp?: InitApp<E>
 }): Factory<E, P> => new Factory<E, P>(init)
 
+// Add `any` if it's undefined to relax types
+// { Variables: Variables } => { Bindings: any, Variables: any }
+// { Bindings: Bindings } => { Bindings: Bindings, Variables: any }
+
+type AddAnyToEnv<T extends { Variables?: object; Bindings?: object }> = {
+  Bindings: undefined extends T['Bindings'] ? any : T['Bindings']
+  Variables: undefined extends T['Variables'] ? any : T['Variables']
+}
+
 export const createMiddleware = <
   E extends Env = any,
   P extends string = string,
-  I extends Input = {}
+  I extends Input = {},
+  E2 extends Env = Simplify<AddAnyToEnv<E>>
 >(
-  middleware: MiddlewareHandler<E, P, I>
-): MiddlewareHandler<E, P, I> => createFactory<E, P>().createMiddleware<I>(middleware)
+  middleware: MiddlewareHandler<E2, P, I>
+): MiddlewareHandler<E2, P, I> => createFactory<E2, P>().createMiddleware<I>(middleware)


### PR DESCRIPTION
If there were type mismatches regarding `Bindings` and `Variables` with nested middleware created by `createMiddleware`, it threw the error. I've fixed it does not throw the type error. 

```ts
type Bindings = {
  MY_VAR_IN_BINDINGS: string
}

const app = new Hono<{ Bindings: Bindings }>()

type Variables = {
  MY_VAR: string
}
const middleware = (_variable: string) =>
  createMiddleware<{ Variables: Variables }>(async (c, next) => {
    await next()
  })

app.get(
  '/',
  createMiddleware<{ Bindings: Bindings }>(async (c, next) => {
    const mw = middleware(c.env.MY_VAR_IN_BINDINGS)
    await mw(c, next) // `c` does not throw an error
  }),
  (c) => {
    return c.json({})
  }
)
````

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
