### PR TITLE
refactor: support TypeScript 5.7 for Deno 2.2

### DIFF
--- a/runtime-tests/deno/hono.test.ts
+++ b/runtime-tests/deno/hono.test.ts
@@ -37,7 +37,8 @@ Deno.test('environment variables', () => {
 
 Deno.test('Buffers', async () => {
   const app = new Hono().get('/', async (c) => {
-    return c.body(Buffer.from('hello'))
+    const encoder = new TextEncoder()
+    return c.body(encoder.encode('hello'))
   })
 
   const res = await app.request('/')

--- a/runtime-tests/deno/hono.test.ts
+++ b/runtime-tests/deno/hono.test.ts
@@ -34,14 +34,3 @@ Deno.test('environment variables', () => {
   const { NAME } = env<{ NAME: string }>(c)
   assertEquals(NAME, 'Deno')
 })
-
-Deno.test('Buffers', async () => {
-  const app = new Hono().get('/', async (c) => {
-    const encoder = new TextEncoder()
-    return c.body(encoder.encode('hello'))
-  })
-
-  const res = await app.request('/')
-  assertEquals(res.status, 200)
-  assertEquals(await res.text(), 'hello')
-})

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -40,7 +40,7 @@ export type WSReadyState = 0 | 1 | 2 | 3
  * An argument for WSContext class
  */
 export interface WSContextInit<T = unknown> {
-  send(data: string | ArrayBuffer, options: SendOptions): void
+  send(data: string | ArrayBuffer | Uint8Array, options: SendOptions): void
   close(code?: number, reason?: string): void
 
   raw?: T

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -22,7 +22,8 @@ import type { JWTPayload } from './types'
 import { utf8Decoder, utf8Encoder } from './utf8'
 
 const encodeJwtPart = (part: unknown): string =>
-  encodeBase64Url(utf8Encoder.encode(JSON.stringify(part))).replace(/=/g, '')
+  encodeBase64Url(utf8Encoder.encode(JSON.stringify(part)).buffer).replace(/=/g, '')
+
 const encodeSignaturePart = (buf: ArrayBufferLike): string => encodeBase64Url(buf).replace(/=/g, '')
 
 const decodeJwtPart = (part: string): TokenHeader | JWTPayload | undefined =>


### PR DESCRIPTION
Fixes #3935

To support TypeScript 5.7, which was introduced in Deno 2.2, I've fixed some things about ArrayBuffer.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
