### PR TITLE
refactor: compare with undefined directly

### DIFF
--- a/src/router/reg-exp-router/trie.ts
+++ b/src/router/reg-exp-router/trie.ts
@@ -57,11 +57,11 @@ export class Trie {
     const paramReplacementMap: ReplacementMap = []
 
     regexp = regexp.replace(/#(\d+)|@(\d+)|\.\*\$/g, (_, handlerIndex, paramIndex) => {
-      if (typeof handlerIndex !== 'undefined') {
+      if (handlerIndex !== undefined) {
         indexReplacementMap[++captureIndex] = Number(handlerIndex)
         return '$()'
       }
-      if (typeof paramIndex !== 'undefined') {
+      if (paramIndex !== undefined) {
         paramReplacementMap[Number(paramIndex)] = ++captureIndex
         return ''
       }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -17,7 +17,7 @@ export function getColorEnabled(): boolean {
   const isNoColor =
     typeof Deno?.noColor === 'boolean'
       ? (Deno.noColor as boolean)
-      : typeof process !== 'undefined'
+      : process !== undefined
       ? // eslint-disable-next-line no-unsafe-optional-chaining
         'NO_COLOR' in process?.env
       : false


### PR DESCRIPTION
It's a bit shorter and more concise (Hono repo uses it widely over `typeof`).

Performance-wise, no changes.

```typescript
import { bench, run } from 'mitata'

const v = 'str'

bench('typeof ', () => {
  const s = typeof v === 'undefined'
})

bench('direct', () => {
  const s = v === undefined
})

await run()
```

```
runtime: node 22.4.0 (arm64-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
typeof                   96.02 ps/iter 101.56 ps           █           !
                 (71.04 ps … 52.26 ns) 111.82 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁
direct                   96.73 ps/iter 101.81 ps           █    ▂      !
                  (71.04 ps … 9.09 ns) 112.06 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁
```

```
runtime: bun 1.1.33 (arm64-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
typeof                   90.79 ps/iter 101.56 ps         █   ▂   ▂     !
                 (61.04 ps … 10.29 ns) 112.06 ps ▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁█▁▁▁▁
direct                   90.38 ps/iter 101.56 ps           █         ▂ !
                  (61.04 ps … 7.02 ns) 101.81 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▇▁▁▁▁█
```

```
runtime: deno 2.0.4 (aarch64-apple-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
typeof                   88.86 ps/iter  91.55 ps           ▂    █      !
                 (61.04 ps … 12.07 ns) 101.81 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁
direct                   89.30 ps/iter  91.55 ps                █      !
                 (61.04 ps … 10.83 ns) 101.81 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
