### PR TITLE
fix(combine): Skip middleware properly in `some()` when next throws

### DIFF
--- a/src/middleware/combine/index.test.ts
+++ b/src/middleware/combine/index.test.ts
@@ -91,6 +91,27 @@ describe('some', () => {
 
     expect(await res.text()).toBe('oops')
   })
+
+  it('Should not call skipped middleware even if next function throws an error', async () => {
+    const middleware1 = () => true
+    const middleware2 = vi.fn(() => true)
+
+    app.use('/', async (c) => {
+      await some(middleware1, middleware2)(c, () => {
+        throw new Error('Error in next function')
+      })
+    })
+    app.get('/', (c) => {
+      return c.text('Hello World')
+    })
+    app.onError((_, c) => {
+      return c.text('oops')
+    })
+    const res = await app.request('http://localhost/')
+
+    expect(middleware2).not.toBeCalled()
+    expect(await res.text()).toBe('oops')
+  })
 })
 
 describe('every', () => {

--- a/src/middleware/combine/index.ts
+++ b/src/middleware/combine/index.ts
@@ -39,20 +39,21 @@ export const some = (...middleware: (MiddlewareHandler | Condition)[]): Middlewa
   return async function some(c, next) {
     let lastError: unknown
     for (const handler of middleware) {
+      let result: unknown
       try {
-        const result = await handler(c, next)
-        if (result === true && !c.finalized) {
-          await next()
-        } else if (result === false) {
-          lastError = new Error('No successful middleware found')
-          continue
-        }
-        lastError = undefined
-        break
+        result = await handler(c, next)
       } catch (error) {
         lastError = error
         continue
       }
+      if (result === true && !c.finalized) {
+        await next()
+      } else if (result === false) {
+        lastError = new Error('No successful middleware found')
+        continue
+      }
+      lastError = undefined
+      break
     }
     if (lastError) {
       throw lastError


### PR DESCRIPTION
fix: #3898

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

