### PR TITLE
refactor(helper/html): Prefer Array.isArray over instanceof Array

### DIFF
--- a/src/helper/html/index.ts
+++ b/src/helper/html/index.ts
@@ -17,8 +17,9 @@ export const html = (
   for (let i = 0, len = strings.length - 1; i < len; i++) {
     buffer[0] += strings[i]
 
-    const children =
-      values[i] instanceof Array ? (values[i] as Array<unknown>).flat(Infinity) : [values[i]]
+    const children = Array.isArray(values[i])
+      ? (values[i] as Array<unknown>).flat(Infinity)
+      : [values[i]]
     for (let i = 0, len = children.length; i < len; i++) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const child = children[i] as any


### PR DESCRIPTION
`Array.isArray` is more widely used in Hono codebase, specially in `jsx` and `css`.

Theoretical reason: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md

And it's a bit shorter 😝 
```typescript
a instanceof Array // 18 chars
Array.isArray(a)  // 16 chars
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
