### PR TITLE
fix(base): define `errorHandler` with `private` not use `#`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -182,7 +182,8 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
   }
 
   #notFoundHandler: NotFoundHandler = notFoundHandler
-  #errorHandler: ErrorHandler = errorHandler
+  // Cannot use `#` because it requires visibility at JavaScript runtime.
+  private errorHandler: ErrorHandler = errorHandler
 
   /**
    * `.route()` allows grouping other Hono instance in routes.
@@ -214,11 +215,11 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     const subApp = this.basePath(path)
     app.routes.map((r) => {
       let handler
-      if (app.#errorHandler === errorHandler) {
+      if (app.errorHandler === errorHandler) {
         handler = r.handler
       } else {
         handler = async (c: Context, next: Next) =>
-          (await compose<Context>([], app.#errorHandler)(c, () => r.handler(c, next))).res
+          (await compose<Context>([], app.errorHandler)(c, () => r.handler(c, next))).res
         ;(handler as any)[COMPOSED_HANDLER] = r.handler
       }
 
@@ -263,7 +264,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    * ```
    */
   onError = (handler: ErrorHandler<E>): Hono<E, S, BasePath> => {
-    this.#errorHandler = handler
+    this.errorHandler = handler
     return this
   }
 
@@ -382,7 +383,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
 
   #handleError(err: unknown, c: Context<E>) {
     if (err instanceof Error) {
-      return this.#errorHandler(err, c)
+      return this.errorHandler(err, c)
     }
     throw err
   }
@@ -431,7 +432,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
         : res ?? this.#notFoundHandler(c)
     }
 
-    const composed = compose<Context>(matchResult[0], this.#errorHandler, this.#notFoundHandler)
+    const composed = compose<Context>(matchResult[0], this.errorHandler, this.#notFoundHandler)
 
     return (async () => {
       try {


### PR DESCRIPTION
With this PR, defining `errorHandler` with `private` not using `#`  in `hono-base.ts`:

```ts
private errorHandler: ErrorHandler = errorHandler
```

This will fix #3671

Since the property defined with `#` will be a completely private member that can't be accessed from outside in the JavaScript runtime phase, problem #3671 occurs. But, if you define it with `private` keyword without `#` it can be accessed from outside in the JavaScript runtime phase.


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
