### PR TITLE
fix(utils/url): prevent double encoding in `safeEncodeURI`

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -319,5 +319,15 @@ describe('url', () => {
         safeEncodeURI('https://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF?abc')
       ).toBe('https://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF?abc')
     })
+
+    it('Should be the same strings', async () => {
+      expect(
+        safeEncodeURI(
+          'https://login.microsoftonline.com/redacted-id&scope=email%20openid%20profile%20offline_access&redirect_uri=https%3A%2F%2Fredacted-domain.org%2Fapi%2Fauth%2Fcallback&client-request-id=redacted-id&response_mode=query&client_info=1&x-client-SKU=msal.js.node&x-client-VER=3.6.4&x-client-OS=linux&x-client-CPU=x64&response_type=code&code_challenge=7C75MO8zdoJZn7_sIpxcFEQzPvzWIMzD2tUf-lqevR0&code_challenge_method=S256'
+        )
+      ).toBe(
+        'https://login.microsoftonline.com/redacted-id&scope=email%20openid%20profile%20offline_access&redirect_uri=https%3A%2F%2Fredacted-domain.org%2Fapi%2Fauth%2Fcallback&client-request-id=redacted-id&response_mode=query&client_info=1&x-client-SKU=msal.js.node&x-client-VER=3.6.4&x-client-OS=linux&x-client-CPU=x64&response_type=code&code_challenge=7C75MO8zdoJZn7_sIpxcFEQzPvzWIMzD2tUf-lqevR0&code_challenge_method=S256'
+      )
+    })
   })
 })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -318,11 +318,13 @@ export const decodeURIComponent_ = decodeURIComponent
  */
 export const safeEncodeURI = (str: string): string => {
   try {
-    // decodeURI will throw if str contains %
-    // In that case, we can assume that str is not encoded
-    return encodeURI(decodeURI(str))
+    // Try to decode the string
+    const decoded = decodeURI(str)
+    // If successful, encode only if it's different from the original
+    return decoded === str ? encodeURI(str) : str
   } catch (e) {
     if (e instanceof URIError) {
+      // If decoding fails, the string is not encoded, so encode it
       return encodeURI(str)
     }
     throw e


### PR DESCRIPTION
Fixes https://github.com/honojs/hono/pull/4297#issuecomment-3117351523

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
