### PR TITLE
fix(proxy): accept a Request object as proxyInit

### DIFF
--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -110,7 +110,8 @@ const preprocessRequestInit = (requestInit: RequestInit): RequestInit => {
  * ```
  */
 export const proxy: ProxyFetch = async (input, proxyInit) => {
-  const { raw, ...requestInit } = proxyInit ?? {}
+  const { raw, ...requestInit } =
+    proxyInit instanceof Request ? { raw: proxyInit } : proxyInit ?? {}
 
   const req = new Request(input, {
     ...buildRequestInitFromRequest(raw),


### PR DESCRIPTION
fix #4021

Also mentioned here: https://github.com/honojs/hono/pull/3928#issuecomment-2662572089

The following writing method should be supported, but it was not working correctly because I overlooked the fact that `…aRawRequest` does not return a property.

```ts
proxy(aUrl, aRawRequest)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
