### PR TITLE
nit: Export CORSOptions type

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -6,7 +6,7 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
-type CORSOptions = {
+export type CORSOptions = {
   origin:
     | string
     | string[]


### PR DESCRIPTION
This will be useful to define custom CORS middlewares while still passing down default options without using something ugly like `NonNullable<Parameters<typeof cors>[0]>` 😅 