### PR TITLE
perf(utils/url): Short circuit the regex in checkOptionalParameter

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -166,7 +166,7 @@ export const checkOptionalParameter = (path: string): string[] | null => {
    in other cases it will return null
   */
 
-  if (path.charCodeAt(path.length - 1) != 63 || !path.match(/\:.+\?$/)) {
+  if (path.charCodeAt(path.length - 1) !== 63 || !path.includes(':')) {
     return null
   }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -166,7 +166,7 @@ export const checkOptionalParameter = (path: string): string[] | null => {
    in other cases it will return null
   */
 
-  if (!path.match(/\:.+\?$/)) {
+  if (path.charCodeAt(path.length - 1) != 63 || !path.match(/\:.+\?$/)) {
     return null
   }
 


### PR DESCRIPTION
Here's a small suggestion to short-circuit the `checkOptionalParameter` check without doing a regex match when we can O(1) determine it won't match.

It's a small optimization, but for the `LinearRouter` in an environment with a lot of routes it is a non-trivial improvement.

Before
```
• GET /user
LinearRouter   1'382 ns/iter     (1'208 ns … 277 µs)  1'334 ns  1'667 ns  5'333 ns

• GET /user/comments
LinearRouter   1'422 ns/iter   (1'377 ns … 1'531 ns)  1'436 ns  1'498 ns  1'531 ns

• GET /user/lookup/username/hey
LinearRouter   4'321 ns/iter   (4'205 ns … 4'551 ns)  4'381 ns  4'551 ns  4'551 ns

• GET /event/abcd1234/comments
LinearRouter   1'610 ns/iter   (1'545 ns … 1'787 ns)  1'626 ns  1'769 ns  1'787 ns

• POST /event/abcd1234/comment
LinearRouter     737 ns/iter     (692 ns … 3'858 ns)    745 ns    926 ns  3'858 ns

• GET /very/deeply/nested/route/hello/there
LinearRouter   1'586 ns/iter   (1'516 ns … 4'462 ns)  1'579 ns  2'244 ns  4'462 ns

• GET /static/index.html
LinearRouter   1'398 ns/iter   (1'345 ns … 1'512 ns)  1'412 ns  1'500 ns  1'512 ns
```

After:
```
• GET /user
LinearRouter   1'062 ns/iter       (875 ns … 307 µs)  1'041 ns  1'416 ns  4'750 ns

• GET /user/comments
LinearRouter   1'108 ns/iter   (1'067 ns … 1'232 ns)  1'126 ns  1'206 ns  1'232 ns

• GET /user/lookup/username/hey
LinearRouter   3'897 ns/iter   (3'814 ns … 4'120 ns)  3'904 ns  4'120 ns  4'120 ns

• GET /event/abcd1234/comments
LinearRouter   1'281 ns/iter   (1'214 ns … 1'517 ns)  1'293 ns  1'413 ns  1'517 ns

• POST /event/abcd1234/comment
LinearRouter     410 ns/iter       (373 ns … 528 ns)    446 ns    473 ns    528 ns

• GET /very/deeply/nested/route/hello/there
LinearRouter   1'288 ns/iter   (1'207 ns … 1'402 ns)  1'315 ns  1'383 ns  1'402 ns

• GET /static/index.html
LinearRouter   1'112 ns/iter   (1'031 ns … 1'200 ns)  1'139 ns  1'182 ns  1'200 ns
```



### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
