### PR TITLE
Add test for POST method in testClient

### DIFF
--- a/src/helper/testing/index.test.ts
+++ b/src/helper/testing/index.test.ts
@@ -17,6 +17,22 @@ describe('hono testClient', () => {
     expect(await res.json()).toEqual({ hello: 'world' })
   })
 
+  it('Should support POST methods', async () => {
+    const app = new Hono().post('/search', async (c) => {
+      const body = await c.req.json()
+      return c.json({ echo: body.hello })
+    })
+    const res = await testClient(app).search.$post(
+      {},
+      {
+        headers: { 'Content-Type': 'application/json' },
+        init: { body: JSON.stringify({ hello: 'world' }) },
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ echo: 'world' })
+  })
+
   it('Should return a correct URL with out throwing an error', async () => {
     const app = new Hono().get('/abc', (c) => c.json(0))
     const url = testClient(app).abc.$url()


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

From the docs, it was not clear to me how to pass a body to the `testClient`. I thought I would start by adding a test case since all existing tests for the `testClient` are all `GET` requests. Later, I plan to open a PR in the docs repo to clarify how to pass a body to the `testClient`.

See docs here https://hono.dev/docs/helpers/testing#testclient