### PR TITLE
feat(jwt): added validation for the issuer (`iss`) claim

### DIFF
--- a/src/middleware/jwt/jwt.ts
+++ b/src/middleware/jwt/jwt.ts
@@ -54,6 +54,7 @@ export const jwt = (options: {
     | { key: string; secret?: string | BufferSource; prefixOptions?: CookiePrefixOptions }
   alg?: SignatureAlgorithm
   headerName?: string
+  issuer?: string | RegExp
 }): MiddlewareHandler => {
   if (!options || !options.secret) {
     throw new Error('JWT auth middleware requires options for "secret"')
@@ -121,7 +122,7 @@ export const jwt = (options: {
     let payload
     let cause
     try {
-      payload = await Jwt.verify(token, options.secret, options.alg)
+      payload = await Jwt.verify(token, options.secret, options.alg, options.issuer)
     } catch (e) {
       cause = e
     }

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -40,6 +40,13 @@ export class JwtTokenIssuedAt extends Error {
   }
 }
 
+export class JwtTokenIssuer extends Error {
+  constructor(expected: string | RegExp, iss: string | null) {
+    super(`expected issuer "${expected}", got ${iss ? `"${iss}"` : 'none'} `)
+    this.name = 'JwtTokenIssuer'
+  }
+}
+
 export class JwtHeaderInvalid extends Error {
   constructor(header: object) {
     super(`jwt header is invalid: ${JSON.stringify(header)}`)
@@ -89,6 +96,10 @@ export type JWTPayload = {
    * The token is checked to ensure it is not issued in the future.
    */
   iat?: number
+  /**
+   * The token is checked to ensure it has been issued by a trusted issuer.
+   */
+  iss?: string
 }
 
 export type { HonoJsonWebKey } from './jws'


### PR DESCRIPTION
This adds validation for the issuer claim (`iss`),
with support for simple strings and complex Regex patterns.

As this only verifies when the user has added an expected issuer, this isn't a breaking change and won't impact usage. You can however opt-in to issuer verification by simply setting the `issuer` option to your expected issuer.

- [x] Added tests
- [x] Ran tests - no errors
- [x] Ran `bun run format:fix` to format the code
- [x] Added [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

I didn't run `bun run lint:fix` as there was existing errors, however I ran `bun run lint` and it returned `47 errors` both before and after my commit.
