### PR TITLE
chore: delete misleading comments

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -142,13 +142,11 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   let cookie = `${name}=${value}`
 
   if (name.startsWith('__Secure-') && !opt.secure) {
-    // FIXME: replace link to RFC
     // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.3.1
     throw new Error('__Secure- Cookie must have Secure attributes')
   }
 
   if (name.startsWith('__Host-')) {
-    // FIXME: replace link to RFC
     // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.3.2
     if (!opt.secure) {
       throw new Error('__Host- Cookie must have Secure attributes')
@@ -165,7 +163,6 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
 
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
     if (opt.maxAge > 34560000) {
-      // FIXME: replace link to RFC
       // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2
       throw new Error(
         'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
@@ -184,7 +181,6 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
 
   if (opt.expires) {
     if (opt.expires.getTime() - Date.now() > 34560000_000) {
-      // FIXME: replace link to RFC
       // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.1
       throw new Error(
         'Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.'
@@ -210,7 +206,6 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.partitioned) {
-    // FIXME: replace link to RFC
     // https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-01.html#section-2.3
     if (!opt.secure) {
       throw new Error('Partitioned Cookie must have Secure attributes')


### PR DESCRIPTION
This is not a problem because the IETF is the organization that manages RFCs for the Internet.

- [x] `bun run format:fix && bun run lint:fix` to format the code
