### PR TITLE
fix(vercel): remove `requestContext`

### DIFF
--- a/src/adapter/vercel/handler.test.ts
+++ b/src/adapter/vercel/handler.test.ts
@@ -1,28 +1,23 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from '../../hono'
 import { handle } from './handler'
 
 describe('Adapter for Next.js', () => {
-  it('Should return 200 response with a `waitUntil` value', async () => {
+  it('Should return 200 response', async () => {
     const app = new Hono()
-    app.get('/api/foo', async (c) => {
+    app.get('/api/author/:name', async (c) => {
+      const name = c.req.param('name')
       return c.json({
-        path: '/api/foo',
-        /**
-         * Checking if the `waitUntil` value is passed.
-         */
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        waitUntil: c.executionCtx.waitUntil() as any,
+        path: '/api/author/:name',
+        name,
       })
     })
     const handler = handle(app)
-    const req = new Request('http://localhost/api/foo')
-    const res = await handler(req, { waitUntil: () => 'waitUntil' } as any)
+    const req = new Request('http://localhost/api/author/hono')
+    const res = await handler(req)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
-      path: '/api/foo',
-      waitUntil: 'waitUntil',
+      path: '/api/author/:name',
+      name: 'hono',
     })
   })
 
@@ -38,10 +33,6 @@ describe('Adapter for Next.js', () => {
 
     const handler = handle(app)
     const req = new Request('http://localhost/api/error')
-    expect(() =>
-      handler(req, {
-        waitUntil: () => {},
-      } as any)
-    ).toThrowError('Custom Error')
+    expect(() => handler(req)).toThrowError('Custom Error')
   })
 })

--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Hono } from '../../hono'
-import type { FetchEventLike } from '../../types'
 
 export const handle =
   (app: Hono<any, any, any>) =>
-  (req: Request, requestContext: FetchEventLike): Response | Promise<Response> => {
-    return app.fetch(req, {}, requestContext as any)
+  (req: Request): Response | Promise<Response> => {
+    return app.fetch(req)
   }


### PR DESCRIPTION
Fixes #3548 

The `requestContext,` which is used in the second argument of the handler, is no longer needed. Because the current version of Next.js passes only the values of `params`. But, you can get the `params` value from `c.req.param()`.

Ref: https://nextjs.org/docs/app/api-reference/file-conventions/route#context-optional
Ref: https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#typescript


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
