### PR TITLE
feat: allow to define a function to select credentials

### DIFF
--- a/src/middleware/jwk/jwk.ts
+++ b/src/middleware/jwk/jwk.ts
@@ -59,7 +59,7 @@ export const jwk = (
   return async function jwk(ctx, next) {
     let credentials = ctx.req.raw.headers.get('Authorization')
     if (options.credentials) {
-        credentials = options.credentials(ctx.req)
+      credentials = options.credentials(ctx.req)
     }
     let token
     if (credentials) {

--- a/src/middleware/jwk/jwk.ts
+++ b/src/middleware/jwk/jwk.ts
@@ -11,6 +11,7 @@ import type { CookiePrefixOptions } from '../../utils/cookie'
 import { Jwt } from '../../utils/jwt'
 import '../../context'
 import type { HonoJsonWebKey } from '../../utils/jwt/jws'
+import { HonoRequest } from '../../request'
 
 /**
  * JWK Auth Middleware for Hono.
@@ -41,7 +42,7 @@ export const jwk = (
   options: {
     keys?: HonoJsonWebKey[] | (() => Promise<HonoJsonWebKey[]>)
     jwks_uri?: string
-    credentials?: () => string
+    credentials?: (req: HonoRequest<string>) => string
     cookie?:
       | string
       | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }

--- a/src/middleware/jwk/jwk.ts
+++ b/src/middleware/jwk/jwk.ts
@@ -38,7 +38,7 @@ import type { HonoJsonWebKey } from '../../utils/jwt/jws'
  * ```
  */
 
-export const jwk = (
+export const jwk = <T>(
   options: {
     keys?: HonoJsonWebKey[] | (() => Promise<HonoJsonWebKey[]>)
     jwks_uri?: string
@@ -48,7 +48,7 @@ export const jwk = (
       | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
   },
   init?: RequestInit
-): MiddlewareHandler => {
+): MiddlewareHandler<{ Variables: { jwtPayload: T } }> => {
   if (!options || !(options.keys || options.jwks_uri)) {
     throw new Error('JWK auth middleware requires options for either "keys" or "jwks_uri" or both')
   }

--- a/src/middleware/jwk/jwk.ts
+++ b/src/middleware/jwk/jwk.ts
@@ -6,12 +6,12 @@
 import type { Context } from '../../context'
 import { getCookie, getSignedCookie } from '../../helper/cookie'
 import { HTTPException } from '../../http-exception'
+import type { HonoRequest } from '../../request'
 import type { MiddlewareHandler } from '../../types'
 import type { CookiePrefixOptions } from '../../utils/cookie'
 import { Jwt } from '../../utils/jwt'
 import '../../context'
 import type { HonoJsonWebKey } from '../../utils/jwt/jws'
-import { HonoRequest } from '../../request'
 
 /**
  * JWK Auth Middleware for Hono.


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

In my project the credentials can be either in `Authorization` or in `X-Authorization` header, therefore I added an optional function to allow arbitrary logic to gather credentials from the request.
