### PR TITLE
fix(jwt): use `header.alg` as fallback in `verifyFromJwks`

### DIFF
--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -153,7 +153,7 @@ export const verifyFromJwks = async (
     throw new JwtTokenInvalid(token)
   }
 
-  return await verify(token, matchingKey, matchingKey.alg as SignatureAlgorithm)
+  return await verify(token, matchingKey, (matchingKey.alg as SignatureAlgorithm) || header.alg)
 }
 
 export const decode = (token: string): { header: TokenHeader; payload: JWTPayload } => {


### PR DESCRIPTION
Fixes #4119

This PR enables using `header.alg` as a fallback in `verifyFromJwks` when `matchingKey.alg` is `undefined`.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
