### PR TITLE
fix(jsr): exclude unused markdown files

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -110,9 +110,6 @@
       "jsr.json",
       "LICENSE",
       "README.md",
-      "docs/CODE_OF_CONDUCT.md",
-      "docs/CONTRIBUTING.md",
-      "docs/MIGRATION.md",
       "src/**/*.ts"
     ],
     "exclude": [


### PR DESCRIPTION
These may have been included because they could not be linked to files on GitHub before on JSR, but now they are linked correctly like npm. Therefore, it is better to exclude them.


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
