### PR TITLE
refactor: use `#` for private methods to reduce the minified file size

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -690,6 +690,8 @@ export class Context<
     })
   }
 
+  #newResponse = this.newResponse
+
   /**
    * `.body()` can return the HTTP response.
    * You can set headers with `.header()` and set HTTP status code with `.status`.
@@ -717,8 +719,8 @@ export class Context<
     headers?: HeaderRecord
   ): Response => {
     return typeof arg === 'number'
-      ? this.newResponse(data, arg, headers)
-      : this.newResponse(data, arg)
+      ? this.#newResponse(data, arg, headers)
+      : this.#newResponse(data, arg)
   }
 
   /**
@@ -750,8 +752,8 @@ export class Context<
     this.#preparedHeaders['content-type'] = TEXT_PLAIN
     // @ts-expect-error `Response` due to missing some types-only keys
     return typeof arg === 'number'
-      ? this.newResponse(text, arg, headers)
-      : this.newResponse(text, arg)
+      ? this.#newResponse(text, arg, headers)
+      : this.#newResponse(text, arg)
   }
 
   /**
@@ -779,7 +781,7 @@ export class Context<
     this.#preparedHeaders['content-type'] = 'application/json; charset=UTF-8'
     /* eslint-disable @typescript-eslint/no-explicit-any */
     return (
-      typeof arg === 'number' ? this.newResponse(body, arg, headers) : this.newResponse(body, arg)
+      typeof arg === 'number' ? this.#newResponse(body, arg, headers) : this.#newResponse(body, arg)
     ) as any
   }
 
@@ -794,14 +796,14 @@ export class Context<
     if (typeof html === 'object') {
       return resolveCallback(html, HtmlEscapedCallbackPhase.Stringify, false, {}).then((html) => {
         return typeof arg === 'number'
-          ? this.newResponse(html, arg, headers)
-          : this.newResponse(html, arg)
+          ? this.#newResponse(html, arg, headers)
+          : this.#newResponse(html, arg)
       })
     }
 
     return typeof arg === 'number'
-      ? this.newResponse(html as string, arg, headers)
-      : this.newResponse(html as string, arg)
+      ? this.#newResponse(html as string, arg, headers)
+      : this.#newResponse(html as string, arg)
   }
 
   /**
@@ -825,7 +827,7 @@ export class Context<
   ): Response & TypedResponse<undefined, T, 'redirect'> => {
     this.#headers ??= new Headers()
     this.#headers.set('Location', location)
-    return this.newResponse(null, status ?? 302) as any
+    return this.#newResponse(null, status ?? 302) as any
   }
 
   /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -623,11 +623,11 @@ export class Context<
     return Object.fromEntries(this.#var)
   }
 
-  #newResponse: NewResponse = (
+  #newResponse(
     data: Data | null,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
-  ): Response => {
+  ): Response {
     // Optimized
     if (this.#isFresh && !headers && !arg && this.#status === 200) {
       return new Response(data, {

--- a/src/context.ts
+++ b/src/context.ts
@@ -623,7 +623,7 @@ export class Context<
     return Object.fromEntries(this.#var)
   }
 
-  newResponse: NewResponse = (
+  #newResponse: NewResponse = (
     data: Data | null,
     arg?: StatusCode | ResponseInit,
     headers?: HeaderRecord
@@ -689,10 +689,7 @@ export class Context<
     })
   }
 
-  #newResponse(...args: unknown[]) {
-    // @ts-expect-error Type mismatch for args in newResponse call
-    return this.newResponse(...args)
-  }
+  newResponse: NewResponse = (...args) => this.#newResponse(...(args as Parameters<NewResponse>))
 
   /**
    * `.body()` can return the HTTP response.

--- a/src/context.ts
+++ b/src/context.ts
@@ -690,7 +690,10 @@ export class Context<
     })
   }
 
-  #newResponse = this.newResponse
+  #newResponse(...args: unknown[]) {
+    // @ts-expect-error Type mismatch for args in newResponse call
+    return this.newResponse(...args)
+  }
 
   /**
    * `.body()` can return the HTTP response.

--- a/src/request.ts
+++ b/src/request.ts
@@ -91,21 +91,21 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   param(key: string): string | undefined
   param<P2 extends string = P>(): Simplify<UnionToIntersection<ParamKeyToRecord<ParamKeys<P2>>>>
   param(key?: string): unknown {
-    return key ? this.getDecodedParam(key) : this.getAllDecodedParams()
+    return key ? this.#getDecodedParam(key) : this.#getAllDecodedParams()
   }
 
-  private getDecodedParam(key: string): string | undefined {
+  #getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
-    const param = this.getParamValue(paramKey)
+    const param = this.#getParamValue(paramKey)
     return param ? (/\%/.test(param) ? tryDecodeURIComponent(param) : param) : undefined
   }
 
-  private getAllDecodedParams(): Record<string, string> {
+  #getAllDecodedParams(): Record<string, string> {
     const decoded: Record<string, string> = {}
 
     const keys = Object.keys(this.#matchResult[0][this.routeIndex][1])
     for (const key of keys) {
-      const value = this.getParamValue(this.#matchResult[0][this.routeIndex][1][key])
+      const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value && typeof value === 'string') {
         decoded[key] = /\%/.test(value) ? tryDecodeURIComponent(value) : value
       }
@@ -114,7 +114,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return decoded
   }
 
-  private getParamValue(paramKey: any): string | undefined {
+  #getParamValue(paramKey: any): string | undefined {
     return this.#matchResult[1] ? this.#matchResult[1][paramKey as any] : paramKey
   }
 
@@ -208,7 +208,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return (this.bodyCache.parsedBody ??= await parseBody(this, options))
   }
 
-  private cachedBody = (key: keyof Body) => {
+  #cachedBody = (key: keyof Body) => {
     const { bodyCache, raw } = this
     const cachedBody = bodyCache[key]
 
@@ -242,7 +242,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    */
   json<T = any>(): Promise<T> {
-    return this.cachedBody('json')
+    return this.#cachedBody('json')
   }
 
   /**
@@ -258,7 +258,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    */
   text(): Promise<string> {
-    return this.cachedBody('text')
+    return this.#cachedBody('text')
   }
 
   /**
@@ -274,7 +274,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    */
   arrayBuffer(): Promise<ArrayBuffer> {
-    return this.cachedBody('arrayBuffer')
+    return this.#cachedBody('arrayBuffer')
   }
 
   /**
@@ -288,7 +288,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/docs/api/request#blob
    */
   blob(): Promise<Blob> {
-    return this.cachedBody('blob')
+    return this.#cachedBody('blob')
   }
 
   /**
@@ -302,7 +302,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @see https://hono.dev/docs/api/request#formdata
    */
   formData(): Promise<FormData> {
-    return this.cachedBody('formData')
+    return this.#cachedBody('formData')
   }
 
   /**

--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -5,7 +5,7 @@ type Route<T> = [RegExp, string, T] // [pattern, method, handler, path]
 
 export class PatternRouter<T> implements Router<T> {
   name: string = 'PatternRouter'
-  private routes: Route<T>[] = []
+  #routes: Route<T>[] = []
 
   add(method: string, path: string, handler: T) {
     const endsWithWildcard = path[path.length - 1] === '*'
@@ -34,14 +34,14 @@ export class PatternRouter<T> implements Router<T> {
     } catch {
       throw new UnsupportedPathError()
     }
-    this.routes.push([re, method, handler])
+    this.#routes.push([re, method, handler])
   }
 
   match(method: string, path: string): Result<T> {
     const handlers: [T, Params][] = []
 
-    for (let i = 0, len = this.routes.length; i < len; i++) {
-      const [pattern, routeMethod, handler] = this.routes[i]
+    for (let i = 0, len = this.#routes.length; i < len; i++) {
+      const [pattern, routeMethod, handler] = this.#routes[i]
 
       if (routeMethod === method || routeMethod === METHOD_NAME_ALL) {
         const match = pattern.exec(path)

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -207,7 +207,7 @@ export class RegExpRouter<T> implements Router<T> {
   match(method: string, path: string): Result<T> {
     clearWildcardRegExpCache() // no longer used.
 
-    const matchers = this.buildAllMatchers()
+    const matchers = this.#buildAllMatchers()
 
     this.match = (method, path) => {
       const matcher = (matchers[method] || matchers[METHOD_NAME_ALL]) as Matcher<T>
@@ -229,13 +229,13 @@ export class RegExpRouter<T> implements Router<T> {
     return this.match(method, path)
   }
 
-  private buildAllMatchers(): Record<string, Matcher<T> | null> {
+  #buildAllMatchers(): Record<string, Matcher<T> | null> {
     const matchers: Record<string, Matcher<T> | null> = Object.create(null)
 
     Object.keys(this.routes!)
       .concat(Object.keys(this.middleware!))
       .forEach((method) => {
-        matchers[method] ||= this.buildMatcher(method)
+        matchers[method] ||= this.#buildMatcher(method)
       })
 
     // Release cache
@@ -244,7 +244,7 @@ export class RegExpRouter<T> implements Router<T> {
     return matchers
   }
 
-  private buildMatcher(method: string): Matcher<T> | null {
+  #buildMatcher(method: string): Matcher<T> | null {
     const routes: [string, HandlerWithMetadata<T>[]][] = []
 
     let hasOwnRoute = method === METHOD_NAME_ALL

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -82,7 +82,7 @@ export class Node<T> {
   }
 
   // getHandlerSets
-  private gHSets(
+  #gHSets(
     node: Node<T>,
     method: string,
     nodeParams: Record<string, string>,
@@ -133,10 +133,10 @@ export class Node<T> {
             // '/hello/*' => match '/hello'
             if (nextNode.children['*']) {
               handlerSets.push(
-                ...this.gHSets(nextNode.children['*'], method, node.params, Object.create(null))
+                ...this.#gHSets(nextNode.children['*'], method, node.params, Object.create(null))
               )
             }
-            handlerSets.push(...this.gHSets(nextNode, method, node.params, Object.create(null)))
+            handlerSets.push(...this.#gHSets(nextNode, method, node.params, Object.create(null)))
           } else {
             tempNodes.push(nextNode)
           }
@@ -152,7 +152,7 @@ export class Node<T> {
           if (pattern === '*') {
             const astNode = node.children['*']
             if (astNode) {
-              handlerSets.push(...this.gHSets(astNode, method, node.params, Object.create(null)))
+              handlerSets.push(...this.#gHSets(astNode, method, node.params, Object.create(null)))
               tempNodes.push(astNode)
             }
             continue
@@ -170,7 +170,7 @@ export class Node<T> {
           const restPathString = parts.slice(i).join('/')
           if (matcher instanceof RegExp && matcher.test(restPathString)) {
             params[name] = restPathString
-            handlerSets.push(...this.gHSets(child, method, node.params, params))
+            handlerSets.push(...this.#gHSets(child, method, node.params, params))
             continue
           }
 
@@ -178,9 +178,11 @@ export class Node<T> {
             if (typeof key === 'string') {
               params[name] = part
               if (isLast) {
-                handlerSets.push(...this.gHSets(child, method, params, node.params))
+                handlerSets.push(...this.#gHSets(child, method, params, node.params))
                 if (child.children['*']) {
-                  handlerSets.push(...this.gHSets(child.children['*'], method, params, node.params))
+                  handlerSets.push(
+                    ...this.#gHSets(child.children['*'], method, params, node.params)
+                  )
                 }
               } else {
                 child.params = params


### PR DESCRIPTION
This PR reduces the bundle size using `#` for the private methods instead of the `private` keyword when the code is minified.

The result for the "Hello World" app with the `hono/tiny` preset. This is minified with `esbuild --minify` command:

```
-rw-r--r--@  1 yusuke  staff  12167 10 31 16:13 current.js
-rw-r--r--@  1 yusuke  staff  11688 10 31 16:18 next.js
```

`479 bytes` will be reduced without changing any logic and without performance degradation!

### `#` vs `private`

For example, you have the code:

```ts
class A {
  private myPrivateMethod() {}
  myPublicMethod() {
    this.myPrivateMethod()
  }
}
```

If you use the `private` keyword for the private method, the function name is not minifed with esbuild

```js
"use strict";class A{myPrivateMethod(){}myPublicMethod(){this.myPrivateMethod()}}
```

Instead of `private`, you can use `#` for the private method.

```ts
class A {
  #myPrivateMethod() {}
  myPublicMethod() {
    this.#myPrivateMethod()
  }
}
```

Then, the function name will be minified!

```js
"use strict";class A{#t(){}myPublicMethod(){this.#t()}}
```
