### PR TITLE
fix: Private name "#errorHandler" must be declared in an enclosing class

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -184,6 +184,10 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   #notFoundHandler: NotFoundHandler = notFoundHandler
   #errorHandler: ErrorHandler = errorHandler
 
+  get errorHandler() {
+    return this.#errorHandler
+  }
+
   /**
    * `.route()` allows grouping other Hono instance in routes.
    *
@@ -214,11 +218,11 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     const subApp = this.basePath(path)
     app.routes.map((r) => {
       let handler
-      if (app.#errorHandler === errorHandler) {
+      if (app.errorHandler === errorHandler) {
         handler = r.handler
       } else {
         handler = async (c: Context, next: Next) =>
-          (await compose<Context>([], app.#errorHandler)(c, () => r.handler(c, next))).res
+          (await compose<Context>([], app.errorHandler)(c, () => r.handler(c, next))).res
         ;(handler as any)[COMPOSED_HANDLER] = r.handler
       }
 


### PR DESCRIPTION
This PR fixes https://github.com/honojs/hono/issues/3671

on `hono-base.ts` the `route` method accepts `app: Hono<SubEnv, SubSchema, SubBasePath>`, so when using the `app` instance we don't have access on private methods.

before the `errorHandler` propery was `private errorHandler` (only valid on typescript) but now is `#errorHandler`, so is not  accessible  anymore.

related: https://github.com/honojs/hono/pull/3596

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
