### PR TITLE
WebSocket: Optional Sec-WebSocket-Protocol Header

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -191,6 +191,9 @@ export const hc = <T extends Hono<any, any, any>>(
         return new WebSocket(...args)
       }
 
+      // Header: Sec-WebSocket-Protocol
+      // TODO@abegehr
+
       return establishWebSocket(targetUrl.toString())
     }
 


### PR DESCRIPTION
This is the only header browsers can pass on `new WebSocket()`-initialization: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Protocol
It can be (mis-)used for auth f.e.: https://stackoverflow.com/questions/4361173/http-headers-in-websockets-client-api/77060459#77060459

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
