### PR TITLE
fix(router): support `/files/:name{.*}`

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -144,6 +144,26 @@ export const runTest = ({
         expect(res.length).toBe(0)
       })
 
+      it('Parameter with {.*} regexp', () => {
+        router.add('GET', '/files/:name{.*}', 'file')
+        let res = match('GET', '/files')
+        expect(res.length).toBe(0)
+
+        res = match('GET', '/files/a')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('file')
+        expect(res[0].params['name']).toEqual('a')
+
+        res = match('GET', '/files/a/b')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('file')
+        expect(res[0].params['name']).toEqual('a/b')
+
+        res = match('GET', '/files/')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('file')
+      })
+
       it('/*', async () => {
         router.add('GET', '/api/*', 'auth middleware')
         router.add('GET', '/api', 'top')

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -10,6 +10,7 @@ describe('LinearRouter', () => {
         tests: [
           'Multi match > `params` per a handler > GET /entry/123/show',
           'Capture regex pattern has trailing wildcard > GET /foo/bar/file.html',
+          'Complex > Parameter with {.*} regexp',
         ],
       },
       {

--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -81,6 +81,9 @@ export class Node {
       const name = pattern[1]
       let regexpStr = pattern[2] || LABEL_REG_EXP_STR
       if (name && pattern[2]) {
+        if (regexpStr === '.*') {
+          throw PATH_ERROR
+        }
         regexpStr = regexpStr.replace(/^\((?!\?:)(?=[^)]+\)$)/, '(?:') // (a|b) => (?:a|b)
         if (/\((?!\?:)/.test(regexpStr)) {
           // prefix(?:a|b) is allowed, but prefix(a|b) is not

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -14,6 +14,7 @@ describe('RegExpRouter', () => {
           'Capture Group > Complex capturing group > GET request',
           'Capture complex multiple directories > GET /part1/middle-b/latest',
           'Capture complex multiple directories > GET /part1/middle-b/end-c/latest',
+          'Complex > Parameter with {.*} regexp',
         ],
       },
       {

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -155,11 +155,11 @@ export class Node<T> {
             continue
           }
 
-          if (!part) {
+          const [key, name, matcher] = pattern
+
+          if (!part && !(matcher instanceof RegExp)) {
             continue
           }
-
-          const [key, name, matcher] = pattern
 
           const child = node.#children[key]
 


### PR DESCRIPTION
I investigated to fix #4325, and I found bugs in the routers.

If the registered path is `/files/:name{.*}`, the behaviors of some routers are incorrect.

Fixes #4325

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
