### PR TITLE
ci: Add Bundle Analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           fail_ci_if_error: true
           directory: ./coverage
+          flags: bundle
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,9 @@ coverage:
       default:
         target: 75%
         threshold: 1%
+
+flags:
+  bundle:
+    paths:
+      - dist/
+    carryforward: true


### PR DESCRIPTION
Hey there! I work over at Sentry on the Codecov team and we've set a goal for adding some of our new features to open source repos already using Codecov. I'm a big fan of Hono, so when I saw this repo using Codecov, it seemed like a good fit :)

What is the new features?

[Bundle Analysis](https://docs.codecov.com/docs/javascript-bundle-analysis) will track your bundle size over time. This can be helpful for finding optimizations or being notified of large changes in bundle size.


Looking forward to your feedback! 