### PR TITLE
feat(logger): include query params

### DIFF
--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -57,6 +57,14 @@ describe('Logger by Middleware', () => {
     expect(log).toMatch(/m?s$/)
   })
 
+  it('Log status 200 with small body and query param', async () => {
+    const res = await app.request('http://localhost/short?foo=bar')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(log.startsWith('--> GET /short?foo=bar \x1b[32m200\x1b[0m')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
   it('Log status 200 with big body', async () => {
     const res = await app.request('http://localhost/long')
     expect(res).not.toBeNull()
@@ -105,7 +113,7 @@ describe('Logger by Middleware', () => {
     const res = await app.request('http://localhost/server-error?status=100')
     expect(res).not.toBeNull()
     expect(res.status).toBe(100)
-    expect(log.startsWith('--> GET /server-error 100')).toBe(true)
+    expect(log.startsWith('--> GET /server-error?status=100 100')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
 
@@ -113,7 +121,7 @@ describe('Logger by Middleware', () => {
     const res = await app.request('http://localhost/server-error?status=700')
     expect(res).not.toBeNull()
     expect(res.status).toBe(700)
-    expect(log.startsWith('--> GET /server-error 700')).toBe(true)
+    expect(log.startsWith('--> GET /server-error?status=700 700')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
 })

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -80,10 +80,9 @@ function log(
  */
 export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async function logger(c, next) {
-    const { method } = c.req
+    const { method, url } = c.req
 
-    const url = new URL(c.req.raw.url)
-    const path = url.pathname + url.search
+    const path = url.slice(url.indexOf('/', 8))
 
     log(fn, LogPrefix.Incoming, method, path)
 

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -5,7 +5,6 @@
 
 import type { MiddlewareHandler } from '../../types'
 import { getColorEnabled } from '../../utils/color'
-import { getPath } from '../../utils/url'
 
 enum LogPrefix {
   Outgoing = '-->',
@@ -83,7 +82,8 @@ export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
   return async function logger(c, next) {
     const { method } = c.req
 
-    const path = getPath(c.req.raw)
+    const url = new URL(c.req.raw.url)
+    const path = url.pathname + url.search
 
     log(fn, LogPrefix.Incoming, method, path)
 


### PR DESCRIPTION
The default value of built-in logger is not very desirable for API servers that use query params.
e.g.) https://hono-hacker-news.deno.dev/

It's a bit disruptive for logging, so we probably won't need to add it right away.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
