### PR TITLE
fix(proxy): include original request signal in proxy request

### DIFF
--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -46,6 +46,7 @@ const buildRequestInitFromRequest = (
     body: request.body,
     duplex: request.body ? 'half' : undefined,
     headers,
+    signal: request.signal,
   }
 }
 


### PR DESCRIPTION
This includes the original [`Request#signal`](https://developer.mozilla.org/en-US/docs/Web/API/Request/signal) in the `RequestInit` options use to create the proxy request

Currently Cloudflare doesn't expose the `abort` event to Workers, but it looks like there is work to implement it, see:

- https://github.com/cloudflare/workerd/issues/3033
- https://github.com/cloudflare/workerd/pull/3488

I'm unsure about other platforms..

fixes #3924