### PR TITLE
fix(context): don't throw the error with `c.header()` when it's finalized

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -199,7 +199,6 @@ describe('Context', () => {
     expect(res.headers.get('x-Custom2')).toBe('Message2-Override')
     expect(res.headers.get('x-Custom3')).toBe('Message3')
     expect(res.status).toBe(201)
-    expect(await res.text()).toBe('this is body')
 
     // res is already set.
     c.res = res
@@ -207,6 +206,8 @@ describe('Context', () => {
     c.status(202)
     expect(c.res.headers.get('X-Custom4')).toBe('Message4')
     expect(c.res.status).toBe(201)
+
+    expect(await res.text()).toBe('this is body')
   })
 
   it('Inherit current status if not specified', async () => {
@@ -409,6 +410,13 @@ describe('Context header', () => {
     })
     c.res = makeResponseHeaderImmutable(new Response('bar'))
     expect(await c.res.text()).toBe('bar')
+    expect(c.res.headers.get('X-Custom')).toBe('Message')
+  })
+
+  it('Should be able to set headers if the context is finalized', async () => {
+    c.res = makeResponseHeaderImmutable(new Response('bar'))
+    expect(c.finalized).toBe(true)
+    c.header('X-Custom', 'Message')
     expect(c.res.headers.get('X-Custom')).toBe('Message')
   })
 })

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -206,7 +206,6 @@ describe('Context', () => {
     c.status(202)
     expect(c.res.headers.get('X-Custom4')).toBe('Message4')
     expect(c.res.status).toBe(201)
-
     expect(await res.text()).toBe('this is body')
   })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -412,31 +412,19 @@ export class Context<
   set res(_res: Response | undefined) {
     this.#isFresh = false
     if (this.#res && _res) {
-      try {
-        for (const [k, v] of this.#res.headers.entries()) {
-          if (k === 'content-type') {
-            continue
-          }
-          if (k === 'set-cookie') {
-            const cookies = this.#res.headers.getSetCookie()
-            _res.headers.delete('set-cookie')
-            for (const cookie of cookies) {
-              _res.headers.append('set-cookie', cookie)
-            }
-          } else {
-            _res.headers.set(k, v)
-          }
+      _res = new Response(_res.body, _res)
+      for (const [k, v] of this.#res.headers.entries()) {
+        if (k === 'content-type') {
+          continue
         }
-      } catch (e) {
-        if (e instanceof TypeError && e.message.includes('immutable')) {
-          // `_res` is immutable (probably a response from a fetch API), so retry with a new response.
-          this.res = new Response(_res.body, {
-            headers: _res.headers,
-            status: _res.status,
-          })
-          return
+        if (k === 'set-cookie') {
+          const cookies = this.#res.headers.getSetCookie()
+          _res.headers.delete('set-cookie')
+          for (const cookie of cookies) {
+            _res.headers.append('set-cookie', cookie)
+          }
         } else {
-          throw e
+          _res.headers.set(k, v)
         }
       }
     }
@@ -524,6 +512,9 @@ export class Context<
    * ```
    */
   header: SetHeaders = (name, value, options): void => {
+    if (this.finalized) {
+      this.#res = new Response((this.#res as Response).body, this.#res)
+    }
     // Clear the header
     if (value === undefined) {
       if (this.#headers) {


### PR DESCRIPTION
Fixes #4055

This is based on https://github.com/honojs/hono/issues/4055#issuecomment-2798854609 by @usualoma. It is a "slightly overhead but simple" pattern. I think it's rare that it should catch the error with `try/catch,` so this simple implementation is better.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
