### PR TITLE
refactor: clean up and reduced code size

### DIFF
--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -14,12 +14,12 @@ type StaticMap<T> = Record<string, Result<T>>
 type Matcher<T> = [RegExp, HandlerData<T>[], StaticMap<T>]
 type HandlerWithMetadata<T> = [T, number] // [handler, paramCount]
 
-const createEmptyParams = () => Object.create(null)
+const createEmptyRecord = () => Object.create(null)
 const emptyParam: string[] = []
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const nullMatcher: Matcher<any> = [/^$/, [], createEmptyParams()]
+const nullMatcher: Matcher<any> = [/^$/, [], createEmptyRecord()]
 
-let wildcardRegExpCache: Record<string, RegExp> = createEmptyParams()
+let wildcardRegExpCache: Record<string, RegExp> = createEmptyRecord()
 function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
     path === '*'
@@ -31,7 +31,7 @@ function buildWildcardRegExp(path: string): RegExp {
 }
 
 function clearWildcardRegExpCache() {
-  wildcardRegExpCache = createEmptyParams()
+  wildcardRegExpCache = createEmptyRecord()
 }
 
 function buildMatcherFromPreprocessedRoutes<T>(
@@ -51,11 +51,11 @@ function buildMatcherFromPreprocessedRoutes<T>(
       isStaticA ? 1 : isStaticB ? -1 : pathA.length - pathB.length
     )
 
-  const staticMap: StaticMap<T> = createEmptyParams()
+  const staticMap: StaticMap<T> = createEmptyRecord()
   for (let i = 0, j = -1, len = routesWithStaticPathFlag.length; i < len; i++) {
     const [pathErrorCheckOnly, path, handlers] = routesWithStaticPathFlag[i]
     if (pathErrorCheckOnly) {
-      staticMap[path] = [handlers.map(([h]) => [h, createEmptyParams()]), emptyParam]
+      staticMap[path] = [handlers.map(([h]) => [h, createEmptyRecord()]), emptyParam]
     } else {
       j++
     }
@@ -72,7 +72,7 @@ function buildMatcherFromPreprocessedRoutes<T>(
     }
 
     handlerData[j] = handlers.map(([h, paramCount]) => {
-      const paramIndexMap: ParamIndexMap = createEmptyParams()
+      const paramIndexMap: ParamIndexMap = createEmptyRecord()
       paramCount -= 1
       for (; paramCount >= 0; paramCount--) {
         const [key, value] = paramAssoc[paramCount]
@@ -128,8 +128,8 @@ export class RegExpRouter<T> implements Router<T> {
   #routes?: Record<string, Record<string, HandlerWithMetadata<T>[]>>
 
   constructor() {
-    this.#middleware = { [METHOD_NAME_ALL]: createEmptyParams() }
-    this.#routes = { [METHOD_NAME_ALL]: createEmptyParams() }
+    this.#middleware = { [METHOD_NAME_ALL]: createEmptyRecord() }
+    this.#routes = { [METHOD_NAME_ALL]: createEmptyRecord() }
   }
 
   add(method: string, path: string, handler: T) {
@@ -142,7 +142,7 @@ export class RegExpRouter<T> implements Router<T> {
 
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
-        handlerMap[method] = createEmptyParams()
+        handlerMap[method] = createEmptyRecord()
         Object.keys(handlerMap[METHOD_NAME_ALL]).forEach((p) => {
           handlerMap[method][p] = [...handlerMap[METHOD_NAME_ALL][p]]
         })
@@ -232,7 +232,7 @@ export class RegExpRouter<T> implements Router<T> {
   }
 
   #buildAllMatchers(): Record<string, Matcher<T> | null> {
-    const matchers: Record<string, Matcher<T> | null> = createEmptyParams()
+    const matchers: Record<string, Matcher<T> | null> = createEmptyRecord()
 
     Object.keys(this.#routes!)
       .concat(Object.keys(this.#middleware!))

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -14,11 +14,12 @@ type StaticMap<T> = Record<string, Result<T>>
 type Matcher<T> = [RegExp, HandlerData<T>[], StaticMap<T>]
 type HandlerWithMetadata<T> = [T, number] // [handler, paramCount]
 
+const createEmptyParams = () => Object.create(null)
 const emptyParam: string[] = []
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const nullMatcher: Matcher<any> = [/^$/, [], Object.create(null)]
+const nullMatcher: Matcher<any> = [/^$/, [], createEmptyParams()]
 
-let wildcardRegExpCache: Record<string, RegExp> = Object.create(null)
+let wildcardRegExpCache: Record<string, RegExp> = createEmptyParams()
 function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
     path === '*'
@@ -30,7 +31,7 @@ function buildWildcardRegExp(path: string): RegExp {
 }
 
 function clearWildcardRegExpCache() {
-  wildcardRegExpCache = Object.create(null)
+  wildcardRegExpCache = createEmptyParams()
 }
 
 function buildMatcherFromPreprocessedRoutes<T>(
@@ -50,11 +51,11 @@ function buildMatcherFromPreprocessedRoutes<T>(
       isStaticA ? 1 : isStaticB ? -1 : pathA.length - pathB.length
     )
 
-  const staticMap: StaticMap<T> = Object.create(null)
+  const staticMap: StaticMap<T> = createEmptyParams()
   for (let i = 0, j = -1, len = routesWithStaticPathFlag.length; i < len; i++) {
     const [pathErrorCheckOnly, path, handlers] = routesWithStaticPathFlag[i]
     if (pathErrorCheckOnly) {
-      staticMap[path] = [handlers.map(([h]) => [h, Object.create(null)]), emptyParam]
+      staticMap[path] = [handlers.map(([h]) => [h, createEmptyParams()]), emptyParam]
     } else {
       j++
     }
@@ -71,7 +72,7 @@ function buildMatcherFromPreprocessedRoutes<T>(
     }
 
     handlerData[j] = handlers.map(([h, paramCount]) => {
-      const paramIndexMap: ParamIndexMap = Object.create(null)
+      const paramIndexMap: ParamIndexMap = createEmptyParams()
       paramCount -= 1
       for (; paramCount >= 0; paramCount--) {
         const [key, value] = paramAssoc[paramCount]
@@ -127,8 +128,8 @@ export class RegExpRouter<T> implements Router<T> {
   #routes?: Record<string, Record<string, HandlerWithMetadata<T>[]>>
 
   constructor() {
-    this.#middleware = { [METHOD_NAME_ALL]: Object.create(null) }
-    this.#routes = { [METHOD_NAME_ALL]: Object.create(null) }
+    this.#middleware = { [METHOD_NAME_ALL]: createEmptyParams() }
+    this.#routes = { [METHOD_NAME_ALL]: createEmptyParams() }
   }
 
   add(method: string, path: string, handler: T) {
@@ -141,7 +142,7 @@ export class RegExpRouter<T> implements Router<T> {
 
     if (!middleware[method]) {
       ;[middleware, routes].forEach((handlerMap) => {
-        handlerMap[method] = Object.create(null)
+        handlerMap[method] = createEmptyParams()
         Object.keys(handlerMap[METHOD_NAME_ALL]).forEach((p) => {
           handlerMap[method][p] = [...handlerMap[METHOD_NAME_ALL][p]]
         })
@@ -231,7 +232,7 @@ export class RegExpRouter<T> implements Router<T> {
   }
 
   #buildAllMatchers(): Record<string, Matcher<T> | null> {
-    const matchers: Record<string, Matcher<T> | null> = Object.create(null)
+    const matchers: Record<string, Matcher<T> | null> = createEmptyParams()
 
     Object.keys(this.#routes!)
       .concat(Object.keys(this.#middleware!))

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -13,21 +13,21 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
   params: Record<string, string>
 }
 
-const createEmptyParams = () => Object.create(null)
+const createEmptyRecord = () => Object.create(null)
 
-const emptyParams = createEmptyParams()
+const emptyParams = createEmptyRecord()
 
 export class Node<T> {
   #methods: Record<string, HandlerSet<T>>[] = []
 
-  #children: Record<string, Node<T>> = createEmptyParams()
+  #children: Record<string, Node<T>> = createEmptyRecord()
   #patterns: Pattern[] = []
   #order: number = 0
-  #params: Record<string, string> = createEmptyParams()
+  #params: Record<string, string> = createEmptyRecord()
 
   constructor(method?: string, handler?: T) {
     if (method && handler) {
-      const m: Record<string, HandlerSet<T>> = createEmptyParams()
+      const m: Record<string, HandlerSet<T>> = createEmptyRecord()
       m[method] = { handler, possibleKeys: [], score: 0 }
       this.#methods = [m]
     }
@@ -63,7 +63,7 @@ export class Node<T> {
       curNode = curNode.#children[p]
     }
 
-    const m: Record<string, HandlerSet<T>> = createEmptyParams()
+    const m: Record<string, HandlerSet<T>> = createEmptyRecord()
 
     const handlerSet: HandlerSet<T> = {
       handler,
@@ -89,7 +89,7 @@ export class Node<T> {
       const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T> | undefined
       const processedSet: Record<number, boolean> = {}
       if (handlerSet) {
-        handlerSet.params = createEmptyParams()
+        handlerSet.params = createEmptyRecord()
         for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
           const key = handlerSet.possibleKeys[i]
           const processed = processedSet[handlerSet.score]
@@ -147,7 +147,7 @@ export class Node<T> {
             const wildcardNode = node.#children['*']
             if (wildcardNode) {
               handlerSets.push(
-                ...this.#getHandlerSets(wildcardNode, method, node.#params, createEmptyParams())
+                ...this.#getHandlerSets(wildcardNode, method, node.#params, createEmptyRecord())
               )
               tempNodes.push(wildcardNode)
             }
@@ -199,7 +199,7 @@ export class Node<T> {
       })
     }
 
-    this.#params = createEmptyParams()
+    this.#params = createEmptyRecord()
 
     return [handlerSets.map(({ handler, params }) => [handler, params] as [T, Params])]
   }

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -13,27 +13,28 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
   params: Record<string, string>
 }
 
+const createEmptyParams = () => Object.create(null)
+
+const emptyParams = createEmptyParams()
+
 export class Node<T> {
-  #methods: Record<string, HandlerSet<T>>[]
+  #methods: Record<string, HandlerSet<T>>[] = []
 
-  #children: Record<string, Node<T>>
-  #patterns: Pattern[]
+  #children: Record<string, Node<T>> = createEmptyParams()
+  #patterns: Pattern[] = []
   #order: number = 0
-  #params: Record<string, string> = Object.create(null)
+  #params: Record<string, string> = createEmptyParams()
 
-  constructor(method?: string, handler?: T, children?: Record<string, Node<T>>) {
-    this.#children = children || Object.create(null)
-    this.#methods = []
+  constructor(method?: string, handler?: T) {
     if (method && handler) {
-      const m: Record<string, HandlerSet<T>> = Object.create(null)
+      const m: Record<string, HandlerSet<T>> = createEmptyParams()
       m[method] = { handler, possibleKeys: [], score: 0 }
       this.#methods = [m]
     }
-    this.#patterns = []
   }
 
   insert(method: string, path: string, handler: T): Node<T> {
-    this.#order = ++this.#order
+    this.#order++
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let curNode: Node<T> = this
@@ -43,10 +44,10 @@ export class Node<T> {
 
     for (let i = 0, len = parts.length; i < len; i++) {
       const p: string = parts[i]
+      const pattern = getPattern(p)
 
-      if (Object.keys(curNode.#children).includes(p)) {
+      if (curNode.#children[p]) {
         curNode = curNode.#children[p]
-        const pattern = getPattern(p)
         if (pattern) {
           possibleKeys.push(pattern[1])
         }
@@ -55,7 +56,6 @@ export class Node<T> {
 
       curNode.#children[p] = new Node()
 
-      const pattern = getPattern(p)
       if (pattern) {
         curNode.#patterns.push(pattern)
         possibleKeys.push(pattern[1])
@@ -63,7 +63,7 @@ export class Node<T> {
       curNode = curNode.#children[p]
     }
 
-    const m: Record<string, HandlerSet<T>> = Object.create(null)
+    const m: Record<string, HandlerSet<T>> = createEmptyParams()
 
     const handlerSet: HandlerSet<T> = {
       handler,
@@ -77,7 +77,6 @@ export class Node<T> {
     return curNode
   }
 
-  // getHandlerSets
   #getHandlerSets(
     node: Node<T>,
     method: string,
@@ -87,10 +86,10 @@ export class Node<T> {
     const handlerSets: HandlerParamsSet<T>[] = []
     for (let i = 0, len = node.#methods.length; i < len; i++) {
       const m = node.#methods[i]
-      const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T>
+      const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T> | undefined
       const processedSet: Record<number, boolean> = {}
-      if (handlerSet !== undefined) {
-        handlerSet.params = Object.create(null)
+      if (handlerSet) {
+        handlerSet.params = createEmptyParams()
         for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
           const key = handlerSet.possibleKeys[i]
           const processed = processedSet[handlerSet.score]
@@ -107,7 +106,6 @@ export class Node<T> {
 
   search(method: string, path: string): [[T, Params][]] {
     const handlerSets: HandlerParamsSet<T>[] = []
-    this.#params = Object.create(null)
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const curNode: Node<T> = this
@@ -129,17 +127,10 @@ export class Node<T> {
             // '/hello/*' => match '/hello'
             if (nextNode.#children['*']) {
               handlerSets.push(
-                ...this.#getHandlerSets(
-                  nextNode.#children['*'],
-                  method,
-                  node.#params,
-                  Object.create(null)
-                )
+                ...this.#getHandlerSets(nextNode.#children['*'], method, node.#params, emptyParams)
               )
             }
-            handlerSets.push(
-              ...this.#getHandlerSets(nextNode, method, node.#params, Object.create(null))
-            )
+            handlerSets.push(...this.#getHandlerSets(nextNode, method, node.#params, emptyParams))
           } else {
             tempNodes.push(nextNode)
           }
@@ -153,12 +144,12 @@ export class Node<T> {
           // Wildcard
           // '/hello/*/foo' => match /hello/bar/foo
           if (pattern === '*') {
-            const astNode = node.#children['*']
-            if (astNode) {
+            const wildcardNode = node.#children['*']
+            if (wildcardNode) {
               handlerSets.push(
-                ...this.#getHandlerSets(astNode, method, node.#params, Object.create(null))
+                ...this.#getHandlerSets(wildcardNode, method, node.#params, createEmptyParams())
               )
-              tempNodes.push(astNode)
+              tempNodes.push(wildcardNode)
             }
             continue
           }
@@ -173,13 +164,16 @@ export class Node<T> {
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
           const restPathString = parts.slice(i).join('/')
-          if (matcher instanceof RegExp && matcher.test(restPathString)) {
+
+          const isMatcher = matcher instanceof RegExp
+
+          if (isMatcher && matcher.test(restPathString)) {
             params[name] = restPathString
             handlerSets.push(...this.#getHandlerSets(child, method, node.#params, params))
             continue
           }
 
-          if (matcher === true || matcher.test(part)) {
+          if (!isMatcher || matcher.test(part)) {
             params[name] = part
             if (isLast) {
               handlerSets.push(...this.#getHandlerSets(child, method, params, node.#params))
@@ -204,6 +198,8 @@ export class Node<T> {
         return a.score - b.score
       })
     }
+
+    this.#params = createEmptyParams()
 
     return [handlerSets.map(({ handler, params }) => [handler, params] as [T, Params])]
   }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -91,11 +91,12 @@ interface ParseBody {
     options?: Partial<ParseBodyOptions>
   ): Promise<T>
 }
-export const parseBody: ParseBody = async (
-  request: HonoRequest | Request,
-  options = Object.create(null)
-) => {
-  const { all = false, dot = false } = options
+export const parseBody: ParseBody = async (request: HonoRequest | Request, options = {}) => {
+  const { all, dot } = {
+    all: false,
+    dot: false,
+    ...options,
+  }
 
   const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
   const contentType = headers.get('Content-Type')

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -52,7 +52,6 @@ export const getPattern = (label: string): Pattern | null => {
   // *            => wildcard
   // :id{[0-9]+}  => ([0-9]+)
   // :id          => (.+)
-  //const name = ''
 
   if (label === '*') {
     return '*'
@@ -61,11 +60,7 @@ export const getPattern = (label: string): Pattern | null => {
   const match = label.match(/^\:([^\{\}]+)(?:\{(.+)\})?$/)
   if (match) {
     if (!patternCache[label]) {
-      if (match[2]) {
-        patternCache[label] = [label, match[1], new RegExp('^' + match[2] + '$')]
-      } else {
-        patternCache[label] = [label, match[1], true]
-      }
+      patternCache[label] = [label, match[1], match[2] ? new RegExp('^' + match[2] + '$') : true]
     }
 
     return patternCache[label]


### PR DESCRIPTION
Some cleanups and commonization of `Object.create(null)` to reduce the amount of code.

`18.5kb -> 18.1kb`

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
