### PR TITLE
perf(types): define `ParamKey` simply

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1939,14 +1939,12 @@ export type ValidationTargets<T extends FormValue = ParsedFormValue, P extends s
 //////                            //////
 ////////////////////////////////////////
 
-type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer Rest}`
-  ? Rest extends `${infer _Pattern}?`
-    ? `${Name}?`
-    : Name
-  : NameWithPattern
-
 type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
-  ? ParamKeyName<NameWithPattern>
+  ? NameWithPattern extends `${infer Name}{${infer Rest}`
+    ? Rest extends `${infer _Pattern}?`
+      ? `${Name}?`
+      : Name
+    : NameWithPattern
   : never
 
 export type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`


### PR DESCRIPTION
`ParamKeyName` is unnecessary since it is used only in `ParamKey`. Removing it introduces decreasing in `Instantiations` for TypeScript.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
