### PR TITLE
fix(client): improve parseResponse type inference for conditional responses

### DIFF
--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,5 +1,6 @@
 import { fetchRP, DetailedError } from './fetch-result-please'
 import type { ClientResponse, ObjectType } from './types'
+import type { SuccessStatusCode } from '../utils/http-status'
 
 export { DetailedError }
 
@@ -87,7 +88,15 @@ export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
 export async function parseResponse<T extends ClientResponse<any>>(
   fetchRes: T | Promise<T>
 ): Promise<
-  T extends ClientResponse<infer RT, infer _, infer RF>
+  Extract<T, ClientResponse<any, SuccessStatusCode, any>> extends never
+    ? T extends ClientResponse<infer RT, infer _, infer RF>
+      ? RF extends 'json'
+        ? RT
+        : RT extends string
+        ? RT
+        : string
+      : never
+    : Extract<T, ClientResponse<any, SuccessStatusCode, any>> extends ClientResponse<infer RT, infer _, infer RF>
     ? RF extends 'json'
       ? RT
       : RT extends string


### PR DESCRIPTION
## Summary
Fixed a type inference issue in `parseResponse` where conditional responses (routes that can return different response types based on conditions) were incorrectly typed as union types instead of just the success response type.

## The Problem
When a route can return multiple response types like this:
```typescript
.get('/api', (c) => {
  if (someCondition) {
    return c.json({ error: 'error' }, 500)  // error response
  }
  return c.json({ data: [...] }, 200)       // success response  
})
```

`parseResponse` was inferring the return type as `{ error: string } | { data: any[] }` but it should only be `{ data: any[] }` because parseResponse throws an error for non-OK responses.

## The Solution
- Used `Extract<>` utility type to filter out only success status code responses from union types
- Added fallback logic for regular responses that don't have explicit status codes
- Updated tests to verify the correct behavior

## Test Plan
- [x] Type inference now correctly returns only success response types for conditional routes
- [x] Existing functionality for regular routes remains unchanged
- [x] All type assertion tests pass