### PR TITLE
chore: consolidate perf-measures GitHub Actions comments

### DIFF
--- a/.github/actions/perf-measures/action.yml
+++ b/.github/actions/perf-measures/action.yml
@@ -2,9 +2,6 @@ name: 'Performance Measures'
 description: 'Run type check and bundle size performance measurements'
 
 inputs:
-  typescript-impl:
-    description: 'TypeScript implementation to use: "tsc" (Current compiler) or "tsgo" (Future compiler implemented in Go)'
-    required: true
   target-ref:
     description: 'Target ref (main or auto). Set to "auto" to delegate ref detection to octocov.'
     required: false
@@ -18,28 +15,19 @@ runs:
     - run: bun install
       shell: bash
 
-    - name: Exit if unknown typescript-impl
-      if: ${{ inputs.typescript-impl != 'tsc' && inputs.typescript-impl != 'tsgo' }}
-      shell: bash
-      run: |
-        echo "::error::Unknown typescript implementation specified: ${{ inputs.typescript-impl }}"
-        exit 1
-
     - name: Performance measurement of type check (tsc)
-      if: ${{ inputs.typescript-impl == 'tsc' }}
       run: |
         bun scripts/generate-app.ts
-        bun tsc -p tsconfig.build.json --diagnostics | bun scripts/process-results.ts > diagnostics.json
+        bun tsc -p tsconfig.build.json --diagnostics | bun scripts/process-results.ts > diagnostics-tsc.json
       shell: bash
       working-directory: perf-measures/type-check
       env:
         BENCHMARK_TS_IMPL_LABEL: tsc
 
     - name: Performance measurement of type check (typescript-go)
-      if: ${{ inputs.typescript-impl == 'tsgo' }}
       run: |
         bun scripts/generate-app.ts
-        bun tsgo -p tsconfig.build.json --diagnostics | bun scripts/process-results.ts > diagnostics.json
+        bun tsgo -p tsconfig.build.json --diagnostics | bun scripts/process-results.ts > diagnostics-tsgo.json
       shell: bash
       working-directory: perf-measures/type-check
       env:
@@ -55,17 +43,19 @@ runs:
       if: ${{ inputs.target-ref == 'auto' }}
       uses: k1LoW/octocov-action@v1
       with:
-        config: perf-measures/.octocov.${{ inputs.typescript-impl }}.perf-measures.yml
+        config: perf-measures/.octocov.consolidated.perf-measures.yml
       env:
         OCTOCOV_CUSTOM_METRICS_BENCHMARK_BUNDLE: perf-measures/bundle-check/size.json
-        OCTOCOV_CUSTOM_METRICS_BENCHMARK_TYPE: perf-measures/type-check/diagnostics.json
+        OCTOCOV_CUSTOM_METRICS_BENCHMARK_TYPE_TSC: perf-measures/type-check/diagnostics-tsc.json
+        OCTOCOV_CUSTOM_METRICS_BENCHMARK_TYPE_TSGO: perf-measures/type-check/diagnostics-tsgo.json
 
     - name: Run octocov with custom target ref
       if: ${{ inputs.target-ref == 'main' }}
       uses: k1LoW/octocov-action@v1
       with:
-        config: perf-measures/.octocov.${{ inputs.typescript-impl }}.perf-measures.main.yml
+        config: perf-measures/.octocov.consolidated.perf-measures.main.yml
       env:
         OCTOCOV_GITHUB_REF: 'refs/heads/main'
         OCTOCOV_CUSTOM_METRICS_BENCHMARK_BUNDLE: perf-measures/bundle-check/size.json
-        OCTOCOV_CUSTOM_METRICS_BENCHMARK_TYPE: perf-measures/type-check/diagnostics.json
+        OCTOCOV_CUSTOM_METRICS_BENCHMARK_TYPE_TSC: perf-measures/type-check/diagnostics-tsc.json
+        OCTOCOV_CUSTOM_METRICS_BENCHMARK_TYPE_TSGO: perf-measures/type-check/diagnostics-tsgo.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,26 +186,18 @@ jobs:
     name: 'Type & Bundle size Check on PR'
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        typescript-impl: ['tsc', 'tsgo']
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/perf-measures
         with:
-          typescript-impl: ${{ matrix.typescript-impl }}
           target-ref: 'auto'
 
   perf-measures-check-on-main:
     name: 'Type & Bundle size Check on Main'
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    strategy:
-      matrix:
-        typescript-impl: ['tsc', 'tsgo']
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/perf-measures
         with:
-          typescript-impl: ${{ matrix.typescript-impl }}
           target-ref: 'main'

--- a/perf-measures/.octocov.consolidated.perf-measures.main.yml
+++ b/perf-measures/.octocov.consolidated.perf-measures.main.yml
@@ -1,0 +1,13 @@
+locale: "en"
+repository: ${GITHUB_REPOSITORY}/perf-measures
+coverage:
+  if: false
+codeToTestRatio:
+  if: false
+testExecutionTime:
+  if: false
+report:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+summary:
+  if: true

--- a/perf-measures/.octocov.consolidated.perf-measures.yml
+++ b/perf-measures/.octocov.consolidated.perf-measures.yml
@@ -1,0 +1,15 @@
+locale: "en"
+repository: ${GITHUB_REPOSITORY}/perf-measures
+coverage:
+  if: false
+codeToTestRatio:
+  if: false
+testExecutionTime:
+  if: false
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+comment:
+  if: is_pull_request
+summary:
+  if: true


### PR DESCRIPTION
## Summary
- Consolidate performance measurement comments from two separate comments into a single comment
- Change from matrix strategy to sequential execution of both TypeScript implementations
- Add consolidated octocov configuration files for unified reporting

## Test plan
- [ ] Verify GitHub Actions run successfully on this PR
- [ ] Confirm that only one performance measurement comment is posted instead of two
- [ ] Check that the comment includes all three sections: Bundle size check, Compiler Diagnostics (tsc), and Compiler Diagnostics (typescript-go)

🤖 Generated with [Claude Code](https://claude.ai/code)