### PR TITLE
feat: add `hcParse` util to smartly parse response from a `hc` fetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "bun-types": "^1.1.39",
         "esbuild": "^0.15.18",
         "eslint": "^9.10.0",
+        "fetch-result-please": "^0.2.0",
         "glob": "^11.0.0",
         "jsdom": "^22.1.0",
         "msw": "^2.6.0",
@@ -648,6 +649,8 @@
 
     "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
 
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
     "detect-libc": ["detect-libc@2.0.3", "", {}, "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="],
 
     "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
@@ -789,6 +792,8 @@
     "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fetch-result-please": ["fetch-result-please@0.2.0", "", { "dependencies": { "destr": "^2.0.5" } }, "sha512-j6usAJi3FmbvgHk1896YnQ2nUs1L3iPRghq6TO99SaTyuTbGhdRqdHcu0HROLzWtMkzJlGRJlCE0QPftdDceFA=="],
 
     "figures": ["figures@1.7.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5", "object-assign": "^4.1.0" } }, "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -667,6 +667,7 @@
     "bun-types": "^1.1.39",
     "esbuild": "^0.15.18",
     "eslint": "^9.10.0",
+    "fetch-result-please": "^0.2.0",
     "glob": "^11.0.0",
     "jsdom": "^22.1.0",
     "msw": "^2.6.0",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { hc } from './client'
+export { hcParse, DetailedError } from './utils'
 export type {
   InferResponseType,
   InferRequestType,

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,4 +1,7 @@
-import type { ObjectType } from './types'
+import { fetchRP, DetailedError } from 'fetch-result-please'
+import type { ClientResponse, ObjectType } from './types'
+
+export { DetailedError }
 
 export const mergePath = (base: string, path: string) => {
   base = base.replace(/\/+$/, '')
@@ -71,4 +74,20 @@ export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
   }
 
   return merged as T
+}
+
+/**
+ * Shortcut to get a consumable response from `hc` fetch calls, with types inference.
+ *
+ * Smartly parse the response data, and automatically throw an error if the response is not ok.
+ *
+ * To handle an error, see {@link DetailedError} interface.
+ *
+ * @example hcParse(client.posts.$get())
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function hcParse<T extends ClientResponse<any>>(
+  fetchRes: T | Promise<T>
+): Promise<T extends ClientResponse<infer RT> ? RT : never> {
+  return fetchRP(fetchRes)
 }


### PR DESCRIPTION
Somewhat resolves #3894

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code - I added some doc, but not fully semantics JSDoc.

Note: this PR adds [`fetch-result-please`](https://www.npmjs.com/package/fetch-result-please) as a dependency so the codebase doesn't have to maintain as much codes, also because we're at `/client` subpath, adding dependency won't really increase the package size of main hono.

Though, if you prefer to not add any new dependency, I have another PR for that alternative version: #4314.