### PR TITLE
chore(secure-headers): format

### DIFF
--- a/src/middleware/secure-headers/index.test.ts
+++ b/src/middleware/secure-headers/index.test.ts
@@ -473,8 +473,8 @@ describe('Secure Headers Middleware', () => {
 
       const res = await app.request('/test')
       const csp = res.headers.get(cspHeaderName)
-      expect(csp).toMatch(`script-src 'self' 'nonce-scriptSrc'`)
-      expect(csp).toMatch(`style-src 'self' 'nonce-styleSrc'`)
+      expect(csp).toMatch("script-src 'self' 'nonce-scriptSrc'")
+      expect(csp).toMatch("style-src 'self' 'nonce-styleSrc'")
       expect(await res.text()).toEqual('script: scriptSrc, style: styleSrc')
     })
   })


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
