### PR TITLE
perf(build): Use WebWorker when removing private fields

### DIFF
--- a/build/remove-private-fields-worker.test.ts
+++ b/build/remove-private-fields-worker.test.ts
@@ -3,7 +3,7 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { removePrivateFields } from './remove-private-fields'
+import { removePrivateFields } from './remove-private-fields-worker'
 
 describe('removePrivateFields', () => {
   it('Works', async () => {

--- a/build/remove-private-fields-worker.ts
+++ b/build/remove-private-fields-worker.ts
@@ -1,0 +1,85 @@
+import * as ts from 'typescript'
+
+export type WorkerInput = {
+  file: string
+  taskId: number
+}
+
+export type WorkerOutput =
+  | {
+      type: 'success'
+      value: string
+      taskId: number
+    }
+  | {
+      type: 'error'
+      value: unknown
+      taskId: number
+    }
+
+const removePrivateTransformer = <T extends ts.Node>(ctx: ts.TransformationContext) => {
+  const visit: ts.Visitor = (node) => {
+    if (ts.isClassDeclaration(node)) {
+      const newMembers = node.members.filter((elem) => {
+        if (ts.isPropertyDeclaration(elem) || ts.isMethodDeclaration(elem)) {
+          for (const modifier of elem.modifiers ?? []) {
+            if (modifier.kind === ts.SyntaxKind.PrivateKeyword) {
+              return false
+            }
+          }
+        }
+        if (elem.name && ts.isPrivateIdentifier(elem.name)) {
+          return false
+        }
+        return true
+      })
+      return ts.factory.createClassDeclaration(
+        node.modifiers,
+        node.name,
+        node.typeParameters,
+        node.heritageClauses,
+        newMembers
+      )
+    }
+    return ts.visitEachChild(node, visit, ctx)
+  }
+
+  return (node: T) => {
+    const visited = ts.visitNode(node, visit)
+    if (!visited) {
+      throw new Error('The result visited is undefined.')
+    }
+    return visited
+  }
+}
+
+export const removePrivateFields = (tsPath: string) => {
+  const program = ts.createProgram([tsPath], {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+  })
+  const file = program.getSourceFile(tsPath)
+
+  const transformed = ts.transform(file!, [removePrivateTransformer])
+  const printer = ts.createPrinter()
+  const transformedSourceFile = transformed.transformed[0] as ts.SourceFile
+  const code = printer.printFile(transformedSourceFile)
+  transformed.dispose()
+  return code
+}
+
+declare const self: Worker
+
+if (globalThis.self) {
+  self.addEventListener('message', function (e) {
+    const { file, taskId } = e.data as WorkerInput
+
+    try {
+      const result = removePrivateFields(file)
+      self.postMessage({ type: 'success', value: result, taskId } satisfies WorkerOutput)
+    } catch (e) {
+      console.error(e)
+      self.postMessage({ type: 'error', value: e, taskId } satisfies WorkerOutput)
+    }
+  })
+}

--- a/build/remove-private-fields.ts
+++ b/build/remove-private-fields.ts
@@ -2,8 +2,7 @@ import { cpus } from 'node:os'
 import type { WorkerInput, WorkerOutput } from './remove-private-fields-worker'
 
 const workers = Array.from({ length: Math.ceil(cpus().length / 2) }).map(
-  () => new Worker(`${import.meta.dirname}/remove-private-fields-worker.ts`),
-  { type: 'module' }
+  () => new Worker(`${import.meta.dirname}/remove-private-fields-worker.ts`, { type: 'module' })
 )
 let workerIndex = 0
 let taskId = 0

--- a/build/remove-private-fields.ts
+++ b/build/remove-private-fields.ts
@@ -1,52 +1,41 @@
-import * as ts from 'typescript'
+import { cpus } from 'node:os'
+import type { WorkerInput, WorkerOutput } from './remove-private-fields-worker'
 
-const removePrivateTransformer = <T extends ts.Node>(ctx: ts.TransformationContext) => {
-  const visit: ts.Visitor = (node) => {
-    if (ts.isClassDeclaration(node)) {
-      const newMembers = node.members.filter((elem) => {
-        if (ts.isPropertyDeclaration(elem) || ts.isMethodDeclaration(elem)) {
-          for (const modifier of elem.modifiers ?? []) {
-            if (modifier.kind === ts.SyntaxKind.PrivateKeyword) {
-              return false
-            }
+const workers = Array.from({ length: Math.ceil(cpus().length / 2) }).map(
+  () => new Worker(`${import.meta.dirname}/remove-private-fields-worker.ts`),
+  { type: 'module' }
+)
+let workerIndex = 0
+let taskId = 0
+
+export async function removePrivateFields(file: string): Promise<string> {
+  const currentTaskId = taskId++
+  const worker = workers[workerIndex]
+  workerIndex = (workerIndex + 1) % workers.length
+
+  return new Promise<string>((resolve, reject) => {
+    const abortController = new AbortController()
+    worker.addEventListener(
+      'message',
+      ({ data: { type, value, taskId } }: { data: WorkerOutput }) => {
+        if (taskId === currentTaskId) {
+          if (type === 'success') {
+            resolve(value)
+          } else {
+            reject(value)
           }
-        }
-        if (elem.name && ts.isPrivateIdentifier(elem.name)) {
-          return false
-        }
-        return true
-      })
-      return ts.factory.createClassDeclaration(
-        node.modifiers,
-        node.name,
-        node.typeParameters,
-        node.heritageClauses,
-        newMembers
-      )
-    }
-    return ts.visitEachChild(node, visit, ctx)
-  }
 
-  return (node: T) => {
-    const visited = ts.visitNode(node, visit)
-    if (!visited) {
-      throw new Error('The result visited is undefined.')
-    }
-    return visited
-  }
+          abortController.abort()
+        }
+      },
+      { signal: abortController.signal }
+    )
+    worker.postMessage({ file, taskId: currentTaskId } satisfies WorkerInput)
+  })
 }
 
-export const removePrivateFields = (tsPath: string) => {
-  const program = ts.createProgram([tsPath], {
-    target: ts.ScriptTarget.ESNext,
-    module: ts.ModuleKind.ESNext,
-  })
-  const file = program.getSourceFile(tsPath)
-
-  const transformed = ts.transform(file!, [removePrivateTransformer])
-  const printer = ts.createPrinter()
-  const transformedSourceFile = transformed.transformed[0] as ts.SourceFile
-  const code = printer.printFile(transformedSourceFile)
-  transformed.dispose()
-  return code
+export function cleanupWorkers() {
+  for (const worker of workers) {
+    worker.terminate()
+  }
 }


### PR DESCRIPTION
`removePrivateFields` is a heavy CPU-bound process. This PR improves performance by using all CPU in WebWorker.

The following is the `removePrivateFields` time for the current build process.

Environemt:
- CPU: Intel(R) Core(TM) i7-12700F (20 Cores)
- RAM: 32GB

Current: 47750.3256ms
This PR: 10963.4007ms

The Github Actions environment is 4 CPUs, so CI may not improve performance that much. I think it will be very fast in local environment.