### PR TITLE
fix(hono-base): remove `.matchRoute` and reduce bundle size

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -382,10 +382,6 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     this.routes.push(r)
   }
 
-  private matchRoute(method: string, path: string) {
-    return this.router.match(method, path)
-  }
-
   private handleError(err: unknown, c: Context<E>) {
     if (err instanceof Error) {
       return this.errorHandler(err, c)
@@ -406,7 +402,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     }
 
     const path = this.getPath(request, { env })
-    const matchResult = this.matchRoute(method, path)
+    const matchResult = this.router.match(method, path)
 
     const c = new Context(request, {
       path,


### PR DESCRIPTION
`.matchRoute` is a private method that is only called from one place and does not wrap a complex process, so I think it can be removed.  
This will reduce the bundle size.  

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
