### PR TITLE
refactor(ssg): mark old hook options as deprecated

### DIFF
--- a/src/helper/ssg/ssg.ts
+++ b/src/helper/ssg/ssg.ts
@@ -168,8 +168,17 @@ export interface SSGPlugin {
 
 export interface ToSSGOptions {
   dir?: string
+  /**
+   * @deprecated Use plugins[].beforeRequestHook instead.
+   */
   beforeRequestHook?: BeforeRequestHook | BeforeRequestHook[]
+  /**
+   * @deprecated Use plugins[].afterResponseHook instead.
+   */
   afterResponseHook?: AfterResponseHook | AfterResponseHook[]
+  /**
+   * @deprecated Use plugins[].afterGenerateHook instead.
+   */
   afterGenerateHook?: AfterGenerateHook | AfterGenerateHook[]
   concurrency?: number
   extensionMap?: Record<string, string>


### PR DESCRIPTION
The legacy hook options can now be fully represented using the plugins interface. To prepare for their eventual removal, I believe we should encourage existing users of the old hook options to migrate to the plugins approach.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
