### PR TITLE
fix(serveStatic): add guard to prevent reading empty folders

### DIFF
--- a/runtime-tests/deno/middleware.test.tsx
+++ b/runtime-tests/deno/middleware.test.tsx
@@ -139,6 +139,22 @@ Deno.test('Serve Static middleware', async () => {
   res = await app.request('http://localhost/static-absolute-root/plain.txt')
   assertEquals(res.status, 200)
   assertEquals(await res.text(), 'Deno!')
+
+  res = await app.request('http://localhost/static')
+  assertEquals(res.status, 404)
+  assertEquals(await res.text(), '404 Not Found')
+
+  res = await app.request('http://localhost/static/dir')
+  assertEquals(res.status, 404)
+  assertEquals(await res.text(), '404 Not Found')
+
+  res = await app.request('http://localhost/static/helloworld/nested')
+  assertEquals(res.status, 404)
+  assertEquals(await res.text(), '404 Not Found')
+
+  res = await app.request('http://localhost/static/helloworld/../')
+  assertEquals(res.status, 404)
+  assertEquals(await res.text(), '404 Not Found')
 })
 
 Deno.test('JWT Authentication middleware', async () => {

--- a/src/adapter/deno/deno.d.ts
+++ b/src/adapter/deno/deno.d.ts
@@ -76,4 +76,12 @@ declare namespace Deno {
      */
     idleTimeout?: number
   }
+
+  /**
+   * Get stats asynchronously for the specified path.
+   *
+   * @param path The path to get stats.
+   * @returns A promise that resolves to Stats object.
+   */
+  export function stat(path: string): Promise<StatsLike>
 }

--- a/src/adapter/deno/deno.d.ts
+++ b/src/adapter/deno/deno.d.ts
@@ -76,12 +76,4 @@ declare namespace Deno {
      */
     idleTimeout?: number
   }
-
-  /**
-   * Get stats asynchronously for the specified path.
-   *
-   * @param path The path to get stats.
-   * @returns A promise that resolves to Stats object.
-   */
-  export function stat(path: string): Promise<StatsLike>
 }

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -2,7 +2,7 @@ import type { ServeStaticOptions } from '../../middleware/serve-static'
 import { serveStatic as baseServeStatic } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
 
-const { open, lstatSync, errors, stat } = Deno
+const { open, lstatSync, errors } = Deno
 
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E>
@@ -10,8 +10,7 @@ export const serveStatic = <E extends Env = Env>(
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {
       try {
-        const fileInfo = await stat(path)
-        if (fileInfo.isDirectory) {
+        if (isDir(path)) {
           return null
         }
 
@@ -35,6 +34,7 @@ export const serveStatic = <E extends Env = Env>(
       } catch {}
       return isDir
     }
+
     return baseServeStatic({
       ...options,
       getContent,

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -2,7 +2,7 @@ import type { ServeStaticOptions } from '../../middleware/serve-static'
 import { serveStatic as baseServeStatic } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
 
-const { open, lstatSync, errors } = Deno
+const { open, lstatSync, errors, stat } = Deno
 
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E>
@@ -10,6 +10,11 @@ export const serveStatic = <E extends Env = Env>(
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {
       try {
+        const fileInfo = await stat(path)
+        if (fileInfo.isDirectory) {
+          return null
+        }
+
         const file = await open(path)
         return file.readable
       } catch (e) {


### PR DESCRIPTION
https://github.com/honojs/hono/issues/3628

This PR addresses an issue where attempting to open an empty directory with `Deno.open` returns a `ReadableStream`, causing unexpected behavior. Specifically, it leads to a status code `200` instead of the expected 404 for directories.

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

