### PR TITLE
fix(aws-lambda): Fix query string handling for v1

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -45,6 +45,8 @@ describe('EventProcessor.createRequest', () => {
         header1: ['value1'],
         header2: ['value1', 'value2', 'value3'],
       },
+      // This value doesn't match multi value's content.
+      // We want to assert handler is using the multi value's content when both are available.
       queryStringParameters: {
         parameter2: 'value',
       },
@@ -96,7 +98,7 @@ describe('EventProcessor.createRequest', () => {
 
     expect(request.method).toEqual('GET')
     expect(request.url).toEqual(
-      'https://id.execute-api.us-east-1.amazonaws.com/my/path?parameter2=value'
+      'https://id.execute-api.us-east-1.amazonaws.com/my/path?parameter1=value1&parameter1=value2&parameter2=value'
     )
     expect(Object.fromEntries(request.headers)).toEqual({
       'content-type': 'application/json',

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -325,10 +325,18 @@ export class EventV1Processor extends EventProcessor<Exclude<LambdaEvent, APIGat
   }
 
   protected getQueryString(event: Exclude<LambdaEvent, APIGatewayProxyEventV2>): string {
-    return Object.entries(event.queryStringParameters || {})
-      .filter(([, value]) => value)
-      .map(([key, value]) => `${key}=${value}`)
-      .join('&')
+    // In the case of gateway Integration either queryStringParameters or multiValueQueryStringParameters can be present not both
+    if (event.multiValueQueryStringParameters) {
+      return Object.entries(event.multiValueQueryStringParameters || {})
+        .filter(([, value]) => value)
+        .map(([key, value]) => `${key}=${value.join(`&${key}=`)}`)
+        .join('&')
+    } else {
+      return Object.entries(event.queryStringParameters || {})
+        .filter(([, value]) => value)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('&')
+    }
   }
 
   protected getCookies(


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

---

Fix handling of multi-value query string on API Gateway v1 event.

Similar to #2782, but for API Gateway v1 event.

API Gateway v2 already handles this case because v2 event uses the raw query string directly.

https://github.com/honojs/hono/blob/190e122180dda4b51e46cbe21a301ccbec1b1f3d/src/adapter/aws-lambda/handler.ts#L285