### PR TITLE
fix(jsx): Fix the JSXNode validation. Allow the function type for props.ref

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -217,7 +217,7 @@ export class JSXNode implements HtmlEscaped {
         buffer[0] += ` ${key}="`
         buffer.unshift('"', v)
       } else if (typeof v === 'function') {
-        if (!key.startsWith('on')) {
+        if (!key.startsWith('on') && key !== 'ref') {
           throw `Invalid prop '${key}' of type 'function' supplied to '${tag}'.`
         }
         // maybe event handler for client components, just ignore in server components

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -359,6 +359,12 @@ describe('render to string', () => {
       expect(template.toString()).toBe('<button>Click</button>')
     })
 
+    it('should be ignored used in ref props', () => {
+      const ref = () => {}
+      const template = <div ref={ref}>Content</div>
+      expect(template.toString()).toBe('<div>Content</div>')
+    })
+
     it('should raise an error if used in other props', () => {
       const onClick = () => {}
       const template = <button data-handler={onClick}>Click</button>


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

According to the [React document](https://react.dev/reference/react-dom/components/common#ref-callback), `ref` should accept the function and it properly implemented. However, the validation in `toStringBuffer()` is not reflect that and causes false positive error. This PR fixes that.

1. I don't have time to implement tests for now, Feel free to add or just close my PR and create the independent fix.
2. Also, I don't checked other validations issues, maybe there is more