### PR TITLE
chore(ci): upgrade bun version to 1.2.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.1.39'
+          bun-version: '1.2.19'
       - run: bun install
       - run: bun run format
       - run: bun run lint
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.1.39'
+          bun-version: '1.2.19'
       - run: bun install
       - run: bun run test:bun
       - uses: actions/upload-artifact@v4
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: '1.1.39'
+          bun-version: '1.2.19'
       - run: bun run test:bun
 
   fastly:


### PR DESCRIPTION
The version of bun currently used in CI (v1.1.39) isn't compatible with the `lockfileVersion` in `bun.lock`

https://github.com/honojs/hono/blob/bd454fe8a6c494050fc48f7a3eb61af3d49f91b4/bun.lock#L2

This causes an error in CI, but `bun install` continues anyway by ignoring the lock file and generating a new one. This defeats the purpose of a lock file 🙈 

https://github.com/honojs/hono/actions/runs/16609360703/job/46988990584#step:4:6

I've updated to use the current version of bun