### PR TITLE
fix(client): remove `index` string when calling `$url()`

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -166,6 +166,7 @@ export const hc = <T extends Hono<any, any, any>>(
           result = result + '?' + buildSearchParams(opts.args[0].query).toString()
         }
       }
+      result = removeIndexString(result)
       return new URL(result)
     }
     if (method === 'ws') {


### PR DESCRIPTION
Fixes #4265

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
