### PR TITLE
fix(ci): handle fork PRs in http-benchmark workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
           bun run benchmark.ts
       - name: Comment PR
         uses: actions/github-script@v7
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           script: |
             const fs = require('fs');
@@ -238,12 +239,18 @@ jobs:
             }
 
             // Post new comment
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: results
             });
+      - name: Show benchmark results for forks
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "## HTTP Performance Benchmark Results"
+          echo "Note: Cannot post comment due to security restrictions on fork PRs"
+          cat benchmarks/http-server/benchmark-results.md
 
   perf-measures-check-on-main:
     name: 'Type & Bundle size Check on Main'


### PR DESCRIPTION
## Summary
- Fix permission errors when external contributors create PRs
- Add conditional logic to handle fork PRs appropriately

## Changes
- Internal PRs: post benchmark comment as before
- Fork PRs: display benchmark results in workflow logs (due to GitHub security restrictions)

Currently, fork PRs cannot post comments due to GitHub's security model for external contributors. This is a limitation of the platform rather than our implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)