### PR TITLE
feat(logger): max length of log can be specified

### DIFF
--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -217,7 +217,6 @@ describe('Logger by Middleware with options', () => {
     app = new Hono()
 
     const logFunc = (str: string) => {
-      console.log(str)
       log = str
     }
 

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -56,11 +56,11 @@ const trim = (str: string, maxLength: number) => {
 
 function log(
   printFunc: PrintFunc,
+  maxLength: number,
   prefix: string,
   method: string,
   path: string,
   status: number = 0,
-  maxLength: number = Infinity,
   elapsed?: string
 ) {
   const trimmedMethod = trim(method, maxLength)
@@ -103,12 +103,12 @@ export const logger = (options: PrintFunc | LoggerOptions = console.log): Middle
 
     const path = url.slice(url.indexOf('/', 8))
 
-    log(printFunc, LogPrefix.Incoming, method, path, maxLength)
+    log(printFunc, maxLength, LogPrefix.Incoming, method, path)
 
     const start = Date.now()
 
     await next()
 
-    log(printFunc, LogPrefix.Outgoing, method, path, c.res.status, maxLength, time(start))
+    log(printFunc, maxLength, LogPrefix.Outgoing, method, path, c.res.status, time(start))
   }
 }


### PR DESCRIPTION
This can mitigate the risk of attack.

Related: https://github.com/honojs/hono/pull/3702#discussion_r1857433017

```js
logger({
  printFunc: logFunc,
  maxLength: 64,
})
// No breaking changes are made because past formats are also supported.
logger(logFunc)
```

```llvm
--> GET /hhhhhhhhhhhhhhh... 200 0ms
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
