### PR TITLE
PoC: feat: Allow handlers and middleware to return functions of the same type as themselves

### DIFF
--- a/src/adapter/cloudflare-pages/handler.ts
+++ b/src/adapter/cloudflare-pages/handler.ts
@@ -60,41 +60,48 @@ export function handleMiddleware<E extends Env = {}, P extends string = any, I e
       executionCtx,
     })
 
-    let response: Response | void = undefined
+    let response: Response | Function | void = undefined
 
-    try {
-      response = await middleware(context, async () => {
-        try {
-          context.res = await executionCtx.next()
-        } catch (error) {
-          if (error instanceof Error) {
-            context.error = error
-          } else {
-            throw error
+    for (;;) {
+      try {
+        response = await middleware(context, async () => {
+          try {
+            context.res = await executionCtx.next()
+          } catch (error) {
+            if (error instanceof Error) {
+              context.error = error
+            } else {
+              throw error
+            }
           }
+        })
+
+        if (typeof response === 'function') {
+          middleware = response as typeof middleware
+          continue
         }
-      })
-    } catch (error) {
-      if (error instanceof Error) {
-        context.error = error
-      } else {
-        throw error
+      } catch (error) {
+        if (error instanceof Error) {
+          context.error = error
+        } else {
+          throw error
+        }
       }
-    }
 
-    if (response) {
-      return response
-    }
+      if (response) {
+        return response as Response
+      }
 
-    if (context.error instanceof HTTPException) {
-      return context.error.getResponse()
-    }
+      if (context.error instanceof HTTPException) {
+        return context.error.getResponse()
+      }
 
-    if (context.error) {
-      throw context.error
-    }
+      if (context.error) {
+        throw context.error
+      }
 
-    return context.res
+      return context.res
+    }
   }
 }
 

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -409,22 +409,30 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     // Do not `compose` if it has only one handler
     if (matchResult[0].length === 1) {
       let res: ReturnType<H>
-      try {
-        res = matchResult[0][0][0][0](c, async () => {
-          c.res = await this.#notFoundHandler(c)
-        })
-      } catch (err) {
-        return this.#handleError(err, c)
-      }
+      let handler = matchResult[0][0][0][0]
+      for (;;) {
+        try {
+          res = handler(c, async () => {
+            c.res = await this.#notFoundHandler(c)
+          })
+        } catch (err) {
+          return this.#handleError(err, c)
+        }
 
-      return res instanceof Promise
-        ? res
-            .then(
-              (resolved: Response | undefined) =>
-                resolved || (c.finalized ? c.res : this.#notFoundHandler(c))
-            )
-            .catch((err: Error) => this.#handleError(err, c))
-        : res ?? this.#notFoundHandler(c)
+        if (typeof res === 'function') {
+          handler = res
+          continue
+        }
+
+        return res instanceof Promise
+          ? res
+              .then(
+                (resolved: Response | undefined) =>
+                  resolved || (c.finalized ? c.res : this.#notFoundHandler(c))
+              )
+              .catch((err: Error) => this.#handleError(err, c))
+          : res ?? this.#notFoundHandler(c)
+      }
     }
 
     const composed = compose(matchResult[0], this.errorHandler, this.#notFoundHandler)

--- a/src/middleware/ip-restriction/index.test.ts
+++ b/src/middleware/ip-restriction/index.test.ts
@@ -56,7 +56,7 @@ describe('ipRestriction middleware', () => {
       () => new Response('error')
     )(new Context(new Request('http://localhost/')), async () => void 0)
     expect(res).toBeTruthy()
-    if (res) {
+    if (res instanceof Response) {
       expect(await res.text()).toBe('error')
     }
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,20 +67,24 @@ export interface RouterRoute {
 //////                            //////
 ////////////////////////////////////////
 
-export type HandlerResponse<O> = Response | TypedResponse<O> | Promise<Response | TypedResponse<O>>
+export type HandlerResponse<O, H extends Handler = Handler> =
+  | Response
+  | TypedResponse<O>
+  | H
+  | Promise<Response | TypedResponse<O> | H>
 
 export type Handler<
   E extends Env = any,
   P extends string = any,
   I extends Input = BlankInput,
-  R extends HandlerResponse<any> = any
+  R extends HandlerResponse<any, Handler<E, P, I>> = any
 > = (c: Context<E, P, I>, next: Next) => R
 
 export type MiddlewareHandler<
   E extends Env = any,
   P extends string = string,
   I extends Input = {}
-> = (c: Context<E, P, I>, next: Next) => Promise<Response | void>
+> = (c: Context<E, P, I>, next: Next) => Promise<Response | MiddlewareHandler<E, P, I> | void>
 
 export type H<
   E extends Env = any,


### PR DESCRIPTION
This PR will add a convenient feature to hono, but it will also increase the complexity, so please be careful. It is currently at the PoC stage.

### What does this enable us to do?

We can dynamically configure middleware with very clean code.
Of course, I know that authentication middleware has the ability to dynamically determine credentials, but with this feature, it is easy to pass settings dynamically even if the middleware does not support it.

```ts
const app = new Hono()
  .get('/shortcut-icon.svg', () => {
    const path = 'dynamic-deterministic-filename.svg'
    return serveStatic({ path })
  })
  .get('/', (c) => {
    return c.text('Hello World')
  })
```

```ts
const app = new Hono()
  .post('*', (c) => {
    const limit = new URL(c.req.url).host === 'localhost' ? 1024 * 1024 * 10 : 1024 * 1024
    return bodyLimit({ maxSize: limit })
  })
  .post('/upload', uploadHandler)
```

```ts
const app = new Hono()
  .post('*', (c) => {
    const username = c.req.header('Authorization')?.split(' ')[1] ?? ''
    return basicAuth({ username, password: passwordMap[username] })
  })
  .get('/', (c) => {
    return c.text('Hello World')
  })
```

### Isn't this just syntax sugar?

Yes, we can call it with `(c, next)` and return it as it is now, so it is safe to think of it as syntax sugar that omits `(c, next)`.

```ts
const app = new Hono()
  .get('/shortcut-icon.svg', (c, next) => {
    const path = 'dynamic-deterministic-filename.svg'
    return serveStatic({ path })(c, next)
  })
  .get('/', (c) => {
    return c.text('Hello World')
  })
```

### When is it particularly useful?

We will be able to solve issues that can be solved simply by using existing middleware in a clean way.

https://github.com/honojs/node-server/issues/205


### Is there any degradation in performance?

I don't think there is any decrease in performance at runtime.
When I compared them in "benchmarks/handle-event", there was no decrease in node and bun.

```
itty-router x 376,693 ops/sec ±4.26% (85 runs sampled)
sunder x 465,962 ops/sec ±3.09% (86 runs sampled)
worktop x 224,003 ops/sec ±4.51% (85 runs sampled)
Hono current main x 513,444 ops/sec ±5.52% (81 runs sampled)
Hono feat:returns-middleware x 525,498 ops/sec ±5.83% (80 runs sampled)
Fastest is Hono feat:returns-middleware,Hono current main
```

There may also be an impact on performance for "types", but I don't know the details of that, so I haven't been able to measure it.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
