### PR TITLE
ci: skip lib check in type check benchmark

### DIFF
--- a/perf-measures/type-check/tsconfig.build.json
+++ b/perf-measures/type-check/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
     "extends": "../tsconfig.json",
-    "include": ["client.ts"]
+    "include": ["client.ts"],
+    "compilerOptions": {
+        "skipLibCheck": true
+    }
 }


### PR DESCRIPTION
- related: https://github.com/honojs/hono/pull/4161#issuecomment-2906504107


As `skipLibCheck` is often set to `true` in actual application development, we will run the benchmarks using this setting as well.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
