### PR TITLE
fix(middleware/cors): explicitly return No Content for the statusText when handling an OPTIONS request

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -81,6 +81,7 @@ describe('CORS by Middleware', () => {
     const res = await app.request(req)
 
     expect(res.status).toBe(204)
+    expect(res.statusText).toBe('No Content')
     expect(res.headers.get('Access-Control-Allow-Methods')?.split(',')[0]).toBe('GET')
     expect(res.headers.get('Access-Control-Allow-Headers')?.split(',')).toEqual([
       'X-PINGOTHER',

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -137,7 +137,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       return new Response(null, {
         headers: c.res.headers,
         status: 204,
-        statusText: c.res.statusText,
+        statusText: 'No Content',
       })
     }
     await next()


### PR DESCRIPTION
When the `cors` middleware processes an `OPTIONS` request by default, it returns the response status text from the context, `c.res.statusText`. However, in most cases, the middleware is executed before any routes or other middlewares that could modify the response `statusText`, leading to a `Not Found` response status. To align with the explicit `204` being returned, the response should also include `No Content`, similar to how the `etag` middleware handles setting the `statusText` to `Not Modified`.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
