### PR TITLE
[PoC] feat: generate TanStack Query Options from Hono Client functions

### DIFF
--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,6 +1,11 @@
+import { Hono } from '../hono'
+import { hc } from './client'
 import {
   buildSearchParams,
   deepMerge,
+  getQueryFn,
+  getQueryKey,
+  getQueryOptions,
   mergePath,
   removeIndexString,
   replaceUrlParam,
@@ -136,6 +141,112 @@ describe('deepMerge', () => {
       params: undefined,
       headers: { hono: '2', demo: 2 },
       timeout: 2,
+    })
+  })
+})
+
+describe('TanStack Query Helper Functions', () => {
+  // Setup a sample Hono app for testing
+  const app = new Hono()
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const route = app
+    .get('/users/:id', (c) => {
+      return c.json({
+        id: c.req.param('id'),
+        name: 'John Doe',
+      })
+    })
+    .get('/posts', (c) => {
+      return c.json([
+        { id: 1, title: 'Post 1' },
+        { id: 2, title: 'Post 2' },
+      ])
+    })
+
+  type AppType = typeof route
+  const client = hc<AppType>('http://localhost')
+
+  describe('getQueryKey', () => {
+    it('should generate correct query key for simple endpoints', () => {
+      const key = getQueryKey(() => client.posts.$get())
+      expect(key).toEqual(['posts.$get()', undefined])
+    })
+
+    it('should generate correct query key for parameterized endpoints', () => {
+      const userId = '123'
+      const key = getQueryKey(() => client.users[':id'].$get({ param: { id: userId } }), [userId])
+      expect(key).toEqual(['users[":id"].$get({ param: { id: userId } })', '123'])
+    })
+
+    it('should include all provided key complements', () => {
+      const key = getQueryKey(() => client.posts.$get(), ['extra1', 'extra2'])
+      expect(key).toEqual(['posts.$get()', 'extra1', 'extra2'])
+    })
+  })
+
+  describe('getQueryFn', () => {
+    it('should return a function that makes the API call', async () => {
+      const queryFn = getQueryFn(() => client.posts.$get())
+      expect(queryFn).toBeInstanceOf(Function)
+    })
+
+    it('should throw error for non-ok responses', async () => {
+      const queryFn = getQueryFn(
+        () => Promise.resolve(new Response(null, { status: 500 })) as unknown
+      )
+      await expect(queryFn()).rejects.toThrow('server error')
+    })
+
+    it('should return parsed JSON data for successful responses', async () => {
+      const mockData = { success: true }
+      const queryFn = getQueryFn(
+        () =>
+          Promise.resolve(
+            new Response(JSON.stringify(mockData), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          ) as unknown
+      )
+      const result = await queryFn()
+      expect(result).toEqual(mockData)
+    })
+  })
+
+  describe('getQueryOptions', () => {
+    it('should return combined queryKey and queryFn', () => {
+      const userId = '123'
+      const options = getQueryOptions(
+        () => client.users[':id'].$get({ param: { id: userId } }),
+        [userId]
+      )
+
+      expect(options).toHaveProperty('queryKey')
+      expect(options).toHaveProperty('queryFn')
+      expect(options.queryKey).toEqual(['users[":id"].$get({ param: { id: userId } })', '123'])
+      expect(options.queryFn).toBeInstanceOf(Function)
+    })
+
+    it('should handle undefined keyComplement', () => {
+      const options = getQueryOptions(() => client.posts.$get())
+      expect(options.queryKey).toEqual(['posts.$get()', undefined])
+      expect(options.queryFn).toBeInstanceOf(Function)
+    })
+
+    it('should work with the returned queryFn', async () => {
+      const mockData = { success: true }
+      const options = getQueryOptions(
+        () =>
+          Promise.resolve(
+            new Response(JSON.stringify(mockData), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          ) as unknown
+      )
+
+      const result = await options.queryFn()
+      expect(result).toEqual(mockData)
     })
   })
 })

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -136,7 +136,7 @@ export function getQueryFn<T extends () => unknown>(fn: T) {
  * {
  *   queryKey: [
  *     "dashboard.deployments.user[\":userId\"].$get({ param: { userId } })",
- *     "0h2s23e0uppe1ee"
+ *     "6h8s62e7uppe4ee"
  *   ],
  *   queryFn: async (): Promise<ResType> => {
  *     const res = await api.dashboard.deployments.user[':userId'].$get({ param: { userId } };

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -93,7 +93,7 @@ export function getQueryKey<T extends () => unknown>(
   keyComplement: unknown[] = [undefined]
 ) {
   const queryKeyString = fn.toString().split('.').slice(1).join('.')
-  return [queryKeyString, ...keyComplement]
+  return [queryKeyString, ...keyComplement].filter(Boolean)
 }
 
 /**


### PR DESCRIPTION
It seems from my research that Hono misses that last tiny bit of functionality for a seamless integration of Hono RPC with TanStack Query.

### Problem:

The "problem" now is that we need to write [queryKeys](https://tanstack.com/query/v5/docs/framework/react/guides/query-keys) and [queryFunctions](https://tanstack.com/query/v5/docs/framework/react/guides/query-functions) for all routes, as is done [here](https://github.com/betterstack-community/betternews-hono-tanstack/blob/main/frontend/src/lib/api.ts). It seems cumbersome and redundant to add React Query helper functions for all routes when they are all available on the Hono client.

According to [this comment](https://github.com/honojs/hono/issues/727#issuecomment-1378814366) this is missing to a few people and a [selling point for tRPC](https://trpc.io/docs/client/react) over Hono RPC. 

### Proposed solution:

I tried to generate Tanstack [queryKey](https://tanstack.com/query/v5/docs/framework/react/guides/query-keys), [queryFn](https://tanstack.com/query/v5/docs/framework/react/guides/query-functions) and [queryOptions](https://tanstack.com/query/v5/docs/framework/react/guides/query-options) by reusing as much of the autocompletion that Hono client provides.

In your frontend code you can do the following: 
```tsx
queryClient.fetchQuery(
    getQueryOptions(
        () => api.dashboard.deployments.user[':userId'].$get({ param: { userId } }), // the RPC endpoint you're targeting
        [userId] // a complement you might want to add to the queryKey 
    )
)
``` 
and this will seamlessly generate the query key and function pair that you need when using React Query:
```tsx
{
  queryKey: [
    "dashboard.deployments.user[\":userId\"].$get({ param: { userId } })", // this is static (variables are passed by name, like userId here)
    "6h8s62e7uppe4ee" // this is dynamic (variables are passed by value, userId has been replaced by "6h8s62e7uppe4ee")
  ],
  queryFn: async (): Promise<ResType> => {
    const res = await api.dashboard.deployments.user[':userId'].$get({ param: { userId } };
    if (!res.ok) {
      throw new Error("server error");
    }
    const data = await res.json();
    return data;
  }
}
```

### Further improvement:

Add a parameter to pass extra [queryOptions](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) to `getQueryOptions`. 
I think it means we need to import types from React Query, which is probably not wanted in this repo. 


### Caveat:

I'm aware that my approach is a bit basic, that I'm not a typescript ninja, and that I probably put the code in the wrong place. Also, I only tested it using React.

I'm very open to your feedback and to the code being improved.

### Thanks

Please let me know what you think, I think it would be a great addition for the many, many Tanstack Query users.


### The author should do the following, if applicable

- [ ✅ ] Add tests
- [ ✅ ] Run tests
- [ ✅ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ✅ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
