### PR TITLE
fix(websocket): add `Uint8Array` to `WSMessageReceive`

### DIFF
--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -82,7 +82,7 @@ export class WSContext<T = unknown> {
   }
 }
 
-export type WSMessageReceive = string | Blob | ArrayBufferLike
+export type WSMessageReceive = string | Blob | ArrayBufferLike | Uint8Array
 
 export const createWSMessageEvent = (source: WSMessageReceive): MessageEvent<WSMessageReceive> => {
   return new MessageEvent<WSMessageReceive>('message', {


### PR DESCRIPTION
This will fix the issue pointed out in https://github.com/honojs/middleware/pull/1077#pullrequestreview-2730692813

In [@hono/node-ws](https://github.com/honojs/middleware/tree/main/packages/node-ws), the `data` in the link can be `Buffer`:

https://github.com/honojs/middleware/blob/b18f24379bb4a1350d0b1da0cb109787dddc5193/packages/node-ws/src/index.ts#L116

But currently, `WSMessageReceive` can not be `Buffer` and the type error throws:

![CleanShot 2025-04-01 at 17 51 07@2x](https://github.com/user-attachments/assets/2d11866c-aeab-4fb5-ab2d-43f16d26f131)

So I added the `Uint8Array`, which is the superclass of `Buffer` to `WSMessageReceive`.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
