### PR TITLE
perf(trie-router): avoid calling spread operator for `Object.create(null)`

### DIFF
--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -13,13 +13,15 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
   params: Record<string, string>
 }
 
+const emptyParams = Object.create(null)
+
 export class Node<T> {
   #methods: Record<string, HandlerSet<T>>[]
 
   #children: Record<string, Node<T>>
   #patterns: Pattern[]
   #order: number = 0
-  #params: Record<string, string> = Object.create(null)
+  #params: Record<string, string> = emptyParams
 
   constructor(method?: string, handler?: T, children?: Record<string, Node<T>>) {
     this.#children = children || Object.create(null)
@@ -107,7 +109,7 @@ export class Node<T> {
 
   search(method: string, path: string): [[T, Params][]] {
     const handlerSets: HandlerParamsSet<T>[] = []
-    this.#params = Object.create(null)
+    this.#params = emptyParams
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const curNode: Node<T> = this
@@ -147,8 +149,7 @@ export class Node<T> {
 
         for (let k = 0, len3 = node.#patterns.length; k < len3; k++) {
           const pattern = node.#patterns[k]
-
-          const params = { ...node.#params }
+          const params = node.#params === emptyParams ? {} : { ...node.#params }
 
           // Wildcard
           // '/hello/*/foo' => match /hello/bar/foo

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -83,7 +83,7 @@ export class Node<T> {
   #getHandlerSets(
     node: Node<T>,
     method: string,
-    nodeParams?: Record<string, string>,
+    nodeParams: Record<string, string>,
     params?: Record<string, string>
   ): HandlerParamsSet<T>[] {
     const handlerSets: HandlerParamsSet<T>[] = []
@@ -94,7 +94,7 @@ export class Node<T> {
       if (handlerSet !== undefined) {
         handlerSet.params = Object.create(null)
         handlerSets.push(handlerSet)
-        if (nodeParams) {
+        if (nodeParams !== emptyParams || (params && params !== emptyParams)) {
           for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
             const key = handlerSet.possibleKeys[i]
             const processed = processedSet[handlerSet.score]
@@ -131,9 +131,11 @@ export class Node<T> {
           if (isLast) {
             // '/hello/*' => match '/hello'
             if (nextNode.#children['*']) {
-              handlerSets.push(...this.#getHandlerSets(nextNode.#children['*'], method))
+              handlerSets.push(
+                ...this.#getHandlerSets(nextNode.#children['*'], method, node.#params)
+              )
             }
-            handlerSets.push(...this.#getHandlerSets(nextNode, method))
+            handlerSets.push(...this.#getHandlerSets(nextNode, method, node.#params))
           } else {
             tempNodes.push(nextNode)
           }


### PR DESCRIPTION
This optimization is based on the discussion in the following Pull Request.
Thanks to @EdamAme-x!
https://github.com/honojs/hono/pull/3732


### benchmarks

via benchmarks/routers

#### node

```
• all together
----------------------------------------------------------------------- -----------------------------
Hono RegExpRouter                   513 ns/iter       (490 ns … 715 ns)    524 ns    595 ns    715 ns
Hono TrieRouter(perf-trie-1208)   1'716 ns/iter   (1'652 ns … 1'895 ns)  1'723 ns  1'892 ns  1'895 ns
Hono TrieRouter(main)             2'203 ns/iter   (2'097 ns … 2'730 ns)  2'213 ns  2'709 ns  2'730 ns

summary for all together
  Hono RegExpRouter
   3.35x faster than Hono TrieRouter(perf-trie-1208)
   4.3x faster than Hono TrieRouter(main)
```

#### bun

```
• all together
----------------------------------------------------------------------- -----------------------------
Hono RegExpRouter                   393 ns/iter       (360 ns … 722 ns)    390 ns    594 ns    722 ns
Hono TrieRouter(perf-trie-1208)   3'191 ns/iter   (2'032 ns … 3'602 ns)  3'351 ns  3'595 ns  3'602 ns
Hono TrieRouter(main)             3'971 ns/iter   (3'732 ns … 4'293 ns)  4'065 ns  4'267 ns  4'293 ns

summary for all together
  Hono RegExpRouter
   8.12x faster than Hono TrieRouter(perf-trie-1208)
   10.1x faster than Hono TrieRouter(main)
```


### The author should do the following, if applicable

- <del>Add tests</del>
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- <del>Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code</del>
