### PR TITLE
refactor: prefer Array|String#includes for size

### DIFF
--- a/src/jsx/intrinsic-element/components.ts
+++ b/src/jsx/intrinsic-element/components.ts
@@ -49,7 +49,7 @@ const insertIntoHead: (
       tags.unshift([tag, props, precedence])
     }
 
-    if (buffer[0].indexOf('</head>') !== -1) {
+    if (buffer[0].includes('</head>')) {
       let insertTags
       if (precedence === undefined) {
         insertTags = tags.map(([tag]) => tag)

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -27,7 +27,7 @@ export const RETAINED_304_HEADERS = [
 ]
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {
-  return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
+  return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).includes(etag)
 }
 
 /**
@@ -77,7 +77,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
         },
       })
       c.res.headers.forEach((_, key) => {
-        if (retainedHeaders.indexOf(key.toLowerCase()) === -1) {
+        if (!retainedHeaders.includes(key.toLowerCase())) {
           c.res.headers.delete(key)
         }
       })

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -32,8 +32,8 @@ export class LinearRouter<T> implements Router<T> {
           continue
         }
 
-        const hasStar = routePath.indexOf('*') !== -1
-        const hasLabel = routePath.indexOf(':') !== -1
+        const hasStar = routePath.includes('*')
+        const hasLabel = routePath.includes(':')
         if (!hasStar && !hasLabel) {
           if (routePath === path || routePath + '/' === path) {
             handlers.push([handler, emptyParams])

--- a/src/router/reg-exp-router/trie.ts
+++ b/src/router/reg-exp-router/trie.ts
@@ -34,7 +34,7 @@ export class Trie {
     for (let i = groups.length - 1; i >= 0; i--) {
       const [mark] = groups[i]
       for (let j = tokens.length - 1; j >= 0; j--) {
-        if (tokens[j].indexOf(mark) !== -1) {
+        if (tokens[j].includes(mark)) {
           tokens[j] = tokens[j].replace(mark, groups[i][1])
           break
         }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -207,10 +207,10 @@ const _decodeURI = (value: string) => {
   if (!/[%+]/.test(value)) {
     return value
   }
-  if (value.indexOf('+') !== -1) {
+  if (value.includes('+')) {
     value = value.replace(/\+/g, ' ')
   }
-  return value.indexOf('%') !== -1 ? decodeURIComponent_(value) : value
+  return value.includes('%') ? decodeURIComponent_(value) : value
 }
 
 const _getQueryParam = (


### PR DESCRIPTION
It's shorter and an intent is clearer:
```typescript
// 17 characters
s.indexOf(n)!==-1

// 13 characters
s.includes(n)
```

```typescript
// 17 characters
s.indexOf(n)===-1

// 14 characters
!s.includes(n)
```


> [!note]
> https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-includes.md

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
