### PR TITLE
fix(language-detector): Detect language from path after getPath changed

### DIFF
--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -159,7 +159,8 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
  */
 export function detectFromPath(c: Context, options: DetectorOptions): string | undefined {
   try {
-    const pathSegments = c.req.path.split('/').filter(Boolean)
+    const url = new URL(c.req.url)
+    const pathSegments = url.pathname.split('/').filter(Boolean)
     const langSegment = pathSegments[options.lookupFromPathIndex]
     return normalizeLanguage(langSegment, options)
   } catch {


### PR DESCRIPTION
Use the source URL from the request to detect language from path. Because `c.req.path` will be updated by the `getPath` method.
```javascript
const languages = ['en', 'es', 'ru']
const app = new Hono({

  getPath: (req) => {
    const url = new URL(req.url)
    let pathname = url.pathname
    for (let idx = 0; idx < languages.length; idx++) {
      if (pathname.startsWith('/' + languages[idx] + '/')) {
        pathname = pathname.replaceAll('/' + languages[idx] + '/', '/')
        break
      }
    }
    return pathname
  }

})
```
Detect language from the path:

```javascript
app.use(languageDetector({
  debug: true,
  order: ['querystring', 'path', 'cookie', 'header'],
  lookupFromPathIndex: 0, // /en/profile → index 0 = 'en'
  convertDetectedLanguage: (lang) => lang.split('-')[0],
  supportedLanguages: languages, // Must include fallback
  fallbackLanguage: 'en', // Required
}))
```

```javascript
app.get('/home', (c) => {...})
```

Then you can visit '/home' route with this url `https://example.com/en/home` .

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
