### PR TITLE
feat(aws-lambda): specify content-type as binary

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -29,6 +29,124 @@ describe('isContentEncodingBinary', () => {
   })
 })
 
+describe('EventProcessor.createResult with contentTypsAsBinary', () => {
+  it('Should encode as base64 when content-type is in contentTypesAsBinary array', async () => {
+    const event: LambdaEvent = {
+      version: '1.0',
+      resource: '/my/path',
+      path: '/my/path',
+      httpMethod: 'GET',
+      headers: {},
+      multiValueHeaders: {},
+      queryStringParameters: {},
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'id',
+        authorizer: { claims: null, scopes: null },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        extendedRequestId: 'request-id',
+        httpMethod: 'GET',
+        identity: {
+          sourceIp: '192.0.2.1',
+          userAgent: 'user-agent',
+          clientCert: {
+            clientCertPem: 'CERT_CONTENT',
+            subjectDN: 'www.example.com',
+            issuerDN: 'Example issuer',
+            serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
+            validity: {
+              notBefore: 'May 28 12:30:02 2019 GMT',
+              notAfter: 'Aug  5 09:36:04 2021 GMT',
+            },
+          },
+        },
+        path: '/my/path',
+        protocol: 'HTTP/1.1',
+        requestId: 'id=',
+        requestTime: '04/Mar/2020:19:15:17 +0000',
+        requestTimeEpoch: 1583349317135,
+        resourcePath: '/my/path',
+        stage: '$default',
+      },
+      pathParameters: {},
+      stageVariables: {},
+      body: null,
+      isBase64Encoded: false,
+    }
+
+    const processor = getProcessor(event)
+    const response = new Response('test content', {
+      headers: { 'content-type': 'application/custom' },
+    })
+
+    const result = await processor.createResult(event, response, {
+      contentTypesAsBinary: ['application/custom'],
+    })
+
+    expect(result.isBase64Encoded).toBe(true)
+    expect(result.body).toBe('dGVzdCBjb250ZW50')
+  })
+
+  it('Should not encode as base64 when content-type is not in contentTypesAsBinary array', async () => {
+    const event: LambdaEvent = {
+      version: '1.0',
+      resource: '/my/path',
+      path: '/my/path',
+      httpMethod: 'GET',
+      headers: {},
+      multiValueHeaders: {},
+      queryStringParameters: {},
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'id',
+        authorizer: { claims: null, scopes: null },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        extendedRequestId: 'request-id',
+        httpMethod: 'GET',
+        identity: {
+          sourceIp: '192.0.2.1',
+          userAgent: 'user-agent',
+          clientCert: {
+            clientCertPem: 'CERT_CONTENT',
+            subjectDN: 'www.example.com',
+            issuerDN: 'Example issuer',
+            serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
+            validity: {
+              notBefore: 'May 28 12:30:02 2019 GMT',
+              notAfter: 'Aug  5 09:36:04 2021 GMT',
+            },
+          },
+        },
+        path: '/my/path',
+        protocol: 'HTTP/1.1',
+        requestId: 'id=',
+        requestTime: '04/Mar/2020:19:15:17 +0000',
+        requestTimeEpoch: 1583349317135,
+        resourcePath: '/my/path',
+        stage: '$default',
+      },
+      pathParameters: {},
+      stageVariables: {},
+      body: null,
+      isBase64Encoded: false,
+    }
+
+    const processor = getProcessor(event)
+    const response = new Response('test content', {
+      headers: { 'content-type': 'application/json' },
+    })
+
+    const result = await processor.createResult(event, response, {
+      contentTypesAsBinary: ['application/custom'],
+    })
+
+    expect(result.isBase64Encoded).toBe(false)
+    expect(result.body).toBe('test content')
+  })
+})
+
 describe('EventProcessor.createRequest', () => {
   it('Should return valid Request object from version 1.0 API Gateway event', () => {
     const event: LambdaEvent = {

--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -81,14 +81,14 @@ describe('EventProcessor.createResult with contentTypsAsBinary', () => {
     })
 
     const result = await processor.createResult(event, response, {
-      contentTypesAsBinary: ['application/custom'],
+      isContentTypeBinary: (contentType: string) => contentType === 'application/custom',
     })
 
     expect(result.isBase64Encoded).toBe(true)
     expect(result.body).toBe('dGVzdCBjb250ZW50')
   })
 
-  it('Should not encode as base64 when content-type is not in contentTypesAsBinary array', async () => {
+  it('Should not encode as base64 when content-type is not in isContentTypeBinary array', async () => {
     const event: LambdaEvent = {
       version: '1.0',
       resource: '/my/path',
@@ -139,7 +139,7 @@ describe('EventProcessor.createResult with contentTypsAsBinary', () => {
     })
 
     const result = await processor.createResult(event, response, {
-      contentTypesAsBinary: ['application/custom'],
+      isContentTypeBinary: (contentType: string) => contentType === 'application/custom',
     })
 
     expect(result.isBase64Encoded).toBe(false)

--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -30,51 +30,51 @@ describe('isContentEncodingBinary', () => {
 })
 
 describe('EventProcessor.createResult with contentTypsAsBinary', () => {
-  it('Should encode as base64 when content-type is in contentTypesAsBinary array', async () => {
-    const event: LambdaEvent = {
-      version: '1.0',
-      resource: '/my/path',
-      path: '/my/path',
+  const event: LambdaEvent = {
+    version: '1.0',
+    resource: '/my/path',
+    path: '/my/path',
+    httpMethod: 'GET',
+    headers: {},
+    multiValueHeaders: {},
+    queryStringParameters: {},
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'id',
+      authorizer: { claims: null, scopes: null },
+      domainName: 'id.execute-api.us-east-1.amazonaws.com',
+      domainPrefix: 'id',
+      extendedRequestId: 'request-id',
       httpMethod: 'GET',
-      headers: {},
-      multiValueHeaders: {},
-      queryStringParameters: {},
-      requestContext: {
-        accountId: '123456789012',
-        apiId: 'id',
-        authorizer: { claims: null, scopes: null },
-        domainName: 'id.execute-api.us-east-1.amazonaws.com',
-        domainPrefix: 'id',
-        extendedRequestId: 'request-id',
-        httpMethod: 'GET',
-        identity: {
-          sourceIp: '192.0.2.1',
-          userAgent: 'user-agent',
-          clientCert: {
-            clientCertPem: 'CERT_CONTENT',
-            subjectDN: 'www.example.com',
-            issuerDN: 'Example issuer',
-            serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
-            validity: {
-              notBefore: 'May 28 12:30:02 2019 GMT',
-              notAfter: 'Aug  5 09:36:04 2021 GMT',
-            },
+      identity: {
+        sourceIp: '192.0.2.1',
+        userAgent: 'user-agent',
+        clientCert: {
+          clientCertPem: 'CERT_CONTENT',
+          subjectDN: 'www.example.com',
+          issuerDN: 'Example issuer',
+          serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
+          validity: {
+            notBefore: 'May 28 12:30:02 2019 GMT',
+            notAfter: 'Aug  5 09:36:04 2021 GMT',
           },
         },
-        path: '/my/path',
-        protocol: 'HTTP/1.1',
-        requestId: 'id=',
-        requestTime: '04/Mar/2020:19:15:17 +0000',
-        requestTimeEpoch: 1583349317135,
-        resourcePath: '/my/path',
-        stage: '$default',
       },
-      pathParameters: {},
-      stageVariables: {},
-      body: null,
-      isBase64Encoded: false,
-    }
+      path: '/my/path',
+      protocol: 'HTTP/1.1',
+      requestId: 'id=',
+      requestTime: '04/Mar/2020:19:15:17 +0000',
+      requestTimeEpoch: 1583349317135,
+      resourcePath: '/my/path',
+      stage: '$default',
+    },
+    pathParameters: {},
+    stageVariables: {},
+    body: null,
+    isBase64Encoded: false,
+  }
 
+  it('Should encode as base64 when content-type is in contentTypesAsBinary array', async () => {
     const processor = getProcessor(event)
     const response = new Response('test content', {
       headers: { 'content-type': 'application/custom' },
@@ -89,50 +89,6 @@ describe('EventProcessor.createResult with contentTypsAsBinary', () => {
   })
 
   it('Should not encode as base64 when content-type is not in isContentTypeBinary array', async () => {
-    const event: LambdaEvent = {
-      version: '1.0',
-      resource: '/my/path',
-      path: '/my/path',
-      httpMethod: 'GET',
-      headers: {},
-      multiValueHeaders: {},
-      queryStringParameters: {},
-      requestContext: {
-        accountId: '123456789012',
-        apiId: 'id',
-        authorizer: { claims: null, scopes: null },
-        domainName: 'id.execute-api.us-east-1.amazonaws.com',
-        domainPrefix: 'id',
-        extendedRequestId: 'request-id',
-        httpMethod: 'GET',
-        identity: {
-          sourceIp: '192.0.2.1',
-          userAgent: 'user-agent',
-          clientCert: {
-            clientCertPem: 'CERT_CONTENT',
-            subjectDN: 'www.example.com',
-            issuerDN: 'Example issuer',
-            serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
-            validity: {
-              notBefore: 'May 28 12:30:02 2019 GMT',
-              notAfter: 'Aug  5 09:36:04 2021 GMT',
-            },
-          },
-        },
-        path: '/my/path',
-        protocol: 'HTTP/1.1',
-        requestId: 'id=',
-        requestTime: '04/Mar/2020:19:15:17 +0000',
-        requestTimeEpoch: 1583349317135,
-        resourcePath: '/my/path',
-        stage: '$default',
-      },
-      pathParameters: {},
-      stageVariables: {},
-      body: null,
-      isBase64Encoded: false,
-    }
-
     const processor = getProcessor(event)
     const response = new Response('test content', {
       headers: { 'content-type': 'application/json' },
@@ -144,6 +100,36 @@ describe('EventProcessor.createResult with contentTypsAsBinary', () => {
 
     expect(result.isBase64Encoded).toBe(false)
     expect(result.body).toBe('test content')
+  })
+
+  it('Should use defaultIsContentTypeBinary when isContentTypeBinary is undefined with binary content', async () => {
+    const processor = getProcessor(event)
+    const response = new Response('test image content', {
+      headers: { 'content-type': 'image/png' },
+    })
+
+    // Pass undefined for isContentTypeBinary to test default behavior
+    const result = await processor.createResult(event, response, {
+      isContentTypeBinary: undefined,
+    })
+
+    expect(result.isBase64Encoded).toBe(true)
+    expect(result.body).toBe('dGVzdCBpbWFnZSBjb250ZW50')
+  })
+
+  it('Should use defaultIsContentTypeBinary when isContentTypeBinary is undefined with non-binary content', async () => {
+    const processor = getProcessor(event)
+    const response = new Response('test text content', {
+      headers: { 'content-type': 'text/plain' },
+    })
+
+    // Pass undefined for isContentTypeBinary to test default behavior
+    const result = await processor.createResult(event, response, {
+      isContentTypeBinary: undefined,
+    })
+
+    expect(result.isBase64Encoded).toBe(false)
+    expect(result.body).toBe('test text content')
   })
 })
 

--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,19 +1,19 @@
 import type { LambdaEvent } from './handler'
-import { getProcessor, isContentEncodingBinary, isContentTypeBinary } from './handler'
+import { getProcessor, isContentEncodingBinary, defaultIsContentTypeBinary } from './handler'
 
 describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
-    expect(isContentTypeBinary('image/png')).toBe(true)
-    expect(isContentTypeBinary('font/woff2')).toBe(true)
-    expect(isContentTypeBinary('image/svg+xml')).toBe(false)
-    expect(isContentTypeBinary('image/svg+xml; charset=UTF-8')).toBe(false)
-    expect(isContentTypeBinary('text/plain')).toBe(false)
-    expect(isContentTypeBinary('text/plain; charset=UTF-8')).toBe(false)
-    expect(isContentTypeBinary('text/css')).toBe(false)
-    expect(isContentTypeBinary('text/javascript')).toBe(false)
-    expect(isContentTypeBinary('application/json')).toBe(false)
-    expect(isContentTypeBinary('application/ld+json')).toBe(false)
-    expect(isContentTypeBinary('application/json')).toBe(false)
+    expect(defaultIsContentTypeBinary('image/png')).toBe(true)
+    expect(defaultIsContentTypeBinary('font/woff2')).toBe(true)
+    expect(defaultIsContentTypeBinary('image/svg+xml')).toBe(false)
+    expect(defaultIsContentTypeBinary('image/svg+xml; charset=UTF-8')).toBe(false)
+    expect(defaultIsContentTypeBinary('text/plain')).toBe(false)
+    expect(defaultIsContentTypeBinary('text/plain; charset=UTF-8')).toBe(false)
+    expect(defaultIsContentTypeBinary('text/css')).toBe(false)
+    expect(defaultIsContentTypeBinary('text/javascript')).toBe(false)
+    expect(defaultIsContentTypeBinary('application/json')).toBe(false)
+    expect(defaultIsContentTypeBinary('application/ld+json')).toBe(false)
+    expect(defaultIsContentTypeBinary('application/json')).toBe(false)
   })
 })
 

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -243,8 +243,8 @@ export abstract class EventProcessor<E extends LambdaEvent> {
   ): Promise<APIGatewayProxyResult> {
     // determine whether the response body should be base64 encoded
     const contentType = res.headers.get('content-type')
-    const _isContentTypeBinary = options.isContentTypeBinary ?? isContentTypeBinary // overwrite default function if provided
-    let isBase64Encoded = contentType && _isContentTypeBinary(contentType) ? true : false
+    const isContentTypeBinary = options.isContentTypeBinary ?? defaultIsContentTypeBinary // overwrite default function if provided
+    let isBase64Encoded = contentType && isContentTypeBinary(contentType) ? true : false
 
     if (!isBase64Encoded) {
       const contentEncoding = res.headers.get('content-encoding')
@@ -507,7 +507,7 @@ const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => 
  * @param contentType The content type to check.
  * @returns True if the content type is binary, false otherwise.
  */
-export const isContentTypeBinary = (contentType: string) => {
+export const defaultIsContentTypeBinary = (contentType: string) => {
   return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
     contentType
   )

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -171,7 +171,7 @@ type HandleOptions = {
  */
 export const handle = <E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'>(
   app: Hono<E, S, BasePath>,
-  { contentTypesAsBinary }: HandleOptions
+  { contentTypesAsBinary }: HandleOptions = { contentTypesAsBinary: [] }
 ): (<L extends LambdaEvent>(
   event: L,
   lambdaContext?: LambdaContext

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -243,7 +243,7 @@ export abstract class EventProcessor<E extends LambdaEvent> {
   ): Promise<APIGatewayProxyResult> {
     // determine whether the response body should be base64 encoded
     const contentType = res.headers.get('content-type')
-    const _isContentTypeBinary = options.isContentTypeBinary ?? isContentTypeBinary // override default function if provided
+    const _isContentTypeBinary = options.isContentTypeBinary ?? isContentTypeBinary // overwrite default function if provided
     let isBase64Encoded = contentType && _isContentTypeBinary(contentType) ? true : false
 
     if (!isBase64Encoded) {
@@ -503,7 +503,7 @@ const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => 
 
 /**
  * Check if the given content type is binary.
- * This is a default function and may be overridden by the user via `isContentTypeBinary` option in handler().
+ * This is a default function and may be overwritten by the user via `isContentTypeBinary` option in handler().
  * @param contentType The content type to check.
  * @returns True if the content type is binary, false otherwise.
  */

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -544,7 +544,7 @@ const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => 
  * @param contentType The content type to check.
  * @returns True if the content type is binary, false otherwise.
  */
-export const defaultIsContentTypeBinary = (contentType: string) => {
+export const defaultIsContentTypeBinary = (contentType: string): boolean => {
   return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
     contentType
   )

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -167,7 +167,44 @@ type HandleOptions = {
 }
 
 /**
- * Accepts events from API Gateway/ELB(`APIGatewayProxyEvent`) and directly through Function Url(`APIGatewayProxyEventV2`)
+ * Converts a Hono application to an AWS Lambda handler.
+ *
+ * Accepts events from API Gateway (v1 and v2), Application Load Balancer (ALB),
+ * and Lambda Function URLs.
+ *
+ * @param app - The Hono application instance
+ * @param options - Optional configuration
+ * @param options.isContentTypeBinary - A function to determine if the content type is binary.
+ *                                      If not provided, the default function will be used.
+ * @returns Lambda handler function
+ *
+ * @example
+ * ```js
+ * import { Hono } from 'hono'
+ * import { handle } from 'hono/aws-lambda'
+ *
+ * const app = new Hono()
+ *
+ * app.get('/', (c) => c.text('Hello from Lambda'))
+ * app.get('/json', (c) => c.json({ message: 'Hello JSON' }))
+ *
+ * export const handler = handle(app)
+ * ```
+ *
+ * @example
+ * ```js
+ * // With custom binary content type detection
+ * import { handle, defaultIsContentTypeBinary } from 'hono/aws-lambda'
+ * export const handler = handle(app, {
+ *   isContentTypeBinary: (contentType) => {
+ *     if (defaultIsContentTypeBinary(contentType)) {
+ *       // default logic same as prior to v4.8.4
+ *       return true
+ *     }
+ *     return contentType.startsWith('image/') || contentType === 'application/pdf'
+ *   }
+ * })
+ * ```
  */
 export const handle = <E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'>(
   app: Hono<E, S, BasePath>,

--- a/src/adapter/aws-lambda/index.ts
+++ b/src/adapter/aws-lambda/index.ts
@@ -3,7 +3,7 @@
  * AWS Lambda Adapter for Hono.
  */
 
-export { handle, streamHandle } from './handler'
+export { handle, streamHandle, defaultIsContentTypeBinary } from './handler'
 export type { APIGatewayProxyResult, LambdaEvent } from './handler'
 export type {
   ApiGatewayRequestContext,


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

## Proposal

- add `contentTypesAsBinary` to spefify which content-type should be treated as binary (will be base64 encoded)

```typescript
// content-type: application/vnd.mapbox-vector-tile will be base64-encoded and response as binary.
handle(app, { contentTypesAsBinary: ['application/vnd.mapbox-vector-tile'] })
```

## motivation

Current implementation treats some pre-defined content-types as "should be base64-encoded".
However, sometimes we need to treat some types other than them as binary (e.g. `'application/vnd.mapbox-vector-tile` https://github.com/mapbox/vector-tile-spec ).

What do yo think?