### PR TITLE
docs(context): fix docstring link in the set header method

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -498,7 +498,7 @@ export class Context<
   /**
    * `.header()` can set headers.
    *
-   * @see {@link https://hono.dev/docs/api/context#body}
+   * @see {@link https://hono.dev/docs/api/context#header}
    *
    * @example
    * ```ts


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
