### PR TITLE
feat(jwt): Add custom header location

### DIFF
--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -1,7 +1,7 @@
+import { describe } from 'vitest'
 import { Hono } from '../../hono'
 import { HTTPException } from '../../http-exception'
 import { jwt } from '.'
-import { describe } from 'vitest'
 
 describe('JWT', () => {
   describe('Credentials in header', () => {
@@ -131,10 +131,10 @@ describe('JWT', () => {
 
     const app = new Hono()
 
-    app.use('/auth/*', jwt({ secret: 'a-secret', header: 'x-custom-auth-header' }))
-    app.use('/auth-unicode/*', jwt({ secret: 'a-secret', header: 'x-custom-auth-header' }))
+    app.use('/auth/*', jwt({ secret: 'a-secret', headerName: 'x-custom-auth-header' }))
+    app.use('/auth-unicode/*', jwt({ secret: 'a-secret', headerName: 'x-custom-auth-header' }))
     app.use('/nested/*', async (c, next) => {
-      const auth = jwt({ secret: 'a-secret', header: 'x-custom-auth-header' })
+      const auth = jwt({ secret: 'a-secret', headerName: 'x-custom-auth-header' })
       return auth(c, next)
     })
 

--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from '../../hono'
 import { HTTPException } from '../../http-exception'
 import { jwt } from '.'
+import { describe } from 'vitest'
 
 describe('JWT', () => {
   describe('Credentials in header', () => {
@@ -113,6 +114,164 @@ describe('JWT', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
       const req = new Request('http://localhost/nested/a')
       req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello world' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+  })
+
+  describe('Credentials in custom header', () => {
+    let handlerExecuted: boolean
+
+    beforeEach(() => {
+      handlerExecuted = false
+    })
+
+    const app = new Hono()
+
+    app.use('/auth/*', jwt({ secret: 'a-secret', header: 'x-custom-auth-header' }))
+    app.use('/auth-unicode/*', jwt({ secret: 'a-secret', header: 'x-custom-auth-header' }))
+    app.use('/nested/*', async (c, next) => {
+      const auth = jwt({ secret: 'a-secret', header: 'x-custom-auth-header' })
+      return auth(c, next)
+    })
+
+    app.get('/auth/*', (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
+    })
+    app.get('/auth-unicode/*', (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
+    })
+    app.get('/nested/*', (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
+    })
+
+    it('Should not authorize', async () => {
+      const req = new Request('http://localhost/auth/a')
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(await res.text()).toBe('Unauthorized')
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should not authorize even if default authorization header present', async () => {
+      const credential =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+      const req = new Request('http://localhost/auth/a')
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(await res.text()).toBe('Unauthorized')
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should authorize', async () => {
+      const credential =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+      const req = new Request('http://localhost/auth/a')
+      req.headers.set('x-custom-auth-header', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello world' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should authorize Unicode', async () => {
+      const credential =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+
+      const req = new Request('http://localhost/auth-unicode/a')
+      req.headers.set('x-custom-auth-header', `Basic ${credential}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello world' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should not authorize Unicode', async () => {
+      const invalidToken =
+        'ssyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+
+      const url = 'http://localhost/auth-unicode/a'
+      const req = new Request(url)
+      req.headers.set('x-custom-auth-header', `Basic ${invalidToken}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toEqual(
+        `Bearer realm="${url}",error="invalid_token",error_description="token verification failure"`
+      )
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should not authorize Unicode even if default authorization header present', async () => {
+      const invalidToken =
+        'ssyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+
+      const url = 'http://localhost/auth-unicode/a'
+      const req = new Request(url)
+      req.headers.set('Authorization', `Basic ${invalidToken}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toEqual(
+        `Bearer realm="${url}",error="invalid_request",error_description="no authorization included in request"`
+      )
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should not authorize', async () => {
+      const invalid_token = 'invalid token'
+      const url = 'http://localhost/auth/a'
+      const req = new Request(url)
+      req.headers.set('x-custom-auth-header', `Bearer ${invalid_token}`)
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toEqual(
+        `Bearer realm="${url}",error="invalid_request",error_description="invalid credentials structure"`
+      )
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should not authorize - nested', async () => {
+      const req = new Request('http://localhost/nested/a')
+      const res = await app.request(req)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(await res.text()).toBe('Unauthorized')
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should not authorize - nested even if default authorization header present', async () => {
+      const credential =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+      const req = new Request('http://localhost/nested/a')
+      const res = await app.request(req)
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(await res.text()).toBe('Unauthorized')
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should authorize - nested', async () => {
+      const credential =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8gd29ybGQifQ.B54pAqIiLbu170tGQ1rY06Twv__0qSHTA0ioQPIOvFE'
+      const req = new Request('http://localhost/nested/a')
+      req.headers.set('x-custom-auth-header', `Bearer ${credential}`)
       const res = await app.request(req)
       expect(res).not.toBeNull()
       expect(res.status).toBe(200)

--- a/src/middleware/jwt/jwt.ts
+++ b/src/middleware/jwt/jwt.ts
@@ -48,12 +48,12 @@ export type JwtVariables<T = any> = {
  * ```
  */
 export const jwt = (options: {
-  secret: SignatureKey,
+  secret: SignatureKey
   cookie?:
     | string
     | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
-  alg?: SignatureAlgorithm,
-  headerName?: string,
+  alg?: SignatureAlgorithm
+  headerName?: string
 }): MiddlewareHandler => {
   if (!options || !options.secret) {
     throw new Error('JWT auth middleware requires options for "secret"')
@@ -65,7 +65,7 @@ export const jwt = (options: {
 
   return async function jwt(ctx, next) {
     const headerName = options.headerName || 'Authorization'
-    
+
     const credentials = ctx.req.raw.headers.get(headerName)
     let token
     if (credentials) {

--- a/src/middleware/jwt/jwt.ts
+++ b/src/middleware/jwt/jwt.ts
@@ -27,7 +27,7 @@ export type JwtVariables<T = any> = {
  * @param {SignatureKey} [options.secret] - A value of your secret key.
  * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
  * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
- * @param {string} [options.header='Authorization'] - The name of the header to look for the JWT token. Default is 'Authorization'.
+ * @param {string} [options.headerName='Authorization'] - The name of the header to look for the JWT token. Default is 'Authorization'.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -38,7 +38,7 @@ export type JwtVariables<T = any> = {
  *   '/auth/*',
  *   jwt({
  *     secret: 'it-is-very-secret',
- *     header: 'x-custom-auth-header', // Optional, default is 'Authorization'
+ *     headerName: 'x-custom-auth-header', // Optional, default is 'Authorization'
  *   })
  * )
  *
@@ -53,7 +53,7 @@ export const jwt = (options: {
     | string
     | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
   alg?: SignatureAlgorithm,
-  header?: string,
+  headerName?: string,
 }): MiddlewareHandler => {
   if (!options || !options.secret) {
     throw new Error('JWT auth middleware requires options for "secret"')
@@ -64,7 +64,7 @@ export const jwt = (options: {
   }
 
   return async function jwt(ctx, next) {
-    const headerName = options.header || 'Authorization'
+    const headerName = options.headerName || 'Authorization'
     
     const credentials = ctx.req.raw.headers.get(headerName)
     let token

--- a/src/middleware/jwt/jwt.ts
+++ b/src/middleware/jwt/jwt.ts
@@ -27,6 +27,7 @@ export type JwtVariables<T = any> = {
  * @param {SignatureKey} [options.secret] - A value of your secret key.
  * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
  * @param {SignatureAlgorithm} [options.alg=HS256] - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+ * @param {string} [options.header='Authorization'] - The name of the header to look for the JWT token. Default is 'Authorization'.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -37,6 +38,7 @@ export type JwtVariables<T = any> = {
  *   '/auth/*',
  *   jwt({
  *     secret: 'it-is-very-secret',
+ *     header: 'x-custom-auth-header', // Optional, default is 'Authorization'
  *   })
  * )
  *
@@ -46,11 +48,12 @@ export type JwtVariables<T = any> = {
  * ```
  */
 export const jwt = (options: {
-  secret: SignatureKey
+  secret: SignatureKey,
   cookie?:
     | string
     | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
-  alg?: SignatureAlgorithm
+  alg?: SignatureAlgorithm,
+  header?: string,
 }): MiddlewareHandler => {
   if (!options || !options.secret) {
     throw new Error('JWT auth middleware requires options for "secret"')
@@ -61,7 +64,9 @@ export const jwt = (options: {
   }
 
   return async function jwt(ctx, next) {
-    const credentials = ctx.req.raw.headers.get('Authorization')
+    const headerName = options.header || 'Authorization'
+    
+    const credentials = ctx.req.raw.headers.get(headerName)
     let token
     if (credentials) {
       const parts = credentials.split(/\s+/)


### PR DESCRIPTION
Add a custom header location to the JWT middleware. 
Follows from https://github.com/honojs/hono/issues/3572.

---

## Possible Alternatives

I wasn't sure how much would be too much, so I stuck to the current changes for now.

But we could also explore other alternatives:

### Function or string
```typescript

export const jwt = (options: {
  secret: SignatureKey
  cookie?:
    | string
    | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
  alg?: SignatureAlgorithm
  header?: string | (() => string | Promise<string>)  // allows more flexibility
```

### Token string getter function 
We can take a function to let the user decide how to get the token. That might play well with the `bearerAuth` middleware as well.
```typescript

export const jwt = (options: {
  secret: SignatureKey
  cookie?:
    | string
    | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
  alg?: SignatureAlgorithm
  header?: () => string

  // We can skip the "token parsing from the header" part if the user gives this.
  tokenFetcherFunction: () => string | Promise<string>
})
```

---

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

_NOTE_ `bun run format:fix && bun run lint:fix` changes too many files, thus, did not push those.
```
        modified:   runtime-tests/lambda-edge/index.test.ts
        modified:   src/adapter/service-worker/handler.test.ts
        modified:   src/helper/css/common.case.test.tsx
        modified:   src/helper/css/common.ts
        modified:   src/helper/html/index.test.ts
        modified:   src/jsx/dom/css.ts
        modified:   src/middleware/jwt/index.test.ts
        modified:   src/middleware/jwt/jwt.ts
        modified:   src/middleware/secure-headers/index.test.ts
        modified:   src/utils/accept.test.ts
```
