### PR TITLE
refactor(pattern-router): reduce bundle size and fix comments

### DIFF
--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -1,7 +1,7 @@
 import type { Params, Result, Router } from '../../router'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
 
-type Route<T> = [RegExp, string, T] // [pattern, method, handler, path]
+type Route<T> = [RegExp, string, T] // [pattern, method, handler]
 
 const emptyParams = Object.create(null)
 
@@ -30,13 +30,15 @@ export class PatternRouter<T> implements Router<T> {
       }
     )
 
-    let re
     try {
-      re = new RegExp(`^${parts.join('')}${endsWithWildcard ? '' : '/?$'}`)
+      this.#routes.push([
+        new RegExp(`^${parts.join('')}${endsWithWildcard ? '' : '/?$'}`),
+        method,
+        handler,
+      ])
     } catch {
       throw new UnsupportedPathError()
     }
-    this.#routes.push([re, method, handler])
   }
 
   match(method: string, path: string): Result<T> {


### PR DESCRIPTION
I noticed that there is no need to declare using `let`.  
Also, one comment was incorrect and has been corrected.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
