### PR TITLE
fix(client): correct inferring empty object from`c.json({})`

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -50,6 +50,7 @@ describe('Basic - JSON', () => {
     )
     .get('/hello-not-found', (c) => c.notFound())
     .get('/null', (c) => c.json(null))
+    .get('/empty', (c) => c.json({}))
 
   type AppType = typeof route
 
@@ -76,6 +77,9 @@ describe('Basic - JSON', () => {
     }),
     http.get('http://localhost/null', () => {
       return HttpResponse.json(null)
+    }),
+    http.get('http://localhost/empty', () => {
+      return HttpResponse.json({})
     }),
     http.get('http://localhost/api/string', () => {
       return HttpResponse.json('a-string')
@@ -137,6 +141,14 @@ describe('Basic - JSON', () => {
     const data = await res.json()
     expectTypeOf(data).toMatchTypeOf<null>()
     expect(data).toBe(null)
+  })
+
+  it('Should get a `{}` content', async () => {
+    const client = hc<AppType>('http://localhost')
+    const res = await client.empty.$get()
+    const data = await res.json()
+    expectTypeOf(data).toMatchTypeOf<{}>()
+    expect(data).toStrictEqual({})
   })
 
   it('Should have correct types - primitives', async () => {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -54,15 +54,6 @@ export type ClientRequest<S extends Schema> = {
       : {}
     : {})
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type BlankRecordToNever<T> = T extends any
-  ? T extends null
-    ? null
-    : keyof T extends never
-    ? never
-    : T
-  : never
-
 type ClientResponseOfEndpoint<T extends Endpoint = Endpoint> = T extends {
   output: infer O
   outputFormat: infer F
@@ -89,11 +80,7 @@ export interface ClientResponse<
   url: string
   redirect(url: string, status: number): Response
   clone(): Response
-  json(): F extends 'text'
-    ? Promise<never>
-    : F extends 'json'
-    ? Promise<BlankRecordToNever<T>>
-    : Promise<unknown>
+  json(): F extends 'text' ? Promise<never> : F extends 'json' ? Promise<T> : Promise<unknown>
   text(): F extends 'text' ? (T extends string ? Promise<T> : Promise<never>) : Promise<string>
   blob(): Promise<Blob>
   formData(): Promise<FormData>


### PR DESCRIPTION
Fixes #3868

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
