### PR TITLE
chore: ignore CLAUDE.local.md in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ out
 
 # IDE-specific settings
 .idea
+
+# Claude Code local files
+CLAUDE.local.md
+settings.local.json


### PR DESCRIPTION
## Summary

Add Claude Code local configuration files to .gitignore to prevent committing personal settings.

Files added to .gitignore:
- `CLAUDE.local.md` - Local Claude Code documentation/notes
- `settings.local.json` - Personal Claude Code configuration

### The author should do the following, if applicable

- [ ] ~~Add tests~~ (N/A - gitignore change only)
- [ ] ~~Run tests~~ (N/A - gitignore change only) 
- [ ] ~~`bun run format:fix && bun run lint:fix` to format the code~~ (N/A - gitignore change only)
- [ ] ~~Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code~~ (N/A - gitignore change only)

🤖 Generated with [Claude Code](https://claude.ai/code)