### PR TITLE
fix(utils/ipaddr): support IPv6-mapped IPv4 address

### DIFF
--- a/src/middleware/ip-restriction/index.test.ts
+++ b/src/middleware/ip-restriction/index.test.ts
@@ -100,6 +100,10 @@ describe('isMatchForRule', () => {
   it('Static Rules', async () => {
     expect(await isMatch({ addr: '192.168.2.1', type: 'IPv4' }, '192.168.2.1')).toBeTruthy()
     expect(await isMatch({ addr: '1234::5678', type: 'IPv6' }, '1234::5678')).toBeTruthy()
+    expect(
+      await isMatch({ addr: '::ffff:127.0.0.1', type: 'IPv6' }, '::ffff:127.0.0.1')
+    ).toBeTruthy()
+    expect(await isMatch({ addr: '::ffff:127.0.0.1', type: 'IPv6' }, '::ffff:7f00:1')).toBeTruthy()
   })
   it('Function Rules', async () => {
     expect(await isMatch({ addr: '0.0.0.0', type: 'IPv4' }, () => true)).toBeTruthy()

--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -1,4 +1,5 @@
 import {
+  convertIPv4BinaryToString,
   convertIPv4ToBinary,
   convertIPv6BinaryToString,
   convertIPv6ToBinary,
@@ -13,12 +14,14 @@ describe('expandIPv6', () => {
     expect(expandIPv6('2001:2::')).toBe('2001:0002:0000:0000:0000:0000:0000:0000')
     expect(expandIPv6('2001:2::')).toBe('2001:0002:0000:0000:0000:0000:0000:0000')
     expect(expandIPv6('2001:0:0:db8::1')).toBe('2001:0000:0000:0db8:0000:0000:0000:0001')
+    expect(expandIPv6('::ffff:127.0.0.1')).toBe('0000:0000:0000:0000:0000:ffff:7f00:0001')
   })
 })
 describe('distinctRemoteAddr', () => {
   it('Should result be valid', () => {
     expect(distinctRemoteAddr('1::1')).toBe('IPv6')
     expect(distinctRemoteAddr('::1')).toBe('IPv6')
+    expect(distinctRemoteAddr('::ffff:127.0.0.1')).toBe('IPv6')
 
     expect(distinctRemoteAddr('192.168.2.0')).toBe('IPv4')
     expect(distinctRemoteAddr('192.168.2.0')).toBe('IPv4')
@@ -35,6 +38,19 @@ describe('convertIPv4ToBinary', () => {
     expect(convertIPv4ToBinary('0.0.1.0')).toBe(1n << 8n)
   })
 })
+
+describe('convertIPv4ToString', () => {
+  // add tons of test cases here
+  test.each`
+    input        | expected
+    ${'0.0.0.0'} | ${'0.0.0.0'}
+    ${'0.0.0.1'} | ${'0.0.0.1'}
+    ${'0.0.1.0'} | ${'0.0.1.0'}
+  `('convertIPv4ToString($input) === $expected', ({ input, expected }) => {
+    expect(convertIPv4BinaryToString(convertIPv4ToBinary(input))).toBe(expected)
+  })
+})
+
 describe('convertIPv6ToBinary', () => {
   it('Should result is valid', () => {
     expect(convertIPv6ToBinary('::0')).toBe(0n)
@@ -42,6 +58,7 @@ describe('convertIPv6ToBinary', () => {
 
     expect(convertIPv6ToBinary('::f')).toBe(15n)
     expect(convertIPv6ToBinary('1234:::5678')).toBe(24196103360772296748952112894165669496n)
+    expect(convertIPv6ToBinary('::ffff:127.0.0.1')).toBe(281472812449793n)
   })
 })
 
@@ -55,6 +72,7 @@ describe('convertIPv6ToString', () => {
     ${'2001:2::'}                                | ${'2001:2::'}
     ${'2001::db8:0:0:0:0:1'}                     | ${'2001:0:db8::1'}
     ${'1234:5678:9abc:def0:1234:5678:9abc:def0'} | ${'1234:5678:9abc:def0:1234:5678:9abc:def0'}
+    ${'::ffff:127.0.0.1'}                        | ${'::ffff:127.0.0.1'}
   `('convertIPv6ToString($input) === $expected', ({ input, expected }) => {
     expect(convertIPv6BinaryToString(convertIPv6ToBinary(input))).toBe(expected)
   })


### PR DESCRIPTION
fixes #3723

### Return value of `getConniInfo(c)`

In all the runtimes, an IPv6-mapped IPv4 address was returned as the remote address, so I think it is appropriate to handle this by fixing `convertIPv6BinaryToString`.

```ts
import { Hono } from './src/'
import { getConnInfo } from './src/adapter/deno/conninfo' // or bun, node-server

export default new Hono().get('/', (c) => {
  return c.json(getConnInfo(c))
})
```

```ts
$ deno serve --unstable-sloppy-imports --host [::] app.ts
$ bun run app.ts
```

```
% curl http://[::ffff:127.0.0.1]:8000/
{"remote":{"address":"::ffff:127.0.0.1","port":64504,"transport":"tcp"}}
% curl http://[::ffff:7f00:1]:8000/
{"remote":{"address":"::ffff:127.0.0.1","port":64519,"transport":"tcp"}}
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
