### PR TITLE
perf(trie-router): optimize 2x faster

### DIFF
--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -14,7 +14,7 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
 }
 
 const emptyParams = Object.create(null)
-const optimizedEmptyParams = (() => {
+const OptimizedEmptyParams = (() => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const E = function () {}
   E.prototype = emptyParams
@@ -99,7 +99,7 @@ export class Node<T> {
       const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T>
       const processedSet: Record<number, boolean> = {}
       if (handlerSet !== undefined) {
-        handlerSet.params = new optimizedEmptyParams()
+        handlerSet.params = new OptimizedEmptyParams()
         for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
           const key = handlerSet.possibleKeys[i]
           const processed = processedSet[handlerSet.score]
@@ -116,7 +116,7 @@ export class Node<T> {
 
   search(method: string, path: string): [[T, Params][]] {
     const handlerSets: HandlerParamsSet<T>[] = []
-    this.#params = new optimizedEmptyParams()
+    this.#params = new OptimizedEmptyParams()
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const curNode: Node<T> = this

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -15,6 +15,7 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
 
 const emptyParams = Object.create(null)
 const optimizedEmptyParams = (() => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const E = function () {}
   E.prototype = emptyParams
   return E

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -19,6 +19,7 @@ const optimizedEmptyParams = (() => {
   const E = function () {}
   E.prototype = emptyParams
   return E
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 })() as unknown as { new (): any }
 
 export class Node<T> {


### PR DESCRIPTION
`TrieRouter` is now much faster!

This PR does not include any attempt to reduce the file size, so a patch must be applied after the merge.

Speedups were achieved by using strange optimization methods to create null objects in JavaScript.

```ts
(() => {
  const E = function () {};
  E.prototype = Object.create(null);
  return E;
})()
```

## Benchmarks

### In Node (1.1x faster)
```llvm
  Hono RegExpRouter
   1.14x faster than Memoirist
   1.38x faster than koa-tree-router
   1.71x faster than @medley/router
   1.89x faster than trek-router
   2.46x faster than rou3
   2.52x faster than find-my-way
   3.78x faster than Hono PatternRouter
   4.61x faster than radix3
   7.89x faster than Hono TrieRouter
   8.11x faster than koa-router
   8.67x faster than Hono BeforeTrieRouter
   35.13x faster than express (WARNING: includes handling)
```

## In Deno (2x faster)
```llvm
  Hono RegExpRouter
   1.13x faster than Memoirist
   1.23x faster than koa-tree-router
   1.39x faster than @medley/router
   1.46x faster than rou3
   1.91x faster than trek-router
   1.98x faster than radix3
   2.4x faster than find-my-way
   4.14x faster than Hono PatternRouter
   4.67x faster than koa-router
   7.86x faster than Hono TrieRouter
   11.2x faster than express (WARNING: includes handling)
   13.12x faster than Hono BeforeTrieRouter
```

## In Bun (1.5x faster)
```llvm
  Memoirist
   1.14x faster than Hono RegExpRouter
   1.42x faster than @medley/router
   2.2x faster than radix3
   2.31x faster than rou3
   2.35x faster than koa-tree-router
   2.93x faster than find-my-way
   4.5x faster than Hono PatternRouter
   4.75x faster than trek-router
   5.61x faster than koa-router
   10.42x faster than Hono TrieRouter
   12.87x faster than express (WARNING: includes handling)
   15.35x faster than Hono BeforeTrieRouter
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
