### PR TITLE
refactor(context): use simple for-of syntax

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -266,8 +266,7 @@ export const TEXT_PLAIN = 'text/plain; charset=UTF-8'
  * @returns The updated Headers object.
  */
 const setHeaders = (headers: Headers, map: Record<string, string> = {}) => {
-  for (let i = 0, keys = Object.keys(map), len = keys.length; i < len; i++) {
-    const key = keys[i]
+  for (const key of Object.keys(map)) {
     headers.set(key, map[key])
   }
   return headers


### PR DESCRIPTION
I think #3592 was a very good improvement. Thanks to @EdamAme-x. In addition to it, I propose using for-of in this pull request. In the runtime environment of 2024, "for-of" will have almost the same speed as low-level "for". It's short and highly readable, so I think it should be used proactively when refactoring.

```ts
import { run, bench } from 'mitata'

const subHeaders = {
  a: '1',
  b: '2',
  c: '3',
  d: '4',
  e: '5',
  f: '6',
}

bench('using .entries', () => {
  const headers = new Headers()

  Object.entries(subHeaders).forEach(([key, value]) => headers.set(key, value))
})

bench('using for syntax', () => {
  const headers = new Headers()

  for (let i = 0, keys = Object.keys(subHeaders), len = keys.length; i < len; i++) {
    const key = keys[i]
    headers.set(key, subHeaders[key])
  }
})

bench('using for-of syntax', () => {
  const headers = new Headers()

  for (const key of Object.keys(subHeaders)) {
    headers.set(key, subHeaders[key])
  }
})

await run()
```

```
cpu: Apple M2 Pro
runtime: node v22.2.0 (arm64-darwin)

benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
using .entries          715 ns/iter     (686 ns … 1'087 ns)    720 ns    809 ns  1'087 ns
using for syntax        553 ns/iter       (510 ns … 739 ns)    557 ns    663 ns    739 ns
using for-of syntax     548 ns/iter       (514 ns … 695 ns)    552 ns    601 ns    695 ns
```

```
cpu: Apple M2 Pro
runtime: deno 2.0.0 (aarch64-apple-darwin)

benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
using .entries          831 ns/iter     (784 ns … 1'608 ns)    856 ns  1'012 ns  1'608 ns
using for syntax        596 ns/iter       (564 ns … 690 ns)    607 ns    673 ns    690 ns
using for-of syntax     567 ns/iter       (524 ns … 728 ns)    584 ns    663 ns    728 ns
```

```
cpu: Apple M2 Pro
runtime: bun 1.1.30 (arm64-darwin)

benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
using .entries          464 ns/iter       (425 ns … 922 ns)    457 ns    814 ns    922 ns
using for syntax        331 ns/iter     (294 ns … 2'067 ns)    334 ns    409 ns  2'067 ns
using for-of syntax     330 ns/iter     (301 ns … 1'672 ns)    331 ns    406 ns  1'672 ns
```

### The author should do the following, if applicable

- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
