### PR TITLE
feat(bun/ws): allow to import `upgradeWebSocket` and `websocket` directly

### DIFF
--- a/src/adapter/bun/websocket.test.ts
+++ b/src/adapter/bun/websocket.test.ts
@@ -1,6 +1,6 @@
 import { Context } from '../../context'
 import type { BunWebSocketData, BunServerWebSocket } from './websocket'
-import { createWSContext, createBunWebSocket } from './websocket'
+import { createWSContext, websocket, upgradeWebSocket, createBunWebSocket } from './websocket'
 
 describe('createWSContext()', () => {
   it('Should send() and close() works', () => {
@@ -22,8 +22,15 @@ describe('createWSContext()', () => {
   })
 })
 describe('upgradeWebSocket()', () => {
+  beforeAll(() => {
+    // @ts-expect-error patch global
+    globalThis.CloseEvent = Event
+  })
+  afterAll(() => {
+    // @ts-expect-error patch global
+    delete globalThis.CloseEvent
+  })
   it('Should throw error when server is null', async () => {
-    const { upgradeWebSocket } = createBunWebSocket()
     const run = async () =>
       await upgradeWebSocket(() => ({}))(
         new Context(new Request('http://localhost'), {
@@ -37,7 +44,6 @@ describe('upgradeWebSocket()', () => {
     await expect(run).rejects.toThrowError(/env has/)
   })
   it('Should response null when upgraded', async () => {
-    const { upgradeWebSocket } = createBunWebSocket()
     const upgraded = await upgradeWebSocket(() => ({}))(
       new Context(new Request('http://localhost'), {
         env: {
@@ -49,7 +55,6 @@ describe('upgradeWebSocket()', () => {
     expect(upgraded).toBeTruthy()
   })
   it('Should response undefined when upgrade failed', async () => {
-    const { upgradeWebSocket } = createBunWebSocket()
     const upgraded = await upgradeWebSocket(() => ({}))(
       new Context(new Request('http://localhost'), {
         env: {
@@ -60,19 +65,7 @@ describe('upgradeWebSocket()', () => {
     )
     expect(upgraded).toBeFalsy()
   })
-})
-describe('createBunWebSocket()', () => {
-  beforeAll(() => {
-    // @ts-expect-error patch global
-    globalThis.CloseEvent = Event
-  })
-  afterAll(() => {
-    // @ts-expect-error patch global
-    delete globalThis.CloseEvent
-  })
   it('Should events are called', async () => {
-    const { websocket, upgradeWebSocket } = createBunWebSocket()
-
     const open = vi.fn()
     const message = vi.fn()
     const close = vi.fn()
@@ -120,8 +113,15 @@ describe('createBunWebSocket()', () => {
     websocket.message(ws, new Uint8Array(16))
     expect(receivedArrayBuffer).toBeInstanceOf(ArrayBuffer)
     expect(receivedArrayBuffer!.byteLength).toBe(16)
-
     websocket.close(ws)
     expect(close).toBeCalled()
+  })
+})
+
+describe('createBunWebSocket()', () => {
+  it('Should create a BunWebSocket', () => {
+    const { upgradeWebSocket, websocket } = createBunWebSocket()
+    expect(upgradeWebSocket).toBe(upgradeWebSocket)
+    expect(websocket).toBe(websocket)
   })
 })


### PR DESCRIPTION
I've just realized that WebSocket helper didn't require `createBunWebSocket` to provide functions used to upgrade connections. 
This PR allows to write code like the code:
```ts
import { upgradeWebSocket, websocket } from 'hono/bun'

app.get('/ws', upgradeWebSocket(...))

export default {
  fetch: app.fetch,
  websocket
}
```
Codes using a WebSocket with Bun will become simpler than before.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
