### PR TITLE
feat(mime): support webmanifest

### DIFF
--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -12,6 +12,7 @@ describe('mime', () => {
     expect(getMimeType('hello.json')).toBe('application/json')
     expect(getMimeType('favicon.ico')).toBe('image/x-icon')
     expect(getMimeType('good.morning.hello.gif')).toBe('image/gif')
+    expect(getMimeType('site.webmanifest')).toBe('application/manifest+json')
     expect(getMimeType('goodmorninghellogif')).toBeUndefined()
     expect(getMimeType('indexjs.abcd')).toBeUndefined()
   })

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -80,6 +80,7 @@ const _baseMimes = {
   wasm: 'application/wasm',
   webm: 'video/webm',
   weba: 'audio/webm',
+  webmanifest: 'application/manifest+json',
   webp: 'image/webp',
   woff: 'font/woff',
   woff2: 'font/woff2',


### PR DESCRIPTION
ref: https://github.com/honojs/hono/issues/3736#issuecomment-2808983166

The web manifest is an important file in explaining information to browsers when installing a website as a PWA.

[The specification](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest) recommends that this file should be associated with `application/manifest+json` or some other JSON-like MIME type, but hono does not currently support this.
This PR will resolve it.

[note]
I think no special action is needed for `@hono/noder-server` as `hono` is marked as peerDependencies in it.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
