### PR TITLE
feat(proxy): add `customFetch` option to allow custom fetch function

### DIFF
--- a/src/helper/proxy/index.test.ts
+++ b/src/helper/proxy/index.test.ts
@@ -255,5 +255,24 @@ describe('Proxy Middleware', () => {
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('ok')
     })
+
+    it('Should call the custom fetch method when specified', async () => {
+      const customFetch = vi.fn().mockImplementation(async () => {
+        return new Response('custom fetch response')
+      })
+      const app = new Hono()
+      app.get('/', () =>
+        proxy(
+          `https://example.com/`,
+          {},
+          {
+            fetch: customFetch,
+          }
+        )
+      )
+      const res = await app.request('/')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('custom fetch response')
+    })
   })
 })

--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -25,8 +25,21 @@ interface ProxyRequestInit extends Omit<RequestInit, 'headers'> {
     | Record<string, string | undefined>
 }
 
+/**
+ * Options for proxy function
+ * @example
+ * { fetch: customFetch } // Use custom fetch function instead of the global `fetch`
+ */
+type ProxyOptions = {
+  fetch: typeof fetch
+}
+
 interface ProxyFetch {
-  (input: string | URL | Request, init?: ProxyRequestInit): Promise<Response>
+  (
+    input: string | URL | Request,
+    init?: ProxyRequestInit,
+    options?: ProxyOptions
+  ): Promise<Response>
 }
 
 const buildRequestInitFromRequest = (
@@ -109,7 +122,7 @@ const preprocessRequestInit = (requestInit: RequestInit): RequestInit => {
  * })
  * ```
  */
-export const proxy: ProxyFetch = async (input, proxyInit) => {
+export const proxy: ProxyFetch = async (input, proxyInit, options) => {
   const { raw, ...requestInit } =
     proxyInit instanceof Request ? { raw: proxyInit } : proxyInit ?? {}
 
@@ -119,7 +132,7 @@ export const proxy: ProxyFetch = async (input, proxyInit) => {
   })
   req.headers.delete('accept-encoding')
 
-  const res = await fetch(req)
+  const res = await (options?.fetch || fetch)(req)
   const resHeaders = new Headers(res.headers)
   hopByHopHeaders.forEach((header) => {
     resHeaders.delete(header)

--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -23,7 +23,7 @@ interface ProxyRequestInit extends Omit<RequestInit, 'headers'> {
     | [string, string][]
     | Record<RequestHeader, string | undefined>
     | Record<string, string | undefined>
-  customFetch: (request: Request) => Promise<Response>
+  customFetch?: (request: Request) => Promise<Response>
 }
 
 interface ProxyFetch {


### PR DESCRIPTION
Resolves #4351

This PR will add the option parameter `customFetch` to allow the user to override the global `fetch` in Proxy helper.

Usage:

```ts
app.get('/', () =>
  proxy(`https://example.com/`, {
    customFetch,
  })
)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
