### PR TITLE
fix(middleware/cors): export CORSOptions type

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -6,7 +6,7 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
-type CORSOptions = {
+export type CORSOptions = {
   origin: string | string[] | ((origin: string, c: Context) => string | undefined | null)
   allowMethods?: string[]
   allowHeaders?: string[]


### PR DESCRIPTION
Exports the CORSOptions interface to allow external usage of the CORS middleware configuration type. 

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
