### PR TITLE
fix(middleware/combine): prevent `c.req.routeIndex` from being changed

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,4 @@
 import { Context } from './context'
-import type { ParamIndexMap, Params } from './router'
 import type { Env, ErrorHandler, NotFoundHandler } from './types'
 
 /**
@@ -31,7 +30,7 @@ interface ComposeContext {
  * @returns {(context: C, next?: Function) => Promise<C>} - A composed middleware function.
  */
 export const compose = <C extends ComposeContext, E extends Env = Env>(
-  middleware: [[Function, unknown], ParamIndexMap | Params][],
+  middleware: [[Function, unknown], unknown][] | [[Function]][],
   onError?: ErrorHandler<E>,
   onNotFound?: NotFoundHandler<E>
 ): ((context: C, next?: Function) => Promise<C>) => {

--- a/src/middleware/combine/index.test.ts
+++ b/src/middleware/combine/index.test.ts
@@ -166,6 +166,22 @@ describe('every', () => {
     expect(await res.text()).toBe('Hello Middleware 1')
     expect(middleware2).not.toBeCalled()
   })
+
+  it('Should pass the path params to middlewares', async () => {
+    const app = new Hono()
+    app.use('*', nextMiddleware)
+    const paramMiddleware: MiddlewareHandler = async (c) => {
+      return c.json(c.req.param(), 200)
+    }
+
+    app.use('/:id', every(paramMiddleware))
+    app.get('/:id', (c) => {
+      return c.text('Hello World')
+    })
+
+    const res = await app.request('http://localhost/123')
+    expect(await res.json()).toEqual({ id: '123' })
+  })
 })
 
 describe('except', () => {


### PR DESCRIPTION
fixes #3657

As I also refactored the relevant parts, there are a lot of changes, but the key point is that c.req.routeIndex must not be changed’ in the following line.

https://github.com/honojs/hono/compare/main...usualoma:hono:fix/conbine-every-route-index?expand=1#diff-0127ebff640ea2834e4434792875961100daac21bcdaae2d033a6a59815da3bfR98


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
