### PR TITLE
fix(helper/factory): Reduce the code size of createMiddleware

### DIFF
--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -316,4 +316,4 @@ export const createMiddleware = <
   I extends Input = {}
 >(
   middleware: MiddlewareHandler<E, P, I>
-): MiddlewareHandler<E, P, I> => createFactory<E, P>().createMiddleware<I>(middleware)
+): MiddlewareHandler<E, P, I> => middleware


### PR DESCRIPTION
`createMiddleware` depends on `Hono`, so `hono/tiny` users cannot use `createMiddleware` and libraries which use `createMiddleware`. `createMiddleware` should not use `Factory`

`createMiddleware` -> `Factory` -> `Hono` (`hono/hono`)

### Libraries which use `createMiddleware`

- @hono/bun-transpiler
- @hono/cloudflare-access
- @hono/esbuild-transpiler
- @hono/oidc-auth
- @hono/prometheus
- @hono/tsyringe