### PR TITLE
feat(utils/mime): add mimetype 'video/quicktime'

### DIFF
--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -60,6 +60,7 @@ const _baseMimes = {
   mid: 'audio/x-midi',
   midi: 'audio/x-midi',
   mjs: 'text/javascript',
+  mov: 'video/quicktime',
   mp3: 'audio/mpeg',
   mp4: 'video/mp4',
   mpeg: 'video/mpeg',


### PR DESCRIPTION
I just add mimetype `video/quicktime` for .mov file extension. 🙇 

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
