### PR TITLE
fix(middleware/bearer-auth): return 403 Forbidden when credentials are invalid

### DIFF
--- a/src/middleware/bearer-auth/index.test.ts
+++ b/src/middleware/bearer-auth/index.test.ts
@@ -264,8 +264,8 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Bearer invalid-token')
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Unauthorized')
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe('Forbidden')
     expect(res.headers.get('x-custom')).toBeNull()
   })
 
@@ -325,8 +325,8 @@ describe('Bearer Auth by Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(handlerExecuted).toBeFalsy()
-    expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Unauthorized')
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe('Forbidden')
   })
 
   it('Should authorize - with any token in list', async () => {
@@ -363,7 +363,7 @@ describe('Bearer Auth by Middleware', () => {
     })
     expect(res).not.toBeNull()
     expect(handlerExecuted).toBeFalsy()
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(403)
   })
 
   it('Should authorize - custom header', async () => {
@@ -382,8 +382,8 @@ describe('Bearer Auth by Middleware', () => {
     const res = await app.request(req)
     expect(res).not.toBeNull()
     expect(handlerExecuted).toBeFalsy()
-    expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Unauthorized')
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe('Forbidden')
   })
 
   it('Should not authorize - custom no authorization header message as string', async () => {
@@ -489,7 +489,7 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Bearer invalid-token')
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(403)
     expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('Custom invalid token message as string')
   })
@@ -499,7 +499,7 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Bearer invalid-token')
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(403)
     expect(res.headers.get('Content-Type')).toMatch('application/json; charset=UTF-8')
     expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('{"message":"Custom invalid token message as object"}')
@@ -510,7 +510,7 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Bearer invalid-token')
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(403)
     expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('Custom invalid token message as function string')
   })
@@ -520,7 +520,7 @@ describe('Bearer Auth by Middleware', () => {
     req.headers.set('Authorization', 'Bearer invalid-token')
     const res = await app.request(req)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(403)
     expect(res.headers.get('Content-Type')).toMatch('application/json; charset=UTF-8')
     expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('{"message":"Custom invalid token message as function object"}')

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -51,10 +51,10 @@ type BearerAuthOptions =
  * @param {Function} [options.hashFunction] - A function to handle hashing for safe comparison of authentication tokens.
  * @param {string | object | MessageFunction} [options.noAuthenticationHeaderMessage="Unauthorized"] - The no authentication header message.
  * @param {string | object | MessageFunction} [options.invalidAuthenticationHeaderMeasage="Bad Request"] - The invalid authentication header message.
- * @param {string | object | MessageFunction} [options.invalidTokenMessage="Unauthorized"] - The invalid token message.
+ * @param {string | object | MessageFunction} [options.invalidTokenMessage="Forbidden"] - The invalid token message.
  * @returns {MiddlewareHandler} The middleware handler function.
  * @throws {Error} If neither "token" nor "verifyToken" options are provided.
- * @throws {HTTPException} If authentication fails, with 401 status code for missing or invalid token, or 400 status code for invalid request.
+ * @throws {HTTPException} If request lacks authentication credentials, return 401 status code; if request is invalid, return 400 status code; if credentials are invalid, return 403 status code.
  *
  * @example
  * ```ts
@@ -147,9 +147,9 @@ export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
           // Invalid Token
           await throwHTTPException(
             c,
-            401,
+            403,
             `${wwwAuthenticatePrefix}error="invalid_token"`,
-            options.invalidTokenMessage || 'Unauthorized'
+            options.invalidTokenMessage || 'Forbidden'
           )
         }
       }


### PR DESCRIPTION
This PR modifies the [Bearer Auth Middleware](https://hono.dev/docs/middleware/builtin/bearer-auth) to return a 403 Forbidden response instead of a 401 Unauthorized response when a Bearer access token is provided in the request but is not allowed by the middleware configuration. According to spec,

> a 403 is returned when a request contains valid credentials, but the client does not have permissions to perform a certain action ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401))

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
