### PR TITLE
Resolve issue when proxying 204

### DIFF
--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -128,7 +128,9 @@ export const proxy: ProxyFetch = async (input, proxyInit) => {
     // Content-Length is the size of the compressed content, not the size of the original content
     resHeaders.delete('content-length')
   }
-
+  // Enforce 204 has no body
+  const body = res.status === 204 ? null : res.body;
+  
   return new Response(res.body, {
     status: res.status,
     statusText: res.statusText,


### PR DESCRIPTION
when proxying 204 the body is null since it has no content. this makes Hono interpret the response as a 200. However, it is a 204.

this is something I found while using Hono. 

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
