### PR TITLE
chore: update `typescript` to `5.9.2`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "prettier": "^2.6.2",
         "publint": "^0.1.16",
         "supertest": "^6.3.4",
-        "typescript": "^5.3.3",
+        "typescript": "^5.9.2",
         "vite-plugin-fastly-js-compute": "^0.4.2",
         "vitest": "^3.2.4",
         "wrangler": "4.12.0",
@@ -1473,7 +1473,7 @@
 
     "type-fest": ["type-fest@4.26.1", "", {}, "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg=="],
 
-    "typescript": ["typescript@5.6.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw=="],
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "typescript-eslint": ["typescript-eslint@8.38.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.38.0", "@typescript-eslint/parser": "8.38.0", "@typescript-eslint/typescript-estree": "8.38.0", "@typescript-eslint/utils": "8.38.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg=="],
 

--- a/package.json
+++ b/package.json
@@ -677,7 +677,7 @@
     "prettier": "^2.6.2",
     "publint": "^0.1.16",
     "supertest": "^6.3.4",
-    "typescript": "^5.3.3",
+    "typescript": "^5.9.2",
     "vite-plugin-fastly-js-compute": "^0.4.2",
     "vitest": "^3.2.4",
     "wrangler": "4.12.0",

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -85,8 +85,8 @@ export const websocket: BunWebSocketHandler<BunWebSocketData> = {
   message(ws, message) {
     const websocketListeners = ws.data.events
     if (websocketListeners.onMessage) {
-      const normalizedReceiveData =
-        typeof message === 'string' ? message : (message.buffer satisfies WSMessageReceive)
+      const normalizedReceiveData: WSMessageReceive =
+        typeof message === 'string' ? message : message.buffer
 
       websocketListeners.onMessage(createWSMessageEvent(normalizedReceiveData), createWSContext(ws))
     }

--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -27,7 +27,7 @@ describe('createBody', () => {
     const data = encoder.encode('test')
     const body = {
       action: 'read-only',
-      data: encodeBase64(data),
+      data: encodeBase64(data.buffer),
       encoding: 'base64',
       inputTruncated: false,
     }

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -175,7 +175,7 @@ const createRequest = (event: CloudFrontEdgeEvent): Request => {
 export const createBody = (
   method: string,
   requestBody: CloudFrontRequest['body']
-): string | Uint8Array | undefined => {
+): string | Uint8Array<ArrayBuffer> | undefined => {
   if (!requestBody || !requestBody.data) {
     return undefined
   }

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -495,7 +495,7 @@ describe('Infer the response/request type', () => {
       const req = client.index.$get
 
       type Actual = InferResponseType<typeof req>
-      type Expected = { ok: boolean }
+      type Expected = { ok: true }
       type verify = Expect<Equal<Expected, Actual>>
     })
 
@@ -558,7 +558,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
     const data = await res.json()
-    type verify = Expect<Equal<boolean, typeof data.ok>>
+    type verify = Expect<Equal<true, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 
@@ -569,7 +569,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.api.search.$get()
     const data = await res.json()
-    type verify = Expect<Equal<boolean, typeof data.ok>>
+    type verify = Expect<Equal<true, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 
@@ -580,7 +580,7 @@ describe('Merge path with `app.route()`', () => {
     const client = hc<AppType>('http://localhost')
     const res = await client.v1.book.$get()
     const data = await res.json()
-    type verify = Expect<Equal<boolean, typeof data.ok>>
+    type verify = Expect<Equal<true, typeof data.ok>>
     expect(data.ok).toBe(true)
   })
 
@@ -1308,7 +1308,7 @@ describe('Redirect response - only types', () => {
     type Actual = InferResponseType<typeof req>
     type Expected =
       | {
-          ok: boolean
+          ok: true
         }
       | undefined
     type verify = Expect<Equal<Expected, Actual>>

--- a/src/context.ts
+++ b/src/context.ts
@@ -29,7 +29,7 @@ type HeaderRecord =
 /**
  * Data type can be a string, ArrayBuffer, Uint8Array (buffer), or ReadableStream.
  */
-export type Data = string | ArrayBuffer | ReadableStream | Uint8Array
+export type Data = string | ArrayBuffer | ReadableStream | Uint8Array<ArrayBuffer>
 
 /**
  * Interface for the execution context in a web worker or similar environment.

--- a/src/helper/ssg/ssg.test.tsx
+++ b/src/helper/ssg/ssg.test.tsx
@@ -367,7 +367,7 @@ describe('saveContentToFile function', () => {
   const gzFileArrayBuffer = gzFileBuffer.buffer.slice(
     gzFileBuffer.byteOffset,
     gzFileBuffer.byteLength + gzFileBuffer.byteOffset
-  )
+  ) as ArrayBuffer
   // PNG, red dot (1x1)
   const pngFileBuffer = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCCAAAALw',
@@ -376,7 +376,7 @@ describe('saveContentToFile function', () => {
   const pngFileArrayBuffer = pngFileBuffer.buffer.slice(
     pngFileBuffer.byteOffset,
     pngFileBuffer.byteLength + pngFileBuffer.byteOffset
-  )
+  ) as ArrayBuffer
 
   const fileData = [
     { routePath: '/', content: 'Home Page', mimeType: 'text/html' },

--- a/src/helper/websocket/index.test.ts
+++ b/src/helper/websocket/index.test.ts
@@ -72,10 +72,10 @@ describe('WSContext', () => {
   })
   it('Should send() works', async () => {
     let ws!: WSContext
-    const promise = new Promise<string | ArrayBuffer>((resolve) => {
+    const promise = new Promise<string | ArrayBuffer | Uint8Array<ArrayBuffer>>((resolve) => {
       ws = new WSContext({
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        send(data, _options) {
+        send(data: string | ArrayBuffer | Uint8Array<ArrayBuffer>, _options) {
           resolve(data)
         },
       } as WSContextInit)

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -70,7 +70,7 @@ export class WSContext<T = unknown> {
     this.url = init.url ? new URL(init.url) : null
     this.protocol = init.protocol ?? null
   }
-  send(source: string | ArrayBuffer | Uint8Array, options?: SendOptions): void {
+  send(source: string | ArrayBuffer | Uint8Array<ArrayBuffer>, options?: SendOptions): void {
     this.#init.send(source, options ?? {})
   }
   raw?: T
@@ -85,7 +85,12 @@ export class WSContext<T = unknown> {
   }
 }
 
-export type WSMessageReceive = string | Blob | ArrayBufferLike
+export type WSMessageReceive =
+  | string
+  | Blob
+  | ArrayBuffer
+  | SharedArrayBuffer
+  | Uint8Array<ArrayBuffer>
 
 export const createWSMessageEvent = (source: WSMessageReceive): MessageEvent<WSMessageReceive> => {
   return new MessageEvent<WSMessageReceive>('message', {

--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -1,16 +1,21 @@
-const mergeBuffers = (buffer1: ArrayBuffer | undefined, buffer2: Uint8Array): Uint8Array => {
+const mergeBuffers = (
+  buffer1: ArrayBuffer | undefined,
+  buffer2: Uint8Array<ArrayBuffer>
+): Uint8Array<ArrayBuffer> => {
   if (!buffer1) {
     return buffer2
   }
-  const merged = new Uint8Array(buffer1.byteLength + buffer2.byteLength)
+  const merged = new Uint8Array<ArrayBuffer>(
+    new ArrayBuffer(buffer1.byteLength + buffer2.byteLength)
+  )
   merged.set(new Uint8Array(buffer1), 0)
   merged.set(buffer2, buffer1.byteLength)
   return merged
 }
 
 export const generateDigest = async (
-  stream: ReadableStream<Uint8Array> | null,
-  generator: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
+  stream: ReadableStream<Uint8Array<ArrayBuffer>> | null,
+  generator: (body: Uint8Array<ArrayBuffer>) => ArrayBuffer | Promise<ArrayBuffer>
 ): Promise<string | null> => {
   if (!stream) {
     return null

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -9,7 +9,7 @@ import { generateDigest } from './digest'
 type ETagOptions = {
   retainedHeaders?: string[]
   weak?: boolean
-  generateDigest?: (body: Uint8Array) => ArrayBuffer | Promise<ArrayBuffer>
+  generateDigest?: (body: Uint8Array<ArrayBuffer>) => ArrayBuffer | Promise<ArrayBuffer>
 }
 
 /**
@@ -40,12 +40,12 @@ function initializeGenerator(
 ): ETagOptions['generateDigest'] | undefined {
   if (!generator) {
     if (crypto && crypto.subtle) {
-      generator = (body: Uint8Array) =>
+      generator = (body: Uint8Array<ArrayBuffer>) =>
         crypto.subtle.digest(
           {
             name: 'SHA-1',
           },
-          body
+          body.buffer
         )
     }
   }

--- a/src/middleware/jwk/index.test.ts
+++ b/src/middleware/jwk/index.test.ts
@@ -275,7 +275,7 @@ describe('JWK', () => {
 
     it('Should not authorize a token without header', async () => {
       const encodeJwtPart = (part: unknown): string =>
-        encodeBase64Url(utf8Encoder.encode(JSON.stringify(part))).replace(/=/g, '')
+        encodeBase64Url(utf8Encoder.encode(JSON.stringify(part)).buffer).replace(/=/g, '')
       const encodeSignaturePart = (buf: ArrayBufferLike): string =>
         encodeBase64Url(buf).replace(/=/g, '')
       const jwtSignWithoutHeader = async (payload: JWTPayload, privateKey: HonoJsonWebKey) => {
@@ -302,7 +302,7 @@ describe('JWK', () => {
 
     it('Should not authorize a token with missing "kid" in header', async () => {
       const encodeJwtPart = (part: unknown): string =>
-        encodeBase64Url(utf8Encoder.encode(JSON.stringify(part))).replace(/=/g, '')
+        encodeBase64Url(utf8Encoder.encode(JSON.stringify(part)).buffer).replace(/=/g, '')
       const encodeSignaturePart = (buf: ArrayBufferLike): string =>
         encodeBase64Url(buf).replace(/=/g, '')
       const jwtSignWithoutKid = async (payload: JWTPayload, privateKey: HonoJsonWebKey) => {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -268,7 +268,7 @@ describe('OnHandlerInterface', () => {
             }
           }
           output: {
-            success: boolean
+            success: true
           }
           outputFormat: 'json'
           status: ContentfulStatusCode
@@ -907,7 +907,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ng: boolean
+                  ng: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -915,7 +915,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ok: boolean
+                  ok: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -923,7 +923,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  default: boolean
+                  default: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -963,7 +963,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ng: boolean
+                  ng: true
                 }
                 outputFormat: 'json'
                 status: 400
@@ -971,7 +971,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ok: boolean
+                  ok: true
                 }
                 outputFormat: 'json'
                 status: 200
@@ -979,7 +979,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  default: boolean
+                  default: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -1017,7 +1017,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ng: boolean
+                  ng: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -1025,7 +1025,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ok: boolean
+                  ok: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -1033,7 +1033,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  default: boolean
+                  default: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -1073,7 +1073,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ng: boolean
+                  ng: true
                 }
                 outputFormat: 'json'
                 status: 400
@@ -1081,7 +1081,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  ok: boolean
+                  ok: true
                 }
                 outputFormat: 'json'
                 status: 200
@@ -1089,7 +1089,7 @@ describe('Different types using json()', () => {
             | {
                 input: {}
                 output: {
-                  default: boolean
+                  default: true
                 }
                 outputFormat: 'json'
                 status: ContentfulStatusCode
@@ -1116,7 +1116,7 @@ describe('json() in an async handler', () => {
         $get: {
           input: {}
           output: {
-            ok: boolean
+            ok: true
           }
           outputFormat: 'json'
           status: ContentfulStatusCode
@@ -1141,7 +1141,7 @@ describe('json() in an async handler', () => {
         $get: {
           input: {}
           output: {
-            ok: boolean
+            ok: true
           }
           outputFormat: 'json'
           status: 200

--- a/src/utils/encode.test.ts
+++ b/src/utils/encode.test.ts
@@ -3,8 +3,8 @@ import { decodeBase64Url, encodeBase64Url } from './encode'
 const toURLBase64 = (base64String: string): string =>
   base64String.replace(/\+|\//g, (m) => ({ '+': '-', '/': '_' }[m] ?? m))
 
-const str2UInt8Array = (s: string): Uint8Array => {
-  const buffer = new Uint8Array(new ArrayBuffer(s.length))
+const str2UInt8Array = (s: string): Uint8Array<ArrayBuffer> => {
+  const buffer = new Uint8Array<ArrayBuffer>(new ArrayBuffer(s.length))
   for (let i = 0, len = buffer.byteLength; i < len; i++) {
     buffer[i] = s.charCodeAt(i)
   }
@@ -48,7 +48,7 @@ describe('base64', () => {
     [str2UInt8Array('sure.'), 'c3VyZS4='],
   ])('%s, %s', (stdDecoded, stdEncoded) => {
     it('encode', () => {
-      const got = encodeBase64Url(stdDecoded)
+      const got = encodeBase64Url(stdDecoded.buffer)
       const want = toURLBase64(stdEncoded)
       expect(got).toStrictEqual(want)
     })

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -3,7 +3,7 @@
  * Encode utility.
  */
 
-export const decodeBase64Url = (str: string): Uint8Array => {
+export const decodeBase64Url = (str: string): Uint8Array<ArrayBuffer> => {
   return decodeBase64(str.replace(/_|-/g, (m) => ({ _: '/', '-': '+' }[m] ?? m)))
 }
 
@@ -22,9 +22,9 @@ export const encodeBase64 = (buf: ArrayBufferLike): string => {
 }
 
 // atob does not support utf-8 characters. So we need a little bit hack.
-export const decodeBase64 = (str: string): Uint8Array => {
+export const decodeBase64 = (str: string): Uint8Array<ArrayBuffer> => {
   const binary = atob(str)
-  const bytes = new Uint8Array(new ArrayBuffer(binary.length))
+  const bytes = new Uint8Array<ArrayBuffer>(new ArrayBuffer(binary.length))
   const half = binary.length / 2
   for (let i = 0, j = binary.length - 1; i <= half; i++, j--) {
     bytes[i] = binary.charCodeAt(i)

--- a/src/utils/jwt/jws.ts
+++ b/src/utils/jwt/jws.ts
@@ -47,7 +47,7 @@ export async function verifying(
   return await crypto.subtle.verify(algorithm, cryptoKey, signature, data)
 }
 
-function pemToBinary(pem: string): Uint8Array {
+function pemToBinary(pem: string): Uint8Array<ArrayBuffer> {
   return decodeBase64(pem.replace(/-+(BEGIN|END).*/g, '').replace(/\s/g, ''))
 }
 

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -339,7 +339,10 @@ describe('JWT', () => {
     }
     const secret = await crypto.subtle.importKey(
       'raw',
-      Buffer.from('cefb73234d5fae4bf27662900732b52943e8d53e871fe0f353da95de4599c21d', 'hex'),
+      Buffer.from(
+        'cefb73234d5fae4bf27662900732b52943e8d53e871fe0f353da95de4599c21d',
+        'hex'
+      ) as BufferSource,
       algorithm,
       false,
       ['sign', 'verify']
@@ -355,7 +358,10 @@ describe('JWT', () => {
 
     const invalidSecret = await crypto.subtle.importKey(
       'raw',
-      Buffer.from('cefb73234d5fae4bf27662900732b52943e8d53e871fe0f353da95de41111111', 'hex'),
+      Buffer.from(
+        'cefb73234d5fae4bf27662900732b52943e8d53e871fe0f353da95de41111111',
+        'hex'
+      ) as BufferSource,
       algorithm,
       false,
       ['sign', 'verify']

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -938,7 +938,7 @@ it('`on`', () => {
           }
         }
         output: {
-          success: boolean
+          success: true
         }
         outputFormat: 'json'
         status: ContentfulStatusCode


### PR DESCRIPTION
This PR updates the `typescript` version and fixes the TypeScript error caused by the update.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
