### PR TITLE
refactor(types): bring adapter/service-worker types up to date

### DIFF
--- a/src/adapter/service-worker/types.ts
+++ b/src/adapter/service-worker/types.ts
@@ -5,7 +5,7 @@ interface ExtendableEvent extends Event {
 
 export interface FetchEvent extends ExtendableEvent {
   readonly clientId: string
-  readonly handled: Promise<undefined>
+  readonly handled: Promise<void>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly preloadResponse: Promise<any>
   readonly request: Request


### PR DESCRIPTION
This PR updates the `FetchEvent.handled` type in `adapter/service-worker`  to be in line with [typescript's webworker types](https://github.com/microsoft/TypeScript/blob/be8678315541e814da14316848a9468e8f90ab11/src/lib/webworker.generated.d.ts#L4119).

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
