### PR TITLE
feat(utils/cookie): Ability to set a priority to cookies in setCookie options

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -170,10 +170,11 @@ describe('Set cookie', () => {
       maxAge: 1000,
       expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
       sameSite: 'Strict',
+      priority: 'High',
       partitioned: true,
     })
     expect(serialized).toBe(
-      '__Secure-great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Partitioned'
+      '__Secure-great_cookie=banana; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Priority=High; Partitioned'
     )
   })
 
@@ -185,10 +186,11 @@ describe('Set cookie', () => {
       maxAge: 1000,
       expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
       sameSite: 'Strict',
+      priority: 'High',
       partitioned: true,
     })
     expect(serialized).toBe(
-      '__Host-great_cookie=banana; Max-Age=1000; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Partitioned'
+      '__Host-great_cookie=banana; Max-Age=1000; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Priority=High; Partitioned'
     )
   })
 
@@ -210,10 +212,11 @@ describe('Set cookie', () => {
       maxAge: 1000,
       expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
       sameSite: 'Strict',
+      priority: 'High',
       partitioned: true,
     })
     expect(serialized).toBe(
-      'great_cookie=banana.hSo6gB7YT2db0WBiEAakEmh7dtwEL0DSp76G23WvHuQ%3D; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Partitioned'
+      'great_cookie=banana.hSo6gB7YT2db0WBiEAakEmh7dtwEL0DSp76G23WvHuQ%3D; Max-Age=1000; Domain=example.com; Path=/; Expires=Sun, 24 Dec 2000 10:30:59 GMT; HttpOnly; Secure; SameSite=Strict; Priority=High; Partitioned'
     )
   })
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -24,6 +24,7 @@ export type CookieOptions = {
   signingSecret?: string
   sameSite?: 'Strict' | 'Lax' | 'None' | 'strict' | 'lax' | 'none'
   partitioned?: boolean
+  priority?: 'Low' | 'Medium' | 'High'
   prefix?: CookiePrefixOptions
 } & PartitionedCookieConstraint
 export type CookiePrefixOptions = 'host' | 'secure'
@@ -202,6 +203,10 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
 
   if (opt.sameSite) {
     cookie += `; SameSite=${opt.sameSite.charAt(0).toUpperCase() + opt.sameSite.slice(1)}`
+  }
+
+  if (opt.priority) {
+    cookie += `; Priority=${opt.priority}`
   }
 
   if (opt.partitioned) {


### PR DESCRIPTION
Hono's `setCookie` did not have `Priority` and I recently needed that option so I forked hono and added it. Nothing's serious been changed—succesfully tested locally.