### PR TITLE
fix: cloning raw HonoRequest before consuming

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -227,7 +227,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
       })
     }
 
-    return (bodyCache[key] = raw[key]())
+    const clonedRaw = raw.clone()
+    return (bodyCache[key] = clonedRaw[key]())
   }
 
   /**


### PR DESCRIPTION
**Problem**

After using Hono validators, the `raw` Request obejct gets consumed during body parsing, making it unusable for external libraries like `better-auth`.
This results in the error:

```shell
TypeError: Cannot construct a Request with a Request object that has already been used.
```

**Root Cause**

The issue occurs in the `#cachedBody` method in `HonoRequest`. When parsing request bodies (json, text, etc.), the method directly calls parsing methods on the raw Request object, which consumes its body stream. Once consumed, the Request cannot be cloned or reused by external libraries.

**Solution**

Clone the raw Request object before consuming its body. This ensures that:
- The original `c.req.raw` remains pristine and can be used by external libraries
- Hono's internal body caching still works correctly
- No breaking changes to existing functionality

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code (Updated a private method, not sure if applicable)
