### PR TITLE
ci: Hide noisy "Unchanged files with check annotations"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+      - name: Hide noisy "Unchanged files with check annotations"
+        if: github.event_name == 'push'
+        run: |
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.1.16'


### PR DESCRIPTION
This PR attempts to remove noisy "Unchanged files with check annotations" in PRs.
That annotations are generated during push tom main branch, but not useful since `eslint-disable-next-line` are ignored somehow 🤷‍♂️ 
<img width="631" alt="image" src="https://github.com/user-attachments/assets/503635a5-c5a8-43ef-b209-7170a520ef37">

Ref. https://github.com/actions/setup-node/issues/72


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
