### PR TITLE
fix(etag): change where to check for `crypto`

### DIFF
--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -10,9 +10,9 @@ const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Ui
 
 export const generateDigest = async (
   stream: ReadableStream<Uint8Array> | null,
-  generator?: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
+  generator: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
-  if (!stream || !generator) {
+  if (!stream) {
     return null
   }
 

--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -10,9 +10,9 @@ const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Ui
 
 export const generateDigest = async (
   stream: ReadableStream<Uint8Array> | null,
-  generator: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
+  generator?: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
-  if (!stream) {
+  if (!stream || !generator) {
     return null
   }
 

--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -12,7 +12,7 @@ export const generateDigest = async (
   stream: ReadableStream<Uint8Array> | null,
   generator: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
-  if (!stream || !crypto || !crypto.subtle) {
+  if (!stream) {
     return null
   }
 

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -86,8 +86,9 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
     let etag = res.headers.get('ETag')
 
     if (!etag) {
-      if (!generator) return
-
+      if (!generator) {
+        return
+      }
       const hash = await generateDigest(res.clone().body, generator)
       if (hash === null) {
         return

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -68,8 +68,6 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
           },
           body
         )
-    } else {
-      throw new Error('`crypto.subtle` is undefined. Etag middleware requires it.')
     }
   }
 
@@ -82,7 +80,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
     let etag = res.headers.get('ETag')
 
     if (!etag) {
-      const hash = await generateDigest(res.clone().body, generator!)
+      const hash = await generateDigest(res.clone().body, generator)
       if (hash === null) {
         return
       }


### PR DESCRIPTION
This PR allows users to specify a hash generation function even in environments where there is no crypto, so the place to check for `crypto` changes.
https://github.com/honojs/hono/pull/3832

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
