### PR TITLE
feat(etag): add `getBody` option

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -329,7 +329,7 @@ describe('Etag Middleware', () => {
       })
     )
     app.get('/etag/custom-both', (c) => {
-      return c.json({ message: 'Different content' })
+      return c.text('Different content')
     })
 
     const res = await app.request('http://localhost/etag/custom-both')
@@ -338,6 +338,7 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('ETag')).toBe(
       '"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"'
     )
+    expect(await res.text()).toBe('Different content')
   })
 
   describe('When crypto is not available', () => {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -290,6 +290,56 @@ describe('Etag Middleware', () => {
     expect(res.status).toBe(304)
   })
 
+  it('Should use custom getBody function', async () => {
+    const customBuffer = new ArrayBuffer(1)
+
+    const app = new Hono()
+    app.use(
+      '/etag/*',
+      etag({
+        getBody: async () => customBuffer,
+      })
+    )
+    app.get('/etag/custom', (c) => {
+      return c.text('Original response content')
+    })
+
+    const res = await app.request('http://localhost/etag/custom')
+    expect(res.headers.get('ETag')).not.toBeFalsy()
+    // ETag should be calculated from custom body, not the actual response
+    expect(res.headers.get('ETag')).toBe('"5ba93c9db0cff93f52b521d7420e43f6eda2784f"')
+    expect(await res.text()).toBe('Original response content')
+  })
+
+  it('Should work with getBody and custom generateDigest', async () => {
+    const customBuffer = new ArrayBuffer(1)
+
+    const app = new Hono()
+    app.use(
+      '/etag/*',
+      etag({
+        getBody: async () => customBuffer,
+        generateDigest: (body) =>
+          crypto.subtle.digest(
+            {
+              name: 'SHA-256',
+            },
+            body
+          ),
+      })
+    )
+    app.get('/etag/custom-both', (c) => {
+      return c.json({ message: 'Different content' })
+    })
+
+    const res = await app.request('http://localhost/etag/custom-both')
+    expect(res.headers.get('ETag')).not.toBeFalsy()
+    // Should use SHA-256 hash of the custom buffer
+    expect(res.headers.get('ETag')).toBe(
+      '"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"'
+    )
+  })
+
   describe('When crypto is not available', () => {
     let _crypto: Crypto | undefined
     beforeAll(() => {


### PR DESCRIPTION
Fixes #4031

This PR introduces a new option `getBody` for ETag middleware.

This will help customize the function to get the content to generate a hash in such a way on the AWS Lambda, which can't use `c.res.clone()`.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
