### PR TITLE
fix(utils/cookie): partitioned typo in CookieOptions

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -8,9 +8,9 @@ import { decodeURIComponent_ } from './url'
 export type Cookie = Record<string, string>
 export type SignedCookie = Record<string, string | false>
 
-type PartitionCookieConstraint =
-  | { partition: true; secure: true }
-  | { partition?: boolean; secure?: boolean } // reset to default
+type PartitionedCookieConstraint =
+  | { partitioned: true; secure: true }
+  | { partitioned?: boolean; secure?: boolean } // reset to default
 type SecureCookieConstraint = { secure: true }
 type HostCookieConstraint = { secure: true; path: '/'; domain?: undefined }
 
@@ -25,7 +25,7 @@ export type CookieOptions = {
   sameSite?: 'Strict' | 'Lax' | 'None' | 'strict' | 'lax' | 'none'
   partitioned?: boolean
   prefix?: CookiePrefixOptions
-} & PartitionCookieConstraint
+} & PartitionedCookieConstraint
 export type CookiePrefixOptions = 'host' | 'secure'
 
 export type CookieConstraint<Name> = Name extends `__Secure-${string}`


### PR DESCRIPTION
This was introduced in PR #2350

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
