### PR TITLE
feat(validator): add formdot target, parse using `c.req.parseBody({ dot: true, all: true})` (#4080)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Context } from './context'
 import type { HonoBase } from './hono-base'
+import type { BodyData } from './utils/body'
 import type { CustomHeader, RequestHeader } from './utils/headers'
 import type { StatusCode } from './utils/http-status'
 import type {
@@ -1930,6 +1931,7 @@ export type ParsedFormValue = string | File
 export type ValidationTargets<T extends FormValue = ParsedFormValue, P extends string = string> = {
   json: any
   form: Record<string, T | T[]>
+  formdot: BodyData<{ dot: true; all: true }>
   query: Record<string, string | string[]>
   param: Record<P, P extends `${infer _}?` ? string | undefined : string>
   header: Record<RequestHeader | CustomHeader, string>


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

Related to #4080, this PR adds a `formdot` target that delegates form parsing to `c.req.parseBody` with `dot` and `all` set. 