### PR TITLE
fix(req): correct `c.req.param` decodes invalid percent strings

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -771,46 +771,22 @@ describe('Routing', () => {
 
     it('should decode alphabets with invalid UTF-8 sequence', async () => {
       app.get('/static/:path', (c) => {
-        try {
-          return c.text(`by c.req.param: ${c.req.param('path')}`) // this should throw an error
-        } catch (e) {
-          return c.text(`by c.req.url: ${c.req.url.replace(/.*\//, '')}`)
-        }
+        return c.text(`by c.req.param: ${c.req.param('path')}`)
       })
 
       const res = await app.request('http://localhost/%73tatic/%A4%A2') // %73 is 's', %A4%A2 is invalid UTF-8 sequence
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('by c.req.url: %A4%A2')
+      expect(await res.text()).toBe('by c.req.param: %A4%A2')
     })
 
     it('should decode alphabets with invalid percent encoding', async () => {
       app.get('/static/:path', (c) => {
-        try {
-          return c.text(`by c.req.param: ${c.req.param('path')}`) // this should throw an error
-        } catch (e) {
-          return c.text(`by c.req.url: ${c.req.url.replace(/.*\//, '')}`)
-        }
+        return c.text(`by c.req.param: ${c.req.param('path')}`)
       })
 
       const res = await app.request('http://localhost/%73tatic/%a') // %73 is 's', %a is invalid percent encoding
       expect(res.status).toBe(200)
-      expect(await res.text()).toBe('by c.req.url: %a')
-    })
-
-    it('should be able to catch URIError', async () => {
-      app.onError((err, c) => {
-        if (err instanceof URIError) {
-          return c.text(err.message, 400)
-        }
-        throw err
-      })
-      app.get('/static/:path', (c) => {
-        return c.text(`by c.req.param: ${c.req.param('path')}`) // this should throw an error
-      })
-
-      const res = await app.request('http://localhost/%73tatic/%a') // %73 is 's', %a is invalid percent encoding
-      expect(res.status).toBe(400)
-      expect(await res.text()).toBe('URI malformed')
+      expect(await res.text()).toBe('by c.req.param: %a')
     })
 
     it('should not double decode', async () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -12,7 +12,7 @@ import type {
 import { parseBody } from './utils/body'
 import type { BodyData, ParseBodyOptions } from './utils/body'
 import type { Simplify, UnionToIntersection } from './utils/types'
-import { getQueryParam, getQueryParams, tryDecode } from './utils/url'
+import { decodeURIComponent_, getQueryParam, getQueryParams, tryDecode } from './utils/url'
 
 type Body = {
   json: any
@@ -22,6 +22,8 @@ type Body = {
   formData: FormData
 }
 type BodyCache = Partial<Body & { parsedBody: BodyData }>
+
+const tryDecodeURIComponent = (str: string) => tryDecode(str, decodeURIComponent_)
 
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
@@ -91,12 +93,10 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return key ? this.getDecodedParam(key) : this.getAllDecodedParams()
   }
 
-  #tryDecodeURIComponent = (str: string) => tryDecode(str, decodeURIComponent)
-
   private getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
     const param = this.getParamValue(paramKey)
-    return param ? this.#tryDecodeURIComponent(param) : undefined
+    return param ? tryDecodeURIComponent(param) : undefined
   }
 
   private getAllDecodedParams(): Record<string, string> {
@@ -106,7 +106,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     for (const key of keys) {
       const value = this.getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value && typeof value === 'string') {
-        decoded[key] = this.#tryDecodeURIComponent(value)
+        decoded[key] = tryDecodeURIComponent(value)
       }
     }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -96,7 +96,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   private getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
     const param = this.getParamValue(paramKey)
-    return param ? tryDecodeURIComponent(param) : undefined
+    return param ? (/\%/.test(param) ? tryDecodeURIComponent(param) : param) : undefined
   }
 
   private getAllDecodedParams(): Record<string, string> {
@@ -106,7 +106,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     for (const key of keys) {
       const value = this.getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value && typeof value === 'string') {
-        decoded[key] = tryDecodeURIComponent(value)
+        decoded[key] = /\%/.test(value) ? tryDecodeURIComponent(value) : value
       }
     }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -74,6 +74,21 @@ export const getPattern = (label: string): Pattern | null => {
   return null
 }
 
+type Decoder = (str: string) => string
+export const tryDecode = (str: string, decoder: Decoder): string => {
+  try {
+    return decoder(str)
+  } catch {
+    return str.replace(/(?:%[0-9A-Fa-f]{2})+/g, (match) => {
+      try {
+        return decoder(match)
+      } catch {
+        return match
+      }
+    })
+  }
+}
+
 /**
  * Try to apply decodeURI() to given string.
  * If it fails, skip invalid percent encoding or invalid UTF-8 sequences, and apply decodeURI() to the rest as much as possible.
@@ -83,19 +98,7 @@ export const getPattern = (label: string): Pattern | null => {
  * tryDecodeURI('Hello%20World') // 'Hello World'
  * tryDecodeURI('Hello%20World/%A4%A2') // 'Hello World/%A4%A2'
  */
-const tryDecodeURI = (str: string): string => {
-  try {
-    return decodeURI(str)
-  } catch {
-    return str.replace(/(?:%[0-9A-Fa-f]{2})+/g, (match) => {
-      try {
-        return decodeURI(match)
-      } catch {
-        return match
-      }
-    })
-  }
-}
+const tryDecodeURI = (str: string) => tryDecode(str, decodeURI)
 
 export const getPath = (request: Request): string => {
   const url = request.url


### PR DESCRIPTION
Fixes #3550

In the current behavior, the `c.req.param()` will throw the error when decoding invalid percent encoding or invalid UTF-8 sequence.

```ts
// app
app.get('/static/:path', (c) => c.text(c.req.param('path'))

// throw `URIError: URI malformed` error:
await app.request('/static/%A4%A2') //  %A4%A2 is invalid UTF-8 sequence

// throw `URIError: URI malformed` error:
await app.request('/static/%a') // %a is invalid percent encoding
```

These behaviors are expected in the current version implementation; they are tested:

https://github.com/honojs/hono/compare/fix/request-dont-throw-error-with-percent-strings?expand=1#diff-8ac13809c9886e994d1db33943de82df4d6c5d88b73fd0270c0189804ff565c2L772-L814

However, according to #3550, throwing the error will stop the application procedure, and it can accept malicious requests. I think it should not throw the error. This should be fixed, though we should rewrite the test code.

### The correct behavior

How to handle the invalid path parameter strings. One way is throwing `400 Bad Request`, but as [I commented](https://github.com/honojs/hono/issues/3550#issuecomment-2436917112), it should follow the decode method of the `getPath()` to resolve the URL path:

https://github.com/honojs/hono/blob/0a99bd3e74cc444d4b968dab775c99674b89835f/src/utils/url.ts#L112

So, the result will be like the following:

```ts
res = await app.request('/static/%A4%A2')
console.log(await res.text()) // %A4%A2

res = await app.request('/static/%a')
console.log(await res.text()) // %a
```

In this PR, I used the same logic of `tryDecodeURI` for `tryDecodeURIComponent`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
