### PR TITLE
chore: podman support for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,11 @@
                 "editor.codeActionsOnSave": {
                     "source.fixAll.eslint": "explicit"
                 }
-            }
+            },
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode"
+            ]
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,12 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
+    "runArgs": [
+        "--userns=keep-id"
+    ],
+    "containerEnv": {
+        "HOME": "/home/node"
+    },
     "customizations": {
         "vscode": {
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
                     "typescriptreact"
                 ],
                 "editor.codeActionsOnSave": {
-                    "source.fixAll.eslint": true
+                    "source.fixAll.eslint": "explicit"
                 }
             }
         }


### PR DESCRIPTION
I ran into some issues when using the Devcontainer setup in VS Code with Podman. This PR changes the devcontainer.json to allow the use of Podman. Docker usage should not be affected. It also adds the Prettier and ESLint Extensions for VS Code explicitly to the Devcontainer.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
