### PR TITLE
refactor: use `Array.prototype.at()` to look at the end

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -127,26 +127,26 @@ export const hc = <T extends Hono<any, any, any>>(
     const parts = [...opts.path]
 
     // allow calling .toString() and .valueOf() on the proxy
-    if (parts[parts.length - 1] === 'toString') {
-      if (parts[parts.length - 2] === 'name') {
+    if (parts.at(-1) === 'toString') {
+      if (parts.at(-2) === 'name') {
         // e.g. hc().somePath.name.toString() -> "somePath"
-        return parts[parts.length - 3] || ''
+        return parts.at(-3) || ''
       }
       // e.g. hc().somePath.toString()
       return proxyCallback.toString()
     }
 
-    if (parts[parts.length - 1] === 'valueOf') {
-      if (parts[parts.length - 2] === 'name') {
+    if (parts.at(-1) === 'valueOf') {
+      if (parts.at(-2) === 'name') {
         // e.g. hc().somePath.name.valueOf() -> "somePath"
-        return parts[parts.length - 3] || ''
+        return parts.at(-3) || ''
       }
       // e.g. hc().somePath.valueOf()
       return proxyCallback
     }
 
     let method = ''
-    if (/^\$/.test(parts[parts.length - 1])) {
+    if (/^\$/.test(parts.at(-1) as string)) {
       const last = parts.pop()
       if (last) {
         method = last.replace(/^\$/, '')

--- a/src/helper/html/index.ts
+++ b/src/helper/html/index.ts
@@ -47,7 +47,7 @@ export const html = (
       }
     }
   }
-  buffer[0] += strings[strings.length - 1]
+  buffer[0] += strings.at(-1) as string
 
   return buffer.length === 1
     ? 'callbacks' in buffer

--- a/src/middleware/trailing-slash/index.ts
+++ b/src/middleware/trailing-slash/index.ts
@@ -28,7 +28,7 @@ export const trimTrailingSlash = (): MiddlewareHandler => {
       c.res.status === 404 &&
       c.req.method === 'GET' &&
       c.req.path !== '/' &&
-      c.req.path[c.req.path.length - 1] === '/'
+      c.req.path.at(-1) === '/'
     ) {
       const url = new URL(c.req.url)
       url.pathname = url.pathname.substring(0, url.pathname.length - 1)
@@ -57,11 +57,7 @@ export const appendTrailingSlash = (): MiddlewareHandler => {
   return async function appendTrailingSlash(c, next) {
     await next()
 
-    if (
-      c.res.status === 404 &&
-      c.req.method === 'GET' &&
-      c.req.path[c.req.path.length - 1] !== '/'
-    ) {
+    if (c.res.status === 404 && c.req.method === 'GET' && c.req.path.at(-1) !== '/') {
       const url = new URL(c.req.url)
       url.pathname += '/'
 

--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -8,7 +8,7 @@ export class PatternRouter<T> implements Router<T> {
   #routes: Route<T>[] = []
 
   add(method: string, path: string, handler: T) {
-    const endsWithWildcard = path[path.length - 1] === '*'
+    const endsWithWildcard = path.at(-1) === '*'
     if (endsWithWildcard) {
       path = path.slice(0, -2)
     }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -130,7 +130,7 @@ export const getPathNoStrict = (request: Request): string => {
   const result = getPath(request)
 
   // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
-  return result.length > 1 && result[result.length - 1] === '/' ? result.slice(0, -1) : result
+  return result.length > 1 && result.at(-1) === '/' ? result.slice(0, -1) : result
 }
 
 export const mergePath = (...paths: string[]): string => {
@@ -139,7 +139,7 @@ export const mergePath = (...paths: string[]): string => {
 
   for (let path of paths) {
     /* ['/hey/','/say'] => ['/hey', '/say'] */
-    if (p[p.length - 1] === '/') {
+    if (p.at(-1) === '/') {
       p = p.slice(0, -1)
       endsWithSlash = true
     }


### PR DESCRIPTION
The size of the bundle is reduced by one ant teardrop.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
