### PR TITLE
refactor(hono-base): use object abbreviation notation

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -377,7 +377,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   #addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
     path = mergePath(this._basePath, path)
-    const r: RouterRoute = { path: path, method: method, handler: handler }
+    const r: RouterRoute = { path, method, handler }
     this.router.add(method, path, [handler, r])
     this.routes.push(r)
   }


### PR DESCRIPTION
Some minifiers have smaller bundle sizes, and readability will also increase.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
