### PR TITLE
perf(middleware/logger): optimize color status

### DIFF
--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -33,14 +33,8 @@ describe('Logger by Middleware', () => {
         Location: '/empty',
       })
     })
-    app.get('/1xx', (c) => {
-      return c.text('', 100)
-    })
     app.get('/5xx', (c) => {
       return c.text('', 511)
-    })
-    app.get('/7xx', (c) => {
-      return c.text('', 777 as never)
     })
   })
 
@@ -101,22 +95,6 @@ describe('Logger by Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(511)
     expect(log.startsWith('--> GET /5xx \x1b[31m511\x1b[0m')).toBe(true)
-    expect(log).toMatch(/m?s$/)
-  })
-
-  it('Log status 777 with empty body', async () => {
-    const res = await app.request('http://localhost/7xx')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(777)
-    expect(log.startsWith('--> GET /7xx \x1b[35m200\x1b[0m')).toBe(true)
-    expect(log).toMatch(/m?s$/)
-  })
-
-  it('Log status 100 with empty body', async () => {
-    const res = await app.request('http://localhost/1xx')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(100)
-    expect(log.startsWith('--> GET /1xx \x1b[35m100\x1b[0m')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
 })

--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -28,6 +28,20 @@ describe('Logger by Middleware', () => {
       return c.text(longRandomString)
     })
     app.get('/empty', (c) => c.text(''))
+    app.get('/redirect', (c) => {
+      return c.text('', 301, {
+        Location: '/empty',
+      })
+    })
+    app.get('/1xx', (c) => {
+      return c.text('', 100)
+    })
+    app.get('/5xx', (c) => {
+      return c.text('', 511)
+    })
+    app.get('/7xx', (c) => {
+      return c.text('', 777 as never)
+    })
   })
 
   it('Log status 200 with empty body', async () => {
@@ -62,6 +76,14 @@ describe('Logger by Middleware', () => {
     expect(log).toMatch(/1s/)
   })
 
+  it('Log status 301 with empty body', async () => {
+    const res = await app.request('http://localhost/redirect')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(301)
+    expect(log.startsWith('--> GET /redirect \x1b[36m301\x1b[0m')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
   it('Log status 404', async () => {
     const msg = 'Default 404 Not Found'
     app.all('*', (c) => {
@@ -71,6 +93,30 @@ describe('Logger by Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(404)
     expect(log.startsWith('--> GET /notfound \x1b[33m404\x1b[0m')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('Log status 511 with empty body', async () => {
+    const res = await app.request('http://localhost/5xx')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(511)
+    expect(log.startsWith('--> GET /5xx \x1b[31m511\x1b[0m')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('Log status 777 with empty body', async () => {
+    const res = await app.request('http://localhost/7xx')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(777)
+    expect(log.startsWith('--> GET /7xx \x1b[35m200\x1b[0m')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('Log status 100 with empty body', async () => {
+    const res = await app.request('http://localhost/1xx')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(100)
+    expect(log.startsWith('--> GET /1xx \x1b[35m100\x1b[0m')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
 })

--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -29,11 +29,9 @@ describe('Logger by Middleware', () => {
     })
     app.get('/empty', (c) => c.text(''))
     app.get('/redirect', (c) => {
-      return c.text('', 301, {
-        Location: '/empty',
-      })
+      return c.redirect('/empty', 301)
     })
-    app.get('/5xx', (c) => {
+    app.get('/server-error', (c) => {
       return c.text('', 511)
     })
   })
@@ -91,10 +89,10 @@ describe('Logger by Middleware', () => {
   })
 
   it('Log status 511 with empty body', async () => {
-    const res = await app.request('http://localhost/5xx')
+    const res = await app.request('http://localhost/server-error')
     expect(res).not.toBeNull()
     expect(res.status).toBe(511)
-    expect(log.startsWith('--> GET /5xx \x1b[31m511\x1b[0m')).toBe(true)
+    expect(log.startsWith('--> GET /server-error \x1b[31m511\x1b[0m')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
 })

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -28,19 +28,22 @@ const time = (start: number) => {
 
 const colorStatus = (status: number) => {
   const colorEnabled = getColorEnabled()
-  if (!colorEnabled) {
-    return `${status}`
+  if (colorEnabled) {
+    switch ((status / 100) | 0) {
+      case 5: // red = error
+        return `\x1b[31m${status}\x1b[0m`
+      case 4: // yellow = warning
+        return `\x1b[33m${status}\x1b[0m`
+      case 3: // cyan = redirect
+        return `\x1b[36m${status}\x1b[0m`
+      case 2: // green = success
+        return `\x1b[32m${status}\x1b[0m`
+    }
   }
-  switch ((status / 100) | 0) {
-    case 5: // red = error
-      return `\x1b[31m${status}\x1b[0m`
-    case 4: // yellow = warning
-      return `\x1b[33m${status}\x1b[0m`
-    case 3: // cyan = redirect
-      return `\x1b[36m${status}\x1b[0m`
-    case 2: // green = success
-      return `\x1b[32m${status}\x1b[0m`
-  }
+  // Fallback to unsupported status code.
+  // E.g.) Bun and Deno supports new Response with 101, but Node.js does not.
+  // And those may evolve to accept more status.
+  return `${status}`
 }
 
 type PrintFunc = (str: string, ...rest: string[]) => void

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -32,18 +32,14 @@ const colorStatus = (status: number) => {
     return `${status}`
   }
   switch ((status / 100) | 0) {
-    case 7: // magenta = ???
-      return `\x1b[35m${status}\x1b[0m`
     case 5: // red = error
       return `\x1b[31m${status}\x1b[0m`
+    case 4: // yellow = warning
+      return `\x1b[33m${status}\x1b[0m`
     case 3: // cyan = redirect
       return `\x1b[36m${status}\x1b[0m`
-    case 2:
-    case 1: // green = success
+    case 2: // green = success
       return `\x1b[32m${status}\x1b[0m`
-    case 4:
-    case 0: // yellow = warning
-      return `\x1b[33m${status}\x1b[0m`
   }
 }
 

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -28,19 +28,23 @@ const time = (start: number) => {
 
 const colorStatus = (status: number) => {
   const colorEnabled = getColorEnabled()
-  const out: { [key: string]: string } = {
-    7: colorEnabled ? `\x1b[35m${status}\x1b[0m` : `${status}`,
-    5: colorEnabled ? `\x1b[31m${status}\x1b[0m` : `${status}`,
-    4: colorEnabled ? `\x1b[33m${status}\x1b[0m` : `${status}`,
-    3: colorEnabled ? `\x1b[36m${status}\x1b[0m` : `${status}`,
-    2: colorEnabled ? `\x1b[32m${status}\x1b[0m` : `${status}`,
-    1: colorEnabled ? `\x1b[32m${status}\x1b[0m` : `${status}`,
-    0: colorEnabled ? `\x1b[33m${status}\x1b[0m` : `${status}`,
+  if (!colorEnabled) {
+    return `${status}`
   }
-
-  const calculateStatus = (status / 100) | 0
-
-  return out[calculateStatus]
+  switch ((status / 100) | 0) {
+    case 7: // magenta = ???
+      return `\x1b[35m${status}\x1b[0m`
+    case 5: // red = error
+      return `\x1b[31m${status}\x1b[0m`
+    case 3: // cyan = redirect
+      return `\x1b[36m${status}\x1b[0m`
+    case 2:
+    case 1: // green = success
+      return `\x1b[32m${status}\x1b[0m`
+    case 4:
+    case 0: // yellow = warning
+      return `\x1b[33m${status}\x1b[0m`
+  }
 }
 
 type PrintFunc = (str: string, ...rest: string[]) => void


### PR DESCRIPTION
This PR optimizes`colorStatus` function in Logger middleware.

Performance-wise, both `if-else` version and `switch` version is the best.
I chose `switch` version which appears cleaner  to me.

I've noticed some status codes (e.g. `700`) are unreachable, so deleted.
```
// Node
> new Response("", {status:800, statusText:"aa"})
Uncaught RangeError: init["status"] must be in the range of 200 to 599, inclusive.
    at initializeResponse (node:internal/deps/undici/undici:9030:15)
    at new Response (node:internal/deps/undici/undici:8822:9)
```

```
// Bun
> new Response("", {status:600})
2 | new Response("", {
    ^
RangeError: The status provided (600) must be 101 or in the range of [200, 599]
```

```
// Deno
> new Response("", {status:800, statusText:"aa"})

Uncaught RangeError: The status provided (800) is not equal to 101 and outside the range [200, 599]
    at initializeAResponse (ext:deno_fetch/23_response.js:183:11)
    at new Response (ext:deno_fetch/23_response.js:338:5)
    at <anonymous>:1:22
```



### Benchmark

```typescript
import { bench, run } from 'mitata'

const colorStatus = (status, colorEnabled) => {
  const out = {
    7: colorEnabled ? `\x1b[35m${status}\x1b[0m` : `${status}`,
    5: colorEnabled ? `\x1b[31m${status}\x1b[0m` : `${status}`,
    4: colorEnabled ? `\x1b[33m${status}\x1b[0m` : `${status}`,
    3: colorEnabled ? `\x1b[36m${status}\x1b[0m` : `${status}`,
    2: colorEnabled ? `\x1b[32m${status}\x1b[0m` : `${status}`,
    1: colorEnabled ? `\x1b[32m${status}\x1b[0m` : `${status}`,
    0: colorEnabled ? `\x1b[33m${status}\x1b[0m` : `${status}`,
  }
  const calculateStatus = (status / 100) | 0
  return out[calculateStatus]
}

const optDict = (status, colorEnabled) => {
  if (!colorEnabled) {
    return `${status}`
  }
  const out = {
    7: `\x1b[35m${status}\x1b[0m`,
    5: `\x1b[31m${status}\x1b[0m`,
    4: `\x1b[33m${status}\x1b[0m`,
    3: `\x1b[36m${status}\x1b[0m`,
    2: `\x1b[32m${status}\x1b[0m`,
    1: `\x1b[32m${status}\x1b[0m`,
    0: `\x1b[33m${status}\x1b[0m`,
  }
  const calculateStatus = (status / 100) | 0
  return out[calculateStatus]
}

const optIfElse = (status, colorEnabled) => {
  if (!colorEnabled) {
    return `${status}`
  }
  const calculateStatus = (status / 100) | 0
  if (calculateStatus === 7) {
    return `\x1b[35m${status}\x1b[0m`
  } else if (calculateStatus === 5) {
    return `\x1b[31m${status}\x1b[0m`
  } else if (calculateStatus === 3) {
    return `\x1b[36m${status}\x1b[0m`
  } else if (calculateStatus === 2 || calculateStatus === 1) {
    return `\x1b[32m${status}\x1b[0m`
  } else if (calculateStatus === 4 || calculateStatus === 0) {
    return `\x1b[33m${status}\x1b[0m`
  }
}
const optSwitch = (status, colorEnabled) => {
  if (!colorEnabled) {
    return `${status}`
  }
  switch ((status / 100) | 0) {
    case 7: return `\x1b[35m${status}\x1b[0m`
    case 5: return `\x1b[31m${status}\x1b[0m`
    case 3: return `\x1b[36m${status}\x1b[0m`
    case 2:
    case 1: return `\x1b[32m${status}\x1b[0m`
    case 4:
    case 0: return `\x1b[33m${status}\x1b[0m`
  }
}

bench('base', () => {
  const s = colorStatus(400, true)
})

bench('dict', () => {
  const s = optDict(400, true)
})

bench('if-else', () => {
  const s = optIfElse(400, true)
})

bench('switch', () => {
  const s = optSwitch(400, true)
})

await run()
```

282 times faster on Node:
```
runtime: node 22.4.0 (arm64-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
base                     36.09 ns/iter  34.52 ns █                    
                (32.88 ns … 160.75 ns)  69.75 ns █▄▂▁▁▁▁▁▁▁▂▂▁▁▁▁▁▁▁▁▁
dict                      9.05 ns/iter   7.79 ns █▂                   
                 (6.70 ns … 163.55 ns)  34.16 ns ██▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁
if-else                 127.68 ps/iter 132.08 ps         █             !
                (101.56 ps … 56.40 ns) 152.59 ps ▁▁▁▁▁▁▁▁█▁▁▁▇▁▁▁▁▁▁▁▁
switch                  127.49 ps/iter 122.07 ps           █           !
                (101.56 ps … 54.14 ns) 142.58 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▃▁▁▁▁▁
```

1020 times faster on Bun:
```
runtime: bun 1.1.33 (arm64-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
base                    107.27 ns/iter 103.91 ns █                    
               (101.11 ns … 196.16 ns) 162.03 ns █▆▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁
dict                     79.73 ns/iter  77.79 ns █▃                   
                (73.59 ns … 157.91 ns) 134.04 ns ██▅▂▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁
if-else                  93.71 ps/iter 101.56 ps           █         ▂ !
                 (61.04 ps … 72.85 ns) 101.81 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▇▁▁▁▁█
switch                   94.10 ps/iter 101.81 ps           ▆         █ !
                 (61.04 ps … 14.82 ns) 101.81 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▅▁▁▁▁█
```


479 times faster on Deno:

```
runtime: deno 2.0.4 (aarch64-apple-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
base                     43.71 ns/iter  48.78 ns █                    
                (38.66 ns … 167.20 ns)  64.42 ns █▆▃▁▁▁▁▂▇▃▂▂▁▁▁▁▁▁▁▁▁
dict                      9.86 ns/iter   7.82 ns █                    
                 (6.78 ns … 184.60 ns)  22.84 ns ██▁▁▁▁▁▁▁▁▁▁▄▃▂▁▁▁▁▁▁
if-else                  99.32 ps/iter 101.81 ps           █    ▆      !
                 (71.04 ps … 61.65 ns) 111.82 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁
switch                   99.70 ps/iter 101.81 ps           █    ▇      !
                 (71.04 ps … 73.63 ns) 111.82 ps ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
