### PR TITLE
fix(websocket): Fix typo in WSContextInit type

### DIFF
--- a/src/helper/websocket/index.test.ts
+++ b/src/helper/websocket/index.test.ts
@@ -1,5 +1,5 @@
 import { Context } from '../../context'
-import type { WSContestInit } from '.'
+import type { WSContextInit } from '.'
 import { WSContext, createWSMessageEvent, defineWebSocketHelper } from '.'
 
 describe('`createWSMessageEvent`', () => {
@@ -46,7 +46,7 @@ describe('WSContext', () => {
         close(code, reason) {
           resolve([code, reason])
         },
-      } as WSContestInit)
+      } as WSContextInit)
     })
     ws.close(0, 'reason')
     const [code, reason] = await promise
@@ -61,7 +61,7 @@ describe('WSContext', () => {
         send(data, _options) {
           resolve(data)
         },
-      } as WSContestInit)
+      } as WSContextInit)
     })
     ws.send('Hello')
     expect(await promise).toBe('Hello')
@@ -69,23 +69,23 @@ describe('WSContext', () => {
   it('Should readyState works', () => {
     const ws = new WSContext({
       readyState: 0,
-    } as WSContestInit)
+    } as WSContextInit)
     expect(ws.readyState).toBe(0)
   })
   it('Should normalize URL', () => {
     const stringURLWS = new WSContext({
       url: 'http://localhost',
-    } as WSContestInit)
+    } as WSContextInit)
     expect(stringURLWS.url).toBeInstanceOf(URL)
 
     const urlURLWS = new WSContext({
       url: new URL('http://localhost'),
-    } as WSContestInit)
+    } as WSContextInit)
     expect(urlURLWS.url).toBeInstanceOf(URL)
 
     const nullURLWS = new WSContext({
       url: undefined,
-    } as WSContestInit)
+    } as WSContextInit)
     expect(nullURLWS.url).toBeNull()
   })
   it('Should normalize message in send()', () => {
@@ -95,7 +95,7 @@ describe('WSContext', () => {
       send(received, _options) {
         data = received
       },
-    } as WSContestInit)
+    } as WSContextInit)
 
     wsContext.send('string')
     expect(data).toBe('string')

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -39,7 +39,7 @@ export type WSReadyState = 0 | 1 | 2 | 3
 /**
  * An argument for WSContext class
  */
-export interface WSContestInit<T = unknown> {
+export interface WSContextInit<T = unknown> {
   send(data: string | ArrayBuffer, options: SendOptions): void
   close(code?: number, reason?: string): void
 
@@ -60,8 +60,8 @@ export interface SendOptions {
  * A context for controlling WebSockets
  */
 export class WSContext<T = unknown> {
-  #init: WSContestInit<T>
-  constructor(init: WSContestInit<T>) {
+  #init: WSContextInit<T>
+  constructor(init: WSContextInit<T>) {
     this.#init = init
     this.raw = init.raw
     this.url = init.url ? new URL(init.url) : null


### PR DESCRIPTION
Changed `WSContestInit` to `WSContextInit` to correctly reflect that this is a WebSocket Context initialization type, not Contest.
This was a simple typo where 'Context' was misspelled as 'Contest' in the type name.