### PR TITLE
feat(adapter/vercel): make it possible to read `process.env` as `c.env`

### DIFF
--- a/src/adapter/vercel/handler.test.ts
+++ b/src/adapter/vercel/handler.test.ts
@@ -48,7 +48,7 @@ describe('Adapter for Next.js', () => {
       return c.json([
         {
           name: 'yusukebe',
-          message: c.env.MESSAGE
+          message: c.env.MESSAGE,
         },
       ])
     })
@@ -59,7 +59,7 @@ describe('Adapter for Next.js', () => {
     expect(await res.json()).toEqual([
       {
         name: 'yusukebe',
-        message: process.env.MESSAGE
+        message: process.env.MESSAGE,
       },
     ])
     delete process.env.MESSAGE

--- a/src/adapter/vercel/handler.test.ts
+++ b/src/adapter/vercel/handler.test.ts
@@ -35,4 +35,33 @@ describe('Adapter for Next.js', () => {
     const req = new Request('http://localhost/api/error')
     expect(() => handler(req)).toThrowError('Custom Error')
   })
+
+  it('Should read `c.env`', async () => {
+    process.env.MESSAGE = 'Hono is hot!'
+
+    const app = new Hono<{
+      Bindings: {
+        MESSAGE: string
+      }
+    }>()
+    app.get('/api/authors', async (c) => {
+      return c.json([
+        {
+          name: 'yusukebe',
+          message: c.env.MESSAGE
+        },
+      ])
+    })
+    const handler = handle(app)
+    const req = new Request('http://localhost/api/authors')
+    const res = await handler(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([
+      {
+        name: 'yusukebe',
+        message: process.env.MESSAGE
+      },
+    ])
+    delete process.env.MESSAGE
+  })
 })

--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -4,5 +4,5 @@ import type { Hono } from '../../hono'
 export const handle =
   (app: Hono<any, any, any>) =>
   (req: Request): Response | Promise<Response> => {
-    return app.fetch(req)
+    return app.fetch(req, process && process?.env)
   }


### PR DESCRIPTION
While building a web app with Hono and Next.js, I found myself wanting to access environment variables in a way that better aligns with Hono’s philosophy.  

However, to do that, I had to create an adapter with a patch similar to this one.  

After trying it out, I thought it might actually be quite useful, so I created this PR.  

Since other adapters also receive `env` in the same way, this approach should work fine with Vercel as well.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
