### PR TITLE
feat: support http+unix scheme

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -111,6 +111,11 @@ describe('url', () => {
       path = getPath(new Request('https://example.com/hello/hey/'))
       expect(path).toBe('/hello/hey/')
     })
+
+    it('getPath - http+unix', () => {
+      const path = getPath(new Request('http+unix://%2Ftmp%2Fsocket%2Esock/hello/'))
+      expect(path).toBe('/hello/')
+    })
   })
 
   describe('getQueryStrings', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -105,7 +105,12 @@ const tryDecodeURI = (str: string) => tryDecode(str, decodeURI)
 
 export const getPath = (request: Request): string => {
   const url = request.url
-  const start = url.indexOf('/', 8)
+  const start = url.indexOf(
+    '/',
+    url.charCodeAt(9) === 58
+      ? 13 // http+unix://
+      : 8 // http:// or https://
+  )
   let i = start
   for (; i < url.length; i++) {
     const charCode = url.charCodeAt(i)


### PR DESCRIPTION
https://github.com/orgs/honojs/discussions/4145


### `http+unix:` scheme

`http+unix` is often used on the client side (e.g., curl), but it is very rarely used on the server side. However, in Deno, when you specify `path` in `Deno.serve`, a string like `http+unix://%2Ftmp%2Fsocket%2Esock/your/path` is passed to the URL of the Request object.

In Deno, it is set with the following code.
https://github.com/denoland/deno/blob/94683caba1d7247ba914107b521efa54b61580b1/runtime/ops/http.rs#L100


`bun` and `node-server` do not use it.

### performance

I compared using the following benchmark script, and `url.charCodeAt(9) === 58 ? 13 : 8` seems to offer the best performance. Compared to the current situation, the performance is reduced by only a few tens of ps. However, since this is not a frequently used feature, it seems wasteful to incur several tens of ps of overhead for this purpose.

```ts
import { run, bench, group } from 'mitata'

const getPathA = (url: string): number => {
  return url.indexOf('/', 8)
}

const getPathB = (url: string): number => {
  return url.indexOf('/', url.charCodeAt(9) === 58 ? 13 : 8)
}

const getPathC = (url: string): number => {
  return url.indexOf('/', url.indexOf(':') + 3)
}

console.log(getPathA('http://localhost/path/to/resource'))
console.log(getPathB('http://localhost/path/to/resource'))
console.log(getPathC('http://localhost/path/to/resource'))
console.log(getPathA('http+unix://localhost/path/to/resource'))
console.log(getPathB('http+unix://localhost/path/to/resource'))
console.log(getPathC('http+unix://localhost/path/to/resource'))

bench('noop', () => {})

group('getPath', () => {
  bench('getPathA', () => {
    getPathA('http://localhost/path/to/resource')
  })
  bench('getPathB', () => {
    getPathB('http://localhost/path/to/resource')
  })
  bench('getPathC', () => {
    getPathB('http://localhost/path/to/resource')
  })
})

run()
```


### Is this safe?

For example, if a scheme such as `http+socket` is introduced in the future, individual responses will be necessary, so future compatibility is not guaranteed with this code. However, since the current code fixed at `8` does not support this either, I don't think it will be any worse than the current situation.



### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
