### PR TITLE
fix(utils/body): normalize key names in parseBody (#4108)

### DIFF
--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -232,19 +232,19 @@ describe('Parse Body Util', () => {
 
   it('should parse multiple values if key ends with `[]`', async () => {
     const data = new FormData()
-    data.append('foo[]', 'aaa')
-    data.append('foo[]', 'bbb')
+    data.append('file[]', 'aaa')
+    data.append('file[]', 'bbb')
     data.append('message', 'hello')
 
     const req = createRequest(FORM_URL, 'POST', data)
 
     expect(await parseBody(req, { all: true })).toEqual({
-      'foo[]': ['aaa', 'bbb'],
+      'file[]': ['aaa', 'bbb'],
       message: 'hello',
     })
   })
 
-  it('should parse single value as array if the key has []', async () => {
+  it('should parse single value as array if the key has `[]`', async () => {
     const data = new FormData()
     data.append('foo[]', 'bar')
     const req = createRequest(FORM_URL, 'POST', data)

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -232,15 +232,25 @@ describe('Parse Body Util', () => {
 
   it('should parse multiple values if key ends with `[]`', async () => {
     const data = new FormData()
-    data.append('file[]', 'aaa')
-    data.append('file[]', 'bbb')
+    data.append('foo[]', 'aaa')
+    data.append('foo[]', 'bbb')
     data.append('message', 'hello')
 
     const req = createRequest(FORM_URL, 'POST', data)
 
     expect(await parseBody(req, { all: true })).toEqual({
-      file: ['aaa', 'bbb'],
+      'foo[]': ['aaa', 'bbb'],
       message: 'hello',
+    })
+  })
+
+  it('should parse single value as array if the key has []', async () => {
+    const data = new FormData()
+    data.append('foo[]', 'bar')
+    const req = createRequest(FORM_URL, 'POST', data)
+
+    expect(await parseBody(req, { all: true })).toEqual({
+      'foo[]': ['bar'],
     })
   })
 

--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -239,7 +239,7 @@ describe('Parse Body Util', () => {
     const req = createRequest(FORM_URL, 'POST', data)
 
     expect(await parseBody(req, { all: true })).toEqual({
-      'file[]': ['aaa', 'bbb'],
+      file: ['aaa', 'bbb'],
       message: 'hello',
     })
   })

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -151,7 +151,8 @@ function convertFormDataToBodyData<T extends BodyData = BodyData>(
     if (!shouldParseAllValues) {
       form[key] = value
     } else {
-      handleParsingAllValues(form, key, value)
+      const keyWithoutBrackets = key.replace(/\[\]$/, '')
+      handleParsingAllValues(form, keyWithoutBrackets, value)
     }
   })
 

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -151,8 +151,7 @@ function convertFormDataToBodyData<T extends BodyData = BodyData>(
     if (!shouldParseAllValues) {
       form[key] = value
     } else {
-      const keyWithoutBrackets = key.replace(/\[\]$/, '')
-      handleParsingAllValues(form, keyWithoutBrackets, value)
+      handleParsingAllValues(form, key, value)
     }
   })
 
@@ -189,7 +188,11 @@ const handleParsingAllValues = (
       form[key] = [form[key] as string | File, value]
     }
   } else {
-    form[key] = value
+    if (!key.endsWith('[]')) {
+      form[key] = value
+    } else {
+      form[key] = [value]
+    }
   }
 }
 


### PR DESCRIPTION
### The author should do the following, if applicable
Fixes #4108 
- [x]  Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
