### PR TITLE
chore(benchmark): add `URLSearchParams` to the query-params benchmark

### DIFF
--- a/benchmarks/query-param/src/bench.mts
+++ b/benchmarks/query-param/src/bench.mts
@@ -1,4 +1,5 @@
 import { run, group, bench } from 'mitata'
+import { getQueryStrings } from '../../../src/utils/url'
 import fastQuerystring from './fast-querystring.mts'
 import hono from './hono.mts'
 import qs from './qs.mts'
@@ -38,6 +39,17 @@ import qs from './qs.mts'
     bench('hono', () => hono(url, key))
     bench('fastQuerystring', () => fastQuerystring(url, key))
     bench('qs', () => qs(url, key))
+    bench('URLSearchParams', () => {
+      const params = new URLSearchParams(getQueryStrings(url))
+      if (key) {
+        return params.get(key)
+      }
+      const obj = {}
+      for (const [k, v] of params) {
+        obj[k] = v
+      }
+      return obj
+    })
   })
 })
 


### PR DESCRIPTION
Added the benchmark written in [the comment](https://github.com/honojs/hono/pull/3565#issuecomment-2442884990).

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
