### PR TITLE
Fixed "Missing Buffer type in the parameter of c.body"

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -29,7 +29,7 @@ type HeaderRecord =
 /**
  * Data type can be a string, ArrayBuffer, or ReadableStream or Buffer.
  */
-export type Data = string | ArrayBuffer | ReadableStream | Buffer
+export type Data = string | ArrayBuffer | ReadableStream | Uint8Array
 
 /**
  * Interface for the execution context in a web worker or similar environment.

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,9 +27,9 @@ type HeaderRecord =
   | Record<string, string | string[]>
 
 /**
- * Data type can be a string, ArrayBuffer, or ReadableStream.
+ * Data type can be a string, ArrayBuffer, or ReadableStream or Buffer.
  */
-export type Data = string | ArrayBuffer | ReadableStream
+export type Data = string | ArrayBuffer | ReadableStream | Buffer
 
 /**
  * Interface for the execution context in a web worker or similar environment.


### PR DESCRIPTION
Updated the "Data" type definitions in src/context.ts to include Buffer.

This fixes issues such as the following [here](https://github.com/honojs/hono/issues/3729)

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
