### PR TITLE
fix(jsx): 'plaintext-only' value for contenteditable attribute

### DIFF
--- a/src/jsx/intrinsic-elements.ts
+++ b/src/jsx/intrinsic-elements.ts
@@ -154,7 +154,7 @@ export namespace JSX {
     autocapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters' | undefined
     autofocus?: boolean | undefined
     class?: string | Promise<string> | undefined
-    contenteditable?: boolean | 'inherit' | undefined
+    contenteditable?: boolean | 'inherit' | 'plaintext-only' | undefined
     contextmenu?: string | undefined
     dir?: string | undefined
     draggable?: 'true' | 'false' | boolean | undefined


### PR DESCRIPTION
Added 'plaintext-only' for the contenteditable attribute to conform to the [HTML specification](https://html.spec.whatwg.org/multipage/interaction.html#contenteditable).

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
