### PR TITLE
fix(utils/color): avoid resolving pacakages via Bun.build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tsc --noEmit && vitest --run && vitest -c .vitest.config/jsx-runtime-default.ts --run && vitest -c .vitest.config/jsx-runtime-dom.ts --run",
     "test:watch": "vitest --watch",
     "test:deno": "deno test --allow-read --allow-env --allow-write --allow-net -c runtime-tests/deno/deno.json runtime-tests/deno && deno test --no-lock -c runtime-tests/deno-jsx/deno.precompile.json runtime-tests/deno-jsx && deno test --no-lock -c runtime-tests/deno-jsx/deno.react-jsx.json runtime-tests/deno-jsx",
-    "test:bun": "bun test --jsx-import-source ../../src/jsx runtime-tests/bun/index.test.tsx",
+    "test:bun": "bun test --jsx-import-source ../../src/jsx runtime-tests/bun/*",
     "test:fastly": "vitest --run --config ./runtime-tests/fastly/vitest.config.ts",
     "test:node": "vitest --run --config ./runtime-tests/node/vitest.config.ts",
     "test:workerd": "vitest --run --config ./runtime-tests/workerd/vitest.config.ts",

--- a/runtime-tests/bun/color.test.ts
+++ b/runtime-tests/bun/color.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test'
+
+test('Bun.build compatibility test', async () => {
+  try {
+    const result = await Bun.build({
+      entrypoints: ['./src/utils/color.ts'],
+      format: 'esm',
+      minify: true,
+      external: [],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.logs).toHaveLength(0)
+    expect(result.outputs).toHaveLength(1)
+
+    const outputContent = await result.outputs[0].text()
+    expect(outputContent).toBeDefined()
+  } catch (error) {
+    throw new Error(`Bun.build failed: ${error}`)
+  }
+})

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -37,14 +37,19 @@ export async function getColorEnabledAsync(): Promise<boolean> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { navigator } = globalThis as any
   // Avoid analysis of cloudflare scheme by bundlers
-  // eslint-disable-next-line prefer-const
-  let cfWorkers = 'cloudflare:workers'
+  const cfWorkers = 'cloudflare:workers'
 
   const isNoColor =
     navigator !== undefined && navigator.userAgent === 'Cloudflare-Workers'
-      ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        'NO_COLOR' in ((await import(cfWorkers)).env ?? {}) // {} is for backward compat
+      ? await (async () => {
+          try {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            return 'NO_COLOR' in ((await import(cfWorkers)).env ?? {}) // {} is for backward compat
+          } catch {
+            return false
+          }
+        })()
       : !getColorEnabled()
 
   return !isNoColor

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -37,7 +37,8 @@ export async function getColorEnabledAsync(): Promise<boolean> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { navigator } = globalThis as any
   // Avoid analysis of cloudflare scheme by bundlers
-  const cfWorkers = 'cloudflare:workers'
+  // eslint-disable-next-line prefer-const
+  let cfWorkers = 'cloudflare:workers'
 
   const isNoColor =
     navigator !== undefined && navigator.userAgent === 'Cloudflare-Workers'


### PR DESCRIPTION
follow up https://github.com/honojs/hono/issues/4233#issuecomment-2990039940

[Bun.build](https://bun.sh/docs/bundler) is smarter than other bundlers and when minifying it will try to resolve a package name, which will result in an error.

~~This PR will switch `cloudflare:workers` variable name declaration from `const` to `let` declaration to prevent the problem.~~
This PR use `async/await` to work around a bug in opennext temporary: https://github.com/honojs/hono/issues/4233#issuecomment-2992430971 Proper opennext support will be prepared later.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
