### PR TITLE
fix(adapter/aws-lambda): APIGWProxyResult should contain either of headers or multiValueHeaders, not both

### DIFF
--- a/runtime-tests/lambda/index.test.ts
+++ b/runtime-tests/lambda/index.test.ts
@@ -249,6 +249,7 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(response.statusCode).toBe(200)
     expect(response.body).toBe('Hello Lambda!')
     expect(response.headers['content-type']).toMatch(/^text\/plain/)
+    expect(response.multiValueHeaders).toBeUndefined()
     expect(response.isBase64Encoded).toBe(false)
   })
 
@@ -268,6 +269,7 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(response.statusCode).toBe(200)
     expect(response.body).toBe('RmFrZSBJbWFnZQ==')
     expect(response.headers['content-type']).toMatch(/^image\/png/)
+    expect(response.multiValueHeaders).toBeUndefined()
     expect(response.isBase64Encoded).toBe(true)
   })
 
@@ -289,6 +291,7 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(response.statusCode).toBe(200)
     expect(response.body).toBe('Hello Lambda!')
     expect(response.headers['content-type']).toMatch(/^text\/plain/)
+    expect(response.multiValueHeaders).toBeUndefined()
     expect(response.isBase64Encoded).toBe(false)
   })
 
@@ -309,6 +312,7 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(response.statusCode).toBe(200)
     expect(response.body).toBe('Hello Lambda!')
     expect(response.headers['content-type']).toMatch(/^text\/plain/)
+    expect(response.multiValueHeaders).toBeUndefined()
     expect(response.isBase64Encoded).toBe(false)
   })
 
@@ -540,6 +544,7 @@ describe('AWS Lambda Adapter for Hono', () => {
             'content-type': 'application/json',
           })
         )
+        expect(albResponse.multiValueHeaders).toBeUndefined()
       })
 
       it('Should extract single-value headers and return 200 (APIGatewayProxyEvent)', async () => {
@@ -687,6 +692,7 @@ describe('AWS Lambda Adapter for Hono', () => {
     expect(albResponse.statusCode).toBe(200)
     expect(albResponse.body).toBe('Valid Cookies')
     expect(albResponse.headers['content-type']).toMatch(/^text\/plain/)
+    expect(albResponse.multiValueHeaders).toBeUndefined()
     expect(albResponse.isBase64Encoded).toBe(false)
   })
 
@@ -709,7 +715,10 @@ describe('AWS Lambda Adapter for Hono', () => {
 
     expect(albResponse.statusCode).toBe(200)
     expect(albResponse.body).toBe('Valid Cookies')
-    expect(albResponse.headers['content-type']).toMatch(/^text\/plain/)
+    expect(albResponse.headers).toBeUndefined()
+    expect(albResponse.multiValueHeaders['content-type']).toEqual([
+      expect.stringMatching(/^text\/plain/),
+    ])
     expect(albResponse.isBase64Encoded).toBe(false)
   })
 
@@ -759,9 +768,8 @@ describe('AWS Lambda Adapter for Hono', () => {
 
     expect(albResponse.statusCode).toBe(200)
     expect(albResponse.body).toBe('Cookies Set')
-    expect(albResponse.headers['content-type']).toMatch(/^text\/plain/)
-    expect(albResponse.multiValueHeaders).toBeDefined()
-    expect(albResponse.multiValueHeaders && albResponse.multiValueHeaders['set-cookie']).toEqual(
+    expect(albResponse.headers).toBeUndefined()
+    expect(albResponse.multiValueHeaders['set-cookie']).toEqual(
       expect.arrayContaining([testCookie1.serialized, testCookie2.serialized])
     )
     expect(albResponse.isBase64Encoded).toBe(false)
@@ -794,6 +802,7 @@ describe('AWS Lambda Adapter for Hono', () => {
       })
     )
     expect(albResponse.headers['content-type']).toMatch(/^application\/json/)
+    expect(albResponse.multiValueHeaders).toBeUndefined()
     expect(albResponse.isBase64Encoded).toBe(false)
   })
 
@@ -823,7 +832,10 @@ describe('AWS Lambda Adapter for Hono', () => {
         key2: 'value2',
       })
     )
-    expect(albResponse.headers['content-type']).toMatch(/^application\/json/)
+    expect(albResponse.headers).toBeUndefined()
+    expect(albResponse.multiValueHeaders['content-type']).toEqual([
+      expect.stringMatching(/^application\/json/),
+    ])
     expect(albResponse.isBase64Encoded).toBe(false)
   })
 
@@ -853,7 +865,10 @@ describe('AWS Lambda Adapter for Hono', () => {
         key2: ['value2', 'otherValue2'],
       })
     )
-    expect(albResponse.headers['content-type']).toMatch(/^application\/json/)
+    expect(albResponse.headers).toBeUndefined()
+    expect(albResponse.multiValueHeaders['content-type']).toEqual([
+      expect.stringMatching(/^application\/json/),
+    ])
     expect(albResponse.isBase64Encoded).toBe(false)
   })
 })

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -70,17 +70,23 @@ export interface ALBProxyEvent {
   requestContext: ALBRequestContext
 }
 
-export interface APIGatewayProxyResult {
+type APIGatewayProxyResultResponseHeaders =
+  | {
+      headers: Record<string, string>
+      multiValueHeaders?: undefined
+    }
+  | {
+      headers?: undefined
+      multiValueHeaders: Record<string, string[]>
+    }
+
+export type APIGatewayProxyResult = {
   statusCode: number
   statusDescription?: string
   body: string
-  headers: Record<string, string>
   cookies?: string[]
-  multiValueHeaders?: {
-    [headerKey: string]: string[]
-  }
   isBase64Encoded: boolean
-}
+} & APIGatewayProxyResultResponseHeaders
 
 const getRequestContext = (
   event: LambdaEvent
@@ -190,11 +196,7 @@ export abstract class EventProcessor<E extends LambdaEvent> {
 
   protected abstract getCookies(event: E, headers: Headers): void
 
-  protected abstract setCookiesToResult(
-    event: E,
-    result: APIGatewayProxyResult,
-    cookies: string[]
-  ): void
+  protected abstract setCookiesToResult(result: APIGatewayProxyResult, cookies: string[]): void
 
   createRequest(event: E): Request {
     const queryString = this.getQueryString(event)
@@ -234,19 +236,27 @@ export abstract class EventProcessor<E extends LambdaEvent> {
 
     const result: APIGatewayProxyResult = {
       body: body,
-      headers: {},
-      multiValueHeaders: event.multiValueHeaders ? {} : undefined,
       statusCode: res.status,
       isBase64Encoded,
+      ...(event.multiValueHeaders
+        ? {
+            multiValueHeaders: {},
+          }
+        : {
+            headers: {},
+          }),
     }
 
     this.setCookies(event, res, result)
-    res.headers.forEach((value, key) => {
-      result.headers[key] = value
-      if (event.multiValueHeaders && result.multiValueHeaders) {
+    if (result.multiValueHeaders) {
+      res.headers.forEach((value, key) => {
         result.multiValueHeaders[key] = [value]
-      }
-    })
+      })
+    } else {
+      res.headers.forEach((value, key) => {
+        result.headers[key] = value
+      })
+    }
 
     return result
   }
@@ -260,7 +270,7 @@ export abstract class EventProcessor<E extends LambdaEvent> {
             .map(([, v]) => v)
 
       if (Array.isArray(cookies)) {
-        this.setCookiesToResult(event, result, cookies)
+        this.setCookiesToResult(result, cookies)
         res.headers.delete('set-cookie')
       }
     }
@@ -286,11 +296,7 @@ export class EventV2Processor extends EventProcessor<APIGatewayProxyEventV2> {
     }
   }
 
-  protected setCookiesToResult(
-    _: APIGatewayProxyEventV2,
-    result: APIGatewayProxyResult,
-    cookies: string[]
-  ): void {
+  protected setCookiesToResult(result: APIGatewayProxyResult, cookies: string[]): void {
     result.cookies = cookies
   }
 
@@ -365,11 +371,7 @@ export class EventV1Processor extends EventProcessor<Exclude<LambdaEvent, APIGat
     return headers
   }
 
-  protected setCookiesToResult(
-    _: APIGatewayProxyEvent,
-    result: APIGatewayProxyResult,
-    cookies: string[]
-  ): void {
+  protected setCookiesToResult(result: APIGatewayProxyResult, cookies: string[]): void {
     result.multiValueHeaders = {
       'set-cookie': cookies,
     }
@@ -446,13 +448,9 @@ export class ALBProcessor extends EventProcessor<ALBProxyEvent> {
     }
   }
 
-  protected setCookiesToResult(
-    event: ALBProxyEvent,
-    result: APIGatewayProxyResult,
-    cookies: string[]
-  ): void {
+  protected setCookiesToResult(result: APIGatewayProxyResult, cookies: string[]): void {
     // when multi value headers is enabled
-    if (event.multiValueHeaders && result.multiValueHeaders) {
+    if (result.multiValueHeaders) {
       result.multiValueHeaders['set-cookie'] = cookies
     } else {
       // otherwise serialize the set-cookie


### PR DESCRIPTION
Closes #3870

- `APIGWProxyResult` now contains `headers` or `multiValueHeaders` mutually-exclusively.
- `handle` is tweaked so the response type can be inferred from the request event type.



### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
