### PR TITLE
fix(hono-base): copy notfound and error handlers in `#clone()`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -172,6 +172,8 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
       router: this.router,
       getPath: this.getPath,
     })
+    clone.errorHandler = this.errorHandler
+    clone.#notFoundHandler = this.#notFoundHandler
     clone.routes = this.routes
     return clone
   }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -3623,7 +3623,7 @@ describe('Generics for Bindings and Variables', () => {
   })
 })
 
-describe.only('app.basePath() with the internal #clone()', () => {
+describe('app.basePath() with the internal #clone()', () => {
   const app = new Hono()
     .notFound((c) => {
       return c.text(`Custom not found`, 404)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -3622,3 +3622,29 @@ describe('Generics for Bindings and Variables', () => {
     })
   })
 })
+
+describe.only('app.basePath() with the internal #clone()', () => {
+  const app = new Hono()
+    .notFound((c) => {
+      return c.text(`Custom not found`, 404)
+    })
+    .onError((error, c) => {
+      return c.text(`Custom error "${error.message}"`, 500)
+    })
+    .basePath('/api')
+    .get('/test', async () => {
+      throw new Error('API Test error')
+    })
+
+  it('Should return the custom not found', async () => {
+    const res = await app.request('/api/not-found')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('Custom not found')
+  })
+
+  it('Should return the custom error', async () => {
+    const res = await app.request('/api/test')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('Custom error "API Test error"')
+  })
+})

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -199,8 +199,12 @@ describe('Parse Body Util', () => {
 
     const req = createRequest(FORM_URL, 'POST', data)
 
-    expect(await parseBody(req, { all: true, dot: true })).toEqual({
-      file: { file1, file2 },
+    const result = await parseBody(req, { all: true, dot: true })
+    expect(result).toMatchObject({
+      file: {
+        file1: { name: 'file1', type: 'application/octet-stream' },
+        file2: { name: 'file2', type: 'application/octet-stream' },
+      },
     })
   })
 
@@ -217,8 +221,12 @@ describe('Parse Body Util', () => {
 
     const req = createRequest(FORM_URL, 'POST', data)
 
-    expect(await parseBody(req, { all: true })).toEqual({
-      file: [file1, file2],
+    const result = await parseBody(req, { all: true })
+    expect(result).toMatchObject({
+      file: [
+        { name: 'file1', type: 'application/octet-stream' },
+        { name: 'file2', type: 'application/octet-stream' },
+      ],
     })
   })
 


### PR DESCRIPTION
Fixes  #4138

With the current implementation, the `errorHandler` and `#notFoundHandler` are not copied in the `#clone()`. So the issue #4138 occurs. In this PR, it copies them.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
