### PR TITLE
perf(router): use `.concat` instead of spread syntax

### DIFF
--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -232,7 +232,7 @@ export class RegExpRouter<T> implements Router<T> {
   private buildAllMatchers(): Record<string, Matcher<T> | null> {
     const matchers: Record<string, Matcher<T> | null> = Object.create(null)
 
-    ;[...Object.keys(this.routes!), ...Object.keys(this.middleware!)].forEach((method) => {
+    Object.keys(this.routes!).concat(Object.keys(this.middleware!)).forEach((method) => {
       matchers[method] ||= this.buildMatcher(method)
     })
 

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -232,9 +232,11 @@ export class RegExpRouter<T> implements Router<T> {
   private buildAllMatchers(): Record<string, Matcher<T> | null> {
     const matchers: Record<string, Matcher<T> | null> = Object.create(null)
 
-    Object.keys(this.routes!).concat(Object.keys(this.middleware!)).forEach((method) => {
-      matchers[method] ||= this.buildMatcher(method)
-    })
+    Object.keys(this.routes!)
+      .concat(Object.keys(this.middleware!))
+      .forEach((method) => {
+        matchers[method] ||= this.buildMatcher(method)
+      })
 
     // Release cache
     this.middleware = this.routes = undefined


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
