### PR TITLE
perf(context): improve performance of context (setHeaders)

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -266,7 +266,10 @@ export const TEXT_PLAIN = 'text/plain; charset=UTF-8'
  * @returns The updated Headers object.
  */
 const setHeaders = (headers: Headers, map: Record<string, string> = {}) => {
-  Object.entries(map).forEach(([key, value]) => headers.set(key, value))
+  for (let i = 0, keys = Object.keys(map), len = keys.length; i < len; i++) {
+    const key = keys[i]
+    headers.set(key, map[key])
+  }
   return headers
 }
 
@@ -627,8 +630,9 @@ export class Context<
     headers?: HeaderRecord
   ): Response => {
     // Optimized
-    if (this.#isFresh && !headers && !arg && this.#status === 200) {
+    if (this.#isFresh && !headers && !arg) {
       return new Response(data, {
+        status: this.#status,
         headers: this.#preparedHeaders,
       })
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -630,9 +630,8 @@ export class Context<
     headers?: HeaderRecord
   ): Response => {
     // Optimized
-    if (this.#isFresh && !headers && !arg) {
+    if (this.#isFresh && !headers && !arg && this.#status === 200) {
       return new Response(data, {
-        status: this.#status,
         headers: this.#preparedHeaders,
       })
     }


### PR DESCRIPTION
Improved performance of `setHeaders` and removed unnecessary checks in `.newResponse`.

The benchmark results are as follows

### In Node (1.5x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: node v20.18.0 (x64-linux)

benchmark             time (avg)             (min … max)       p75       p99      p995
-------------------------------------------------------- -----------------------------
using .entries      1.19 µs/iter     (1.07 µs … 1.63 ms)   1.12 µs   2.69 µs   2.89 µs
using for syntax   707.2 ns/iter (683.65 ns … 948.47 ns) 714.47 ns 948.47 ns 948.47 ns
```

### In Deno (4x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: deno 2.0.4 (x86_64-unknown-linux-gnu)

benchmark             time (avg)             (min … max)       p75       p99      p995
-------------------------------------------------------- -----------------------------
using .entries      3.83 µs/iter     (2.44 µs … 2.88 ms)   3.48 µs   7.12 µs   7.65 µs
using for syntax   893.5 ns/iter   (836.79 ns … 1.32 µs) 881.82 ns   1.32 µs   1.32 µs
```

### In Bun (1.5x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: bun 1.1.33 (x64-linux)

benchmark             time (avg)             (min … max)       p75       p99      p995
-------------------------------------------------------- -----------------------------
using .entries    771.93 ns/iter   (704.77 ns … 1.25 µs) 788.32 ns   1.25 µs   1.25 µs
using for syntax   533.1 ns/iter   (440.84 ns … 1.89 µs) 522.99 ns 945.47 ns   1.89 µs
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
