### PR TITLE
refactor(request): `toLowerCase()` is unnecessary for `req.header()`

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -161,6 +161,20 @@ describe('headers', () => {
     const foo = req.header('foo')
     expect(foo).toEqual('')
   })
+
+  test('Keys of the arguments for req.header() are not case-sensitive', () => {
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: 'abc',
+          lowercase: 'lowercase value',
+        },
+      })
+    )
+    expect(req.header('Content-Type')).toBe('application/json')
+    expect(req.header('ApiKey')).toBe('abc')
+  })
 })
 
 const text = '{"foo":"bar"}'

--- a/src/request.ts
+++ b/src/request.ts
@@ -178,7 +178,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   header(): Record<RequestHeader | (string & CustomHeader), string>
   header(name?: string) {
     if (name) {
-      return this.raw.headers.get(name.toLowerCase()) ?? undefined
+      return this.raw.headers.get(name) ?? undefined
     }
 
     const headerData: Record<string, string | undefined> = {}


### PR DESCRIPTION
The arg of `get` in the `Headers` object is not case-insensitive. So, the `name.toLowerCase()` is unnecessary.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
