### PR TITLE
chore: Add Cloudflare Static Assets reference to serveStatic deprecation notice

### DIFF
--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -14,8 +14,8 @@ export type ServeStaticOptions<E extends Env = Env> = BaseServeStaticOptions<E> 
  * `serveStatic` in the Cloudflare Workers adapter is deprecated.
  * You can serve static files directly using Cloudflare Static Assets.
  * @see https://developers.cloudflare.com/workers/static-assets/
- * Cloudflare Static Assets is currently in open beta. If this doesn't work for you, 
- * please consider using Cloudflare Pages. You can start to create the Cloudflare Pages 
+ * Cloudflare Static Assets is currently in open beta. If this doesn't work for you,
+ * please consider using Cloudflare Pages. You can start to create the Cloudflare Pages
  * application with the `npm create hono@latest` command.
  */
 export const serveStatic = <E extends Env = Env>(

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -12,8 +12,11 @@ export type ServeStaticOptions<E extends Env = Env> = BaseServeStaticOptions<E> 
 /**
  * @deprecated
  * `serveStatic` in the Cloudflare Workers adapter is deprecated.
- * If you want to create an application serving static assets, please consider using Cloudflare Pages.
- * You can start to create the Cloudflare Pages application with the `npm create hono@latest` command.
+ * You can serve static files directly using Cloudflare Static Assets.
+ * @see https://developers.cloudflare.com/workers/static-assets/
+ * Cloudflare Static Assets is currently in open beta. If this doesn't work for you, 
+ * please consider using Cloudflare Pages. You can start to create the Cloudflare Pages 
+ * application with the `npm create hono@latest` command.
  */
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E>


### PR DESCRIPTION
Cloudflare Static Assets is now in open beta, promoted as a solution for SSR apps: https://blog.cloudflare.com/builder-day-2024-announcements/#static-asset-hosting

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
