### PR TITLE
fix(parseResponse): should not include error responses in result

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -136,6 +136,15 @@ export type InferRequestOptionsType<T> = T extends (
   ? NonNullable<R>
   : never
 
+export type FilterClientResponses<
+  T extends ClientResponse<any, any, any>,
+  U extends number = StatusCode
+> = T extends ClientResponse<infer RT, infer RC, infer RF>
+  ? RC extends U
+    ? ClientResponse<RT, RC, RF>
+    : never
+  : never
+
 type PathToChain<
   Path extends string,
   E extends Schema,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -136,7 +136,10 @@ export type InferRequestOptionsType<T> = T extends (
   ? NonNullable<R>
   : never
 
-export type FilterClientResponses<
+/**
+ * Filter a ClientResponse type so it only includes responses of specific status codes.
+ */
+export type FilterClientResponseByStatusCode<
   T extends ClientResponse<any, any, any>,
   U extends number = StatusCode
 > = T extends ClientResponse<infer RT, infer RC, infer RF>

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -207,7 +207,7 @@ describe('parseResponse', async () => {
       })
     }),
     http.get('http://localhost/rawBuffer', () => {
-      return HttpResponse.arrayBuffer(new TextEncoder().encode('hono'), {
+      return HttpResponse.arrayBuffer(new TextEncoder().encode('hono').buffer, {
         headers: {
           'content-type': 'x/custom-type',
         },

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -256,19 +256,6 @@ describe('parseResponse', async () => {
       expect(result).toEqual({ message: 'hi' })
       type _verify = Expect<Equal<typeof result, { message: string }>>
     }),
-    it('should bypass error responses in the result type inference - simple 404', async () => {
-      const result = await parseResponse(client['404'].$get())
-      expect(result).toBeUndefined()
-      type _verify = Expect<Equal<typeof result, undefined>>
-    }),
-    it('should bypass error responses in the result type inference - conditional - json', async () => {
-      const result = await parseResponse(client['might-error-json'].$get())
-      type _verify = Expect<Equal<typeof result, { data: { id: number }[] }>>
-    }),
-    it('should bypass error responses in the result type inference - conditional - mixed json/text', async () => {
-      const result = await parseResponse(client['might-error-mixed-json-text'].$get())
-      type _verify = Expect<Equal<typeof result, { message: string }>>
-    }),
     it('should auto parse the json response - sync fetch', async () => {
       const result = await parseResponse(await client.json.$get())
       expect(result).toEqual({ message: 'hi' })
@@ -304,6 +291,30 @@ describe('parseResponse', async () => {
         // @ts-expect-error noRoute is not defined
         parseResponse(client['noRoute'].$get())
       ).rejects.toThrowErrorMatchingInlineSnapshot('[TypeError: fetch failed]')
+    }),
+    it('(type-only) should bypass error responses in the result type inference - simple 404', async () => {
+      type ResultType = Awaited<
+        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['404']['$get']>>>>
+      >
+      type _verify = Expect<Equal<Awaited<ResultType>, undefined>>
+    }),
+    it('(type-only) should bypass error responses in the result type inference - conditional - json', async () => {
+      type ResultType = Awaited<
+        ReturnType<
+          typeof parseResponse<Awaited<ReturnType<(typeof client)['might-error-json']['$get']>>>
+        >
+      >
+      type _verify = Expect<Equal<ResultType, { data: { id: number }[] }>>
+    }),
+    it('(type-only) should bypass error responses in the result type inference - conditional - mixed json/text', async () => {
+      type ResultType = Awaited<
+        ReturnType<
+          typeof parseResponse<
+            Awaited<ReturnType<(typeof client)['might-error-mixed-json-text']['$get']>>
+          >
+        >
+      >
+      type _verify = Expect<Equal<ResultType, { message: string }>>
     }),
   ])
 })

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -235,23 +235,8 @@ describe('parseResponse', async () => {
       expect(result).toEqual({ message: 'hi' })
       type _verify = Expect<Equal<typeof result, { message: string }>>
     }),
-    it('example of conditional response with type inference', async () => {
-      const result = await client['json-conditional'].$get()
-      if (result.ok) {
-        const json = await result.json()
-        expect(json).toEqual({ data: [{ id: 1 }, { id: 2 }] })
-        type _verify = Expect<Equal<typeof json, { data: { id: number }[] }>>
-      } else {
-        const json = await result.json()
-        type _verify = Expect<Equal<typeof json, { error: string }>>
-        expect(json).toEqual({ error: 'error' })
-        const text = await result.text()
-        expect(text).toEqual('error')
-      }
-    }),
     it('should auto parse the json response - async fetch with conditional response', async () => {
       const result = await parseResponse(client['json-conditional'].$get())
-      expect(result).toEqual({ data: [{ id: 1 }, { id: 2 }] })
       type _verify = Expect<Equal<typeof result, { data: { id: number }[] }>>
     }),
     it('should auto parse the json response - sync fetch', async () => {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,5 +1,6 @@
 import { fetchRP, DetailedError } from './fetch-result-please'
 import type { ClientResponse, ObjectType } from './types'
+import type { SuccessStatusCode } from '../utils/http-status'
 
 export { DetailedError }
 
@@ -87,7 +88,15 @@ export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
 export async function parseResponse<T extends ClientResponse<any>>(
   fetchRes: T | Promise<T>
 ): Promise<
-  T extends ClientResponse<infer RT, infer _, infer RF>
+  Extract<T, ClientResponse<any, SuccessStatusCode, any>> extends never
+    ? T extends ClientResponse<infer RT, infer _, infer RF>
+      ? RF extends 'json'
+        ? RT
+        : RT extends string
+        ? RT
+        : string
+      : never
+    : Extract<T, ClientResponse<any, SuccessStatusCode, any>> extends ClientResponse<infer RT, infer _, infer RF>
     ? RF extends 'json'
       ? RT
       : RT extends string

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -4,7 +4,7 @@ import type {
   ServerErrorStatusCode,
 } from '../utils/http-status'
 import { fetchRP, DetailedError } from './fetch-result-please'
-import type { ClientResponse, FilterClientResponses, ObjectType } from './types'
+import type { ClientResponse, FilterClientResponseByStatusCode, ObjectType } from './types'
 
 export { DetailedError }
 
@@ -92,14 +92,14 @@ export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
 export async function parseResponse<T extends ClientResponse<any>>(
   fetchRes: T | Promise<T>
 ): Promise<
-  FilterClientResponses<
+  FilterClientResponseByStatusCode<
     T,
     Exclude<ContentfulStatusCode, ClientErrorStatusCode | ServerErrorStatusCode> // Filter out the error responses
   > extends never
     ? // Filtered responses does not include any contentful responses, exit with undefined
       undefined
     : // Filtered responses includes contentful responses, proceed to infer the type
-    FilterClientResponses<
+    FilterClientResponseByStatusCode<
         T,
         Exclude<ContentfulStatusCode, ClientErrorStatusCode | ServerErrorStatusCode>
       > extends ClientResponse<infer RT, infer _, infer RF>

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,6 +1,6 @@
+import type { SuccessStatusCode } from '../utils/http-status'
 import { fetchRP, DetailedError } from './fetch-result-please'
 import type { ClientResponse, ObjectType } from './types'
-import type { SuccessStatusCode } from '../utils/http-status'
 
 export { DetailedError }
 
@@ -96,7 +96,11 @@ export async function parseResponse<T extends ClientResponse<any>>(
         ? RT
         : string
       : never
-    : Extract<T, ClientResponse<any, SuccessStatusCode, any>> extends ClientResponse<infer RT, infer _, infer RF>
+    : Extract<T, ClientResponse<any, SuccessStatusCode, any>> extends ClientResponse<
+        infer RT,
+        infer _,
+        infer RF
+      >
     ? RF extends 'json'
       ? RT
       : RT extends string


### PR DESCRIPTION
Continuing from #4346, because I did a lot of updates and I can't push to the existing PR so I created a new one, I added more test cases and use another approach that is cleaner and fixes all problems.

In summary: 
* The PR adds a new type util: `FilterClientResponseByStatusCode`, which is used by `parseResponse` to exclude error responses.  
* More test cases are also added to make sure `parseResponse` is correct in use cases where a route will also return error responses.
* Some minor adjustments are also done in this PR, like:
  * Use `c.text` instead of `c.notFound` for correct `TypedResponse` infer and test
  * Add `.buffer` chain for `/rawBuffer` return, this fixes a minor type issue in newest node version.

---

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code