### PR TITLE
fix(aws-lambda): preserve percent-encoded values in query strings

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -383,15 +383,18 @@ export class EventV1Processor extends EventProcessor<Exclude<LambdaEvent, APIGat
 
   protected getQueryString(event: Exclude<LambdaEvent, APIGatewayProxyEventV2>): string {
     // In the case of gateway Integration either queryStringParameters or multiValueQueryStringParameters can be present not both
+    // API Gateway passes decoded values, so we need to re-encode them to preserve the original URL
     if (event.multiValueQueryStringParameters) {
       return Object.entries(event.multiValueQueryStringParameters || {})
         .filter(([, value]) => value)
-        .map(([key, value]) => `${key}=${value.join(`&${key}=`)}`)
+        .map(([key, values]) =>
+          values.map((value) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join('&')
+        )
         .join('&')
     } else {
       return Object.entries(event.queryStringParameters || {})
         .filter(([, value]) => value)
-        .map(([key, value]) => `${key}=${value}`)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value || '')}`)
         .join('&')
     }
   }


### PR DESCRIPTION
Fixes #4358

API Gateway provides decoded query parameters to Lambda, but `c.req.url` should preserve the original percent-encoded format. This change ensures query parameters are properly re-encoded when constructing the URL.

Also refactored the test code.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
