### PR TITLE
fix(helper/adapter): `env` should set `c` type correctly

### DIFF
--- a/src/helper/adapter/index.test.ts
+++ b/src/helper/adapter/index.test.ts
@@ -1,9 +1,29 @@
-import { getRuntimeKey } from '.'
+import { Hono } from '../../hono'
+import { env, getRuntimeKey } from '.'
 
 describe('getRuntimeKey', () => {
   it('Should return the current runtime key', () => {
     // Now, using the `bun run test` command.
     // But `vitest` depending Node.js will run this test so the RuntimeKey will be `node`.
     expect(getRuntimeKey()).toBe('node')
+  })
+})
+
+describe('env', () => {
+  describe('Types', () => {
+    type Env = {
+      Bindings: {
+        MY_VAR: string
+      }
+    }
+    const app = new Hono<Env>()
+
+    it('Should set the type of the Context correctly and not throw a type error')
+    app.get('/var', (c) => {
+      const { MY_VAR } = env<{ MY_VAR: string }>(c)
+      return c.json({
+        var: MY_VAR,
+      })
+    })
   })
 })

--- a/src/helper/adapter/index.ts
+++ b/src/helper/adapter/index.ts
@@ -7,7 +7,14 @@ import type { Context } from '../../context'
 
 export type Runtime = 'node' | 'deno' | 'bun' | 'workerd' | 'fastly' | 'edge-light' | 'other'
 
-export const env = <T extends Record<string, unknown>, C extends Context = Context<{}>>(
+export const env = <
+  T extends Record<string, unknown>,
+  C extends Context = Context<
+    {} & {
+      Bindings: T
+    }
+  >
+>(
   c: C,
   runtime?: Runtime
 ): T & C['env'] => {


### PR DESCRIPTION
Fixes #3854

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
