### PR TITLE
fix(utils/url): use `isByteString` in `safeEncodeURI`

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -310,24 +310,28 @@ describe('url', () => {
       expect(safeEncodeURI('こんにちは')).toBe('%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF')
     })
 
-    it('Encode unencoded, but URI invalid ASCII chars', async () => {
-      expect(safeEncodeURI('https://example.com/%hello')).toBe('https://example.com/%25hello')
+    it('Keep strings with invalid ASCII chars', async () => {
+      expect(safeEncodeURI('https://example.com/%hello')).toBe('https://example.com/%hello')
     })
 
-    it('Do not change the encoded string', async () => {
+    it('Keep strings with an encoded string', async () => {
       expect(
         safeEncodeURI('https://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF?abc')
       ).toBe('https://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF?abc')
     })
 
-    it('Should be the same strings', async () => {
+    it('Keep strings with encoded :// unchanged', () => {
+      expect(safeEncodeURI('https://localhost/api?redirect_uri=https%3A%2F%2Fexample.com')).toBe(
+        'https://localhost/api?redirect_uri=https%3A%2F%2Fexample.com'
+      )
+    })
+
+    it('Keep strings with encoded spaces and :// unchanged', async () => {
       expect(
         safeEncodeURI(
-          'https://login.microsoftonline.com/redacted-id&scope=email%20openid%20profile%20offline_access&redirect_uri=https%3A%2F%2Fredacted-domain.org%2Fapi%2Fauth%2Fcallback&client-request-id=redacted-id&response_mode=query&client_info=1&x-client-SKU=msal.js.node&x-client-VER=3.6.4&x-client-OS=linux&x-client-CPU=x64&response_type=code&code_challenge=7C75MO8zdoJZn7_sIpxcFEQzPvzWIMzD2tUf-lqevR0&code_challenge_method=S256'
+          'https://localhost/api?redirect_uri=https%3A%2F%2Fexample.com&scope=email%20profile'
         )
-      ).toBe(
-        'https://login.microsoftonline.com/redacted-id&scope=email%20openid%20profile%20offline_access&redirect_uri=https%3A%2F%2Fredacted-domain.org%2Fapi%2Fauth%2Fcallback&client-request-id=redacted-id&response_mode=query&client_info=1&x-client-SKU=msal.js.node&x-client-VER=3.6.4&x-client-OS=linux&x-client-CPU=x64&response_type=code&code_challenge=7C75MO8zdoJZn7_sIpxcFEQzPvzWIMzD2tUf-lqevR0&code_challenge_method=S256'
-      )
+      ).toBe('https://localhost/api?redirect_uri=https%3A%2F%2Fexample.com&scope=email%20profile')
     })
   })
 })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -316,17 +316,12 @@ export const decodeURIComponent_ = decodeURIComponent
  * and not double-encoded.
  * The input string may or may not escaped by encodeURI.
  */
+
+const isByteString = (str: string): boolean => {
+  // eslint-disable-next-line no-control-regex
+  return !/[^\x00-\xFF]/.test(str)
+}
+
 export const safeEncodeURI = (str: string): string => {
-  try {
-    // Try to decode the string
-    const decoded = decodeURI(str)
-    // If successful, encode only if it's different from the original
-    return decoded === str ? encodeURI(str) : str
-  } catch (e) {
-    if (e instanceof URIError) {
-      // If decoding fails, the string is not encoded, so encode it
-      return encodeURI(str)
-    }
-    throw e
-  }
+  return isByteString(str) ? str : encodeURI(str)
 }


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
