### PR TITLE
fix(hono-base): don't use Symbol for `COMPOSED_HANDLER`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -26,12 +26,8 @@ import type {
   RouterRoute,
   Schema,
 } from './types'
+import { COMPOSED_HANDLER } from './utils/constants'
 import { getPath, getPathNoStrict, mergePath } from './utils/url'
-
-/**
- * Symbol used to mark a composed handler.
- */
-export const COMPOSED_HANDLER = Symbol('composedHandler')
 
 const notFoundHandler = (c: Context) => {
   return c.text('404 Not Found', 404)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Constant used to mark a composed handler.
+ */
+export const COMPOSED_HANDLER = '__COMPOSED_HANDLER'

--- a/src/utils/handler.ts
+++ b/src/utils/handler.ts
@@ -3,7 +3,7 @@
  * Handler utility.
  */
 
-import { COMPOSED_HANDLER } from '../hono-base'
+import { COMPOSED_HANDLER } from './constants'
 
 export const isMiddleware = (handler: Function) => handler.length > 1
 export const findTargetHandler = (handler: Function): Function => {


### PR DESCRIPTION
Fixes #3760

This PR resolves the problem described in #3760. It uses a string value for `COMPOSED_HANDLER` instead of a Symbol. We should add a test for a `fix` change, but in this PR, it's challenging to reproduce the problem in #3760, so it doesn't include a test.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
