### PR TITLE
perf(router): sort handlers by score only when necessary

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -121,6 +121,18 @@ describe('Name path', () => {
     expect(resB[0][0]).toEqual('resource')
     expect(resB[0][1]).toEqual({ id: 'b' })
   })
+
+  it('Should return a sorted values', () => {
+    const node = new Node()
+    node.insert('get', '/resource/a', 'A')
+    node.insert('get', '/resource/*', 'Star')
+    const [res] = node.search('get', '/resource/a')
+    console.log(res)
+    expect(res).not.toBeNull()
+    expect(res.length).toBe(2)
+    expect(res[0][0]).toEqual('A')
+    expect(res[1][0]).toEqual('Star')
+  })
 })
 
 describe('Name path - Multiple route', () => {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -127,7 +127,6 @@ describe('Name path', () => {
     node.insert('get', '/resource/a', 'A')
     node.insert('get', '/resource/*', 'Star')
     const [res] = node.search('get', '/resource/a')
-    console.log(res)
     expect(res).not.toBeNull()
     expect(res.length).toBe(2)
     expect(res[0][0]).toEqual('A')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -198,10 +198,13 @@ export class Node<T> {
 
       curNodes = tempNodes
     }
-    const results = handlerSets.sort((a, b) => {
-      return a.score - b.score
-    })
 
-    return [results.map(({ handler, params }) => [handler, params] as [T, Params])]
+    if (handlerSets.length > 1) {
+      handlerSets.sort((a, b) => {
+        return a.score - b.score
+      })
+    }
+
+    return [handlerSets.map(({ handler, params }) => [handler, params] as [T, Params])]
   }
 }


### PR DESCRIPTION
Sorting was also done when number of handlers was 0 or 1, so it is no longer done.  
Also, there is no need to create a new variable.

## Benchmarks

### In Node
```llvm
summary for all together
  Hono RegExpRouter
   1.39x faster than Memoirist
   1.5x faster than koa-tree-router
   1.66x faster than @medley/router
   2.15x faster than rou3
   2.33x faster than trek-router
   2.97x faster than find-my-way
   4.28x faster than Hono PatternRouter
   5.43x faster than radix3
   8.01x faster than koa-router
   8.96x faster than Hono TrieRouter
   9.13x faster than Hono BeforeTrieRouter
   39.24x faster than express (WARNING: includes handling)
```

### In Bun
```llvm
summary for all together
  Hono RegExpRouter
   1.01x faster than Memoirist
   1.23x faster than @medley/router
   2.12x faster than koa-tree-router
   2.13x faster than rou3
   2.19x faster than radix3
   2.33x faster than find-my-way
   3.87x faster than trek-router
   4.06x faster than Hono PatternRouter
   5.43x faster than koa-router
   10.29x faster than Hono TrieRouter
   10.45x faster than Hono BeforeTrieRouter
   11.37x faster than express (WARNING: includes handling)
```

There is some improvement in performance, though not significantly.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code


