### PR TITLE
fix(helper/proxy): missing proxy response status

### DIFF
--- a/src/helper/proxy/index.test.ts
+++ b/src/helper/proxy/index.test.ts
@@ -227,7 +227,7 @@ describe('Proxy Middleware', () => {
       expect(await res.text()).toBe('client disconnect')
     })
 
-    it.fails('not found', async () => {
+    it('not found', async () => {
       const app = new Hono()
       app.get('/proxy/:path', (c) => proxy(`https://example.com/${c.req.param('path')}`))
       const res = await app.request('/proxy/404')

--- a/src/helper/proxy/index.test.ts
+++ b/src/helper/proxy/index.test.ts
@@ -226,5 +226,12 @@ describe('Proxy Middleware', () => {
       const res = await resPromise
       expect(await res.text()).toBe('client disconnect')
     })
+
+    it.fails('not found', async () => {
+      const app = new Hono()
+      app.get('/proxy/:path', (c) => proxy(`https://example.com/${c.req.param('path')}`))
+      const res = await app.request('/proxy/404')
+      expect(res.status).toBe(404)
+    })
   })
 })

--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -130,7 +130,8 @@ export const proxy: ProxyFetch = async (input, proxyInit) => {
   }
 
   return new Response(res.body, {
-    ...res,
+    status: res.status,
+    statusText: res.statusText,
     headers: resHeaders,
   })
 }


### PR DESCRIPTION
- [x] add failing test
- [x] find out why the response status is missing (default value of 200)

Turns out that `Request` and `Response` classes do not have enumerable properties, so using the spread operator yields an empty object 🤯 
```js
console.log({ ...new Request('http://a') }) // {}
console.log({ ...new Response(null) }) // {}
```
I haven't found where this is mentioned in the [standards documentation](https://fetch.spec.whatwg.org/) 😩 

fixes #3926 
