### PR TITLE
fix(jsx): cloneElement didn't copy children

### DIFF
--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource ./ */
+
+import type { JSXNode } from './base'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { cloneElement, jsx, Fragment } from './base'
+
+describe('cloneElement', () => {
+  it('should clone an element with new props', () => {
+    const element = <div className='original'>Hello</div>
+    const clonedElement = cloneElement(element, { className: 'cloned' })
+    expect((clonedElement as unknown as JSXNode).props.className).toBe('cloned')
+    expect((clonedElement as unknown as JSXNode).props.children).toBe('Hello')
+  })
+
+  it('should clone a children element', () => {
+    const fnElement = ({ message }: { message: string }) => <div>{message}</div>
+    const element = fnElement({ message: 'Hello' })
+    const clonedElement = cloneElement(element, {})
+    expect(element.toString()).toBe('<div>Hello</div>')
+    expect(clonedElement.toString()).toBe('<div>Hello</div>')
+  })
+
+  it('should clone an element with new children', () => {
+    const fnElement = ({ message }: { message: string }) => <div>{message}</div>
+    const element = fnElement({ message: 'Hello' })
+    const clonedElement = cloneElement(element, {}, 'World')
+    expect(element.toString()).toBe('<div>Hello</div>')
+    expect(clonedElement.toString()).toBe('<div>World</div>')
+  })
+})

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -433,7 +433,7 @@ export const cloneElement = <T extends JSXNode | JSX.Element>(
   return jsx(
     (element as JSXNode).tag,
     { ...(element as JSXNode).props, ...props },
-    ...(children.length ? children : childrenToClone)
+    ...childrenToClone
   ) as T
 }
 

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -423,10 +423,17 @@ export const cloneElement = <T extends JSXNode | JSX.Element>(
   props: Partial<Props>,
   ...children: Child[]
 ): T => {
+  let childrenToClone
+  if (children.length > 0) {
+    childrenToClone = children
+  } else {
+    const c = (element as JSXNode).props.children
+    childrenToClone = Array.isArray(c) ? c : [c]
+  }
   return jsx(
     (element as JSXNode).tag,
     { ...(element as JSXNode).props, ...props },
-    ...(children as (string | number | HtmlEscapedString)[])
+    ...(children.length ? children : childrenToClone)
   ) as T
 }
 


### PR DESCRIPTION
### The author should do the following, if applicable

When I use Hono JSX with [html-react-parser](https://github.com/remarkablemark/html-react-parser/blob/a71f4dc78b8a0aed88bb692704d480a46ac83cde/src/dom-to-react.ts#L53), I realized `cloneElement` didn't copy children.

I wrote fix and tests.


I only changed `jsx` (server side) implementation and  haven't checked `jsx/dom`. That might also have the issue.

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
