### PR TITLE
fix(cors): avoid setting `Access-Control-Allow-Origin` if there is no matching origin

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -68,11 +68,15 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
   const findAllowOrigin = ((optsOrigin) => {
     if (typeof optsOrigin === 'string') {
-      return () => optsOrigin
+      if (optsOrigin === '*') {
+        return () => optsOrigin
+      } else {
+        return (origin: string) => (optsOrigin === origin ? origin : null)
+      }
     } else if (typeof optsOrigin === 'function') {
       return optsOrigin
     } else {
-      return (origin: string) => (optsOrigin.includes(origin) ? origin : optsOrigin[0])
+      return (origin: string) => (optsOrigin.includes(origin) ? origin : null)
     }
   })(opts.origin)
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

Even if the `Origin` header of a request does not match a origin specified by `origin` option, CORS middleware always sets `Access-Control-Allow-Origin` header. I don't see this as a serious problem, but in some cases it may unintentionally expose a server setting.

### References

- https://github.com/expressjs/cors/blob/v2.8.5/test/test.js#L251-L262 - `cors` package seems not to set the `Access-Control-Allow-Origin` if the `Origin` header of a request does not match allowed origins
- https://fetch.spec.whatwg.org/#cors-check - A CORS check returns failure if the `Access-Control-Allow-Origin` header is missing
  - [Currently, CORS middleware returns a origin specified by `origin` option as the `Access-Control-Allow-Origin` if the option does not match the `Origin` header of a request](https://github.com/honojs/hono/blob/v4.6.4/src/middleware/cors/index.ts#L70-L76), so changes in this PR would have no particular negative impact