### PR TITLE
fix(compress): avoid compressing if transfer-encoding is set

### DIFF
--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -46,6 +46,18 @@ describe('Compress Middleware', () => {
     c.header('Content-Length', '1024')
     return c.body(new Uint8Array(1024)) // Simulated compressed data
   })
+  app.get('/transfer-encoding-deflate', (c) => {
+    c.header('Content-Type', 'application/octet-stream')
+    c.header('Transfer-Encoding', 'deflate')
+    c.header('Content-Length', '1024')
+    return c.body(new Uint8Array(1024)) // Simulated deflate data
+  })
+  app.get('/chunked', (c) => {
+    c.header('Content-Type', 'application/octet-stream')
+    c.header('Transfer-Encoding', 'chunked')
+    c.header('Content-Length', '1024')
+    return c.body(new Uint8Array(1024)) // Simulated chunked data
+  })
   app.get('/stream', (c) =>
     stream(c, async (stream) => {
       c.header('Content-Type', 'text/plain')
@@ -132,6 +144,18 @@ describe('Compress Middleware', () => {
     it('should not remove Content-Length when not compressing', async () => {
       const res = await testCompression('/jpeg-image', 'gzip', null)
       expect(res.headers.get('Content-Length')).toBeDefined()
+    })
+
+    it('should not compress transfer-encoding: deflate', async () => {
+      const res = await testCompression('/transfer-encoding-deflate', 'gzip', null)
+      expect(res.headers.get('Content-Length')).toBe('1024')
+      expect(res.headers.get('Transfer-Encoding')).toBe('deflate')
+    })
+
+    it('should not compress transfer-encoding: chunked', async () => {
+      const res = await testCompression('/chunked', 'gzip', null)
+      expect(res.headers.get('Content-Length')).toBe('1024')
+      expect(res.headers.get('Transfer-Encoding')).toBe('chunked')
     })
   })
 

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -42,6 +42,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     // Check if response should be compressed
     if (
       ctx.res.headers.has('Content-Encoding') || // already encoded
+      ctx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
       ctx.req.method === 'HEAD' || // HEAD request
       (contentLength && Number(contentLength) < threshold) || // content-length below threshold
       !shouldCompress(ctx.res) || // not compressible type


### PR DESCRIPTION
fix #3991

As is the case when Transfer-Encoding is chunked, I think it is better not to re-encode in other cases as well, so I have made it so that if Transfer-Encoding is present, compressing is skipped.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Transfer-Encoding

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
