### PR TITLE
Support custom secret keys for signing JWTs

### DIFF
--- a/src/utils/jwt/jws.ts
+++ b/src/utils/jwt/jws.ts
@@ -50,7 +50,7 @@ async function importPrivateKey(key: SignatureKey, alg: KeyImporterAlgorithm): P
     throw new Error('`crypto.subtle.importKey` is undefined. JWT auth middleware requires it.')
   }
   if (isCryptoKey(key)) {
-    if (key.type !== 'private') {
+    if (key.type !== 'private' && key.type !== 'secret') {
       throw new Error(`unexpected non private key: CryptoKey.type is ${key.type}`)
     }
     return key


### PR DESCRIPTION
- Expanded key type check to include 'secret' for JWT signing. This aligns importPrivateKey method with importPublicKey method for handling "secret" type keys.

- Added a test case to sign, verify, and decode using a custom secret, ensuring the correct flow and error handling with mismatched keys.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
