### PR TITLE
feat(ws): allow to use upgradeWebSocket in handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -674,8 +674,5 @@
   },
   "engines": {
     "node": ">=16.9.0"
-  },
-  "dependencies": {
-    "@hono/zod-validator": "^0.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -674,5 +674,8 @@
   },
   "engines": {
     "node": ">=16.9.0"
+  },
+  "dependencies": {
+    "@hono/zod-validator": "^0.4.3"
   }
 }

--- a/src/helper/websocket/index.test.ts
+++ b/src/helper/websocket/index.test.ts
@@ -36,6 +36,16 @@ describe('defineWebSocketHelper', () => {
     await upgradeWebSocket(() => ({}))(new Context(new Request('http://localhost')), next)
     expect(next).toBeCalled()
   })
+  it('Use upgradeWebSocket in return', async () => {
+    const upgradeWebSocket = defineWebSocketHelper(() => {
+      return new Response('Hello World', {
+        status: 200,
+      })
+    })
+    const c = new Context(new Request('http://localhost'))
+    const res = await upgradeWebSocket(c, {})
+    expect((res as Response).status).toBe(200)
+  })
 })
 describe('WSContext', () => {
   it('Should close() works', async () => {

--- a/src/helper/websocket/index.test.ts
+++ b/src/helper/websocket/index.test.ts
@@ -46,6 +46,13 @@ describe('defineWebSocketHelper', () => {
     const res = await upgradeWebSocket(c, {})
     expect((res as Response).status).toBe(200)
   })
+  it('When upgrading failed and use it in handler, it should throw error', async () => {
+    const upgradeWebSocket = defineWebSocketHelper(() => {
+      return
+    })
+    const c = new Context(new Request('http://localhost'))
+    expect(() => upgradeWebSocket(c, {})).rejects.toThrow()
+  })
 })
 describe('WSContext', () => {
   it('Should close() works', async () => {

--- a/src/helper/websocket/index.test.ts
+++ b/src/helper/websocket/index.test.ts
@@ -44,7 +44,7 @@ describe('defineWebSocketHelper', () => {
     })
     const c = new Context(new Request('http://localhost'))
     const res = await upgradeWebSocket(c, {})
-    expect((res as Response).status).toBe(200)
+    expect(res.status).toBe(200)
   })
   it('When upgrading failed and use it in handler, it should throw error', async () => {
     const upgradeWebSocket = defineWebSocketHelper(() => {

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -29,7 +29,9 @@ export interface UpgradeWebSocket<T = unknown, U = any, _WSEvents = WSEvents<T>>
       outputFormat: 'ws'
     }
   >
-  (c: Context, events: _WSEvents, options?: U): Promise<TypedResponse<{}, StatusCode, 'ws'>>
+  (c: Context, events: _WSEvents, options?: U): Promise<
+    Response & TypedResponse<{}, StatusCode, 'ws'>
+  >
 }
 
 /**

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -5,7 +5,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Context } from '../../context'
-import type { MiddlewareHandler } from '../../types'
+import type { MiddlewareHandler, TypedResponse } from '../../types'
+import type { StatusCode } from '../../utils/http-status'
 
 /**
  * WebSocket Event Listeners type
@@ -28,7 +29,7 @@ export interface UpgradeWebSocket<T = unknown, U = any, _WSEvents = WSEvents<T>>
       outputFormat: 'ws'
     }
   >
-  (c: Context, events: _WSEvents, options?: U): Promise<Response>
+  (c: Context, events: _WSEvents, options?: U): Promise<TypedResponse<{}, StatusCode, 'ws'>>
 }
 
 /**


### PR DESCRIPTION
Closes #3005, and related to #3202 and #3845.

By the pull request, you would use upgradeWebSocket after `return` in handler like that:
```ts
const app = new Hono()

app.get('/', (c) => {
  return upgradeWebSocket(c, {
    onOpen: (_e, ws) => {
      ws.send('Hello World!')
    }
  })
})
```

A thing what I will be glad is `c.req.param` will be type-safe.

![A code that shows `c.req.param` is completed by VSCode](https://github.com/user-attachments/assets/e39b138d-050b-42c3-889f-17414b6f116f)

Also bindings and variables are supported.
```ts
const app = new Hono<{
  Bindings: {
    DB: {
      insert: (v: string | Blob | ArrayBuffer) => void
    }
  }
}>()

app.get('/:room', (c) => {
  return upgradeWebSocket(c, {
    onMessage(e) {
      c.env.DB.insert(e.data)
    }
  })
})
```
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
