### PR TITLE
perf(utils/url): shorten mergePath and optimize for normal use cases.

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -136,38 +136,27 @@ export const getPathNoStrict = (request: Request): string => {
   return result.length > 1 && result.at(-1) === '/' ? result.slice(0, -1) : result
 }
 
-export const mergePath = (...paths: string[]): string => {
-  let p: string = ''
-  let endsWithSlash = false
-
-  for (let path of paths) {
-    // calculate endsWithSlash at the start of each iteration
-    endsWithSlash = p.at(-1) === '/'
-
-    /* ['/hey/','/say'] => ['/hey', '/say'] */
-    if (endsWithSlash) {
-      p = p.slice(0, -1)
-    }
-
-    /* ['/hey','say'] => ['/hey', '/say'] */
-    if (path[0] !== '/') {
-      path = `/${path}`
-    }
-
-    /* ['/hey/', '/'] => `/hey/` */
-    if (path === '/' && endsWithSlash) {
-      p = `${p}/`
-    } else if (path !== '/') {
-      p = `${p}${path}`
-    }
-
-    /* ['/', '/'] => `/` */
-    if (path === '/' && p === '') {
-      p = '/'
-    }
+/**
+ * Merge paths.
+ * @param {string[]} ...paths - The paths to merge.
+ * @returns {string} The merged path.
+ * @example
+ * mergePath('/api', '/users') // '/api/users'
+ * mergePath('/api/', '/users') // '/api/users'
+ * mergePath('/api', '/') // '/api'
+ * mergePath('/api/', '/') // '/api/'
+ */
+export const mergePath: (...paths: string[]) => string = (
+  base: string | undefined,
+  sub: string | undefined,
+  ...rest: string[]
+): string => {
+  if (rest.length) {
+    sub = mergePath(sub as string, ...rest)
   }
-
-  return p
+  return `${base?.[0] === '/' ? '' : '/'}${base}${
+    sub === '/' ? '' : `${base?.at(-1) === '/' ? '' : '/'}${sub?.[0] === '/' ? sub.slice(1) : sub}`
+  }`
 }
 
 export const checkOptionalParameter = (path: string): string[] | null => {


### PR DESCRIPTION
I ❤️  ternary operators.
I ❤️  recursive calls.


### Requirements for `mergePath`

We can pass any number of paths to `mergePath`, but in the hono core, only the pattern of passing two is used.

Looking at https://github.com/honojs/hono/issues/3909, it seems that third-party middleware sometimes uses more than three, but even so, such usage is rare.

Also, many apps do not use `mergePath`, and even when they do, they use it in the initialisation process rather than at runtime.

Therefore, the following can be considered as requirements for `mergePath` optimisation.
* The minified code should be small
* It should be particularly fast when there are two arguments


### Benchmarks

The following are the results of benchmarking using node.js, but the same trend applies to bun and deno.

<details>

<summary>bench.ts</summary>

```ts
import { run, bench, group } from 'mitata'

export const mergePathNew: (...paths: string[]) => string = (
  base: string | undefined,
  sub: string | undefined,
  ...rest: string[]
): string => {
  if (rest.length) {
    sub = mergePathNew(sub as string, ...rest)
  }
  return `${base?.[0] === '/' ? '' : '/'}${base}${
    sub === '/' ? '' : `${base?.at(-1) === '/' ? '' : '/'}${sub?.[0] === '/' ? sub.slice(1) : sub}`
  }`
}

export const mergePath = (...paths: string[]): string => {
  let p: string = ''
  let endsWithSlash = false

  for (let path of paths) {
    // calculate endsWithSlash at the start of each iteration
    endsWithSlash = p.at(-1) === '/'

    /* ['/hey/','/say'] => ['/hey', '/say'] */
    if (endsWithSlash) {
      p = p.slice(0, -1)
    }

    /* ['/hey','say'] => ['/hey', '/say'] */
    if (path[0] !== '/') {
      path = `/${path}`
    }

    /* ['/hey/', '/'] => `/hey/` */
    if (path === '/' && endsWithSlash) {
      p = `${p}/`
    } else if (path !== '/') {
      p = `${p}${path}`
    }

    /* ['/', '/'] => `/` */
    if (path === '/' && p === '') {
      p = '/'
    }
  }

  return p
}

bench('noop', () => {})

group('two paths', () => {
  bench('mergePath', () => mergePath('/api', '/users'))
  bench('mergePathNew', () => mergePathNew('/api', '/users'))
})

group('three paths', () => {
  bench('mergePath', () => mergePath('/api', '/users', '/books'))
  bench('mergePathNew', () => mergePathNew('/api', '/users', '/books'))
})

group('four paths', () => {
  bench('mergePath', () => mergePath('/api', '/users', '/books', 'abc'))
  bench('mergePathNew', () => mergePathNew('/api', '/users', '/books', 'abc'))
})

run()
```

</details>

```
$ npx tsx bench.ts
clk: ~3.26 GHz
cpu: Apple M2 Pro
runtime: node 22.2.0 (arm64-darwin)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
noop                          91.73 ps/iter  91.55 ps           █           !
                      (61.04 ps … 10.61 ns) 122.07 ps        ▃  █          
                    (  0.10  b …  39.68  b)   0.10  b ▁▁▁▁▁▁▁█▁▁█▁▁▃▁▁▁▃▁▁▁

• two paths
------------------------------------------- -------------------------------
mergePath                     27.66 ns/iter  27.66 ns  █                   
                      (26.33 ns … 72.84 ns)  36.11 ns  █▄                  
                    ( 11.97  b … 402.39  b)  32.42  b ▂██▆▄▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁

mergePathNew                   9.09 ns/iter   8.96 ns     █                
                       (8.15 ns … 49.93 ns)  11.62 ns    ▆█▂               
                    (  0.65  b … 159.85  b)  24.23  b ▁▂▄███▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁

• three paths
------------------------------------------- -------------------------------
mergePath                     40.99 ns/iter  40.51 ns  █                   
                      (39.54 ns … 78.74 ns)  59.87 ns ██                   
                    ( 32.57  b … 191.97  b)  94.08  b ██▅▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

mergePathNew                  48.77 ns/iter  48.11 ns █                    
                     (46.91 ns … 101.89 ns)  69.49 ns █                    
                    ( 96.62  b … 349.48  b) 144.73  b ██▄▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• four paths
------------------------------------------- -------------------------------
mergePath                     83.45 ns/iter  85.86 ns █                    
                     (78.91 ns … 145.58 ns) 113.45 ns █                    
                    ( 61.64  b … 612.01  b) 188.52  b ██▅▅▅▅▃▂▂▁▁▂▁▁▁▁▁▁▁▁▁

mergePathNew                  94.30 ns/iter  95.42 ns  █                   
                     (89.07 ns … 156.45 ns) 124.85 ns  █                   
                    ( 35.98  b … 472.98  b) 248.95  b ██▇▆▄▄▂▁▂▂▂▂▂▂▂▁▁▁▁▁▁

               benchmark was likely optimized out (dead code elimination) = !
               https://github.com/evanwashere/mitata#writing-good-benchmarks
```


### Minified result

#### main

```
$ npx esbuild --minify src/utils/url.ts | wc
       1      74    2767
```

#### pref/util-merge-path

```
$ npx esbuild --minify src/utils/url.ts | wc
       1      69    2731
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code