### PR TITLE
fix(cookie): support lowercase priority for compatibility with other libraries

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -269,4 +269,21 @@ describe('Set cookie', () => {
       })
     }).toThrowError('Partitioned Cookie must have Secure attributes')
   })
+
+  it('Should serialize cookie with lowercase priority values', () => {
+    const lowSerialized = serialize('test_cookie', 'value', {
+      priority: 'low',
+    })
+    expect(lowSerialized).toBe('test_cookie=value; Priority=Low')
+
+    const mediumSerialized = serialize('test_cookie', 'value', {
+      priority: 'medium',
+    })
+    expect(mediumSerialized).toBe('test_cookie=value; Priority=Medium')
+
+    const highSerialized = serialize('test_cookie', 'value', {
+      priority: 'high',
+    })
+    expect(highSerialized).toBe('test_cookie=value; Priority=High')
+  })
 })

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -23,7 +23,7 @@ export type CookieOptions = {
   secure?: boolean
   sameSite?: 'Strict' | 'Lax' | 'None' | 'strict' | 'lax' | 'none'
   partitioned?: boolean
-  priority?: 'Low' | 'Medium' | 'High'
+  priority?: 'Low' | 'Medium' | 'High' | 'low' | 'medium' | 'high'
   prefix?: CookiePrefixOptions
 } & PartitionedCookieConstraint
 export type CookiePrefixOptions = 'host' | 'secure'
@@ -206,7 +206,7 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.priority) {
-    cookie += `; Priority=${opt.priority}`
+    cookie += `; Priority=${opt.priority.charAt(0).toUpperCase() + opt.priority.slice(1)}`
   }
 
   if (opt.partitioned) {


### PR DESCRIPTION
---

This PR adds support for lowercase priority values in cookies, similar to how sameSite is handled, to improve compatibility with other libraries.

Currently, a conflict occurs when used alongside libraries that depend on [jshttp/cookie](https://github.com/jshttp/cookie).

For example, using Hono with `next` or `@supabase/ssr` may result in type errors due to differing expectations for the casing of priority values.

<img width="1043" height="143" alt="screen" src="https://github.com/user-attachments/assets/33b271f5-7f0b-4373-bcf6-1ae31e85cdf9" />

---

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
