### PR TITLE
fix(hono/context): content-type be overridden by default response when append headers

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -172,6 +172,17 @@ describe('Context', () => {
     expect(foo).toBe('Bar, Buzz')
   })
 
+  it('c.body() - content-type cannot be overridden by the default response when append headers', async () => {
+    const triggerResGetter = c.res
+    c.header('Vary', 'Accept-Encoding', { append: true })
+    const res = c.body('<h1>Hi</h1>', 200, {
+      'X-Foo': ['Bar', 'Buzz'],
+      'Content-Type': 'text/html;charset=utf-8',
+    })
+    const foo = res.headers.get('Content-Type')
+    expect(foo).toBe('text/html;charset=utf-8')
+  })
+
   it('c.status()', async () => {
     c.status(201)
     const res = c.body('Hi')

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -173,14 +173,11 @@ describe('Context', () => {
   })
 
   it('c.body() - content-type cannot be overridden by the default response when append headers', async () => {
-    const triggerResGetter = c.res
     c.header('Vary', 'Accept-Encoding', { append: true })
-    const res = c.body('<h1>Hi</h1>', 200, {
-      'X-Foo': ['Bar', 'Buzz'],
-      'Content-Type': 'text/html;charset=utf-8',
-    })
-    const foo = res.headers.get('Content-Type')
-    expect(foo).toBe('text/html;charset=utf-8')
+    c.res
+    c.header('Content-Type', 'text/html')
+    const res = c.body('<h1>Hi</h1>')
+    expect(res.headers.get('Content-Type')).toMatch('text/html')
   })
 
   it('c.status()', async () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -670,7 +670,7 @@ export class Context<
       this.#res.headers.forEach((v, k) => {
         if (k === 'set-cookie') {
           this.#headers?.append(k, v)
-        } else if (this.finalized || k !== 'content-type') {
+        } else if (k !== 'content-type') {
           this.#headers?.set(k, v)
         }
       })

--- a/src/context.ts
+++ b/src/context.ts
@@ -670,7 +670,7 @@ export class Context<
       this.#res.headers.forEach((v, k) => {
         if (k === 'set-cookie') {
           this.#headers?.append(k, v)
-        } else {
+        } else if (this.finalized || k !== 'content-type') {
           this.#headers?.set(k, v)
         }
       })


### PR DESCRIPTION
fix node-server bug https://github.com/honojs/node-server/issues/226

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
