### PR TITLE
fix(utils/color): avoid unhandled scheme errors

### DIFF
--- a/src/utils/color.test.ts
+++ b/src/utils/color.test.ts
@@ -1,3 +1,4 @@
+import * as esbuild from 'esbuild'
 import { getColorEnabled, getColorEnabledAsync } from './color'
 
 describe('getColorEnabled() / getColorEnabledAsync() - With colors enabled', () => {
@@ -19,5 +20,30 @@ describe('getColorEnabled() / getColorEnabledAsync() - With NO_COLOR environment
   it('should return false', async () => {
     expect(getColorEnabled()).toBe(false)
     expect(await getColorEnabledAsync()).toBe(false)
+  })
+})
+
+describe('esbuild compatibility test', () => {
+  it('should build color.ts with esbuild without errors', async () => {
+    try {
+      const result = await esbuild.build({
+        entryPoints: [__filename.replace('.test.ts', '.ts')],
+        bundle: true,
+        format: 'esm',
+        target: 'es2022',
+        write: false,
+        logLevel: 'silent',
+        external: [],
+      })
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+      expect(result.outputFiles).toHaveLength(1)
+
+      const outputContent = result.outputFiles[0].text
+      expect(outputContent).toBeDefined()
+    } catch (error) {
+      throw new Error(`esbuild failed: ${error}`)
+    }
   })
 })

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -36,12 +36,14 @@ export function getColorEnabled(): boolean {
 export async function getColorEnabledAsync(): Promise<boolean> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { navigator } = globalThis as any
+  // Avoid analysis of cloudflare scheme by bundlers
+  const cfWorkers = 'cloudflare:workers'
 
   const isNoColor =
     navigator !== undefined && navigator.userAgent === 'Cloudflare-Workers'
       ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        'NO_COLOR' in ((await import('cloudflare:workers')).env ?? {}) // ?? {} is for backward compat
+        'NO_COLOR' in ((await import(cfWorkers)).env ?? {}) // {} is for backward compat
       : !getColorEnabled()
 
   return !isNoColor


### PR DESCRIPTION
fixes #4232, #4233

Popular bundlers(`esbuild`, `webpack`) check packages and provide optimizations, but `cloudflare:workers` is often not supported by default. In this PR, to avoid these optimization checks, change a package name to a variable name.

This PR adds a test to check whether these issues can be avoided in `esbuild`. We should also add `webpack` tests, but I didn't have a smart way. `webpack` has been checked to work with at least [this repository](https://github.com/ryuapp/check-color-next).

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
