### PR TITLE
fix(types): rm ExcludeEmptyObject to fix massively increased type instantiations

### DIFF
--- a/perf-measures/type-check/client.ts
+++ b/perf-measures/type-check/client.ts
@@ -1,4 +1,4 @@
-import type { app } from './generated/app'
 import { hc } from '../../src/client'
+import type { app } from './generated/app'
 
 const client = hc<typeof app>('/')

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,5 @@
 import type { Hono } from '../hono'
+import type { HonoBase } from '../hono-base'
 import type { Endpoint, ResponseFormat, Schema } from '../types'
 import type { StatusCode, SuccessStatusCode } from '../utils/http-status'
 import type { HasRequiredKeys } from '../utils/types'
@@ -159,7 +160,7 @@ type PathToChain<
     }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Client<T> = T extends Hono<any, infer S, any>
+export type Client<T> = T extends HonoBase<any, infer S, any>
   ? S extends Record<infer K, Schema>
     ? K extends string
       ? PathToChain<K, S>

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -99,8 +99,6 @@ type MountOptions =
       replaceRequest?: MountReplaceRequest
     }
 
-type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T
-
 class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'> {
   get!: HandlerInterface<E, 'get', S, BasePath>
   post!: HandlerInterface<E, 'post', S, BasePath>
@@ -214,11 +212,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   >(
     path: SubPath,
     app: Hono<SubEnv, SubSchema, SubBasePath>
-  ): Hono<
-    E,
-    ExcludeEmptyObject<MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> | S>,
-    BasePath
-  > {
+  ): Hono<E, MergeSchemaPath<SubSchema, MergePath<BasePath, SubPath>> | S, BasePath> {
     const subApp = this.basePath(path)
     app.routes.map((r) => {
       let handler

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -26,7 +26,6 @@ import type {
   RouterRoute,
   Schema,
 } from './types'
-import type { ExcludeEmptyObject } from './utils/types'
 import { getPath, getPathNoStrict, mergePath } from './utils/url'
 
 /**
@@ -99,6 +98,8 @@ type MountOptions =
       optionHandler?: MountOptionHandler
       replaceRequest?: MountReplaceRequest
     }
+
+type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T
 
 class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'> {
   get!: HandlerInterface<E, 'get', S, BasePath>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -97,5 +97,3 @@ export type IsAny<T> = boolean extends (T extends never ? true : false) ? true :
  * @see https://github.com/Microsoft/TypeScript/issues/29729
  */
 export type StringLiteralUnion<T> = T | (string & Record<never, never>)
-
-export type ExcludeEmptyObject<T> = T extends {} ? ({} extends T ? never : T) : T


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

It's super weird, but if `ExcludeEmptyObject` is outside of `hono-base.ts`, "Type instantiation is excessively deep and possibly infinite." error occurs.
Please use this script to check
https://github.com/honojs/hono/pull/3443#issuecomment-2380551431

I don't know the cause at all, it may be a kind of cache issue, though