### PR TITLE
fix(middleware/etag): should return 304 when weak etag is passed in  'If-None-Match'

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -270,6 +270,26 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('x-message')).toBeFalsy()
   })
 
+  it('Should return 304 when weak ETag in If-None-Match matches the generated ETag', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    app.get('/etag/abc', (c) => {
+      return c.text('Hono is hot')
+    })
+    let res = await app.request('http://localhost/etag/abc')
+    const headerEtag = res.headers.get('ETag')!
+
+    expect(headerEtag).not.toBeFalsy()
+
+    res = await app.request('http://localhost/etag/abc', {
+      headers: {
+        'If-None-Match': 'W/"d104fafdb380655dab607c9bddc4d4982037afa1"'
+      }
+    })
+
+    expect(res.status).toBe(304)
+  })
+
   describe('When crypto is not available', () => {
     let _crypto: Crypto | undefined
     beforeAll(() => {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -283,8 +283,8 @@ describe('Etag Middleware', () => {
 
     res = await app.request('http://localhost/etag/abc', {
       headers: {
-        'If-None-Match': 'W/"d104fafdb380655dab607c9bddc4d4982037afa1"'
-      }
+        'If-None-Match': 'W/"d104fafdb380655dab607c9bddc4d4982037afa1"',
+      },
     })
 
     expect(res.status).toBe(304)

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -27,11 +27,12 @@ export const RETAINED_304_HEADERS = [
   'vary',
 ]
 
-const stripWeak = (tag: string) => tag.replace(/^W\//, "");
+const stripWeak = (tag: string) => tag.replace(/^W\//, '')
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {
-  return ifNoneMatch != null &&
-    ifNoneMatch.split(/,\s*/).some(t => stripWeak(t) === stripWeak(etag));
+  return (
+    ifNoneMatch != null && ifNoneMatch.split(/,\s*/).some((t) => stripWeak(t) === stripWeak(etag))
+  )
 }
 
 function initializeGenerator(

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -27,8 +27,11 @@ export const RETAINED_304_HEADERS = [
   'vary',
 ]
 
+const stripWeak = (tag: string) => tag.replace(/^W\//, "");
+
 function etagMatches(etag: string, ifNoneMatch: string | null) {
-  return ifNoneMatch != null && ifNoneMatch.split(/,\s*/).indexOf(etag) > -1
+  return ifNoneMatch != null &&
+    ifNoneMatch.split(/,\s*/).some(t => stripWeak(t) === stripWeak(etag));
 }
 
 function initializeGenerator(


### PR DESCRIPTION
close: https://github.com/honojs/hono/issues/4170

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code