### PR TITLE
fix(router/trie-router): fix label with trailing wildcard pattern

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -497,6 +497,19 @@ export const runTest = ({
       })
     })
 
+    describe('Capture regex pattern has trailing wildcard', () => {
+      beforeEach(() => {
+        router.add('GET', '/:dir{[a-z]+}/*/file.html', 'file.html')
+      })
+
+      it('GET /foo/bar/file.html', () => {
+        const res = match('GET', '/foo/bar/file.html')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('file.html')
+        expect(res[0].params['dir']).toEqual('foo')
+      })
+    })
+
     describe('non ascii characters', () => {
       beforeEach(() => {
         router.add('ALL', '/$/*', 'middleware $')

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -7,7 +7,10 @@ describe('LinearRouter', () => {
     skip: [
       {
         reason: 'UnsupportedPath',
-        tests: ['Multi match > `params` per a handler > GET /entry/123/show'],
+        tests: [
+          'Multi match > `params` per a handler > GET /entry/123/show',
+          'Capture regex pattern has trailing wildcard > GET /foo/bar/file.html',
+        ],
       },
       {
         reason: 'LinearRouter allows trailing slashes',

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -150,6 +150,7 @@ export class Node<T> {
             const astNode = node.#children['*']
             if (astNode) {
               handlerSets.push(...this.#getHandlerSets(astNode, method, node.#params))
+              astNode.#params = params
               tempNodes.push(astNode)
             }
             continue


### PR DESCRIPTION
TrieRouter was not able to obtain parameters in the pattern of the added test, so I fixed it.

https://github.com/honojs/hono/compare/main...usualoma:fix/label-trailing-wildcard?expand=1#diff-18f50c43f41503d5cc65c9d783b57e0c683eb26957f59a11edb2d099f40114c2R502

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
