### PR TITLE
feat(factory): Allow HonoOptions<E> with factory

### DIFF
--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -272,6 +272,22 @@ describe('createApp', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('bar')
   })
+
+  it('Should use the default options', async () => {
+    const app = createFactory({ defaultOptions: { strict: false } }).createApp()
+    app.get('/hello', (c) => c.text('hello'))
+    const res = await app.request('/hello/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+  })
+
+  it('Should override the default options when creating', async () => {
+    const app = createFactory({ defaultOptions: { strict: true } }).createApp({ strict: false })
+    app.get('/hello', (c) => c.text('hello'))
+    const res = await app.request('/hello/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+  })
 })
 
 describe('Lint rules', () => {

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -273,16 +273,16 @@ describe('createApp', () => {
     expect(await res.text()).toBe('bar')
   })
 
-  it('Should use the default options', async () => {
-    const app = createFactory({ defaultOptions: { strict: false } }).createApp()
+  it('Should use the default app options', async () => {
+    const app = createFactory({ defaultAppOptions: { strict: false } }).createApp()
     app.get('/hello', (c) => c.text('hello'))
     const res = await app.request('/hello/')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('hello')
   })
 
-  it('Should override the default options when creating', async () => {
-    const app = createFactory({ defaultOptions: { strict: true } }).createApp({ strict: false })
+  it('Should override the default app options when creating', async () => {
+    const app = createFactory({ defaultAppOptions: { strict: true } }).createApp({ strict: false })
     app.get('/hello', (c) => c.text('hello'))
     const res = await app.request('/hello/')
     expect(res.status).toBe(200)

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from '../../hono'
+import type { HonoOptions } from '../../hono-base'
 import type {
   Env,
   H,
@@ -285,13 +286,19 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
 
 export class Factory<E extends Env = any, P extends string = any> {
   private initApp?: InitApp<E>
+  #defaultOptions?: HonoOptions<E>
 
-  constructor(init?: { initApp?: InitApp<E> }) {
+  constructor(init?: { initApp?: InitApp<E>; defaultOptions?: HonoOptions<E> }) {
     this.initApp = init?.initApp
+    this.#defaultOptions = init?.defaultOptions
   }
 
-  createApp = (): Hono<E> => {
-    const app = new Hono<E>()
+  createApp = (options?: HonoOptions<E>): Hono<E> => {
+    const app = new Hono<E>(
+      options && this.#defaultOptions
+        ? { ...this.#defaultOptions, ...options }
+        : options ?? this.#defaultOptions
+    )
     if (this.initApp) {
       this.initApp(app)
     }
@@ -308,6 +315,7 @@ export class Factory<E extends Env = any, P extends string = any> {
 
 export const createFactory = <E extends Env = any, P extends string = any>(init?: {
   initApp?: InitApp<E>
+  defaultOptions?: HonoOptions<E>
 }): Factory<E, P> => new Factory<E, P>(init)
 
 export const createMiddleware = <

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -286,18 +286,18 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
 
 export class Factory<E extends Env = any, P extends string = any> {
   private initApp?: InitApp<E>
-  #defaultOptions?: HonoOptions<E>
+  #defaultAppOptions?: HonoOptions<E>
 
-  constructor(init?: { initApp?: InitApp<E>; defaultOptions?: HonoOptions<E> }) {
+  constructor(init?: { initApp?: InitApp<E>; defaultAppOptions?: HonoOptions<E> }) {
     this.initApp = init?.initApp
-    this.#defaultOptions = init?.defaultOptions
+    this.#defaultAppOptions = init?.defaultAppOptions
   }
 
   createApp = (options?: HonoOptions<E>): Hono<E> => {
     const app = new Hono<E>(
-      options && this.#defaultOptions
-        ? { ...this.#defaultOptions, ...options }
-        : options ?? this.#defaultOptions
+      options && this.#defaultAppOptions
+        ? { ...this.#defaultAppOptions, ...options }
+        : options ?? this.#defaultAppOptions
     )
     if (this.initApp) {
       this.initApp(app)
@@ -315,7 +315,7 @@ export class Factory<E extends Env = any, P extends string = any> {
 
 export const createFactory = <E extends Env = any, P extends string = any>(init?: {
   initApp?: InitApp<E>
-  defaultOptions?: HonoOptions<E>
+  defaultAppOptions?: HonoOptions<E>
 }): Factory<E, P> => new Factory<E, P>(init)
 
 export const createMiddleware = <


### PR DESCRIPTION
When using factory, options such as `strict: false` cannot be specified. This Pull Request allows you to specify options when calling `createFactory` and `createApp`.

```ts
const factory = createFactory({ defaultOptions: { strict: false } });
const app = factory.createApp({ options: { strict: true } }); // Override defaultOptions
```

### The author should do the following, if applicable

- [x] Add tests
- [X] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
