### PR TITLE
aws-lambda adapter - add alb event requestContext undefined check for testing convenience

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -407,7 +407,7 @@ class ALBProcessor extends EventProcessor<ALBProxyEvent> {
 
   protected getQueryString(event: ALBProxyEvent): string {
     // In the case of ALB Integration either queryStringParameters or multiValueQueryStringParameters can be present not both
-    /* 
+    /*
       In other cases like when using the serverless framework, the event object does contain both queryStringParameters and multiValueQueryStringParameters:
       Below is an example event object for this URL: /payment/b8c55e69?select=amount&select=currency
       {
@@ -471,7 +471,10 @@ export const getProcessor = (event: LambdaEvent): EventProcessor<LambdaEvent> =>
 }
 
 const isProxyEventALB = (event: LambdaEvent): event is ALBProxyEvent => {
-  return Object.hasOwn(event.requestContext, 'elb')
+  if (event.requestContext) {
+    return Object.hasOwn(event.requestContext, 'elb')
+  }
+  return false
 }
 
 const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => {


### PR DESCRIPTION
### Issue Summary

While testing a lambda using `aws lambda invoke` or from the AWS Console,  the current `aws-lambda` adapter `isProxyEventALB` implementation results in following error:

```sh
{
    "errorType": "TypeError",
    "errorMessage": "Cannot convert undefined or null to object",
    "stack": [
        "TypeError: Cannot convert undefined or null to object",
        "    at Function.hasOwn (<anonymous>)",
        "    at isProxyEventALB (/var/task/index.js:1816:17)",
        "    at getProcessor (/var/task/index.js:1807:7)",
        "    at Runtime.handler (/var/task/index.js:1620:23)",
        "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)"
    ]
}
```

This can be reproduced by scaffolding a lambda project using `npm create hono@latest` and deploying it in an AWS account without any changes to the code.

### Benefits of the fix

A fix by adding an undefined check for `event.requestContext` will significantly ease the testing of lambda using simple tools like `aws lambda invoke` and AWS Console.



### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
