### PR TITLE
feat(middleware/cache): add `cacheableStatusCodes` option

### DIFF
--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -290,32 +290,13 @@ describe('Cache Middleware', () => {
     expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: '*' })).toThrow()
   })
 
-  it.each(['GET', 'HEAD', 'POST', 'PATCH'])('Should cache %s method requests', async (method) => {
-    await app.request('http://localhost/default/200/', { method: method })
-    const res = await app.request('http://localhost/default/200/', { method: method })
+  it.each([200])('Should cache %i in default cacheable status codes', async (code) => {
+    await app.request(`http://localhost/default/${code}/`)
+    const res = await app.request(`http://localhost/default/${code}/`)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(code)
     expect(res.headers.get('cache-control')).toBe('max-age=10')
   })
-
-  it.each(['PUT', 'DELETE', 'OPTIONS'])('Should not cache %s method requests', async (method) => {
-    await app.request('http://localhost/default/200/', { method: method })
-    const res = await app.request('http://localhost/default/200/', { method: method })
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).not.toBe('max-age=10')
-  })
-
-  it.each([200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501])(
-    'Should cache %i in default cacheable status codes',
-    async (code) => {
-      await app.request(`http://localhost/default/${code}/`)
-      const res = await app.request(`http://localhost/default/${code}/`)
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(code)
-      expect(res.headers.get('cache-control')).toBe('max-age=10')
-    }
-  )
 
   it.each([
     100, 101, 102, 103, 201, 202, 205, 207, 208, 226, 302, 303, 304, 307, 308, 400, 401, 402, 403,
@@ -340,7 +321,7 @@ describe('Cache Middleware', () => {
   it.each([
     100, 101, 102, 103, 202, 205, 207, 208, 226, 302, 303, 304, 307, 308, 400, 401, 402, 403, 406,
     407, 408, 409, 411, 412, 413, 415, 416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431,
-    451,
+    451, 500, 502, 503, 504, 505, 506, 507, 508, 510, 511,
   ])('Should not cache %i in custom cacheable status codes', async (code) => {
     await app.request(`http://localhost/custom/${code}/`)
     const res = await app.request(`http://localhost/custom/${code}/`)

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -168,10 +168,37 @@ describe('Cache Middleware', () => {
     return c.text('cached')
   })
 
+  app.use('/default/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.get('/default/:code/', (c) => {
+    const code = parseInt(c.req.param('code'))
+    // Intended to avoid the following error: `RangeError: init[“status”] must be in the range of 200 to 599, inclusive.`
+    const res = {
+      status: code,
+      headers: new Headers(),
+      clone: () => res,
+    } as Response
+    return res
+  })
+
   app.use(
-    '/not-found/*',
-    cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10', vary: ['Accept'] })
+    '/custom/*',
+    cache({
+      cacheName: 'my-app-v1',
+      wait: true,
+      cacheControl: 'max-age=10',
+      cacheableStatusCodes: [200, 201],
+    })
   )
+  app.get('/custom/:code/', (c) => {
+    const code = parseInt(c.req.param('code'))
+    // Intended to avoid the following error: `RangeError: init[“status”] must be in the range of 200 to 599, inclusive.`
+    const res = {
+      status: code,
+      headers: new Headers(),
+      clone: () => res,
+    } as Response
+    return res
+  })
 
   const ctx = new Context()
 
@@ -263,12 +290,47 @@ describe('Cache Middleware', () => {
     expect(() => cache({ cacheName: 'my-app-v1', wait: true, vary: '*' })).toThrow()
   })
 
-  it('Should not cache if it is not found', async () => {
-    const res = await app.request('/not-found/')
+  it.each([200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501])(
+    'Should cache %i in default cacheable status codes',
+    async (code) => {
+      await app.request(`http://localhost/default/${code}/`)
+      const res = await app.request(`http://localhost/default/${code}/`)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(code)
+      expect(res.headers.get('cache-control')).toBe('max-age=10')
+    }
+  )
+
+  it.each([
+    100, 101, 102, 103, 201, 202, 205, 207, 208, 226, 302, 303, 304, 307, 308, 400, 401, 402, 403,
+    406, 407, 408, 409, 411, 412, 413, 415, 416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429,
+    431, 451, 500, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+  ])('Should not cache %i in default cacheable status codes', async (code) => {
+    await app.request(`http://localhost/default/${code}/`)
+    const res = await app.request(`http://localhost/default/${code}/`)
     expect(res).not.toBeNull()
-    expect(res.status).toBe(404)
-    expect(res.headers.get('cache-control')).toBeFalsy()
-    expect(res.headers.get('vary')).toBeFalsy()
+    expect(res.status).toBe(code)
+    expect(res.headers.get('cache-control')).not.toBe('max-age=10')
+  })
+
+  it.each([200, 201])('Should cache %i in custom cacheable status codes', async (code) => {
+    await app.request(`http://localhost/custom/${code}/`)
+    const res = await app.request(`http://localhost/custom/${code}/`)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(code)
+    expect(res.headers.get('cache-control')).toBe('max-age=10')
+  })
+
+  it.each([
+    100, 101, 102, 103, 202, 205, 207, 208, 226, 302, 303, 304, 307, 308, 400, 401, 402, 403, 406,
+    407, 408, 409, 411, 412, 413, 415, 416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431,
+    451,
+  ])('Should not cache %i in custom cacheable status codes', async (code) => {
+    await app.request(`http://localhost/custom/${code}/`)
+    const res = await app.request(`http://localhost/custom/${code}/`)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(code)
+    expect(res.headers.get('cache-control')).not.toBe('max-age=10')
   })
 
   it('Should not be enabled if caches is not defined', async () => {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -18,12 +18,7 @@ const defaultCacheableStatusCodes: ReadonlyArray<number> = [
  * RFC 7231 Section 4.2.3 specifies methods that can be cached.
  * See: https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.3
  */
-const cacheableMethods: ReadonlyMap<string, boolean> = new Map([
-  ['GET', true],
-  ['HEAD', true],
-  ['POST', true],
-  ['PATCH', true],
-])
+const cacheableMethods: ReadonlySet<string> = new Set(['GET', 'HEAD', 'POST', 'PATCH'])
 
 /**
  * Cache Middleware for Hono.
@@ -84,10 +79,10 @@ export const cache = (options: {
 
   const cacheableStatusCodes = (options.cacheableStatusCodes ?? defaultCacheableStatusCodes).reduce(
     (acc, code) => {
-      acc.set(code, true)
+      acc.add(code)
       return acc
     },
-    new Map<number, boolean>()
+    new Set<number>()
   )
 
   const addHeader = (c: Context) => {
@@ -128,7 +123,7 @@ export const cache = (options: {
   }
 
   return async function cache(c, next) {
-    if (!cacheableMethods.get(c.req.method)) {
+    if (!cacheableMethods.has(c.req.method)) {
       await next()
       return
     }
@@ -146,7 +141,7 @@ export const cache = (options: {
     }
 
     await next()
-    if (!cacheableStatusCodes.get(c.res.status)) {
+    if (!cacheableStatusCodes.has(c.res.status)) {
       return
     }
     addHeader(c)

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -15,6 +15,17 @@ const defaultCacheableStatusCodes: ReadonlyArray<number> = [
 ]
 
 /**
+ * RFC 7231 Section 4.2.3 specifies methods that can be cached.
+ * See: https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.3
+ */
+const cacheableMethods: ReadonlyMap<string, boolean> = new Map([
+  ['GET', true],
+  ['HEAD', true],
+  ['POST', true],
+  ['PATCH', true],
+])
+
+/**
  * Cache Middleware for Hono.
  *
  * @see {@link https://hono.dev/docs/middleware/builtin/cache}
@@ -117,6 +128,10 @@ export const cache = (options: {
   }
 
   return async function cache(c, next) {
+    if (!cacheableMethods.get(c.req.method)) {
+      await next()
+      return
+    }
     let key = c.req.url
     if (options.keyGenerator) {
       key = await options.keyGenerator(c)

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -7,18 +7,9 @@ import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
 /**
- * RFC 7231 Section 6.1 specifies status codes that can be cached by default.
- * See: https://datatracker.ietf.org/doc/html/rfc7231#section-6.1
+ * status codes that can be cached by default.
  */
-const defaultCacheableStatusCodes: ReadonlyArray<number> = [
-  200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501,
-]
-
-/**
- * RFC 7231 Section 4.2.3 specifies methods that can be cached.
- * See: https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.3
- */
-const cacheableMethods: ReadonlySet<string> = new Set(['GET', 'HEAD', 'POST', 'PATCH'])
+const defaultCacheableStatusCodes: ReadonlyArray<number> = [200]
 
 /**
  * Cache Middleware for Hono.
@@ -117,10 +108,6 @@ export const cache = (options: {
   }
 
   return async function cache(c, next) {
-    if (!cacheableMethods.has(c.req.method)) {
-      await next()
-      return
-    }
     let key = c.req.url
     if (options.keyGenerator) {
       key = await options.keyGenerator(c)

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -22,7 +22,7 @@ const defaultCacheableStatusCodes: ReadonlyArray<number> = [200]
  * @param {string} [options.cacheControl] - A string of directives for the `Cache-Control` header.
  * @param {string | string[]} [options.vary] - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
  * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
- * @param {number[]} [options.cacheableStatusCodes=[200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501]] - An array of status codes that can be cached.
+ * @param {number[]} [options.cacheableStatusCodes=[200]] - An array of status codes that can be cached.
  * @returns {MiddlewareHandler} The middleware handler function.
  * @throws {Error} If the `vary` option includes "*".
  *

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -78,12 +78,6 @@ export const cache = (options: {
   }
 
   const cacheableStatusCodes = new Set(options.cacheableStatusCodes ?? defaultCacheableStatusCodes)
-    (acc, code) => {
-      acc.add(code)
-      return acc
-    },
-    new Set<number>()
-  )
 
   const addHeader = (c: Context) => {
     if (cacheControlDirectives) {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -5,11 +5,12 @@
 
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
+import type { StatusCode } from '../../utils/http-status'
 
 /**
  * status codes that can be cached by default.
  */
-const defaultCacheableStatusCodes: ReadonlyArray<number> = [200]
+const defaultCacheableStatusCodes: ReadonlyArray<StatusCode> = [200]
 
 /**
  * Cache Middleware for Hono.
@@ -43,7 +44,7 @@ export const cache = (options: {
   cacheControl?: string
   vary?: string | string[]
   keyGenerator?: (c: Context) => Promise<string> | string
-  cacheableStatusCodes?: number[]
+  cacheableStatusCodes?: StatusCode[]
 }): MiddlewareHandler => {
   if (!globalThis.caches) {
     console.log('Cache Middleware is not enabled because caches is not defined.')
@@ -68,7 +69,9 @@ export const cache = (options: {
     )
   }
 
-  const cacheableStatusCodes = new Set(options.cacheableStatusCodes ?? defaultCacheableStatusCodes)
+  const cacheableStatusCodes = new Set<number>(
+    options.cacheableStatusCodes ?? defaultCacheableStatusCodes
+  )
 
   const addHeader = (c: Context) => {
     if (cacheControlDirectives) {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -77,7 +77,7 @@ export const cache = (options: {
     )
   }
 
-  const cacheableStatusCodes = (options.cacheableStatusCodes ?? defaultCacheableStatusCodes).reduce(
+  const cacheableStatusCodes = new Set(options.cacheableStatusCodes ?? defaultCacheableStatusCodes)
     (acc, code) => {
       acc.add(code)
       return acc


### PR DESCRIPTION
This pull request updates the cache middleware to avoid caching when it is defined as uncacheable in RFC 7231.
Caching will no longer occur under the following conditions.

## Conditions for Avoiding Caching

### 1. Status codes defined as uncacheable by default

> Responses with status codes that are defined as cacheable by default
(e.g., 200, 203, 204, 206, 300, 301, 404, 405, 410, 414, and 501 in this specification)
https://datatracker.ietf.org/doc/html/rfc7231#section-6.1

Additionally, It introducing an optional argument to allow caching of arbitrary status codes.

```ts
// In this case, only 412 will be cached.
app.use(
  '/*',
  cache({
    cacheName: 'foo',
    wait: true,
    cacheControl: 'max-age=10',
    cacheableStatusCodes: [412],
  })
)
```

### 2. Request methods defined as uncacheable

Only GET, HEAD, POST, and PATCH will be cached, otherwise it is no longer cached.

> this specification defines GET, HEAD, and POST as
   cacheable

https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.3

> A response to this method is only cacheable if it contains explicit freshness information (such as an Expires header or "Cache-Control: max-age" directive) as well as the Content-Location header matching the Request-URI, indicating that the PATCH response body is a resource representation.

https://datatracker.ietf.org/doc/html/rfc5789#section-2

## See also
- https://developer.mozilla.org/en-US/docs/Glossary/Cacheable

Thank you.

## The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
