### PR TITLE
feat(cors): Correct origin function return type asynchronously returning null or undefined for origin

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -10,7 +10,10 @@ type CORSOptions = {
   origin:
     | string
     | string[]
-    | ((origin: string, c: Context) => Promise<string> | string | undefined | null)
+    | ((
+        origin: string,
+        c: Context
+      ) => Promise<string | undefined | null> | string | undefined | null)
   allowMethods?: string[] | ((origin: string, c: Context) => Promise<string[]> | string[])
   allowHeaders?: string[]
   maxAge?: number
@@ -24,7 +27,7 @@ type CORSOptions = {
  * @see {@link https://hono.dev/docs/middleware/builtin/cors}
  *
  * @param {CORSOptions} [options] - The options for the CORS middleware.
- * @param {string | string[] | ((origin: string, c: Context) => Promise<string> | string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
+ * @param {string | string[] | ((origin: string, c: Context) => Promise<string | undefined | null> | string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
  * @param {string[] | ((origin: string, c: Context) => Promise<string[]> | string[])} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
  * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
  * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.


### PR DESCRIPTION
Forgot about that in [this PR](https://github.com/honojs/hono/pull/4373)

Updates the `origin` function's return type. The `Promise` can now resolve to `undefined` or `null`, aligning it with the synchronous return type.