### PR TITLE
fix(utils/url): calculate ends with slash on every iteration

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -152,6 +152,8 @@ describe('url', () => {
       expect(mergePath('/book', 'hey', 'say')).toBe('/book/hey/say')
       expect(mergePath('/book', '/hey/', '/say/')).toBe('/book/hey/say/')
       expect(mergePath('/book', '/hey/', '/say/', '/')).toBe('/book/hey/say/')
+      expect(mergePath('/book', '/hey', '/say', '/')).toBe('/book/hey/say')
+      expect(mergePath('/', '/book', '/hey', '/say', '/')).toBe('/book/hey/say')
 
       expect(mergePath('book', '/')).toBe('/book')
       expect(mergePath('book/', '/')).toBe('/book/')

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -141,10 +141,12 @@ export const mergePath = (...paths: string[]): string => {
   let endsWithSlash = false
 
   for (let path of paths) {
+    // calculate endsWithSlash at the start of each iteration
+    endsWithSlash = p.at(-1) === '/'
+
     /* ['/hey/','/say'] => ['/hey', '/say'] */
-    if (p.at(-1) === '/') {
+    if (endsWithSlash) {
       p = p.slice(0, -1)
-      endsWithSlash = true
     }
 
     /* ['/hey','say'] => ['/hey', '/say'] */


### PR DESCRIPTION
This fixes #3909

I don't know if this is the best way of doing this, if you can find a better/faster way let me know! :) 

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
