### PR TITLE
perf(helper/cookie): fast-path for name specified

### DIFF
--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -45,7 +45,6 @@ describe('Cookie Middleware', () => {
 
         expect(res.headers.get('Yummy-Cookie')).toBe('choco')
         expect(res.headers.get('Tasty-Cookie')).toBe('strawberry')
-        expect(res.headers.get('No-Such-Cookie')).toBeNull()
       })
     })
 
@@ -96,7 +95,6 @@ describe('Cookie Middleware', () => {
       const res = await app.request(req)
       expect(res.headers.get('Fortune-Cookie')).toBe('lots-of-money')
       expect(res.headers.get('Fruit-Cookie')).toBe('INVALID')
-      expect(res.headers.get('No-Such-Cookie')).toBeNull()
     })
 
     it('Get signed cookie', async () => {

--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -45,6 +45,7 @@ describe('Cookie Middleware', () => {
 
         expect(res.headers.get('Yummy-Cookie')).toBe('choco')
         expect(res.headers.get('Tasty-Cookie')).toBe('strawberry')
+        expect(res.headers.get('No-Such-Cookie')).toBeNull()
       })
     })
 
@@ -95,6 +96,7 @@ describe('Cookie Middleware', () => {
       const res = await app.request(req)
       expect(res.headers.get('Fortune-Cookie')).toBe('lots-of-money')
       expect(res.headers.get('Fruit-Cookie')).toBe('INVALID')
+      expect(res.headers.get('No-Such-Cookie')).toBeNull()
     })
 
     it('Get signed cookie', async () => {

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -31,6 +31,14 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBeUndefined()
   })
 
+  it('Should parse one cookie specified by name even if it is not found', () => {
+    const cookieString = 'yummy_cookie=choco; tasty_cookie = strawberry '
+    const cookie: Cookie = parse(cookieString, 'no_such_cookie')
+    expect(cookie['yummy_cookie']).toBeUndefined()
+    expect(cookie['tasty_cookie']).toBeUndefined()
+    expect(cookie['no_such_cookie']).toBeUndefined()
+  })
+
   it('Should parse cookies with no value', () => {
     const cookieString = 'yummy_cookie=; tasty_cookie = ; best_cookie= ; last_cookie=""'
     const cookie: Cookie = parse(cookieString)

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -7,7 +7,6 @@ describe('Parse cookie', () => {
     const cookie: Cookie = parse(cookieString)
     expect(cookie['yummy_cookie']).toBe('choco')
     expect(cookie['tasty_cookie']).toBe('strawberry')
-    expect(cookie['no_such_cookie']).toBeUndefined()
   })
 
   it('Should parse quoted cookie values', () => {
@@ -46,7 +45,6 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBe('')
     expect(cookie['best_cookie']).toBe('')
     expect(cookie['last_cookie']).toBe('')
-    expect(cookie['no_such_cookie']).toBeUndefined()
   })
 
   it('Should parse cookies but not process signed cookies', () => {
@@ -58,7 +56,6 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBe('strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig=')
     expect(cookie['great_cookie']).toBe('rating3.5')
     expect(cookie['best_cookie']).toBe('sugar.valueShapedLikeASignatureButIsNotASignature=')
-    expect(cookie['no_such_cookie']).toBeUndefined()
   })
 
   it('Should ignore invalid cookie names', () => {

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -7,6 +7,7 @@ describe('Parse cookie', () => {
     const cookie: Cookie = parse(cookieString)
     expect(cookie['yummy_cookie']).toBe('choco')
     expect(cookie['tasty_cookie']).toBe('strawberry')
+    expect(cookie['no_such_cookie']).toBeUndefined()
   })
 
   it('Should parse quoted cookie values', () => {
@@ -37,6 +38,7 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBe('')
     expect(cookie['best_cookie']).toBe('')
     expect(cookie['last_cookie']).toBe('')
+    expect(cookie['no_such_cookie']).toBeUndefined()
   })
 
   it('Should parse cookies but not process signed cookies', () => {
@@ -48,6 +50,7 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBe('strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig=')
     expect(cookie['great_cookie']).toBe('rating3.5')
     expect(cookie['best_cookie']).toBe('sugar.valueShapedLikeASignatureButIsNotASignature=')
+    expect(cookie['no_such_cookie']).toBeUndefined()
   })
 
   it('Should ignore invalid cookie names', () => {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -78,16 +78,17 @@ const validCookieValueRegEx = /^[ !#-:<-[\]-~]*$/
 
 export const parse = (cookie: string, name?: string): Cookie => {
   const pairs = cookie.trim().split(';')
-  return pairs.reduce((parsedCookie, pairStr) => {
+  const parsedCookie: Cookie = {}
+  for (let pairStr of pairs) {
     pairStr = pairStr.trim()
     const valueStartPos = pairStr.indexOf('=')
     if (valueStartPos === -1) {
-      return parsedCookie
+      continue
     }
 
     const cookieName = pairStr.substring(0, valueStartPos).trim()
     if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
-      return parsedCookie
+      continue
     }
 
     let cookieValue = pairStr.substring(valueStartPos + 1).trim()
@@ -96,10 +97,13 @@ export const parse = (cookie: string, name?: string): Cookie => {
     }
     if (validCookieValueRegEx.test(cookieValue)) {
       parsedCookie[cookieName] = decodeURIComponent_(cookieValue)
+      if (name) {
+        // Fast-path: return only the demanded-key immediately. Other keys are not needed.
+        break
+      }
     }
-
-    return parsedCookie
-  }, {} as Cookie)
+  }
+  return parsedCookie
 }
 
 export const parseSigned = async (

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -77,6 +77,10 @@ const validCookieNameRegEx = /^[\w!#$%&'*.^`|~+-]+$/
 const validCookieValueRegEx = /^[ !#-:<-[\]-~]*$/
 
 export const parse = (cookie: string, name?: string): Cookie => {
+  if (name && cookie.indexOf(name) === -1) {
+    // Fast-path: return immediately if the demanded-key is not in the cookie string
+    return {}
+  }
   const pairs = cookie.trim().split(';')
   const parsedCookie: Cookie = {}
   for (let pairStr of pairs) {


### PR DESCRIPTION
I find myself using `getCookie(c, 'name')` a lot, so I want to make it faster.
In this PR,

- `Array.reduce` is replaced with plain `for-of` loop, which is a bit faster and allows early return
- Two early returns (fast-paths) are added for the cases where `name` is specified


Overall, the optimized version is faster in all three cases

- When parse-all cookie, a bit faster (1-2%).
- When the `name` is specified and
    - found in cookie, several times faster (depending on cookie length and key position, though)
    - not found in cookie, a lot more faster


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Benchmark

<details>
<summary>benchmark code</summary>

```typescript
import { bench, run } from 'mitata'

const decodeURIComponent_ = decodeURIComponent
const validCookieNameRegEx = /^[\w!#$%&'*.^`|~+-]+$/
const validCookieValueRegEx = /^[ !#-:<-[\]-~]*$/

const baseParse = (cookie, name) => {
  const pairs = cookie.trim().split(';')
  return pairs.reduce((parsedCookie, pairStr) => {
    pairStr = pairStr.trim()
    const valueStartPos = pairStr.indexOf('=')
    if (valueStartPos === -1) {
      return parsedCookie
    }

    const cookieName = pairStr.substring(0, valueStartPos).trim()
    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
      return parsedCookie
    }

    let cookieValue = pairStr.substring(valueStartPos + 1).trim()
    if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
      cookieValue = cookieValue.slice(1, -1)
    }
    if (validCookieValueRegEx.test(cookieValue)) {
      parsedCookie[cookieName] = decodeURIComponent_(cookieValue)
    }

    return parsedCookie
  }, {})
}

export const optimizedParse = (cookie, name) => {
  if (name && cookie.indexOf(name) === -1) {
    // Fast-path: return the single-key object of the provided name
    return {}
  }
  const pairs = cookie.trim().split(';')
  const parsedCookie = {}
  for (const _pairStr of pairs) {
    const pairStr = _pairStr.trim()
    const valueStartPos = pairStr.indexOf('=')
    if (valueStartPos === -1) {
      continue
    }

    const cookieName = pairStr.substring(0, valueStartPos).trim()
    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
      continue
    }

    let cookieValue = pairStr.substring(valueStartPos + 1).trim()
    if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
      cookieValue = cookieValue.slice(1, -1)
    }
    if (validCookieValueRegEx.test(cookieValue)) {
      parsedCookie[cookieName] = decodeURIComponent_(cookieValue)
      if (name) {
        // Fast-path: return the single-key object of the provided name
        break
      }
    }
  }
  return parsedCookie
}

const cookieString = 'yummy_cookie=chocolate; tasty_cookie=strawberry; great_cookie=oreo; bad_cookie=raisin; ok_cookie=vanilla; ugly_cookie=peanut; nice_cookie=macadamia; japanese_cookie=matcha; chinese_cookie=red bean; korean_cookie=rice cake; american_cookie=chocolate chip; italian_cookie=cannoli; french_cookie=macaron; german_cookie=lebkuchen;'

bench('base all', () => {
  const s = baseParse(cookieString)
})
bench('base name found', () => {
  const s = baseParse(cookieString, 'yummy_cookie')
})
bench('base name not found', () => {
  const s = baseParse(cookieString, 'no_such_cookie')
})
bench('opt all', () => {
  const s = optimizedParse(cookieString)
})
bench('opt name found', () => {
  const s = optimizedParse(cookieString, 'yummy_cookie')
})
bench('opt name not found', () => {
  const s = optimizedParse(cookieString, 'no_such_cookie')
})

await run()
```
</details>


```
runtime: node 22.4.0 (arm64-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
base all                  3.87 µs/iter   3.93 µs   ▄   █▄   █      ▄  
                   (3.76 µs … 4.00 µs)   4.00 µs █▅██████▅▁▅█▅▅▅▁█▅█▅▁
base name found         811.98 ns/iter 825.36 ns         █▂           
               (758.14 ns … 872.27 ns) 865.90 ns ▂▂▁▁▂▂▂███▄▄▅▅▃▅▃▂▂▁▁
base name not found     596.51 ns/iter 607.47 ns        ▃█            
               (547.59 ns … 668.62 ns) 651.10 ns ▁▂▂▁▂▁▁███▃▅█▄▂▂▂▂▁▁▁
opt all                   3.85 µs/iter   3.89 µs     ▄▄▄  ▄ █         
                   (3.73 µs … 4.00 µs)   3.99 µs █▅█▁███▁█████▅▅▅█▁▅█▁
opt name found          309.37 ns/iter 309.96 ns █▄                   
               (303.07 ns … 376.55 ns) 354.06 ns ██▆▄▃▂▂▁▁▁▁▁▁▁▂▁▁▁▁▁▁
opt name not found      115.38 ns/iter 115.02 ns █                    
               (113.52 ns … 159.12 ns) 134.62 ns ██▃▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁
```
```
runtime: bun 1.1.33 (arm64-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
base all                  4.03 µs/iter   4.08 µs  ▅█                  
                   (3.82 µs … 4.52 µs)   4.50 µs ▄██▄▆▁▁▁▃▁▁▁▁▁▁▁▁▃▆▄▃
base name found           1.36 µs/iter   1.37 µs         █            
                   (1.16 µs … 1.60 µs)   1.57 µs ▁▁▁▁▂▁▁▆██▆▃▃▂▁▁▁▁▂▃▂
base name not found       1.08 µs/iter   1.11 µs          █           
                 (956.42 ns … 1.18 µs)   1.17 µs ▁▁▁▁▁▁▂▁▅██▅▄▄▃▆▆▄▂▁▁
opt all                   3.94 µs/iter   3.87 µs     █                
                   (3.62 µs … 4.51 µs)   4.51 µs ▂▁▁▂█▆▃▁▁▁▁▂▁▁▁▁▁▁▄▃▁
opt name found          293.67 ns/iter 290.44 ns █▇                   
               (273.91 ns … 695.67 ns) 659.94 ns ██▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
opt name not found      143.82 ns/iter 145.19 ns ▅█                   
               (140.40 ns … 211.33 ns) 158.55 ns ███▄▃▃▄▃▃▃▂▂▂▁▁▁▁▁▁▁▁
```
```
runtime: deno 2.0.4 (aarch64-apple-darwin)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
base all                  3.77 µs/iter   3.80 µs     █  ▂▅▂           
                   (3.67 µs … 3.91 µs)   3.90 µs ▇▄▇▄█▇▇███▄▄▇▄▄▄▇▄▁▁▄
base name found         822.18 ns/iter 825.56 ns        █▇            
               (773.38 ns … 905.11 ns) 888.21 ns ▂▂▂▁▁▁▂███▄▃▃▁▂▂▁▁▁▂▁
base name not found     618.17 ns/iter 627.11 ns        ▃█▂           
               (553.50 ns … 736.12 ns) 692.33 ns ▁▂▂▁▁▁▁███▆▅▄▃▃▂▂▁▁▂▁
opt all                   3.68 µs/iter   3.69 µs  ▅▂▂█▂▂ ▂            
                   (3.64 µs … 3.78 µs)   3.76 µs ▄██████▇█▇▁▄▄▇▄▄▁▇▁▁▁
opt name found          303.38 ns/iter 307.35 ns  █                   
               (293.99 ns … 405.34 ns) 341.54 ns ▆█▆▄▄▆▅▂▃▂▁▂▂▁▁▂▁▁▁▁▁
opt name not found      115.66 ns/iter 115.95 ns █                    
               (113.24 ns … 147.32 ns) 134.09 ns ██▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁
```