### PR TITLE
fix(streaming) Prevent console.error(undefined) when pipe is aborted

### DIFF
--- a/src/helper/streaming/stream.test.ts
+++ b/src/helper/streaming/stream.test.ts
@@ -71,6 +71,28 @@ describe('Basic Streaming Helper', () => {
     expect(aborted).toBeTruthy()
   })
 
+  it('Check stream Response if pipe is aborted by abort signal', async () => {
+    const ac = new AbortController()
+    const req = new Request('http://localhost/', { signal: ac.signal })
+    const c = new Context(req)
+
+    let aborted = false
+    const res = stream(c, async (stream) => {
+      stream.onAbort(() => {
+        aborted = true
+      })
+      await stream.pipe(new ReadableStream())
+    })
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const pReading = reader.read()
+    ac.abort()
+    await pReading
+    expect(aborted).toBeTruthy()
+  })
+
   it('Check stream Response if error occurred', async () => {
     const onError = vi.fn()
     const res = stream(

--- a/src/helper/streaming/stream.ts
+++ b/src/helper/streaming/stream.ts
@@ -22,7 +22,11 @@ export const stream = (
     try {
       await cb(stream)
     } catch (e) {
-      if (e instanceof Error && onError) {
+      if (e === undefined) {
+        // If reading is canceled without a reason value (e.g. by StreamingApi)
+        // then the .pipeTo() promise will reject with undefined.
+        // In this case, do nothing because the stream is already closed.
+      } else if (e instanceof Error && onError) {
         await onError(e, stream)
       } else {
         console.error(e)


### PR DESCRIPTION
Previously, using `.pipe()` in a stream helper response would cause `console.error(undefined)` to be logged whenever the request was cancelled.

These logs did not show up in NodeJS locally, but they are visible in either Bun or in AWS CloudWatch Logs when running on AWS Lambda.

NodeJS Example:

```ts
import { serve } from '@hono/node-server';
import { Hono } from 'hono';
import { stream } from 'hono/streaming';

const originalError = console.error;
console.error = (...args) => {
  originalError('ERROR', ...args);
};

export const app = new Hono()

  .get('/test', c => {
    return stream(
      c,
      s =>
        s.pipe(
          new ReadableStream(),
        ),
      async (err, s) => {
        console.log('error', err);
      },
    );
  });

serve({
  fetch: app.fetch,
  port: 3000,
});
// Then run curl http://localhost:3000/test then press CTRL+C
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
