### PR TITLE
feat(hono/context): contentful status code typing

### DIFF
--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -4,7 +4,7 @@ import { hc } from '../../client'
 import type { ClientRequest } from '../../client/types'
 import { Hono } from '../../index'
 import type { ToSchema, TypedResponse } from '../../types'
-import type { StatusCode } from '../../utils/http-status'
+import type { ContentfulStatusCode, StatusCode } from '../../utils/http-status'
 import { validator } from '../../validator'
 import { createFactory, createMiddleware } from './index'
 
@@ -106,7 +106,7 @@ describe('createHandler', () => {
             input: {}
             output: 'A'
             outputFormat: 'text'
-            status: StatusCode
+            status: ContentfulStatusCode
           }
         }>
       }>()

--- a/src/http-exception.ts
+++ b/src/http-exception.ts
@@ -3,7 +3,7 @@
  * This module provides the `HTTPException` class.
  */
 
-import type { StatusCode } from './utils/http-status'
+import type { ContentfulStatusCode } from './utils/http-status'
 
 /**
  * Options for creating an `HTTPException`.
@@ -45,14 +45,14 @@ type HTTPExceptionOptions = {
  */
 export class HTTPException extends Error {
   readonly res?: Response
-  readonly status: StatusCode
+  readonly status: ContentfulStatusCode
 
   /**
    * Creates an instance of `HTTPException`.
    * @param status - HTTP status code for the exception. Defaults to 500.
    * @param options - Additional options for the exception.
    */
-  constructor(status: StatusCode = 500, options?: HTTPExceptionOptions) {
+  constructor(status: ContentfulStatusCode = 500, options?: HTTPExceptionOptions) {
     super(options?.message, { cause: options?.cause })
     this.res = options?.res
     this.status = status

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -7,7 +7,7 @@ import type { Context } from '../../context'
 import { HTTPException } from '../../http-exception'
 import type { MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
-import type { StatusCode } from '../../utils/http-status'
+import type { ContentfulStatusCode } from '../../utils/http-status'
 
 const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
@@ -87,7 +87,7 @@ export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
 
   const throwHTTPException = async (
     c: Context,
-    status: StatusCode,
+    status: ContentfulStatusCode,
     wwwAuthenticateHeader: string,
     messageOption: string | object | MessageFunction
   ): Promise<Response> => {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -20,7 +20,7 @@ import type {
   ToSchema,
   TypedResponse,
 } from './types'
-import type { StatusCode } from './utils/http-status'
+import type { ContentfulStatusCode, StatusCode } from './utils/http-status'
 import type { Equal, Expect } from './utils/types'
 import { validator } from './validator'
 
@@ -96,7 +96,7 @@ describe('HandlerInterface', () => {
               message: string
             }
             outputFormat: 'json'
-            status: StatusCode
+            status: ContentfulStatusCode
           }
         }
       }
@@ -135,7 +135,7 @@ describe('HandlerInterface', () => {
               message: string
             }
             outputFormat: 'json'
-            status: StatusCode
+            status: ContentfulStatusCode
           }
         }
       }
@@ -163,7 +163,7 @@ describe('HandlerInterface', () => {
             }
             output: 'foo'
             outputFormat: 'text'
-            status: StatusCode
+            status: ContentfulStatusCode
           }
         }
       }
@@ -192,7 +192,7 @@ describe('HandlerInterface', () => {
             }
             output: string
             outputFormat: 'text'
-            status: StatusCode
+            status: ContentfulStatusCode
           }
         }
       }
@@ -217,7 +217,7 @@ describe('HandlerInterface', () => {
             }
             output: string
             outputFormat: 'text'
-            status: StatusCode
+            status: ContentfulStatusCode
           }
         }
       } & {
@@ -271,7 +271,7 @@ describe('OnHandlerInterface', () => {
             success: boolean
           }
           outputFormat: 'json'
-          status: StatusCode
+          status: ContentfulStatusCode
         }
       }
     }
@@ -376,7 +376,7 @@ describe('Support c.json(undefined)', () => {
           input: {}
           output: never
           outputFormat: 'json'
-          status: StatusCode
+          status: ContentfulStatusCode
         }
       }
     }
@@ -460,7 +460,7 @@ describe('`json()`', () => {
             message: string
           }
           outputFormat: 'json'
-          status: StatusCode
+          status: ContentfulStatusCode
         }
       }
     }
@@ -902,7 +902,7 @@ describe('Different types using json()', () => {
                   ng: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
             | {
                 input: {}
@@ -910,7 +910,7 @@ describe('Different types using json()', () => {
                   ok: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
             | {
                 input: {}
@@ -918,7 +918,7 @@ describe('Different types using json()', () => {
                   default: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
         }
       }
@@ -974,7 +974,7 @@ describe('Different types using json()', () => {
                   default: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
         }
       }
@@ -1012,7 +1012,7 @@ describe('Different types using json()', () => {
                   ng: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
             | {
                 input: {}
@@ -1020,7 +1020,7 @@ describe('Different types using json()', () => {
                   ok: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
             | {
                 input: {}
@@ -1028,7 +1028,7 @@ describe('Different types using json()', () => {
                   default: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
         }
       }
@@ -1084,7 +1084,7 @@ describe('Different types using json()', () => {
                   default: boolean
                 }
                 outputFormat: 'json'
-                status: StatusCode
+                status: ContentfulStatusCode
               }
         }
       }
@@ -1111,7 +1111,7 @@ describe('json() in an async handler', () => {
             ok: boolean
           }
           outputFormat: 'json'
-          status: StatusCode
+          status: ContentfulStatusCode
         }
       }
     }
@@ -2269,5 +2269,24 @@ describe('generic typed variables', () => {
     type Actual = ExtractSchema<typeof route>['/']['$get']['output']
     type Expected = { data: string }
     expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+})
+describe('status code', () => {
+  const app = new Hono()
+
+  it('should only allow to return .json() with contentful status codes', async () => {
+    const route = app.get('/', async (c) => c.json({}))
+    type Actual = ExtractSchema<typeof route>['/']['$get']['status']
+    expectTypeOf<Actual>().toEqualTypeOf<ContentfulStatusCode>()
+  })
+  it('should only allow to return .body(null) with all status codes', async () => {
+    const route = app.get('/', async (c) => c.body(null))
+    type Actual = ExtractSchema<typeof route>['/']['$get']['status']
+    expectTypeOf<Actual>().toEqualTypeOf<StatusCode>()
+  })
+  it('should only allow to return .text() with contentful status codes', async () => {
+    const route = app.get('/', async (c) => c.text('whatever'))
+    type Actual = ExtractSchema<typeof route>['/']['$get']['status']
+    expectTypeOf<Actual>().toEqualTypeOf<ContentfulStatusCode>()
   })
 })

--- a/src/utils/http-status.ts
+++ b/src/utils/http-status.ts
@@ -67,3 +67,6 @@ export type StatusCode =
   | ClientErrorStatusCode
   | ServerErrorStatusCode
   | UnofficialStatusCode
+
+export type ContentlessStatusCode = 101 | 204 | 205 | 304
+export type ContentfulStatusCode = Exclude<StatusCode, ContentlessStatusCode>

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -10,7 +10,7 @@ import type {
   ParsedFormValue,
   ValidationTargets,
 } from '../types'
-import type { StatusCode } from '../utils/http-status'
+import type { ContentfulStatusCode } from '../utils/http-status'
 import type { Equal, Expect } from '../utils/types'
 import type { ValidationFunction } from './validator'
 import { validator } from './validator'
@@ -65,7 +65,7 @@ describe('Basic', () => {
         }
         output: 'Valid!'
         outputFormat: 'text'
-        status: StatusCode
+        status: ContentfulStatusCode
       }
     }
   }
@@ -477,7 +477,7 @@ describe('Validator middleware with a custom validation function', () => {
           }
         }
         outputFormat: 'json'
-        status: StatusCode
+        status: ContentfulStatusCode
       }
     }
   }
@@ -540,7 +540,7 @@ describe('Validator middleware with Zod validates JSON', () => {
           }
         }
         outputFormat: 'json'
-        status: StatusCode
+        status: ContentfulStatusCode
       }
     }
   }
@@ -829,7 +829,7 @@ describe('Validator middleware with Zod multiple validators', () => {
           title: string
         }
         outputFormat: 'json'
-        status: StatusCode
+        status: ContentfulStatusCode
       }
     }
   }
@@ -893,7 +893,7 @@ it('With path parameters', () => {
         }
         output: 'Valid!'
         outputFormat: 'text'
-        status: StatusCode
+        status: ContentfulStatusCode
       }
     }
   }
@@ -941,7 +941,7 @@ it('`on`', () => {
           success: boolean
         }
         outputFormat: 'json'
-        status: StatusCode
+        status: ContentfulStatusCode
       }
     }
   }
@@ -1198,7 +1198,7 @@ describe('Transform', () => {
             page: number
           }
           outputFormat: 'json'
-          status: StatusCode
+          status: ContentfulStatusCode
         }
       }
     }


### PR DESCRIPTION
### Contentful status code

Resolves https://github.com/honojs/hono/issues/1518

All in all, prohibits returning `c.json()` or `c.text()` or `c.html()` with 101, 204, 205, and 304 status codes.

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
