### PR TITLE
feat(etag): allow for custom hashing methods to be used to etag

### DIFF
--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -9,13 +9,21 @@ const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Ui
 }
 
 export const generateDigest = async (
-  stream: ReadableStream<Uint8Array> | null
+  stream: ReadableStream<Uint8Array> | null,
+  generateDigest?: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
   if (!stream || !crypto || !crypto.subtle) {
     return null
   }
 
   let result: ArrayBuffer | undefined = undefined
+  generateDigest ||= (body: Uint8Array) =>
+    crypto.subtle.digest(
+      {
+        name: 'SHA-1',
+      },
+      body
+    )
 
   const reader = stream.getReader()
   for (;;) {
@@ -24,12 +32,7 @@ export const generateDigest = async (
       break
     }
 
-    result = await crypto.subtle.digest(
-      {
-        name: 'SHA-1',
-      },
-      mergeBuffers(result, value)
-    )
+    result = await generateDigest(mergeBuffers(result, value))
   }
 
   if (!result) {

--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -10,20 +10,13 @@ const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Ui
 
 export const generateDigest = async (
   stream: ReadableStream<Uint8Array> | null,
-  generateDigest?: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
+  generateDigest: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
   if (!stream || !crypto || !crypto.subtle) {
     return null
   }
 
   let result: ArrayBuffer | undefined = undefined
-  generateDigest ||= (body: Uint8Array) =>
-    crypto.subtle.digest(
-      {
-        name: 'SHA-1',
-      },
-      body
-    )
 
   const reader = stream.getReader()
   for (;;) {

--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -10,7 +10,7 @@ const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Ui
 
 export const generateDigest = async (
   stream: ReadableStream<Uint8Array> | null,
-  generateDigest: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
+  generator: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
   if (!stream || !crypto || !crypto.subtle) {
     return null
@@ -25,7 +25,7 @@ export const generateDigest = async (
       break
     }
 
-    result = await generateDigest(mergeBuffers(result, value))
+    result = await generator(mergeBuffers(result, value))
   }
 
   if (!result) {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -25,7 +25,7 @@ describe('Etag Middleware', () => {
     app.use(
       '/etag/*',
       etag({
-        generateDigest: (body: Uint8Array) =>
+        generateDigest: (body) =>
           crypto.subtle.digest(
             {
               name: 'SHA-256',

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -57,7 +57,7 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false
-  const _generateDigest =
+  const generator =
     options?.generateDigest ??
     ((body: Uint8Array) =>
       crypto.subtle.digest(
@@ -76,7 +76,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
     let etag = res.headers.get('ETag')
 
     if (!etag) {
-      const hash = await generateDigest(res.clone().body, _generateDigest)
+      const hash = await generateDigest(res.clone().body, generator)
       if (hash === null) {
         return
       }

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -39,7 +39,7 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
  * @param {ETagOptions} [options] - The options for the ETag middleware.
  * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
  * @param {string[]} [options.retainedHeaders=RETAINED_304_HEADERS] - The headers that you want to retain in the 304 Response.
- * @param {function(Uint8Array): ArrayBuffer | Promise<ArrayBuffer> | undefined} [options.generateDigest] -
+ * @param {function(Uint8Array): ArrayBuffer | Promise<ArrayBuffer>} [options.generateDigest] -
  * A custom digest generation function. By default, it uses 'SHA-1'
  * This function is called with the response body as a `Uint8Array` and should return a hash as an `ArrayBuffer` or a Promise of one.
  * @returns {MiddlewareHandler} The middleware handler function.

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -9,6 +9,7 @@ import { generateDigest } from './digest'
 type ETagOptions = {
   retainedHeaders?: string[]
   weak?: boolean
+  generateDigest?: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 }
 
 /**
@@ -63,7 +64,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
     let etag = res.headers.get('ETag')
 
     if (!etag) {
-      const hash = await generateDigest(res.clone().body)
+      const hash = await generateDigest(res.clone().body, options?.generateDigest)
       if (hash === null) {
         return
       }

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -39,6 +39,9 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
  * @param {ETagOptions} [options] - The options for the ETag middleware.
  * @param {boolean} [options.weak=false] - Define using or not using a weak validation. If true is set, then `W/` is added to the prefix of the value.
  * @param {string[]} [options.retainedHeaders=RETAINED_304_HEADERS] - The headers that you want to retain in the 304 Response.
+ * @param {function(Uint8Array): ArrayBuffer | Promise<ArrayBuffer> | undefined} [options.generateDigest] -
+ * A custom digest generation function. By default, it uses 'SHA-1'
+ * This function is called with the response body as a `Uint8Array` and should return a hash as an `ArrayBuffer` or a Promise of one.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -84,7 +84,6 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
     }
 
     if (etagMatches(etag, ifNoneMatch)) {
-      await c.res.blob() // Force using body
       c.res = new Response(null, {
         status: 304,
         statusText: 'Not Modified',


### PR DESCRIPTION
resolve: https://github.com/honojs/hono/issues/3829

```ts
const app = new Hono()

app.use(
  '/etag/*',
  etag({
    generateDigest: (body: Uint8Array) =>
      crypto.subtle.digest({
          name: 'SHA-256',
        },
        body
      ),
  })
)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
