### PR TITLE
fix(serve-static): silence `NotFound` warning on Deno

### DIFF
--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -4,7 +4,7 @@ import type { Env, MiddlewareHandler } from '../../types'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-const { open, lstatSync } = Deno
+const { open, lstatSync, errors } = Deno
 
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E>
@@ -16,7 +16,9 @@ export const serveStatic = <E extends Env = Env>(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return file ? (file.readable as any) : null
       } catch (e) {
-        console.warn(`${e}`)
+        if (!(e instanceof errors.NotFound)) {
+          console.warn(`${e}`)
+        }
       }
     }
     const pathResolve = (path: string) => {


### PR DESCRIPTION
Silences the `NotFound` warning when a file is not found using `serveStatic` for Deno.

```
NotFound: No such file or directory (os error 2)
```

Noticed that this is already the default behaviour for Bun's adapter according to #1810 but it is not with Deno due to Deno not allowing to check directly for a file's existence. Ignoring the error is the only way to avoid the warning.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
