### PR TITLE
fix(etag): fallback if `res.clone()` is not supported

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -155,6 +155,29 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('ETag')).toBeNull()
   })
 
+  it('Should handle clone() not supported (Lambda-like environment)', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    app.get('/etag/no-clone', (c) => {
+      const originalResponse = c.text('Lambda test content')
+      // Mock Lambda environment where clone() doesn't work properly
+      const mockResponse = new Response(originalResponse.body, {
+        status: originalResponse.status,
+        statusText: originalResponse.statusText,
+        headers: originalResponse.headers,
+      })
+      // Override clone to throw error (Lambda-like behavior)
+      mockResponse.clone = () => {
+        throw new Error('clone() not supported in Lambda')
+      }
+      return mockResponse
+    })
+    const res = await app.request('/etag/no-clone')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('ETag')).not.toBeNull()
+    expect(await res.text()).toBe('Lambda test content')
+  })
+
   it('Should return etag header - weak', async () => {
     const app = new Hono()
     app.use('/etag/*', etag({ weak: true }))

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -168,7 +168,7 @@ describe('Etag Middleware', () => {
       })
       // Override clone to throw error (AWS Lambda-like behavior)
       mockResponse.clone = () => {
-        throw new Error('clone() not supported in Lambda')
+        throw new Error('clone() not supported in AWS Lambda')
       }
       return mockResponse
     })

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -160,13 +160,13 @@ describe('Etag Middleware', () => {
     app.use('/etag/*', etag())
     app.get('/etag/no-clone', (c) => {
       const originalResponse = c.text('Lambda test content')
-      // Mock Lambda environment where clone() doesn't work properly
+      // Mock AWS Lambda environment where clone() doesn't work properly
       const mockResponse = new Response(originalResponse.body, {
         status: originalResponse.status,
         statusText: originalResponse.statusText,
         headers: originalResponse.headers,
       })
-      // Override clone to throw error (Lambda-like behavior)
+      // Override clone to throw error (AWS Lambda-like behavior)
       mockResponse.clone = () => {
         throw new Error('clone() not supported in Lambda')
       }


### PR DESCRIPTION
This PR handles the environment that does not support it. I'm not sure the Lambda does not support `res.clone()`, but if so, this PR will fix #4031.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
