### PR TITLE
docs(CONTRIBUTING): remove text about `yarn`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,15 +28,9 @@ After that, please install the dependency environment.
 bun install
 ```
 
-If you can't do that, there is also a `yarn.lock` file, so you can do the same with the `yarn` command.
-
-```bash
-yarn install --frozen-lockfile
-```
-
 ## PRs
 
-Please ensure your PR passes tests with `bun run test` or `yarn test`.
+Please ensure your PR passes tests with `bun run test`.
 
 ## Third-party middleware
 


### PR DESCRIPTION
`yarn.lock` has been removed by https://github.com/honojs/hono/pull/3846