### PR TITLE
fix(service-worker): pass `FetchEvent` as second argument to `app.fetch`

### DIFF
--- a/src/adapter/service-worker/handler.ts
+++ b/src/adapter/service-worker/handler.ts
@@ -24,7 +24,7 @@ export const handle = (
   return (evt) => {
     evt.respondWith(
       (async () => {
-        const res = await app.fetch(evt.request)
+        const res = await app.fetch(evt.request, evt)
         if (opts.fetch && res.status === 404) {
           return await opts.fetch(evt.request)
         }


### PR DESCRIPTION
Fixes #4324

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
