### PR TITLE
fix(hono-base): prevent options object mutation

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -162,10 +162,9 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
       return this as any
     }
 
-    const strict = options.strict ?? true
-    delete options.strict
-    Object.assign(this, options)
-    this.getPath = strict ? options.getPath ?? getPath : getPathNoStrict
+    const { strict, ...optionsWithoutStrict } = options
+    Object.assign(this, optionsWithoutStrict)
+    this.getPath = strict ?? true ? options.getPath ?? getPath : getPathNoStrict
   }
 
   #clone(): Hono<E, S, BasePath> {

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -305,89 +305,98 @@ describe('Register handlers without a path', () => {
   })
 })
 
-describe('router option', () => {
-  it('Should be SmartRouter', () => {
-    const app = new Hono()
-    expect(app.router instanceof SmartRouter).toBe(true)
-  })
-  it('Should be RegExpRouter', () => {
-    const app = new Hono({
-      router: new RegExpRouter(),
+describe('Options', () => {
+  describe('router option', () => {
+    it('Should be SmartRouter', () => {
+      const app = new Hono()
+      expect(app.router instanceof SmartRouter).toBe(true)
     })
-    expect(app.router instanceof RegExpRouter).toBe(true)
-  })
-})
-
-describe('strict parameter', () => {
-  describe('strict is true with not slash', () => {
-    const app = new Hono()
-
-    app.get('/hello', (c) => {
-      return c.text('/hello')
-    })
-
-    it('/hello/ is not found', async () => {
-      let res = await app.request('http://localhost/hello')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
-      res = await app.request('http://localhost/hello/')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(404)
+    it('Should be RegExpRouter', () => {
+      const app = new Hono({
+        router: new RegExpRouter(),
+      })
+      expect(app.router instanceof RegExpRouter).toBe(true)
     })
   })
 
-  describe('strict is true with slash', () => {
-    const app = new Hono()
+  describe('strict parameter', () => {
+    describe('strict is true with not slash', () => {
+      const app = new Hono()
 
-    app.get('/hello/', (c) => {
-      return c.text('/hello/')
+      app.get('/hello', (c) => {
+        return c.text('/hello')
+      })
+
+      it('/hello/ is not found', async () => {
+        let res = await app.request('http://localhost/hello')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        res = await app.request('http://localhost/hello/')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(404)
+      })
     })
 
-    it('/hello is not found', async () => {
-      let res = await app.request('http://localhost/hello/')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
-      res = await app.request('http://localhost/hello')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(404)
+    describe('strict is true with slash', () => {
+      const app = new Hono()
+
+      app.get('/hello/', (c) => {
+        return c.text('/hello/')
+      })
+
+      it('/hello is not found', async () => {
+        let res = await app.request('http://localhost/hello/')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        res = await app.request('http://localhost/hello')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(404)
+      })
+    })
+
+    describe('strict is false', () => {
+      const app = new Hono({ strict: false })
+
+      app.get('/hello', (c) => {
+        return c.text('/hello')
+      })
+
+      it('/hello and /hello/ are treated as the same', async () => {
+        let res = await app.request('http://localhost/hello')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        res = await app.request('http://localhost/hello/')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+      })
+    })
+
+    describe('strict is false with `getPath` option', () => {
+      const app = new Hono({
+        strict: false,
+        getPath: getPath,
+      })
+
+      app.get('/hello', (c) => {
+        return c.text('/hello')
+      })
+
+      it('/hello and /hello/ are treated as the same', async () => {
+        let res = await app.request('http://localhost/hello')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        res = await app.request('http://localhost/hello/')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+      })
     })
   })
 
-  describe('strict is false', () => {
-    const app = new Hono({ strict: false })
-
-    app.get('/hello', (c) => {
-      return c.text('/hello')
-    })
-
-    it('/hello and /hello/ are treated as the same', async () => {
-      let res = await app.request('http://localhost/hello')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
-      res = await app.request('http://localhost/hello/')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
-    })
-  })
-
-  describe('strict is false with `getPath` option', () => {
-    const app = new Hono({
-      strict: false,
-      getPath: getPath,
-    })
-
-    app.get('/hello', (c) => {
-      return c.text('/hello')
-    })
-
-    it('/hello and /hello/ are treated as the same', async () => {
-      let res = await app.request('http://localhost/hello')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
-      res = await app.request('http://localhost/hello/')
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
-    })
+  it('Should not modify the options passed to it', () => {
+    const options = { strict: true }
+    const clone = structuredClone(options)
+    const app = new Hono(clone)
+    expect(clone).toEqual(options)
   })
 })
 


### PR DESCRIPTION
Fixes #3970
Based on #3971

As the [comment](https://github.com/honojs/hono/pull/3972#issuecomment-2698529533), the following test does not pass.

```ts
const opts = { strict: false }
const a1 = new Hono(opts)
const a2 = new Hono(opts)

a2.get('/hello', (c) => c.text('hello'))

const res = await a2.request('/hello/')
expect(res.status).toBe(200)
expect(await res.text()).toBe('hello')
```

This means `opts` passed to Hono's options will be mutated. This PR will fix it.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
