### PR TITLE
feat: warn when json validator does not find a content type in the request

### DIFF
--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -115,17 +115,17 @@ describe('JSON', () => {
     expect(data).toEqual({ foo: 'bar' })
   })
 
-  it('Should not validate if Content-Type is not set', async () => {
+  it('Should return 415 response if Content-Type is not set', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
       body: JSON.stringify({ foo: 'bar' }),
     })
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(415)
     const data = await res.json()
     expect(data.foo).toBeUndefined()
   })
 
-  it('Should not validate if Content-Type is wrong', async () => {
+  it('Should return 415 response if Content-Type is wrong', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
       headers: {
@@ -133,7 +133,7 @@ describe('JSON', () => {
       },
       body: JSON.stringify({ foo: 'bar' }),
     })
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(415)
   })
 
   it('Should validate if Content-Type is a application/json with a charset', async () => {
@@ -231,6 +231,29 @@ describe('FormData', () => {
     expect(await res.json()).toEqual({ message: 'hi' })
   })
 
+  it('Should return 415 response if Content-Type is not set', async () => {
+    const formData = new FormData()
+    formData.append('message', 'hi')
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      body: formData,
+    })
+    expect(res.status).toBe(415)
+  })
+
+  it('Should return 415 response if Content-Type is wrong', async () => {
+    const formData = new FormData()
+    formData.append('message', 'hi')
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain;charset=utf-8',
+      },
+      body: formData,
+    })
+    expect(res.status).toBe(415)
+  })
+  
   it('Should validate a URL Encoded Data', async () => {
     const params = new URLSearchParams()
     params.append('foo', 'bar')

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -72,8 +72,7 @@ export const validator = <
     switch (target) {
       case 'json':
         if (!contentType || !jsonRegex.test(contentType)) {
-          const message = 'missing Content-Type header "application/json"'
-          throw new HTTPException(415, { message })
+          throw new HTTPException(415, { message: ERROR_MESSAGE_JSON })
           break
         }
         try {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -64,7 +64,6 @@ export const validator = <
     E,
     P2
   >,
-  { warn = true } = {}
 ): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
@@ -73,11 +72,8 @@ export const validator = <
     switch (target) {
       case 'json':
         if (!contentType || !jsonRegex.test(contentType)) {
-          if (warn) {
-            console.warn(
-              'Validator target is "json" but request is missing a Content-Type header containing "application/json"'
-            )
-          }
+          const message = 'missing a Content-Type header "application/json"'
+          throw new HTTPException(415, { message })
           break
         }
         try {
@@ -92,11 +88,8 @@ export const validator = <
           !contentType ||
           !(multipartRegex.test(contentType) || urlencodedRegex.test(contentType))
         ) {
-          if (warn) {
-            console.warn(
-              'Validator target is "form" but request is missing a Content-Type header containing "multipart/form-data" or "application/x-www-form-encoded"'
-            )
-          }
+          const message = 'missing a Content-Type header "application/x-www-form-encoded"'
+          throw new HTTPException(415, { message })
           break
         }
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -63,7 +63,7 @@ export const validator = <
     OutputType,
     E,
     P2
-  >,
+  >
 ): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -27,8 +27,8 @@ const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))
 const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
 const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
 
-const ERROR_MESSSAGE_JSON = 'missing Content-Type header "application/json"'
-const ERROR_MESSSAGE_FORM = 'missing Content-Type header "multipart/form-data" or "application/x-www-form-urlencoded"'
+const ERROR_MESSAGE_JSON = 'missing Content-Type header "application/json"'
+const ERROR_MESSAGE_FORM = 'missing Content-Type header "multipart/form-data" or "application/x-www-form-urlencoded"'
 
 export const validator = <
   InputType,

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -72,7 +72,9 @@ export const validator = <
     switch (target) {
       case 'json':
         if (!contentType || !jsonRegex.test(contentType)) {
-          console.warn('Validator target is "json" but request is missing a Content-Type header containing "application/json"')
+          console.warn(
+            'Validator target is "json" but request is missing a Content-Type header containing "application/json"'
+          )
           break
         }
         try {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -72,7 +72,7 @@ export const validator = <
     switch (target) {
       case 'json':
         if (!contentType || !jsonRegex.test(contentType)) {
-          const message = 'missing a Content-Type header "application/json"'
+          const message = 'missing Content-Type header "application/json"'
           throw new HTTPException(415, { message })
           break
         }
@@ -88,7 +88,7 @@ export const validator = <
           !contentType ||
           !(multipartRegex.test(contentType) || urlencodedRegex.test(contentType))
         ) {
-          const message = 'missing a Content-Type header "application/x-www-form-encoded"'
+          const message = 'missing Content-Type header "application/x-www-form-encoded"'
           throw new HTTPException(415, { message })
           break
         }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -72,6 +72,7 @@ export const validator = <
     switch (target) {
       case 'json':
         if (!contentType || !jsonRegex.test(contentType)) {
+          console.warn('Validator target is "json" but request is missing a Content-Type header containing "application/json"')
           break
         }
         try {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -89,6 +89,9 @@ export const validator = <
           !contentType ||
           !(multipartRegex.test(contentType) || urlencodedRegex.test(contentType))
         ) {
+          console.warn(
+            'Validator target is "form" but request is missing a Content-Type header containing "multipart/form-data" or "application/x-www-form-encoded"'
+          )
           break
         }
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -27,8 +27,8 @@ const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))
 const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
 const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
 
-const ERROR_MESSAGE_JSON = 'missing Content-Type header "application/json"'
-const ERROR_MESSAGE_FORM = 'missing Content-Type header "multipart/form-data" or "application/x-www-form-urlencoded"'
+const ERROR_MESSAGE_JSON = 'Missing Content-Type header "application/json"'
+const ERROR_MESSAGE_FORM = 'Missing Content-Type header "multipart/form-data" or "application/x-www-form-urlencoded"'
 
 export const validator = <
   InputType,

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -63,7 +63,8 @@ export const validator = <
     OutputType,
     E,
     P2
-  >
+  >,
+  { warn = true } = {}
 ): MiddlewareHandler<E, P, V> => {
   return async (c, next) => {
     let value = {}
@@ -72,9 +73,11 @@ export const validator = <
     switch (target) {
       case 'json':
         if (!contentType || !jsonRegex.test(contentType)) {
-          console.warn(
-            'Validator target is "json" but request is missing a Content-Type header containing "application/json"'
-          )
+          if (warn) {
+            console.warn(
+              'Validator target is "json" but request is missing a Content-Type header containing "application/json"'
+            )
+          }
           break
         }
         try {
@@ -89,9 +92,11 @@ export const validator = <
           !contentType ||
           !(multipartRegex.test(contentType) || urlencodedRegex.test(contentType))
         ) {
-          console.warn(
-            'Validator target is "form" but request is missing a Content-Type header containing "multipart/form-data" or "application/x-www-form-encoded"'
-          )
+          if (warn) {
+            console.warn(
+              'Validator target is "form" but request is missing a Content-Type header containing "multipart/form-data" or "application/x-www-form-encoded"'
+            )
+          }
           break
         }
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -27,6 +27,9 @@ const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))
 const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
 const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
 
+const ERROR_MESSSAGE_JSON = 'missing Content-Type header "application/json"'
+const ERROR_MESSSAGE_FORM = 'missing Content-Type header "multipart/form-data" or "application/x-www-form-urlencoded"'
+
 export const validator = <
   InputType,
   P extends string,
@@ -87,8 +90,7 @@ export const validator = <
           !contentType ||
           !(multipartRegex.test(contentType) || urlencodedRegex.test(contentType))
         ) {
-          const message = 'missing Content-Type header "application/x-www-form-encoded"'
-          throw new HTTPException(415, { message })
+          throw new HTTPException(415, { message: ERROR_MESSAGE_FORM })
           break
         }
 


### PR DESCRIPTION
When a validator has a target 'json' it will now warn if a request is missing a `Content-Type: application/json` header.

Closes https://github.com/honojs/middleware/issues/841

Added some docs too https://github.com/honojs/website/pull/540

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
