### PR TITLE
perf(utils/url): improve performance of url utility

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -104,7 +104,7 @@ export const getPath = (request: Request): string => {
   const url = request.url
   const start = url.indexOf('/', 8)
   let i = start
-  for (const len = url.length; i < len; i++) {
+  for (; i < url.length; i++) {
     const charCode = url.charCodeAt(i)
     if (charCode === 37) {
       // '%'

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -104,7 +104,7 @@ export const getPath = (request: Request): string => {
   const url = request.url
   const start = url.indexOf('/', 8)
   let i = start
-  for (; i < url.length; i++) {
+  for (const len = url.length; i < len; i++) {
     const charCode = url.charCodeAt(i)
     if (charCode === 37) {
       // '%'
@@ -210,7 +210,7 @@ const _decodeURI = (value: string) => {
   if (value.indexOf('+') !== -1) {
     value = value.replace(/\+/g, ' ')
   }
-  return /%/.test(value) ? decodeURIComponent_(value) : value
+  return value.indexOf('%') !== -1 ? decodeURIComponent_(value) : value
 }
 
 const _getQueryParam = (


### PR DESCRIPTION
In addition to the cache of length,  
we have speeded up the check for the presence of characters in the string. (indexOf is faster than regex.)

### In Node (8x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: node v20.18.0 (x64-linux)

benchmark            time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------- -----------------------------
Regex              95.21 ns/iter  (86.64 ns … 219.82 ns)   93.3 ns 197.55 ns 210.05 ns
IndexOf            12.2 ns/iter    (11.1 ns … 31.96 ns)  11.41 ns  24.33 ns  24.79 ns
```

### In Deno (10x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: deno 2.0.4 (x86_64-unknown-linux-gnu)

benchmark            time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------- -----------------------------
Regex             102.29 ns/iter  (87.24 ns … 297.28 ns)  96.56 ns 195.11 ns 218.04 ns
IndexOf           10.21 ns/iter       (8 ns … 35.67 ns)  15.25 ns   16.7 ns  21.92 ns
```

### In Bun (5x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: bun 1.1.33 (x64-linux)

benchmark            time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------- -----------------------------
Regex              46.93 ns/iter  (40.01 ns … 134.89 ns)   43.2 ns 103.53 ns 116.53 ns
IndexOf            9.63 ns/iter    (8.63 ns … 25.99 ns)   8.64 ns  21.18 ns  24.36 ns
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
