### PR TITLE
ci(perf-measures): support `KB`

### DIFF
--- a/perf-measures/bundle-check/scripts/check-bundle-size.ts
+++ b/perf-measures/bundle-check/scripts/check-bundle-size.ts
@@ -31,7 +31,7 @@ async function main() {
       key: 'bundle-size-kb',
       name: 'Bundle Size (KB)',
       value: parseFloat((bundleSize / 1024).toFixed(2)),
-      unit: 'KB',
+      unit: 'K',
     })
 
     const benchmark = {

--- a/perf-measures/bundle-check/scripts/check-bundle-size.ts
+++ b/perf-measures/bundle-check/scripts/check-bundle-size.ts
@@ -30,7 +30,7 @@ async function main() {
     metrics.push({
       key: 'bundle-size-kb',
       name: 'Bundle Size (KB)',
-      value: (bundleSize / 1024).toFixed(2),
+      value: (bundleSize / 1024).toFixed(2).toString(),
       unit: 'KB',
     })
 

--- a/perf-measures/bundle-check/scripts/check-bundle-size.ts
+++ b/perf-measures/bundle-check/scripts/check-bundle-size.ts
@@ -30,7 +30,7 @@ async function main() {
     metrics.push({
       key: 'bundle-size-kb',
       name: 'Bundle Size (KB)',
-      value: (bundleSize / 1024).toFixed(2).toString(),
+      value: parseFloat((bundleSize / 1024).toFixed(2)),
       unit: 'KB',
     })
 

--- a/perf-measures/bundle-check/scripts/check-bundle-size.ts
+++ b/perf-measures/bundle-check/scripts/check-bundle-size.ts
@@ -19,12 +19,21 @@ async function main() {
 
     const bundleSize = fs.statSync(tempFilePath).size
     const metrics = []
+
     metrics.push({
-      key: 'bundle-size',
-      name: 'Bundle Size',
+      key: 'bundle-size-b',
+      name: 'Bundle Size (B)',
       value: bundleSize,
       unit: 'B',
     })
+
+    metrics.push({
+      key: 'bundle-size-kb',
+      name: 'Bundle Size (KB)',
+      value: (bundleSize / 1024).toFixed(2),
+      unit: 'KB',
+    })
+
     const benchmark = {
       key: 'bundle-size-check',
       name: 'Bundle size check',


### PR DESCRIPTION
We can check `kb`