### PR TITLE
fix(proxy): remove spread operator from `Request` and `Response` classes

### DIFF
--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -108,12 +108,10 @@ const preprocessRequestInit = (requestInit: RequestInit): RequestInit => {
  * })
  * ```
  */
-export const proxy: ProxyFetch = async (input, proxyInit) => {
-  const { raw, ...requestInit } = proxyInit ?? {}
-
+export const proxy: ProxyFetch = async (input, proxyInit = {}) => {
   const req = new Request(input, {
-    ...buildRequestInitFromRequest(raw),
-    ...preprocessRequestInit(requestInit as RequestInit),
+    ...buildRequestInitFromRequest(proxyInit.raw),
+    ...preprocessRequestInit(proxyInit as RequestInit),
   })
   req.headers.delete('accept-encoding')
 

--- a/src/helper/ssg/ssg.test.tsx
+++ b/src/helper/ssg/ssg.test.tsx
@@ -701,14 +701,14 @@ describe('Combined Response hooks - modify response content', () => {
   const prependContentAfterResponseHook = (prefix: string): AfterResponseHook => {
     return async (res: Response): Promise<Response> => {
       const originalText = await res.text()
-      return new Response(`${prefix}${originalText}`, { ...res })
+      return new Response(`${prefix}${originalText}`, res)
     }
   }
 
   const appendContentAfterResponseHook = (suffix: string): AfterResponseHook => {
     return async (res: Response): Promise<Response> => {
       const originalText = await res.text()
-      return new Response(`${originalText}${suffix}`, { ...res })
+      return new Response(`${originalText}${suffix}`, res)
     }
   }
 


### PR DESCRIPTION
Removes usage of the spread operator (`...`) on `Request` and `Response` classes

Follow-up from #3927