### PR TITLE
fix(factory): support `defaultAppOptions` after calling `createApp`

### DIFF
--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -383,6 +383,16 @@ describe('createFactory', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('hello')
   })
+
+  it('Should apply the default app options after calling createApp', async () => {
+    const factory = createFactory({ defaultAppOptions: { strict: false } })
+    factory.createApp() // Call once
+    const secondApp = factory.createApp()
+    secondApp.get('/hello', (c) => c.text('hello'))
+    const res = await secondApp.request('/hello/')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+  })
 })
 
 describe('Lint rules', () => {

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -294,10 +294,11 @@ export class Factory<E extends Env = Env, P extends string = string> {
   }
 
   createApp = (options?: HonoOptions<E>): Hono<E> => {
+    const defaultAppOptions = { ...this.#defaultAppOptions }
     const app = new Hono<E>(
       options && this.#defaultAppOptions
-        ? { ...this.#defaultAppOptions, ...options }
-        : options ?? this.#defaultAppOptions
+        ? { ...defaultAppOptions, ...options }
+        : options ?? defaultAppOptions
     )
     if (this.initApp) {
       this.initApp(app)


### PR DESCRIPTION
Fixes #3970

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
