### PR TITLE
perf(trie-router): optimize and remove unnecessary processes

### DIFF
--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -154,7 +154,7 @@ export class Node<T> {
           // '/hello/*/foo' => match /hello/bar/foo
           if (pattern === '*') {
             const astNode = node.children['*']
-            if (node.children['*']) {
+            if (astNode) {
               handlerSets.push(
                 ...this.#getHandlerSets(astNode, method, node.params, Object.create(null))
               )

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -63,10 +63,6 @@ export class Node<T> {
       curNode = curNode.children[p]
     }
 
-    if (!curNode.methods.length) {
-      curNode.methods = []
-    }
-
     const m: Record<string, HandlerSet<T>> = Object.create(null)
 
     const handlerSet: HandlerSet<T> = {
@@ -82,7 +78,7 @@ export class Node<T> {
   }
 
   // getHandlerSets
-  #gHSets(
+  #getHandlerSets(
     node: Node<T>,
     method: string,
     nodeParams: Record<string, string>,
@@ -92,7 +88,7 @@ export class Node<T> {
     for (let i = 0, len = node.methods.length; i < len; i++) {
       const m = node.methods[i]
       const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T>
-      const processedSet: Record<string, boolean> = Object.create(null)
+      const processedSet: Record<number, boolean> = {}
       if (handlerSet !== undefined) {
         handlerSet.params = Object.create(null)
         for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
@@ -131,12 +127,15 @@ export class Node<T> {
           nextNode.params = node.params
           if (isLast) {
             // '/hello/*' => match '/hello'
-            if (nextNode.children['*']) {
+            const astNode = nextNode.children['*']
+            if (astNode) {
               handlerSets.push(
-                ...this.#gHSets(nextNode.children['*'], method, node.params, Object.create(null))
+                ...this.#getHandlerSets(astNode, method, node.params, Object.create(null))
               )
             }
-            handlerSets.push(...this.#gHSets(nextNode, method, node.params, Object.create(null)))
+            handlerSets.push(
+              ...this.#getHandlerSets(nextNode, method, node.params, Object.create(null))
+            )
           } else {
             tempNodes.push(nextNode)
           }
@@ -152,7 +151,9 @@ export class Node<T> {
           if (pattern === '*') {
             const astNode = node.children['*']
             if (astNode) {
-              handlerSets.push(...this.#gHSets(astNode, method, node.params, Object.create(null)))
+              handlerSets.push(
+                ...this.#getHandlerSets(astNode, method, node.params, Object.create(null))
+              )
               tempNodes.push(astNode)
             }
             continue
@@ -170,24 +171,21 @@ export class Node<T> {
           const restPathString = parts.slice(i).join('/')
           if (matcher instanceof RegExp && matcher.test(restPathString)) {
             params[name] = restPathString
-            handlerSets.push(...this.#gHSets(child, method, node.params, params))
+            handlerSets.push(...this.#getHandlerSets(child, method, node.params, params))
             continue
           }
 
           if (matcher === true || matcher.test(part)) {
-            if (typeof key === 'string') {
-              params[name] = part
-              if (isLast) {
-                handlerSets.push(...this.#gHSets(child, method, params, node.params))
-                if (child.children['*']) {
-                  handlerSets.push(
-                    ...this.#gHSets(child.children['*'], method, params, node.params)
-                  )
-                }
-              } else {
-                child.params = params
-                tempNodes.push(child)
+            params[name] = part
+            if (isLast) {
+              handlerSets.push(...this.#getHandlerSets(child, method, params, node.params))
+              const astNode = child.children['*']
+              if (astNode) {
+                handlerSets.push(...this.#getHandlerSets(astNode, method, params, node.params))
               }
+            } else {
+              child.params = params
+              tempNodes.push(child)
             }
           }
         }

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -127,10 +127,14 @@ export class Node<T> {
           nextNode.params = node.params
           if (isLast) {
             // '/hello/*' => match '/hello'
-            const astNode = nextNode.children['*']
-            if (astNode) {
+            if (nextNode.children['*']) {
               handlerSets.push(
-                ...this.#getHandlerSets(astNode, method, node.params, Object.create(null))
+                ...this.#getHandlerSets(
+                  nextNode.children['*'],
+                  method,
+                  node.params,
+                  Object.create(null)
+                )
               )
             }
             handlerSets.push(
@@ -150,7 +154,7 @@ export class Node<T> {
           // '/hello/*/foo' => match /hello/bar/foo
           if (pattern === '*') {
             const astNode = node.children['*']
-            if (astNode) {
+            if (node.children['*']) {
               handlerSets.push(
                 ...this.#getHandlerSets(astNode, method, node.params, Object.create(null))
               )
@@ -179,9 +183,10 @@ export class Node<T> {
             params[name] = part
             if (isLast) {
               handlerSets.push(...this.#getHandlerSets(child, method, params, node.params))
-              const astNode = child.children['*']
-              if (astNode) {
-                handlerSets.push(...this.#getHandlerSets(astNode, method, params, node.params))
+              if (child.children['*']) {
+                handlerSets.push(
+                  ...this.#getHandlerSets(child.children['*'], method, params, node.params)
+                )
               }
             } else {
               child.params = params


### PR DESCRIPTION
1. The following process is not necessary and has been removed.

https://github.com/honojs/hono/pull/3647/files#diff-bf1549ba9405f87c376d2d338883f54bfeb6a91f40b28e62dd2ce5e9d4edd4e5L66-L69

2. Since it will be minified, I changed the name to be easy to understand.

Related: https://github.com/honojs/hono/pull/3596

https://github.com/honojs/hono/pull/3647/files#diff-bf1549ba9405f87c376d2d338883f54bfeb6a91f40b28e62dd2ce5e9d4edd4e5L85

3. Since only the type number is used for the key, an empty object should be created instead of `Object.create(null)`. It is faster and smaller.

Node and Bun (8x~ faster)
```llvm
runtime: node 20.18.0 (x64-linux)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
= Object.create(null)    16.67 ns/iter  15.13 ns  █                   
                 (13.54 ns … 96.35 ns)  42.71 ns ▇█▂▁▂▂▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁
= {}                      2.41 ns/iter   2.22 ns  █                   
                  (1.84 ns … 95.40 ns)   8.21 ns ▁█▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
```

```llvm
runtime: deno 2.0.5 (x86_64-unknown-linux-gnu)

benchmark              avg (min … max) p75   p99    (min … top 1%)
-------------------------------------- -------------------------------
= Object.create(null)    16.64 ns/iter  14.93 ns  █                   
                (12.03 ns … 137.93 ns)  33.21 ns ▁██▃▁▁▁▁▁▁▁▁▁▁▅▂▁▁▁▁▁
= {}                      2.70 ns/iter   2.19 ns █                    
                  (2.03 ns … 62.84 ns)  16.17 ns █▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
```
In Bun, the speed of both is almost the same.

https://github.com/honojs/hono/pull/3647/files#diff-bf1549ba9405f87c376d2d338883f54bfeb6a91f40b28e62dd2ce5e9d4edd4e5L95

~~4. Multiple index accesses are eliminated and the size is reduced.~~

~~https://github.com/honojs/hono/pull/3647/files#diff-bf1549ba9405f87c376d2d338883f54bfeb6a91f40b28e62dd2ce5e9d4edd4e5R130~~

5. Remove as it is not a necessary check

https://github.com/honojs/hono/pull/3647/files#diff-bf1549ba9405f87c376d2d338883f54bfeb6a91f40b28e62dd2ce5e9d4edd4e5L178

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
