### PR TITLE
Revert "fix(etag): fallback if `res.clone()` is not supported (#4198)"

### DIFF
--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -9,25 +9,23 @@ const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Ui
 }
 
 export const generateDigest = async (
-  input: ReadableStream<Uint8Array> | ArrayBuffer | null,
+  stream: ReadableStream<Uint8Array> | null,
   generator: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
-  if (!input) {
+  if (!stream) {
     return null
   }
 
   let result: ArrayBuffer | undefined = undefined
-  if (input instanceof ArrayBuffer) {
-    result = await generator(new Uint8Array(input))
-  } else {
-    const reader = input.getReader()
-    for (;;) {
-      const { value, done } = await reader.read()
-      if (done) {
-        break
-      }
-      result = await generator(mergeBuffers(result, value))
+
+  const reader = stream.getReader()
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) {
+      break
     }
+
+    result = await generator(mergeBuffers(result, value))
   }
 
   if (!result) {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -155,29 +155,6 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('ETag')).toBeNull()
   })
 
-  it('Should handle clone() not supported (Lambda-like environment)', async () => {
-    const app = new Hono()
-    app.use('/etag/*', etag())
-    app.get('/etag/no-clone', (c) => {
-      const originalResponse = c.text('Lambda test content')
-      // Mock AWS Lambda environment where clone() doesn't work properly
-      const mockResponse = new Response(originalResponse.body, {
-        status: originalResponse.status,
-        statusText: originalResponse.statusText,
-        headers: originalResponse.headers,
-      })
-      // Override clone to throw error (AWS Lambda-like behavior)
-      mockResponse.clone = () => {
-        throw new Error('clone() not supported in AWS Lambda')
-      }
-      return mockResponse
-    })
-    const res = await app.request('/etag/no-clone')
-    expect(res.status).toBe(200)
-    expect(res.headers.get('ETag')).not.toBeNull()
-    expect(await res.text()).toBe('Lambda test content')
-  })
-
   it('Should return etag header - weak', async () => {
     const app = new Hono()
     app.use('/etag/*', etag({ weak: true }))

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -93,15 +93,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
       if (!generator) {
         return
       }
-      let hash: string | null = null
-      try {
-        hash = await generateDigest(res.clone().body, generator)
-      } catch {
-        // Fallback for environments where res.clone() is not supported (e.g., AWS Lambda)
-        const buffer = await res.arrayBuffer()
-        hash = await generateDigest(buffer, generator)
-        c.res = new Response(buffer, res)
-      }
+      const hash = await generateDigest(res.clone().body, generator)
       if (hash === null) {
         return
       }


### PR DESCRIPTION
This reverts commit 548d73f06139cb50ee974e8e7d82ef511b6fef29.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
