### PR TITLE
feat(hono/jwk): Extended with `allow_anon` option & passing `Context` to callbacks

### DIFF
--- a/src/middleware/jwk/index.test.ts
+++ b/src/middleware/jwk/index.test.ts
@@ -43,7 +43,7 @@ describe('JWK', () => {
     })
   })
 
-  describe('options.skip_if_no_token = true', () => {
+  describe('options.allow_anon = true', () => {
     let handlerExecuted: boolean
 
     beforeEach(() => {
@@ -52,16 +52,16 @@ describe('JWK', () => {
 
     const app = new Hono()
 
-    app.use('/skip-auth-if-no-token/*', jwk({ keys: verify_keys, skip_if_no_token: true }))
+    app.use('/backend-auth-or-anon/*', jwk({ keys: verify_keys, allow_anon: true }))
 
-    app.get('/skip-auth-if-no-token/*', (c) => {
+    app.get('/backend-auth-or-anon/*', (c) => {
       handlerExecuted = true
       const payload = c.get('jwtPayload')
       return c.json(payload ?? { message: 'hello anon' })
     })
 
     it('Should skip JWK if no token is present', async () => {
-      const req = new Request('http://localhost/skip-auth-if-no-token/a')
+      const req = new Request('http://localhost/backend-auth-or-anon/a')
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)
@@ -71,7 +71,7 @@ describe('JWK', () => {
 
     it('Should authorize if token is present', async () => {
       const credential = await Jwt.sign({ message: 'hello world' }, test_keys.private_keys[0])
-      const req = new Request('http://localhost/skip-auth-if-no-token/a')
+      const req = new Request('http://localhost/backend-auth-or-anon/a')
       req.headers.set('Authorization', `Bearer ${credential}`)
       const res = await app.request(req)
       expect(res).not.toBeNull()
@@ -83,7 +83,7 @@ describe('JWK', () => {
     it('Should not authorize if bad token is present', async () => {
       const invalidToken =
         'ssyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
-      const url = 'http://localhost/skip-auth-if-no-token/a'
+      const url = 'http://localhost/backend-auth-or-anon/a'
       const req = new Request(url)
       req.headers.set('Authorization', `Basic ${invalidToken}`)
       const res = await app.request(req)

--- a/src/middleware/jwk/index.test.ts
+++ b/src/middleware/jwk/index.test.ts
@@ -43,6 +43,59 @@ describe('JWK', () => {
     })
   })
 
+  describe('options.skip_if_no_token = true', () => {
+    let handlerExecuted: boolean
+
+    beforeEach(() => {
+      handlerExecuted = false
+    })
+
+    const app = new Hono()
+
+    app.use('/skip-auth-if-no-token/*', jwk({ keys: verify_keys, skip_if_no_token: true }))
+
+    app.get('/skip-auth-if-no-token/*', (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload ?? { message: 'hello anon' })
+    })
+
+    it('Should skip JWK if no token is present', async () => {
+      const req = new Request('http://localhost/skip-auth-if-no-token/a')
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello anon' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should authorize if token is present', async () => {
+      const credential = await Jwt.sign({ message: 'hello world' }, test_keys.private_keys[0])
+      const req = new Request('http://localhost/skip-auth-if-no-token/a')
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello world' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should not authorize if bad token is present', async () => {
+      const invalidToken =
+        'ssyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+      const url = 'http://localhost/skip-auth-if-no-token/a'
+      const req = new Request(url)
+      req.headers.set('Authorization', `Basic ${invalidToken}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toEqual(
+        `Bearer realm="${url}",error="invalid_token",error_description="token verification failure"`
+      )
+      expect(handlerExecuted).toBeFalsy()
+    })
+  })
+
   describe('Credentials in header', () => {
     let handlerExecuted: boolean
 
@@ -78,7 +131,7 @@ describe('JWK', () => {
       '/auth-with-keys-and-jwks_uri/*',
       jwk({
         keys: verify_keys,
-        jwks_uri: 'http://localhost/.well-known/jwks.json',
+        jwks_uri: () => 'http://localhost/.well-known/jwks.json',
       })
     )
     app.use(

--- a/src/middleware/jwk/jwk.ts
+++ b/src/middleware/jwk/jwk.ts
@@ -28,7 +28,7 @@ import type { HonoJsonWebKey } from '../../utils/jwt/jws'
  * ```ts
  * const app = new Hono()
  *
- * app.use("/auth/*", jwk({ jwks_uri: (c) => `https://${c.env.backendServer}/.well-known/jwks.json` }))
+ * app.use("/auth/*", jwk({ jwks_uri: (c) => `https://${c.env.authServer}/.well-known/jwks.json` }))
  *
  * app.get('/auth/page', (c) => {
  *   return c.text('You are authorized')

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -22,8 +22,7 @@ import type { JWTPayload } from './types'
 import { utf8Decoder, utf8Encoder } from './utf8'
 
 const encodeJwtPart = (part: unknown): string =>
-  encodeBase64Url(utf8Encoder.encode(JSON.stringify(part)).buffer).replace(/=/g, '')
-
+  encodeBase64Url(utf8Encoder.encode(JSON.stringify(part))).replace(/=/g, '')
 const encodeSignaturePart = (buf: ArrayBufferLike): string => encodeBase64Url(buf).replace(/=/g, '')
 
 const decodeJwtPart = (part: string): TokenHeader | JWTPayload | undefined =>
@@ -111,7 +110,7 @@ export const verify = async (
 export const verifyFromJwks = async (
   token: string,
   options: {
-    keys?: HonoJsonWebKey[] | (() => Promise<HonoJsonWebKey[]>)
+    keys?: HonoJsonWebKey[]
     jwks_uri?: string
   },
   init?: RequestInit
@@ -125,8 +124,6 @@ export const verifyFromJwks = async (
     throw new JwtHeaderRequiresKid(header)
   }
 
-  let keys = typeof options.keys === 'function' ? await options.keys() : options.keys
-
   if (options.jwks_uri) {
     const response = await fetch(options.jwks_uri, init)
     if (!response.ok) {
@@ -139,16 +136,16 @@ export const verifyFromJwks = async (
     if (!Array.isArray(data.keys)) {
       throw new Error('invalid JWKS response. "keys" field is not an array')
     }
-    if (keys) {
-      keys.push(...data.keys)
+    if (options.keys) {
+      options.keys.push(...data.keys)
     } else {
-      keys = data.keys
+      options.keys = data.keys
     }
-  } else if (!keys) {
+  } else if (!options.keys) {
     throw new Error('verifyFromJwks requires options for either "keys" or "jwks_uri" or both')
   }
 
-  const matchingKey = keys.find((key) => key.kid === header.kid)
+  const matchingKey = options.keys.find((key) => key.kid === header.kid)
   if (!matchingKey) {
     throw new JwtTokenInvalid(token)
   }

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -22,7 +22,7 @@ import type { JWTPayload } from './types'
 import { utf8Decoder, utf8Encoder } from './utf8'
 
 const encodeJwtPart = (part: unknown): string =>
-  encodeBase64Url(utf8Encoder.encode(JSON.stringify(part))).replace(/=/g, '')
+  encodeBase64Url(utf8Encoder.encode(JSON.stringify(part)).buffer).replace(/=/g, '')
 const encodeSignaturePart = (buf: ArrayBufferLike): string => encodeBase64Url(buf).replace(/=/g, '')
 
 const decodeJwtPart = (part: string): TokenHeader | JWTPayload | undefined =>


### PR DESCRIPTION
Adding two main useful features people have been asking for in the [original PR](https://github.com/honojs/hono/pull/3826) + some slight changes.

### New features:
- **Allow anonymous requests** by setting the new **`allow_anon`** option to `true`
  - https://github.com/honojs/hono/pull/3826#issuecomment-2656576941
- **Optional callback for the `jwks_uri`** instead of only a hard-coded string
- **`Context`** is now **included in all callbacks**, so you can **e.g** pull information from `c.env` such as auth server
  - https://github.com/honojs/hono/pull/3826#issuecomment-2687416251
- Callbacks now can be either **async or sync**

**Example:**
```ts
app.use(
  '/auth/*',
  jwk({
    jwks_uri: (c) => `https://${c.env.authServer}/.well-known/jwks.json`,
    allow_anon: true
  })
)
```
**Note 1**: This PR allows having a single endpoint for both authenticated and non-authenticated requests through `allow_anon`. The variable `c.get("jwtPayload")` can be used **to differentiate authenticated requests from anonymous requests** since hono requires requests to have `exp` and `iat` in the payload (in the `verify` stage) which means the payload would always be defined for authenticated requests and be reliably used as indicator.

**Note 2**: Setting `allow_anon` to `true` means requests without a token present (in either header/cookie) would be allowed to pass through the middleware successfully.

**Tests**: Added 3 extra tests + modified one test to cover `jwks_uri` being a function.
```
✓ src/middleware/jwk/index.test.ts (34)
 ```
 
This PR breaks no code at all except for `Jwt.verifyFromJwks(...)`—specifically removed callbacks support from it since they're redundant and can be called outside, and also since only the middleware can provide the `Context` variable to the callbacks.