### PR TITLE
feat(cors): Allow async functions for `origin` and `allowMethods`

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -229,7 +229,7 @@ describe('CORS by Middleware', () => {
   })
 
   it('Allow origins by promise returning function', async () => {
-    let req = new Request('http://localhost/api4/abc', {
+    let req = new Request('http://localhost/api8/abc', {
       headers: {
         Origin: 'http://subdomain.example.com',
       },
@@ -237,11 +237,11 @@ describe('CORS by Middleware', () => {
     let res = await app.request(req)
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://subdomain.example.com')
 
-    req = new Request('http://localhost/api4/abc')
+    req = new Request('http://localhost/api8/abc')
     res = await app.request(req)
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
 
-    req = new Request('http://localhost/api4/abc', {
+    req = new Request('http://localhost/api8/abc', {
       headers: {
         Referer: 'http://evil-example.com/',
       },

--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -58,6 +58,32 @@ describe('CORS by Middleware', () => {
     })
   )
 
+  app.use(
+    '/api8/*',
+    cors({
+      origin: (origin) =>
+        new Promise<string>((resolve) =>
+          resolve(origin.endsWith('.example.com') ? origin : 'http://example.com')
+        ),
+    })
+  )
+
+  app.use(
+    '/api9/*',
+    cors({
+      origin: (origin) =>
+        new Promise<string>((resolve) => resolve(origin === 'http://example.com' ? origin : '*')),
+      allowMethods: (origin) =>
+        new Promise<string[]>((resolve) =>
+          resolve(
+            origin === 'http://example.com'
+              ? ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE']
+              : ['GET', 'HEAD']
+          )
+        ),
+    })
+  )
+
   app.get('/api/abc', (c) => {
     return c.json({ success: true })
   })
@@ -202,6 +228,28 @@ describe('CORS by Middleware', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
   })
 
+  it('Allow origins by promise returning function', async () => {
+    let req = new Request('http://localhost/api4/abc', {
+      headers: {
+        Origin: 'http://subdomain.example.com',
+      },
+    })
+    let res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://subdomain.example.com')
+
+    req = new Request('http://localhost/api4/abc')
+    res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+
+    req = new Request('http://localhost/api4/abc', {
+      headers: {
+        Referer: 'http://evil-example.com/',
+      },
+    })
+    res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+  })
+
   it('With raw Response object', async () => {
     const res = await app.request('http://localhost/api5/abc')
 
@@ -231,6 +279,28 @@ describe('CORS by Middleware', () => {
     expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD,POST,PATCH,DELETE')
 
     const req2 = new Request('http://localhost/api7/abc', {
+      headers: {
+        Origin: 'http://example.org',
+      },
+      method: 'OPTIONS',
+    })
+    const res2 = await app.request(req2)
+    expect(res2.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(res2.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD')
+  })
+
+  it('Allow methods by promise returning function', async () => {
+    const req = new Request('http://localhost/api9/abc', {
+      headers: {
+        Origin: 'http://example.com',
+      },
+      method: 'OPTIONS',
+    })
+    const res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD,POST,PATCH,DELETE')
+
+    const req2 = new Request('http://localhost/api9/abc', {
       headers: {
         Origin: 'http://example.org',
       },

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -7,8 +7,11 @@ import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
 type CORSOptions = {
-  origin: string | string[] | ((origin: string, c: Context) => string | undefined | null)
-  allowMethods?: string[] | ((origin: string, c: Context) => string[])
+  origin:
+    | string
+    | string[]
+    | ((origin: string, c: Context) => Promise<string> | string | undefined | null)
+  allowMethods?: string[] | ((origin: string, c: Context) => Promise<string[]> | string[])
   allowHeaders?: string[]
   maxAge?: number
   credentials?: boolean
@@ -21,8 +24,8 @@ type CORSOptions = {
  * @see {@link https://hono.dev/docs/middleware/builtin/cors}
  *
  * @param {CORSOptions} [options] - The options for the CORS middleware.
- * @param {string | string[] | ((origin: string, c: Context) => string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
- * @param {string[] | ((origin: string, c: Context) => string[])} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string | string[] | ((origin: string, c: Context) => Promise<string> | string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
+ * @param {string[] | ((origin: string, c: Context) => Promise<string[]> | string[])} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
  * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
  * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
  * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
@@ -95,7 +98,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
       c.res.headers.set(key, value)
     }
 
-    const allowOrigin = findAllowOrigin(c.req.header('origin') || '', c)
+    const allowOrigin = await findAllowOrigin(c.req.header('origin') || '', c)
     if (allowOrigin) {
       set('Access-Control-Allow-Origin', allowOrigin)
     }
@@ -125,7 +128,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
         set('Access-Control-Max-Age', opts.maxAge.toString())
       }
 
-      const allowMethods = findAllowMethods(c.req.header('origin') || '', c)
+      const allowMethods = await findAllowMethods(c.req.header('origin') || '', c)
       if (allowMethods.length) {
         set('Access-Control-Allow-Methods', allowMethods.join(','))
       }


### PR DESCRIPTION
This PR updates the CORS middleware to support asynchronous functions for the `origin` and `allowMethods` options.

This allows for dynamic, asynchronous logic (e.g., database lookups) when determining CORS headers.

```ts
app.use(
  '/api/*',
  cors({
    origin: async (origin) => {
      // e.g. check an allow-list in a database
      const isAllowed = await db.isOriginAllowed(origin)
      return isAllowed ? origin : 'https://fallback.example.com'
    },
  })
)
```

This change is backward-compatible.