### PR TITLE
fix(types): should populate `output` type for `c.body()`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -121,13 +121,16 @@ interface NewResponse {
  */
 interface BodyRespond {
   // if we return content, only allow the status codes that allow for returning the body
-  <U extends ContentfulStatusCode>(data: Data, status?: U, headers?: HeaderRecord): Response &
-    TypedResponse<unknown, U, 'body'>
-  <U extends StatusCode>(data: null, status?: U, headers?: HeaderRecord): Response &
+  <T extends Data, U extends ContentfulStatusCode>(
+    data: T,
+    status?: U,
+    headers?: HeaderRecord
+  ): Response & TypedResponse<T, U, 'body'>
+  <T extends Data, U extends ContentfulStatusCode>(data: T, init?: ResponseOrInit<U>): Response &
+    TypedResponse<T, U, 'body'>
+  <T extends null, U extends StatusCode>(data: T, status?: U, headers?: HeaderRecord): Response &
     TypedResponse<null, U, 'body'>
-  <U extends ContentfulStatusCode>(data: Data, init?: ResponseOrInit<U>): Response &
-    TypedResponse<unknown, U, 'body'>
-  <U extends StatusCode>(data: null, init?: ResponseOrInit<U>): Response &
+  <T extends null, U extends StatusCode>(data: T, init?: ResponseOrInit<U>): Response &
     TypedResponse<null, U, 'body'>
 }
 


### PR DESCRIPTION
Resolves #4316

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
