### PR TITLE
feat(csrf): Add modern CSRF protection with Fetch Metadata support

### DIFF
--- a/src/middleware/csrf/index.test.ts
+++ b/src/middleware/csrf/index.test.ts
@@ -347,6 +347,14 @@ describe('CSRF by Middleware', () => {
         )
         expect(res.status).toBe(403)
       })
+
+      it('should block unknown values', async () => {
+        const res = await app.request(
+          'http://localhost/form',
+          buildSimplePostRequestData({ secFetchSite: 'any' })
+        )
+        expect(res.status).toBe(403)
+      })
     })
 
     describe('string[]', () => {


### PR DESCRIPTION
 ### Add modern CSRF protection with Fetch Metadata support

**Why this change?**

Modern browsers support [Fetch Metadata headers (Sec-Fetch-Site)](https://web.dev/articles/fetch-metadata) which provide a more reliable way to detect cross-origin requests than traditional Origin header checking alone. This enhancement adds opt-in support for Fetch Metadata based CSRF protection while maintaining full backwards compatibility.

### References and Inspiration

The implementation is inspired by:
- the go std lib (net/http) implementation: https://github.com/golang/go/blob/5dac42363ba8281a3f4f08e03af2292b763adc38/src/net/http/csrf.go#L122-L163
- the go RFC https://github.com/golang/go/issues/73626#issue-3046320918

More references:
- https://web.dev/articles/fetch-metadata
- https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header
- https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF#fetch_metadata

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
- [x] Update the documentation -> Website PR: https://github.com/honojs/website/pull/721
