### PR TITLE
feat(cors): allowedMethods by function

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -8,7 +8,7 @@ import type { MiddlewareHandler } from '../../types'
 
 type CORSOptions = {
   origin: string | string[] | ((origin: string, c: Context) => string | undefined | null)
-  allowMethods?: string[]
+  allowMethods?: string[] | ((origin: string, c: Context) => string[])
   allowHeaders?: string[]
   maxAge?: number
   credentials?: boolean
@@ -22,7 +22,7 @@ type CORSOptions = {
  *
  * @param {CORSOptions} [options] - The options for the CORS middleware.
  * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
- * @param {string[]} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string[] | ((origin: string, c: Context) => string[])} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
  * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
  * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
  * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
@@ -80,6 +80,16 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
     }
   })(opts.origin)
 
+  const findAllowMethods = ((optsAllowMethods) => {
+    if (typeof optsAllowMethods === 'function') {
+      return optsAllowMethods
+    } else if (Array.isArray(optsAllowMethods)) {
+      return () => optsAllowMethods
+    } else {
+      return () => []
+    }
+  })(opts.allowMethods)
+
   return async function cors(c, next) {
     function set(key: string, value: string) {
       c.res.headers.set(key, value)
@@ -115,8 +125,9 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
         set('Access-Control-Max-Age', opts.maxAge.toString())
       }
 
-      if (opts.allowMethods?.length) {
-        set('Access-Control-Allow-Methods', opts.allowMethods.join(','))
+      const allowMethods = findAllowMethods(c.req.header('origin') || '', c)
+      if (allowMethods?.length) {
+        set('Access-Control-Allow-Methods', allowMethods.join(','))
       }
 
       let headers = opts.allowHeaders

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -126,7 +126,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       }
 
       const allowMethods = findAllowMethods(c.req.header('origin') || '', c)
-      if (allowMethods?.length) {
+      if (allowMethods.length) {
         set('Access-Control-Allow-Methods', allowMethods.join(','))
       }
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

## Proposal

In my usecase, it is needed to set different `Access-Control-Allow-Methods` by origins.
Then, I modified `hono/cors` for 'allowedMethods' to accept `function` like `origins`.
How do you think?

## Usecase

`GET` or `HEAD` can be performed from any origins, but others only from specific origin.

```typescript
app.use(
  '/api7/*',
  cors({
    origin: (origin) => (origin === 'http://example.com' ? origin : '*'),
    allowMethods: (origin) =>
      origin === 'http://example.com'
        ? ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE']
        : ['GET', 'HEAD'],
  })
)
```