### PR TITLE
feat(hono/testing): Allow passing hc options to testClient

### DIFF
--- a/src/helper/testing/index.test.ts
+++ b/src/helper/testing/index.test.ts
@@ -17,6 +17,16 @@ describe('hono testClient', () => {
     expect(await res.json()).toEqual({ hello: 'world' })
   })
 
+  it('Should use the passed in headers', async () => {
+    const app = new Hono().get('/search', (c) => {
+      return c.json({ query: c.req.header('x-query') })
+    })
+    const res = await testClient(app, undefined, undefined, {
+      headers: { 'x-query': 'abc' },
+    }).search.$get()
+    expect(await res.json()).toEqual({ query: 'abc' })
+  })
+
   it('Should return a correct URL with out throwing an error', async () => {
     const app = new Hono().get('/abc', (c) => c.json(0))
     const url = testClient(app).abc.$url()

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -17,7 +17,7 @@ export const testClient = <T extends Hono<any, Schema, string>>(
   app: T,
   Env?: ExtractEnv<T>['Bindings'] | {},
   executionCtx?: ExecutionContext,
-  options?: Omit<ClientRequestOptions, "fetch">
+  options?: Omit<ClientRequestOptions, 'fetch'>
 ): UnionToIntersection<Client<T>> => {
   const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
     return app.request(input, init, Env, executionCtx)

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { hc } from '../../client'
-import type { Client } from '../../client/types'
+import type { Client, ClientRequestOptions } from '../../client/types'
 import type { ExecutionContext } from '../../context'
 import type { Hono } from '../../hono'
 import type { Schema } from '../../types'
@@ -16,11 +16,12 @@ type ExtractEnv<T> = T extends Hono<infer E, Schema, string> ? E : never
 export const testClient = <T extends Hono<any, Schema, string>>(
   app: T,
   Env?: ExtractEnv<T>['Bindings'] | {},
-  executionCtx?: ExecutionContext
+  executionCtx?: ExecutionContext,
+  options?: Omit<ClientRequestOptions, "fetch">
 ): UnionToIntersection<Client<T>> => {
   const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
     return app.request(input, init, Env, executionCtx)
   }
 
-  return hc<typeof app>('http://localhost', { fetch: customFetch })
+  return hc<typeof app>('http://localhost', { ...options, fetch: customFetch })
 }


### PR DESCRIPTION
This PR makes it possible to pass hc options to testClient. This excludes the `fetch` option, which is always passed by the testClient; removing it obviates the need for testClient entirely.

I needed this because I wanted my testClient to always pass certain headers for authentication in dev mode.

<!--
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
-->