### PR TITLE
fix(jsx): throw new Error instead of string

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -209,7 +209,7 @@ export class JSXNode implements HtmlEscaped {
         }
       } else if (key === 'dangerouslySetInnerHTML') {
         if (children.length > 0) {
-          throw 'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
+          throw new Error('Can only set one of `children` or `props.dangerouslySetInnerHTML`.')
         }
 
         children = [raw(v.__html)]
@@ -218,7 +218,7 @@ export class JSXNode implements HtmlEscaped {
         buffer.unshift('"', v)
       } else if (typeof v === 'function') {
         if (!key.startsWith('on')) {
-          throw `Invalid prop '${key}' of type 'function' supplied to '${tag}'.`
+          throw new Error(`Invalid prop '${key}' of type 'function' supplied to '${tag}'.`)
         }
         // maybe event handler for client components, just ignore in server components
       } else {

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -188,7 +188,7 @@ describe('render to string', () => {
     it('Should get an error if both dangerouslySetInnerHTML and children are specified', () => {
       expect(() =>
         (<span dangerouslySetInnerHTML={{ __html: '" is allowed here' }}>Hello</span>).toString()
-      ).toThrow()
+      ).toThrow(Error)
     })
   })
 
@@ -362,7 +362,7 @@ describe('render to string', () => {
     it('should raise an error if used in other props', () => {
       const onClick = () => {}
       const template = <button data-handler={onClick}>Click</button>
-      expect(() => template.toString()).toThrow()
+      expect(() => template.toString()).toThrow(Error)
     })
   })
 


### PR DESCRIPTION
fixes #4235

We should throw an `Error` instance instead of a string.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
