### PR TITLE
feat(css): add CSP nonce to hono/css related style and script tags

### DIFF
--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -130,7 +130,7 @@ Deno.test('JSX: css with CSP nonce', async () => {
   const htmlEscapedString = 'callbacks' in awaitedHtml ? awaitedHtml : await awaitedHtml.toString()
   assertEquals(
     await resolveCallback(htmlEscapedString, HtmlEscapedCallbackPhase.Stringify, false, {}),
-    '<html><head><style nonce="1234" id="hono-css">.css-3142110215{color:red}</style></head><body><div class="css-3142110215"></div></body></html>'
+    '<html><head><style id="hono-css" nonce="1234">.css-3142110215{color:red}</style></head><body><div class="css-3142110215"></div></body></html>'
   )
 })
 

--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -111,6 +111,29 @@ Deno.test('JSX: css', async () => {
   )
 })
 
+Deno.test('JSX: css with CSP nonce', async () => {
+  const className = css`
+    color: red;
+  `
+  const html = (
+    <html>
+      <head>
+        <Style nonce='1234' />
+      </head>
+      <body>
+        <div class={className}></div>
+      </body>
+    </html>
+  )
+
+  const awaitedHtml = await html
+  const htmlEscapedString = 'callbacks' in awaitedHtml ? awaitedHtml : await awaitedHtml.toString()
+  assertEquals(
+    await resolveCallback(htmlEscapedString, HtmlEscapedCallbackPhase.Stringify, false, {}),
+    '<html><head><style nonce="1234" id="hono-css">.css-3142110215{color:red}</style></head><body><div class="css-3142110215"></div></body></html>'
+  )
+})
+
 Deno.test('JSX: normalize key', async () => {
   const className = <div className='foo'></div>
   const htmlFor = <div htmlFor='foo'></div>

--- a/src/helper/css/common.case.test.tsx
+++ b/src/helper/css/common.case.test.tsx
@@ -488,6 +488,21 @@ export const renderTest = (
           '<style id="hono-css">.css-478287868{padding:0}</style><h1 class="css-478287868">Hello!</h1>'
         )
       })
+
+      it('Should render CSS styles with CSP nonce', async () => {
+        const headerClass = css`
+          background-color: blue;
+        `
+        const template = (
+          <>
+            <Style nonce='1234' />
+            <h1 class={headerClass}>Hello!</h1>
+          </>
+        )
+        expect(await toString(template)).toBe(
+          '<style id="hono-css" nonce="1234">.css-2458908649{background-color:blue}</style><h1 class="css-2458908649">Hello!</h1>'
+        )
+      })
     })
   })
 }

--- a/src/helper/css/index.test.tsx
+++ b/src/helper/css/index.test.tsx
@@ -239,6 +239,23 @@ describe('CSS Helper', () => {
       })
     })
 
+    app.get('/stream-with-nonce', (c) => {
+      const stream = renderToReadableStream(
+        <>
+          <Style nonce='1234' />
+          <Suspense fallback={<p>Loading...</p>}>
+            <h1 class={headerClass}>Hello!</h1>
+          </Suspense>
+        </>
+      )
+      return c.body(stream, {
+        headers: {
+          'Content-Type': 'text/html; charset=UTF-8',
+          'Transfer-Encoding': 'chunked',
+        },
+      })
+    })
+
     it('/sync', async () => {
       const res = await app.request('http://localhost/sync')
       expect(res).not.toBeNull()
@@ -255,6 +272,22 @@ describe('CSS Helper', () => {
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:0')
+if(!d)return
+do{n=d.nextSibling;n.remove()}while(n.nodeType!=8||n.nodeValue!='/$')
+d.replaceWith(c.content)
+})(document)
+</script>`
+      )
+    })
+
+    it('/stream-with-nonce', async () => {
+      const res = await app.request('http://localhost/stream-with-nonce')
+      expect(res).not.toBeNull()
+      expect(await res.text()).toBe(
+        `<style id="hono-css" nonce="1234"></style><template id="H:1"></template><p>Loading...</p><!--/$--><script nonce="1234">document.querySelector('#hono-css').textContent+=".css-2458908649{background-color:blue}"</script><template data-hono-target="H:1"><h1 class="css-2458908649">Hello!</h1></template><script>
+((d,c,n) => {
+c=d.currentScript.previousSibling
+d=d.getElementById('H:1')
 if(!d)return
 do{n=d.nextSibling;n.remove()}while(n.nodeType!=8||n.nodeValue!='/$')
 d.replaceWith(c.content)

--- a/src/helper/css/index.test.tsx
+++ b/src/helper/css/index.test.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource ../../jsx */
 import { Hono } from '../../'
 import { html } from '../../helper/html'
-import { isValidElement } from '../../jsx'
 import type { JSXNode } from '../../jsx'
+import { isValidElement } from '../../jsx'
 import { Suspense, renderToReadableStream } from '../../jsx/streaming'
 import type { HtmlEscapedString } from '../../utils/html'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../../utils/html'
@@ -55,6 +55,18 @@ describe('CSS Helper', () => {
         <h1 class="${headerClass}">Hello!</h1>`
       expect(await toString(template)).toBe(
         `<style id="hono-css">.css-2458908649{background-color:blue}</style>
+        <h1 class="css-2458908649">Hello!</h1>`
+      )
+    })
+
+    it('Should render CSS styles with `html` tag function and CSP nonce', async () => {
+      const headerClass = css`
+        background-color: blue;
+      `
+      const template = html`${Style({ nonce: '1234' })}
+        <h1 class="${headerClass}">Hello!</h1>`
+      expect(await toString(template)).toBe(
+        `<style id="hono-css" nonce="1234">.css-2458908649{background-color:blue}</style>
         <h1 class="css-2458908649">Hello!</h1>`
       )
     })

--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -103,7 +103,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultConte
     }
 
     const addClassNameToContext: HtmlEscapedCallback = ({ context }) => {
-      if (!contextMap.get(context)) {
+      if (!contextMap.has(context)) {
         contextMap.set(context, [{}, {}])
       }
       const [toAdd, added] = contextMap.get(context) as usedClassNameData

--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -63,7 +63,7 @@ export const createCssContext = ({ id }: { id: Readonly<string> }): DefaultConte
 
   const contextMap: WeakMap<object, usedClassNameData> = new WeakMap()
 
-  const replaceStyleRe = new RegExp(`(<style id="${id}">.*?)(</style>)`)
+  const replaceStyleRe = new RegExp(`(<style id="${id}"(?: nonce="[^"]*")?>.*?)(</style>)`)
 
   const newCssClassNameObject = (cssClassName: CssClassNameCommon): Promise<string> => {
     const appendStyle: HtmlEscapedCallback = ({ buffer, context }): Promise<string> | undefined => {

--- a/src/jsx/dom/css.test.tsx
+++ b/src/jsx/dom/css.test.tsx
@@ -52,6 +52,18 @@ describe('Style and css for jsx/dom', () => {
     )
   })
 
+  it('<Style nonce="1234" />', async () => {
+    const App = () => {
+      return (
+        <div>
+          <Style nonce='1234' />
+        </div>
+      )
+    }
+    render(<App />, root)
+    expect(root.innerHTML).toBe('<div><style id="hono-css" nonce="1234"></style></div>')
+  })
+
   it('<Style>{css`global`}</Style>', async () => {
     const App = () => {
       return (

--- a/src/jsx/dom/css.ts
+++ b/src/jsx/dom/css.ts
@@ -120,11 +120,12 @@ export const createCssJsxDomObjects: CreateCssJsxDomObjectsType = ({ id }) => {
     },
   }
 
-  const Style: FC<PropsWithChildren<void>> = ({ children }) =>
+  const Style: FC<PropsWithChildren<{ nonce?: string }>> = ({ children, nonce }) =>
     ({
       tag: 'style',
       props: {
         id,
+        nonce,
         children:
           children &&
           (Array.isArray(children) ? children : [children]).map(

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -11,7 +11,7 @@ export const HtmlEscapedCallbackPhase = {
 type HtmlEscapedCallbackOpts = {
   buffer?: [string]
   phase: (typeof HtmlEscapedCallbackPhase)[keyof typeof HtmlEscapedCallbackPhase]
-  context: object // An object unique to each JSX tree. This object is used as the WeakMap key.
+  context: Readonly<object> // An object unique to each JSX tree. This object is used as the WeakMap key.
 }
 export type HtmlEscapedCallback = (opts: HtmlEscapedCallbackOpts) => Promise<string> | undefined
 export type HtmlEscaped = {


### PR DESCRIPTION
closes #3694

This PR extends upon the work of https://github.com/honojs/hono/pull/2577 with the goal to bring the CSS nonce to the inline `style` and `script` tags created by the usage of `hono/css`. The goal is to be able to add `<Style nonce={nonce} />` in order to comply with strict CSP rules.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code

### To Do
- [ ]  There are still two test failures related to `<script nonce="1234">document.querySelector('#hono-css').textContent+="..."</script>` being added to the snapshot which should end up there. One should test if this is only due to the test setup and the `<script>` tag not being executed in the test environment.

@usualoma could you provide me with some pointers on where to start further debugging these test failures? I see that you've implemented most code around CSP and CSS. 

```bash
 FAIL  src/helper/css/index.test.tsx > CSS Helper > render css > Booleans, Null, and Undefined Are Ignored > Should render CSS styles with CSP nonce
AssertionError: expected '<script nonce="1234">document.querySe…' to be '<style id="hono-css" nonce="1234">.cs…' // Object.is equality

Expected: "<style id="hono-css" nonce="1234">.css-2458908649{background-color:blue}</style><h1 class="css-2458908649">Hello!</h1>"
Received: "<script nonce="1234">document.querySelector('#hono-css').textContent+=".css-2458908649{background-color:blue}"</script><style id="hono-css" nonce="1234"></style><h1 class="css-2458908649">Hello!</h1>"

 ❯ src/helper/css/common.case.test.tsx:502:42
    500|           </>
    501|         )
    502|         expect(await toString(template)).toBe(
       |                                          ^
    503|           '<style id="hono-css" nonce="1234">.css-2458908649{background-color:blue}</style><h1 class="css-2458908649">Hello!</h1>'
    504|         )

 FAIL  src/helper/css/index.test.tsx > CSS Helper > with `html` tag function > Should render CSS styles with `html` tag function and CSP nonce
AssertionError: expected '<script nonce="1234">document.querySe…' to be '<style id="hono-css" nonce="1234">.cs…' // Object.is equality

- Expected
+ Received

- <style id="hono-css" nonce="1234">.css-2458908649{background-color:blue}</style>
+ <script nonce="1234">document.querySelector('#hono-css').textContent+=".css-2458908649{background-color:blue}"</script><style id="hono-css" nonce="1234"></style>
          <h1 class="css-2458908649">Hello!</h1>

 ❯ src/helper/css/index.test.tsx:68:40
     66|       const template = html`${Style({ nonce: '1234' })}
     67|         <h1 class="${headerClass}">Hello!</h1>`
     68|       expect(await toString(template)).toBe(
       |                                        ^
     69|         `<style id="hono-css" nonce="1234">.css-2458908649{background-color:blue}</style>
     70|         <h1 class="css-2458908649">Hello!</h1>`
```


- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
