### PR TITLE
feat(parseResponse): set `DetailedError.name` (+ error tests)

### DIFF
--- a/src/client/fetch-result-please.ts
+++ b/src/client/fetch-result-please.ts
@@ -57,6 +57,7 @@ export class DetailedError extends Error {
     options: { detail?: any; code?: any; statusCode?: number; log?: any } = {}
   ) {
     super(message)
+    this.name = 'DetailedError'
     this.log = options.log
     this.detail = options.detail
     this.code = options.code


### PR DESCRIPTION
This PR simply set the `.name` for the `DetailedError` class, which is a good pratice, so user is able to do a fast equality check in code / search for the error in log.

I forgot to add it previously and just hit a case where I need it because I have `DetailedError` classes coming from multiple source and `instanceof` is a bit wonky.

I also added tests for cases where error is thrown.

Theoretically "breaking", but should be safe to include in next patch.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the codefix 
