### PR TITLE
fix(websocket): prevent sending entire buffer when streaming Uint8Array chunks

### DIFF
--- a/src/helper/websocket/index.test.ts
+++ b/src/helper/websocket/index.test.ts
@@ -89,7 +89,7 @@ describe('WSContext', () => {
     expect(nullURLWS.url).toBeNull()
   })
   it('Should normalize message in send()', () => {
-    let data: string | ArrayBuffer | null = null
+    let data: string | ArrayBuffer | Uint8Array | null = null
     const wsContext = new WSContext({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       send(received, _options) {
@@ -104,6 +104,6 @@ describe('WSContext', () => {
     expect(data).toBeInstanceOf(ArrayBuffer)
 
     wsContext.send(new Uint8Array(16))
-    expect(data).toBeInstanceOf(ArrayBuffer)
+    expect(data).toBeInstanceOf(Uint8Array)
   })
 })

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -69,7 +69,7 @@ export class WSContext<T = unknown> {
   }
   send(source: string | ArrayBuffer | Uint8Array, options?: SendOptions): void {
     this.#init.send(
-      typeof source === 'string' ? source : source instanceof Uint8Array ? source.buffer : source,
+      source,
       options ?? {}
     )
   }

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -68,10 +68,7 @@ export class WSContext<T = unknown> {
     this.protocol = init.protocol ?? null
   }
   send(source: string | ArrayBuffer | Uint8Array, options?: SendOptions): void {
-    this.#init.send(
-      source,
-      options ?? {}
-    )
+    this.#init.send(source, options ?? {})
   }
   raw?: T
   binaryType: BinaryType = 'arraybuffer'


### PR DESCRIPTION
## Problem
When sending a `Uint8Array` through the WebSocket's `send()` method, the current implementation converts it to its underlying `ArrayBuffer` using `source.buffer`. This becomes problematic when the `Uint8Array` is a view over a larger buffer, which is common in streaming scenarios.

For example, when streaming data with Bun, it internally uses a buffer pool with 16KB buffers for efficiency. So if you have a `Uint8Array` chunk of 800 bytes, it's actually a view over a 16KB buffer. The current implementation sends the entire 16KB buffer instead of just the 800 bytes of actual data:

```typescript
// Current implementation
send(source: string | ArrayBuffer | Uint8Array) {
    this.#init.send(
      source instanceof Uint8Array 
        ? source.buffer  // Sends entire 16KB buffer! 
        : source
    )
}
```

This causes:

1. Unnecessary bandwidth usage - sending 16KB when only 800 bytes are needed
2. Potential data corruption on the client side - the unused portion of the buffer might contain old data
3. Performance issues when streaming large amounts of data

## Solution
We should send the `Uint8Array` directly without converting it to its buffer. This preserves the view information and sends only the actual data:
```typescript
send(source: string | ArrayBuffer | Uint8Array, options?: SendOptions): void {
    this.#init.send(source, options ?? {})
}
```

## Example
```typescript
// Streaming scenario with Bun
const reader = response.body?.getReader();
while (true) {
  const { done, value } = await reader.read();
  if (done) break;
  
  console.log(value.byteLength);      // e.g., 800 bytes
  console.log(value.buffer.byteLength); // 16384 bytes (Bun's pooled buffer)
  
  // Before: sends all 16384 bytes
  // After: sends only the actual 800 bytes
  ws.send(value);
}
```
The WebSocket API can handle `Uint8Array` directly, so there's no need for the conversion to `ArrayBuffer`. This change ensures we only send the actual data bytes while maintaining all existing functionality.
