### PR TITLE
feat(logger): set color enabled in global

### DIFF
--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -126,12 +126,17 @@ describe('Logger by Middleware', () => {
   })
 
   it('Can change logger color', async () => {
-    const res = await app.request('http://localhost/empty')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
     setLoggerColorEnabled(false)
+    const res1 = await app.request('http://localhost/empty')
+    expect(res1).not.toBeNull()
+    expect(res1.status).toBe(200)
     expect(log.startsWith('--> GET /empty 200')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+
     setLoggerColorEnabled(true)
+    const res2 = await app.request('http://localhost/empty')
+    expect(res2).not.toBeNull()
+    expect(res2.status).toBe(200)
     expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
@@ -214,10 +219,10 @@ describe('Logger by Middleware in NO_COLOR', () => {
   })
 
   it('setLoggerColorEnabled take precedence over NO_COLOR', async () => {
+    setLoggerColorEnabled(true)
     const res = await app.request('http://localhost/empty')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    setLoggerColorEnabled(true)
     expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
   })
 })

--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -1,16 +1,15 @@
 import { Hono } from '../../hono'
+import { logger, setLoggerColorEnabled } from '.'
 
 describe('Logger by Middleware', () => {
   let app: Hono
   let log: string
-  let setLoggerColorEnabled: (enabled: boolean) => void
 
   beforeEach(async () => {
     function sleep(time: number) {
       return new Promise((resolve) => setTimeout(resolve, time))
     }
-    const { logger, setLoggerColorEnabled: _ } = await import('.')
-    setLoggerColorEnabled = _
+
     app = new Hono()
 
     const logFn = (str: string) => {
@@ -140,93 +139,5 @@ describe('Logger by Middleware', () => {
     expect(res2.status).toBe(200)
     expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
     expect(log).toMatch(/m?s$/)
-  })
-})
-
-describe('Logger by Middleware in NO_COLOR', () => {
-  let app: Hono
-  let log: string
-  let setLoggerColorEnabled: (enabled: boolean) => void
-
-  beforeEach(async () => {
-    vi.stubEnv('NO_COLOR', '1')
-    function sleep(time: number) {
-      return new Promise((resolve) => setTimeout(resolve, time))
-    }
-
-    const { logger, setLoggerColorEnabled: _ } = await import('.')
-    setLoggerColorEnabled = _
-    app = new Hono()
-
-    const logFn = (str: string) => {
-      log = str
-    }
-
-    const shortRandomString = 'hono'
-    const longRandomString = 'hono'.repeat(1000)
-
-    app.use('*', logger(logFn))
-    app.get('/short', (c) => c.text(shortRandomString))
-    app.get('/long', (c) => c.text(longRandomString))
-    app.get('/seconds', async (c) => {
-      await sleep(1000)
-
-      return c.text(longRandomString)
-    })
-    app.get('/empty', (c) => c.text(''))
-  })
-  afterAll(() => {
-    vi.unstubAllEnvs()
-  })
-  it('Log status 200 with empty body', async () => {
-    const res = await app.request('http://localhost/empty')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(log.startsWith('--> GET /empty 200')).toBe(true)
-    expect(log).toMatch(/m?s$/)
-  })
-
-  it('Log status 200 with small body', async () => {
-    const res = await app.request('http://localhost/short')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(log.startsWith('--> GET /short 200')).toBe(true)
-    expect(log).toMatch(/m?s$/)
-  })
-
-  it('Log status 200 with big body', async () => {
-    const res = await app.request('http://localhost/long')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(log.startsWith('--> GET /long 200')).toBe(true)
-    expect(log).toMatch(/m?s$/)
-  })
-
-  it('Time in seconds', async () => {
-    const res = await app.request('http://localhost/seconds')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(log.startsWith('--> GET /seconds 200')).toBe(true)
-    expect(log).toMatch(/1s/)
-  })
-
-  it('Log status 404', async () => {
-    const msg = 'Default 404 Not Found'
-    app.all('*', (c) => {
-      return c.text(msg, 404)
-    })
-    const res = await app.request('http://localhost/notfound')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(404)
-    expect(log.startsWith('--> GET /notfound 404')).toBe(true)
-    expect(log).toMatch(/m?s$/)
-  })
-
-  it('setLoggerColorEnabled take precedence over NO_COLOR', async () => {
-    setLoggerColorEnabled(true)
-    const res = await app.request('http://localhost/empty')
-    expect(res).not.toBeNull()
-    expect(res.status).toBe(200)
-    expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
   })
 })

--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { logger } from '.'
+import { logger, setLoggerColorEnabled } from '.'
 
 describe('Logger by Middleware', () => {
   let app: Hono
@@ -124,6 +124,17 @@ describe('Logger by Middleware', () => {
     expect(log.startsWith('--> GET /server-error?status=700 700')).toBe(true)
     expect(log).toMatch(/m?s$/)
   })
+
+  it('Can change logger color', async () => {
+    const res = await app.request('http://localhost/empty')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    setLoggerColorEnabled(false)
+    expect(log.startsWith('--> GET /empty 200')).toBe(true)
+    setLoggerColorEnabled(true)
+    expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
 })
 
 describe('Logger by Middleware in NO_COLOR', () => {
@@ -200,5 +211,13 @@ describe('Logger by Middleware in NO_COLOR', () => {
     expect(res.status).toBe(404)
     expect(log.startsWith('--> GET /notfound 404')).toBe(true)
     expect(log).toMatch(/m?s$/)
+  })
+
+  it('setLoggerColorEnabled take precedence over NO_COLOR', async () => {
+    const res = await app.request('http://localhost/empty')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    setLoggerColorEnabled(true)
+    expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
   })
 })

--- a/src/middleware/logger/index.test.ts
+++ b/src/middleware/logger/index.test.ts
@@ -1,15 +1,16 @@
 import { Hono } from '../../hono'
-import { logger, setLoggerColorEnabled } from '.'
 
 describe('Logger by Middleware', () => {
   let app: Hono
   let log: string
+  let setLoggerColorEnabled: (enabled: boolean) => void
 
-  beforeEach(() => {
+  beforeEach(async () => {
     function sleep(time: number) {
       return new Promise((resolve) => setTimeout(resolve, time))
     }
-
+    const { logger, setLoggerColorEnabled: _ } = await import('.')
+    setLoggerColorEnabled = _
     app = new Hono()
 
     const logFn = (str: string) => {
@@ -145,13 +146,16 @@ describe('Logger by Middleware', () => {
 describe('Logger by Middleware in NO_COLOR', () => {
   let app: Hono
   let log: string
+  let setLoggerColorEnabled: (enabled: boolean) => void
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.stubEnv('NO_COLOR', '1')
     function sleep(time: number) {
       return new Promise((resolve) => setTimeout(resolve, time))
     }
 
+    const { logger, setLoggerColorEnabled: _ } = await import('.')
+    setLoggerColorEnabled = _
     app = new Hono()
 
     const logFn = (str: string) => {

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -97,8 +97,8 @@ export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
 
 /**
  * Sets color output option for logger middleware builtin Hono.
- * @param {boolean} enabled - Sets to `true` to enable colorized logging, or `false` to disable it. 
+ * @param {boolean} enabled - Sets to `true` to enable colorized logging, or `false` to disable it.
  */
-export function setLoggerColorEnabled(enabled: boolean): void{
+export function setLoggerColorEnabled(enabled: boolean): void {
   colorEnabled = enabled
 }

--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -6,6 +6,8 @@
 import type { MiddlewareHandler } from '../../types'
 import { getColorEnabled } from '../../utils/color'
 
+let colorEnabled = getColorEnabled()
+
 enum LogPrefix {
   Outgoing = '-->',
   Incoming = '<--',
@@ -26,7 +28,6 @@ const time = (start: number) => {
 }
 
 const colorStatus = (status: number) => {
-  const colorEnabled = getColorEnabled()
   if (colorEnabled) {
     switch ((status / 100) | 0) {
       case 5: // red = error
@@ -92,4 +93,12 @@ export const logger = (fn: PrintFunc = console.log): MiddlewareHandler => {
 
     log(fn, LogPrefix.Outgoing, method, path, c.res.status, time(start))
   }
+}
+
+/**
+ * Sets color output option for logger middleware builtin Hono.
+ * @param {boolean} enabled - Sets to `true` to enable colorized logging, or `false` to disable it. 
+ */
+export function setLoggerColorEnabled(enabled: boolean): void{
+  colorEnabled = enabled
 }

--- a/src/middleware/logger/no-color.test.ts
+++ b/src/middleware/logger/no-color.test.ts
@@ -1,0 +1,89 @@
+import { Hono } from '../../hono'
+
+describe('Logger by Middleware in NO_COLOR', () => {
+  let app: Hono
+  let log: string
+  let setLoggerColorEnabled: (enabled: boolean) => void
+
+  beforeEach(async () => {
+    vi.stubEnv('NO_COLOR', '1')
+    function sleep(time: number) {
+      return new Promise((resolve) => setTimeout(resolve, time))
+    }
+    const { logger, setLoggerColorEnabled: _ } = await import('.')
+    setLoggerColorEnabled = _
+
+    app = new Hono()
+
+    const logFn = (str: string) => {
+      log = str
+    }
+
+    const shortRandomString = 'hono'
+    const longRandomString = 'hono'.repeat(1000)
+
+    app.use('*', logger(logFn))
+    app.get('/short', (c) => c.text(shortRandomString))
+    app.get('/long', (c) => c.text(longRandomString))
+    app.get('/seconds', async (c) => {
+      await sleep(1000)
+
+      return c.text(longRandomString)
+    })
+    app.get('/empty', (c) => c.text(''))
+  })
+  afterAll(() => {
+    vi.unstubAllEnvs()
+  })
+  it('Log status 200 with empty body', async () => {
+    const res = await app.request('http://localhost/empty')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(log.startsWith('--> GET /empty 200')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('Log status 200 with small body', async () => {
+    const res = await app.request('http://localhost/short')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(log.startsWith('--> GET /short 200')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('Log status 200 with big body', async () => {
+    const res = await app.request('http://localhost/long')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(log.startsWith('--> GET /long 200')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('Time in seconds', async () => {
+    const res = await app.request('http://localhost/seconds')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(log.startsWith('--> GET /seconds 200')).toBe(true)
+    expect(log).toMatch(/1s/)
+  })
+
+  it('Log status 404', async () => {
+    const msg = 'Default 404 Not Found'
+    app.all('*', (c) => {
+      return c.text(msg, 404)
+    })
+    const res = await app.request('http://localhost/notfound')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(404)
+    expect(log.startsWith('--> GET /notfound 404')).toBe(true)
+    expect(log).toMatch(/m?s$/)
+  })
+
+  it('setLoggerColorEnabled take precedence over NO_COLOR', async () => {
+    setLoggerColorEnabled(true)
+    const res = await app.request('http://localhost/empty')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(log.startsWith('--> GET /empty \x1b[32m200\x1b[0m')).toBe(true)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "ES2022",
     "target": "ES2022",
     "declaration": true,
     "moduleResolution": "Bundler",


### PR DESCRIPTION
Provides a function to toggle color output as an escape hatch for some runtimes that are not Node.js compatible.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
