### PR TITLE
feat(logger): support for `NO_COLOR` on cloudflare workers

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -12,7 +12,7 @@
  */
 export function getColorEnabled(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { process, Deno } = globalThis as any
+  const { process, Deno, navigator } = globalThis as any
 
   const isNoColor =
     typeof Deno?.noColor === 'boolean'
@@ -20,6 +20,10 @@ export function getColorEnabled(): boolean {
       : process !== undefined
       ? // eslint-disable-next-line no-unsafe-optional-chaining
         'NO_COLOR' in process?.env
+      : navigator.userAgent === 'Cloudflare Workers'
+      ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        'NO_COLOR' in (import('cloudflare:workers').then((module) => module.env) ?? {})
       : false
 
   return !isNoColor


### PR DESCRIPTION
closes #3751

Currently, `process.env` is available on Cloudflare Workers with `nodejs_compat` flag, so there may not be a need to support it. And no tests for this are currently written. because runtime tests for workerd need to be updated to the latest version, which is a hassle. If that is necessary for us, I will wait for it.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
