### PR TITLE
fix(lambda-edge-adapter): Support Alternate Domain Names and Multiple Cookies in Lambda@Edge

### DIFF
--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -105,7 +105,10 @@ interface CloudFrontResult {
 const convertHeaders = (headers: Headers): CloudFrontHeaders => {
   const cfHeaders: CloudFrontHeaders = {}
   headers.forEach((value, key) => {
-    cfHeaders[key.toLowerCase()] = [{ key: key.toLowerCase(), value }]
+    cfHeaders[key.toLowerCase()] = [
+      ...(cfHeaders[key.toLowerCase()] || []),
+      { key: key.toLowerCase(), value },
+    ]
   })
   return cfHeaders
 }

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -150,7 +150,10 @@ const createResult = async (res: Response): Promise<CloudFrontResult> => {
 
 const createRequest = (event: CloudFrontEdgeEvent): Request => {
   const queryString = event.Records[0].cf.request.querystring
-  const urlPath = `https://${event.Records[0].cf.request.headers.host[0].value}${event.Records[0].cf.request.uri}`
+  const host =
+    event.Records[0].cf.request.headers?.host?.[0]?.value ||
+    event.Records[0].cf.config.distributionDomainName
+  const urlPath = `https://${host}${event.Records[0].cf.request.uri}`
   const url = queryString ? `${urlPath}?${queryString}` : urlPath
 
   const headers = new Headers()

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -147,7 +147,7 @@ const createResult = async (res: Response): Promise<CloudFrontResult> => {
 
 const createRequest = (event: CloudFrontEdgeEvent): Request => {
   const queryString = event.Records[0].cf.request.querystring
-  const urlPath = `https://${event.Records[0].cf.config.distributionDomainName}${event.Records[0].cf.request.uri}`
+  const urlPath = `https://${event.Records[0].cf.request.headers.host[0].value}${event.Records[0].cf.request.uri}`
   const url = queryString ? `${urlPath}?${queryString}` : urlPath
 
   const headers = new Headers()


### PR DESCRIPTION
This pull request introduces support for using alternate domain names in front of a CloudFront distribution. Additionally, it enhances cookie handling by supporting the setting of multiple cookies, addressing the previous limitation where only the last cookie was set.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
