### PR TITLE
refactor(jsx): add `override` to `toStringToBuffer` in classes extending `JSXNode`

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -242,7 +242,7 @@ export class JSXNode implements HtmlEscaped {
 }
 
 class JSXFunctionNode extends JSXNode {
-  toStringToBuffer(buffer: StringBufferWithCallbacks): void {
+  override toStringToBuffer(buffer: StringBufferWithCallbacks): void {
     const { children } = this
 
     const res = (this.tag as Function).call(null, {
@@ -284,7 +284,7 @@ class JSXFunctionNode extends JSXNode {
 }
 
 export class JSXFragmentNode extends JSXNode {
-  toStringToBuffer(buffer: StringBufferWithCallbacks): void {
+  override toStringToBuffer(buffer: StringBufferWithCallbacks): void {
     childrenToStringToBuffer(this.children, buffer)
   }
 }


### PR DESCRIPTION
Avoid the error when running `test:deno`:

![CleanShot 2024-10-11 at 16 39 28@2x](https://github.com/user-attachments/assets/33ebdfc0-da78-4cb8-93a9-d9c80db9d03b)

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
