### PR TITLE
perf(utils): use `| 0` instead of `Math.floor`

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -162,7 +162,7 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
         'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
       )
     }
-    cookie += `; Max-Age=${Math.floor(opt.maxAge)}`
+    cookie += `; Max-Age=${opt.maxAge | 0}`
   }
 
   if (opt.domain && opt.prefix !== 'host') {

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -74,7 +74,7 @@ export const verify = async (
   if (!isTokenHeader(header)) {
     throw new JwtHeaderInvalid(header)
   }
-  const now = Math.floor(Date.now() / 1000)
+  const now = (Date.now() / 1000) | 0
   if (payload.nbf && payload.nbf > now) {
     throw new JwtTokenNotBefore(token)
   }


### PR DESCRIPTION
`| 0` is faster than `Math.floor`

## In Node (2x~ faster)
```llvm
cpu: AMD EPYC 7763 64-Core Processor
runtime: node 20.18.0 (x64-linux)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
Use `| 0`                 4.47 ns/iter   4.19 ns █                    
                  (4.17 ns … 59.67 ns)   9.24 ns █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
Use `Math.floor`          8.45 ns/iter   6.78 ns █                    
                 (6.56 ns … 382.53 ns)  27.72 ns █▁▁▁▁▁▂▃▁▁▁▁▁▁▁▁▁▁▁▁▁
```

## In Deno (4x~ faster)
```llvm
runtime: deno 2.0.4 (x86_64-unknown-linux-gnu)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
Use `| 0`                 1.57 ns/iter   1.40 ns ▂█                   
                 (1.32 ns … 138.07 ns)   3.28 ns ██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▁
Use `Math.floor`          5.72 ns/iter   4.78 ns █                    
                  (4.64 ns … 89.83 ns)  17.58 ns █▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁
```

## In Bun (2x~ faster)
```llvm
runtime: bun 1.1.33 (x64-linux)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
Use `| 0`                 2.86 ns/iter   2.53 ns █                    
                 (2.52 ns … 233.34 ns)   5.02 ns █▁▁▁▁▁▁▁▁▁▁▁▁▂▂▁▁▁▁▁▁
Use `Math.floor`          5.30 ns/iter   4.80 ns █                    
                  (4.78 ns … 92.85 ns)   9.88 ns █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
