### PR TITLE
ci: specify timeout for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   coverage:
     name: 'Coverage'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - main
       - bun
@@ -41,6 +42,7 @@ jobs:
   main:
     name: 'Main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -62,6 +64,7 @@ jobs:
   jsr-dry-run:
     name: "Checking if it's valid for JSR"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
@@ -73,6 +76,7 @@ jobs:
   deno:
     name: 'Deno'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
@@ -91,6 +95,7 @@ jobs:
   bun:
     name: 'Bun'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -102,9 +107,11 @@ jobs:
         with:
           name: coverage-bun
           path: coverage/
+
   fastly:
     name: 'Fastly Compute'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -119,6 +126,7 @@ jobs:
   node:
     name: 'Node.js v${{ matrix.node }}'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node: ['18.18.2', '20.x', '22.x']
@@ -140,6 +148,7 @@ jobs:
   workerd:
     name: 'workerd'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -157,6 +166,7 @@ jobs:
   lambda:
     name: 'AWS Lambda'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -171,6 +181,7 @@ jobs:
   lambda-edge:
     name: 'Lambda@Edge'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -185,6 +196,7 @@ jobs:
   perf-measures-type-and-bundle-check-on-pr:
     name: 'Type & Bundle size Check on PR'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -210,6 +222,7 @@ jobs:
   perf-measures-type-and-bundle-check-on-main:
     name: 'Type & Bundle size Check on Main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### The author should do the following, if applicable

Maybe [this workflow](https://github.com/honojs/hono/actions/runs/14440296335/job/40488744441) is hung up.
This PR sets a 10 minute timeout for all CI jobs.

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code


