### PR TITLE
chore(jsx): export ComponentWithChildren type

### DIFF
--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -25,7 +25,7 @@ type Component = (
   c: Context
 ) => HtmlEscapedString | Promise<HtmlEscapedString>
 
-type ComponentWithChildren = (
+export type ComponentWithChildren = (
   props: PropsWithChildren<PropsForRenderer & { Layout: FC }>,
   c: Context
 ) => HtmlEscapedString | Promise<HtmlEscapedString>


### PR DESCRIPTION
When I run `npm run type-check` on [this repository](https://github.com/yasuaki640/gpt-web-client), I get the following type error.

```shell
npm run type-check 

> type-check
> tsc

src/middleware/layout.ts:4:45 - error TS2345: Argument of type 'FC' is not assignable to parameter of type 'ComponentWithChildren'.
  Type 'HtmlEscapedString | Promise<HtmlEscapedString> | null' is not assignable to type 'HtmlEscapedString | Promise<HtmlEscapedString>'.
    Type 'null' is not assignable to type 'HtmlEscapedString | Promise<HtmlEscapedString>'.

4 export const LayoutMiddleware = jsxRenderer(Layout);
                                              ~~~~~~


Found 1 error in src/middleware/layout.ts:4
```

I think the easiest way to fix this is to export the `ComponentsWithChildren` type.

https://github.com/honojs/hono/blob/4eb101dd03e66e20dfda86e6e5ebce8045d61d05/src/middleware/jsx-renderer/index.ts#L28

Since it can happen that a jsx renderer argument is defined in a different jsx file, I think exporting the type is a good idea, what do you think ?

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
