### PR TITLE
fix(cookie): get deleted value with prefix

### DIFF
--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -430,5 +430,19 @@ describe('Cookie Middleware', () => {
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('choco')
     })
+
+    app.get('/delete-cookie-with-prefix', (c) => {
+      const deleted = deleteCookie(c, 'delicious_cookie', { prefix: 'secure' })
+      return c.text(deleted || '')
+    })
+
+    it('Get deleted value with prefix', async () => {
+      const cookieString = '__Secure-delicious_cookie=choco'
+      const req = new Request('http://localhost/delete-cookie-with-prefix')
+      req.headers.set('Cookie', cookieString)
+      const res = await app.request(req)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('choco')
+    })
   })
 })

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -10,7 +10,7 @@ import type { Cookie, CookieOptions, CookiePrefixOptions, SignedCookie } from '.
 interface GetCookie {
   (c: Context, key: string): string | undefined
   (c: Context): Cookie
-  (c: Context, key: string, prefixOptions: CookiePrefixOptions): string | undefined
+  (c: Context, key: string, prefixOptions?: CookiePrefixOptions): string | undefined
 }
 
 interface GetSignedCookie {
@@ -20,7 +20,7 @@ interface GetSignedCookie {
     c: Context,
     secret: string | BufferSource,
     key: string,
-    prefixOptions: CookiePrefixOptions
+    prefixOptions?: CookiePrefixOptions
   ): Promise<string | undefined | false>
 }
 
@@ -124,7 +124,7 @@ export const setSignedCookie = async (
 }
 
 export const deleteCookie = (c: Context, name: string, opt?: CookieOptions): string | undefined => {
-  const deletedCookie = getCookie(c, name)
+  const deletedCookie = getCookie(c, name, opt?.prefix)
   setCookie(c, name, '', { ...opt, maxAge: 0 })
   return deletedCookie
 }


### PR DESCRIPTION
Deleting a cookie with `{ prefix: CookiePrefixOptions }` doesn't return the cookie value as the `prefix` isn't passed to `getCookie()`