### PR TITLE
[WIP] feat: passing middleware types

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -944,8 +944,8 @@ describe('Infer the response types from middlewares', () => {
   it('Should infer all possible response statuses', async () => {
     const req = await client.posts.$post({
       json: {
-        title: 'hello'
-      }
+        title: 'hello',
+      },
     })
 
     type Actual = typeof req.status
@@ -956,20 +956,20 @@ describe('Infer the response types from middlewares', () => {
   it('Should properly assign response to corresponding status', async () => {
     const req = await client.posts.$post({
       json: {
-        title: 'hello'
-      }
+        title: 'hello',
+      },
     })
 
     if (req.status === 200) {
-      const data = await req.json();
+      const data = await req.json()
 
       expectTypeOf(data).toEqualTypeOf<{ title: string }>()
     } else if (req.status === 400) {
-      const data = await req.json();
+      const data = await req.json()
 
       expectTypeOf(data).toEqualTypeOf<{ error: 'Bad request' }>()
     } else if (req.status === 401) {
-      const data = await req.json();
+      const data = await req.json()
 
       expectTypeOf(data).toEqualTypeOf<{ error: 'Unauthorized' }>()
     }

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -870,6 +870,112 @@ describe('Infer the response type with different status codes', () => {
   })
 })
 
+describe('Infer the response types from middlewares', () => {
+  const app = new Hono()
+    .get(
+      '/',
+      validator('query', (input, c) => {
+        if (!input.page || typeof input.page !== 'string') {
+          return c.json({ error: 'Bad request' as const }, 400)
+        }
+
+        return input as { page: string }
+      }),
+      async (c) => {
+        const query = c.req.valid('query')
+        return c.json({ data: 'foo', page: query.page }, 200)
+      }
+    )
+    .post(
+      '/posts',
+      async (c, next) => {
+        const auth = c.req.header('authorization')
+        if (!auth || !auth.startsWith('Bearer ')) {
+          return c.json({ error: 'Unauthorized' as const }, 401)
+        }
+        return next()
+      },
+      validator('json', (input, c) => {
+        if (!input.title) {
+          return c.json({ error: 'Bad request' as const }, 400)
+        }
+
+        return input as { title: string }
+      }),
+      (c) => {
+        const data = c.req.valid('json')
+        return c.json(data, 200)
+      }
+    )
+
+  type AppType = typeof app
+  const client = hc<AppType>('', { fetch: app.request })
+
+  it('Should infer response type of status 200 correctly', () => {
+    const req = client.posts.$post
+
+    type Actual = InferResponseType<typeof req, 200>
+    type Expected = {
+      title: string
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer response type of status 400 correctly', () => {
+    const req = client.posts.$post
+
+    type Actual = InferResponseType<typeof req, 400>
+    type Expected = {
+      error: 'Bad request'
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer response type of status 401 correctly', () => {
+    const req = client.posts.$post
+
+    type Actual = InferResponseType<typeof req, 401>
+    type Expected = {
+      error: 'Unauthorized'
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer all possible response statuses', async () => {
+    const req = await client.posts.$post({
+      json: {
+        title: 'hello'
+      }
+    })
+
+    type Actual = typeof req.status
+    type Expected = 200 | 400 | 401
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should properly assign response to corresponding status', async () => {
+    const req = await client.posts.$post({
+      json: {
+        title: 'hello'
+      }
+    })
+
+    if (req.status === 200) {
+      const data = await req.json();
+
+      expectTypeOf(data).toEqualTypeOf<{ title: string }>()
+    } else if (req.status === 400) {
+      const data = await req.json();
+
+      expectTypeOf(data).toEqualTypeOf<{ error: 'Bad request' }>()
+    } else if (req.status === 401) {
+      const data = await req.json();
+
+      expectTypeOf(data).toEqualTypeOf<{ error: 'Unauthorized' }>()
+    }
+  })
+})
+
 describe('$url() with a param option', () => {
   const app = new Hono()
     .get('/posts/:id/comments', (c) => c.json({ ok: true }))

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -305,9 +305,9 @@ export class Factory<E extends Env = Env, P extends string = string> {
     return app
   }
 
-  createMiddleware = <I extends Input = {}>(
-    middleware: MiddlewareHandler<E, P, I>
-  ): MiddlewareHandler<E, P, I> => middleware
+  createMiddleware = <I extends Input = {}, R extends HandlerResponse<any> = Response>(
+    middleware: MiddlewareHandler<E, P, I, R>
+  ): MiddlewareHandler<E, P, I, R> => middleware
 
   createHandlers: CreateHandlersInterface<E, P> = (...handlers: any) => {
     // @ts-expect-error this should not be typed
@@ -323,7 +323,8 @@ export const createFactory = <E extends Env = Env, P extends string = string>(in
 export const createMiddleware = <
   E extends Env = any,
   P extends string = string,
-  I extends Input = {}
+  I extends Input = {},
+  R extends HandlerResponse<any> = Response
 >(
-  middleware: MiddlewareHandler<E, P, I>
-): MiddlewareHandler<E, P, I> => middleware
+  middleware: MiddlewareHandler<E, P, I, R>
+): MiddlewareHandler<E, P, I, R> => middleware

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -109,10 +109,12 @@ describe('HandlerInterface', () => {
     const middleware: MiddlewareHandler<
       Env,
       '/foo',
-      { in: { json: Payload }; out: { json: Payload } }
+      { in: { json: Payload }; out: { json: Payload } },
+      never
     > = async (_c, next) => {
       await next()
     }
+
     test('Context and AppType', () => {
       const route = app.get('/foo', middleware, (c) => {
         type Expected = Context<Env, '/foo', { in: { json: Payload }; out: { json: Payload } }>
@@ -145,7 +147,7 @@ describe('HandlerInterface', () => {
 
   describe('With path parameters', () => {
     const app = new Hono<Env>()
-    const middleware: MiddlewareHandler<Env, '/post/:id'> = async (_c, next) => {
+    const middleware: MiddlewareHandler<Env, '/post/:id', {}, never> = async (_c, next) => {
       await next()
     }
     it('Should have the `param` type', () => {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -2410,7 +2410,7 @@ describe('RPC supports Middleware responses', () => {
     const res = await client.single.$get()
 
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2423,10 +2423,10 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.double.$get()
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2440,13 +2440,13 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.foo.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2461,16 +2461,16 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.bar.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 300) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2486,19 +2486,19 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.baz.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 300) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
     }
     if (res.status === 201) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2515,22 +2515,22 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.qux.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 300) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
     }
     if (res.status === 201) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
     }
     if (res.status === 202) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2548,25 +2548,25 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.seven.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 300) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
     }
     if (res.status === 201) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
     }
     if (res.status === 202) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
     }
     if (res.status === 203) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2585,28 +2585,28 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.eight.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 401) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
     }
     if (res.status === 300) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
     }
     if (res.status === 201) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
     }
     if (res.status === 202) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
     }
     if (res.status === 203) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 
@@ -2626,31 +2626,31 @@ describe('RPC supports Middleware responses', () => {
     const client = hc<typeof app>('http://localhost', { fetch: app.request })
     const res = await client.nine.$get()
     if (res.status === 500) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
     }
     if (res.status === 400) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
     }
     if (res.status === 401) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
     }
     if (res.status === 403) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>()
     }
     if (res.status === 300) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
     }
     if (res.status === 201) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
     }
     if (res.status === 202) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
     }
     if (res.status === 203) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>()
     }
     if (res.status === 200) {
-      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
     }
   })
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectTypeOf } from 'vitest'
+import { hc } from './client'
 import { Context } from './context'
 import { createMiddleware } from './helper/factory'
 import { Hono } from './hono'
@@ -2399,5 +2400,430 @@ describe('status code', () => {
 
     type Actual = ExtractSchema<typeof router>['/']['$get']['status']
     expectTypeOf<Actual>().toEqualTypeOf<204 | 201 | 200>()
+  })
+})
+
+describe('RPC supports Middleware responses', () => {
+  it('Should handle the responses from 1 handler', async () => {
+    const app = new Hono().get('/single', (c) => c.json({ '200': true }, 200))
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.single.$get()
+
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 2 handlers', async () => {
+    const app = new Hono().get(
+      '/double',
+      async (c) => c.json({ '400': true }, 400),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.double.$get()
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 3 handlers', async () => {
+    const app = new Hono().get(
+      '/foo',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.foo.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 4 handlers', async () => {
+    const app = new Hono().get(
+      '/bar',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '300': true }, 300),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.bar.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 5 handlers', async () => {
+    const app = new Hono().get(
+      '/baz',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '300': true }, 300),
+      async (c) => c.json({ '201': true }, 201),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.baz.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+    }
+    if (res.status === 201) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 6 handlers', async () => {
+    const app = new Hono().get(
+      '/qux',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '300': true }, 300),
+      async (c) => c.json({ '201': true }, 201),
+      async (c) => c.json({ '202': true }, 202),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.qux.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+    }
+    if (res.status === 201) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+    }
+    if (res.status === 202) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 7 handlers', async () => {
+    const app = new Hono().get(
+      '/seven',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '300': true }, 300),
+      async (c) => c.json({ '201': true }, 201),
+      async (c) => c.json({ '202': true }, 202),
+      async (c) => c.json({ '203': true }, 203),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.seven.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+    }
+    if (res.status === 201) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+    }
+    if (res.status === 202) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+    }
+    if (res.status === 203) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 8 handlers', async () => {
+    const app = new Hono().get(
+      '/eight',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '401': true }, 401),
+      async (c) => c.json({ '300': true }, 300),
+      async (c) => c.json({ '201': true }, 201),
+      async (c) => c.json({ '202': true }, 202),
+      async (c) => c.json({ '203': true }, 203),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.eight.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 401) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>();
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+    }
+    if (res.status === 201) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+    }
+    if (res.status === 202) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+    }
+    if (res.status === 203) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 9 handlers', async () => {
+    const app = new Hono().get(
+      '/nine',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '401': true }, 401),
+      async (c) => c.json({ '403': true }, 403),
+      async (c) => c.json({ '300': true }, 300),
+      async (c) => c.json({ '201': true }, 201),
+      async (c) => c.json({ '202': true }, 202),
+      async (c) => c.json({ '203': true }, 203),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.nine.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>();
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>();
+    }
+    if (res.status === 401) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>();
+    }
+    if (res.status === 403) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>();
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>();
+    }
+    if (res.status === 201) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>();
+    }
+    if (res.status === 202) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>();
+    }
+    if (res.status === 203) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>();
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>();
+    }
+  })
+
+  it('Should handle the responses from 10 handlers', async () => {
+    const app = new Hono().get(
+      '/ten',
+      async (c) => c.json({ '500': true }, 500),
+      async (c) => c.json({ '400': true }, 400),
+      async (c) => c.json({ '401': true }, 401),
+      async (c) => c.json({ '403': true }, 403),
+      async (c) => c.json({ '404': true }, 404),
+      async (c) => c.json({ '300': true }, 300),
+      async (c) => c.json({ '201': true }, 201),
+      async (c) => c.json({ '202': true }, 202),
+      async (c) => c.json({ '203': true }, 203),
+      (c) => c.json({ '200': true }, 200)
+    )
+    const client = hc<typeof app>('http://localhost', { fetch: app.request })
+    const res = await client.ten.$get()
+    if (res.status === 500) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 500: true }>()
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+    }
+    if (res.status === 401) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+    }
+    if (res.status === 403) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>()
+    }
+    if (res.status === 404) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 404: true }>()
+    }
+    if (res.status === 300) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
+    }
+    if (res.status === 201) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
+    }
+    if (res.status === 202) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
+    }
+    if (res.status === 203) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>()
+    }
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+    }
+  })
+
+  const middleware = createMiddleware(async () => {})
+  const handler = (c: Context) => c.json({ ok: true }, 200)
+  type Expected = {
+    '/': {
+      $get: {
+        input: {}
+        output: {
+          ok: true
+        }
+        outputFormat: 'json'
+        status: 200
+      }
+    }
+  }
+
+  it('Should infer the correct response type with 1 middleware and 1 handler', () => {
+    const routes = new Hono().get('/', middleware, handler)
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 1 middleware and 2 handler', () => {
+    const routes = new Hono().get('/', middleware, handler, handler)
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 2 middleware and 1 handler', () => {
+    const routes = new Hono().get('/', middleware, middleware, handler)
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 3 middleware and 1 handler', () => {
+    const routes = new Hono().get('/', middleware, middleware, middleware, handler)
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 4 middleware and 1 handler', () => {
+    const routes = new Hono().get('/', middleware, middleware, middleware, middleware, handler)
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 5 middleware and 1 handler', () => {
+    const routes = new Hono().get(
+      '/',
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      handler
+    )
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 6 middleware and 1 handler', () => {
+    const routes = new Hono().get(
+      '/',
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      handler
+    )
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 7 middleware and 1 handler', () => {
+    const routes = new Hono().get(
+      '/',
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      handler
+    )
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 8 middleware and 1 handler', () => {
+    const routes = new Hono().get(
+      '/',
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      handler
+    )
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  it('Should infer the correct response type with 9 middleware and 1 handler', () => {
+    const routes = new Hono().get(
+      '/',
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      middleware,
+      handler
+    )
+    type Actual = ExtractSchema<typeof routes>
+    type verify = Expect<Equal<Expected, Actual>>
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1133,7 +1133,7 @@ export interface MiddlewareHandlerInterface<
   // app.get(path, handler)
   <P extends string, MergedPath extends MergePath<BasePath, P>, E2 extends Env = E>(
     path: P,
-    handler: MiddlewareHandler<E2, MergedPath>
+    handler: MiddlewareHandler<E2, MergedPath, any, any>
   ): HonoBase<IntersectNonAnyTypes<[E, E2]>, ChangePathOfSchema<S, MergedPath>, BasePath>
 
   // app.use(handler x3)
@@ -1143,7 +1143,11 @@ export interface MiddlewareHandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     P extends string = MergePath<BasePath, ExtractStringKey<S>>
   >(
-    ...handlers: [MiddlewareHandler<E2, P>, MiddlewareHandler<E3, P>, MiddlewareHandler<E4, P>]
+    ...handlers: [
+      MiddlewareHandler<E2, P, any, any>,
+      MiddlewareHandler<E3, P, any, any>,
+      MiddlewareHandler<E4, P, any, any>
+    ]
   ): HonoBase<IntersectNonAnyTypes<[E, E2, E3, E4]>, S, BasePath>
 
   // app.get(path, handler x2)
@@ -2420,18 +2424,6 @@ export type ExtractSchemaForStatusCode<T, Status extends number> = {
     >
   }
 }
-
-// export type ExtractHandlerResponse<T> = T extends (c: any, next: any) => Promise<infer R>
-//   ? R extends void
-//     ? never // Handler returns void → never
-//     : R extends Response | TypedResponse<any, any, any>
-//     ? R // Handler returns a response → keep it
-//     : never // Something else → never
-//   : T extends (c: any, next: any) => infer R
-//   ? R extends Response | TypedResponse<any, any, any>
-//     ? R
-//     : never
-//   : never
 
 export type ExtractHandlerResponse<T> = T extends (c: any, next: any) => Promise<infer R>
   ? Exclude<R, void> extends never

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,12 +130,16 @@ export interface HandlerInterface<
     I2 extends Input = I,
     R extends HandlerResponse<any> = any,
     E2 extends Env = E,
-    E3 extends Env = IntersectNonAnyTypes<[E, E2]>
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>
   >(
-    ...handlers: [H<E2, P, I>, H<E3, P, I2, R>]
+    ...handlers: [H<E2, P, I> & M1, H<E3, P, I2, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, P, I2, MergeTypedResponse<R>>,
+    S & ToSchema<M, P, I2, MergeTypedResponse<R> | MergeTypedResponse<MR1>>,
     BasePath
   >
 
@@ -160,12 +164,19 @@ export interface HandlerInterface<
     I3 extends Input = I & I2,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
-    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
+    E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>
   >(
-    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3, R>]
+    ...handlers: [H<E2, P, I> & M1, H<E3, P, I2> & M2, H<E4, P, I3, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, P, I3, MergeTypedResponse<R>>,
+    S &
+      ToSchema<M, P, I3, MergeTypedResponse<R> | MergeTypedResponse<MR1> | MergeTypedResponse<MR2>>,
     BasePath
   >
 
@@ -202,12 +213,29 @@ export interface HandlerInterface<
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
-    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
+    E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>
   >(
-    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4, R>]
+    ...handlers: [H<E2, P, I> & M1, H<E3, P, I2> & M2, H<E4, P, I3> & M3, H<E5, P, I4, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, P, I4, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I4,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+      >,
     BasePath
   >
 
@@ -230,11 +258,7 @@ export interface HandlerInterface<
     MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>
   >(
     path: P,
-    ...handlers: [
-      H<E2, MergedPath, I, any> & M1,
-      H<E3, MergedPath, I2, any> & M2,
-      H<E4, MergedPath, I3, R>
-    ]
+    ...handlers: [H<E2, MergedPath, I> & M1, H<E3, MergedPath, I2> & M2, H<E4, MergedPath, I3, R>]
   ): HonoBase<
     E,
     S &
@@ -260,12 +284,38 @@ export interface HandlerInterface<
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
+    E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    M4 extends H<E5, P, any> = H<E5, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>
   >(
-    ...handlers: [H<E2, P, I>, H<E3, P, I2>, H<E4, P, I3>, H<E5, P, I4>, H<E6, P, I5, R>]
+    ...handlers: [
+      H<E2, P, I> & M1,
+      H<E3, P, I2> & M2,
+      H<E4, P, I3> & M3,
+      H<E5, P, I4> & M4,
+      H<E6, P, I5, R>
+    ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, P, I5, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I5,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+      >,
     BasePath
   >
 
@@ -328,19 +378,42 @@ export interface HandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    M4 extends H<E5, P, any> = H<E5, P, any>,
+    M5 extends H<E6, P, any> = H<E6, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>
   >(
     ...handlers: [
-      H<E2, P, I>,
-      H<E3, P, I2>,
-      H<E4, P, I3>,
-      H<E5, P, I4>,
-      H<E6, P, I5>,
+      H<E2, P, I> & M1,
+      H<E3, P, I2> & M2,
+      H<E4, P, I3> & M3,
+      H<E5, P, I4> & M4,
+      H<E6, P, I5> & M5,
       H<E7, P, I6, R>
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, P, I6, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I6,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+      >,
     BasePath
   >
 
@@ -372,10 +445,10 @@ export interface HandlerInterface<
   >(
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I> & MR1,
-      H<E3, MergedPath, I2> & MR2,
-      H<E4, MergedPath, I3> & MR3,
-      H<E5, MergedPath, I4> & MR4,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
       H<E6, MergedPath, I5, R>
     ]
   ): HonoBase<
@@ -411,20 +484,46 @@ export interface HandlerInterface<
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    M4 extends H<E5, P, any> = H<E5, P, any>,
+    M5 extends H<E6, P, any> = H<E6, P, any>,
+    M6 extends H<E7, P, any> = H<E7, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>
   >(
     ...handlers: [
-      H<E2, P, I>,
-      H<E3, P, I2>,
-      H<E4, P, I3>,
-      H<E5, P, I4>,
-      H<E6, P, I5>,
-      H<E7, P, I6>,
+      H<E2, P, I> & M1,
+      H<E3, P, I2> & M2,
+      H<E4, P, I3> & M3,
+      H<E5, P, I4> & M4,
+      H<E6, P, I5> & M5,
+      H<E7, P, I6> & M6,
       H<E8, P, I7, R>
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, P, I7, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I7,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+      >,
     BasePath
   >
 
@@ -444,18 +543,45 @@ export interface HandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
+    E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, any> = H<E2, MergedPath, any>,
+    M2 extends H<E3, MergedPath, any> = H<E3, MergedPath, any>,
+    M3 extends H<E4, MergedPath, any> = H<E4, MergedPath, any>,
+    M4 extends H<E5, MergedPath, any> = H<E5, MergedPath, any>,
+    M5 extends H<E6, MergedPath, any> = H<E6, MergedPath, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>
   >(
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
       H<E7, MergedPath, I6, R>
     ]
-  ): HonoBase<E, S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponse<R>>, BasePath>
+  ): HonoBase<
+    E,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I6,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+      >,
+    BasePath
+  >
 
   // app.get(handler x 8)
   <
@@ -476,21 +602,50 @@ export interface HandlerInterface<
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    M4 extends H<E5, P, any> = H<E5, P, any>,
+    M5 extends H<E6, P, any> = H<E6, P, any>,
+    M6 extends H<E7, P, any> = H<E7, P, any>,
+    M7 extends H<E8, P, any> = H<E8, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>,
+    MR7 extends HandlerResponse<any> = ExtractHandlerResponse<M7>
   >(
     ...handlers: [
-      H<E2, P, I>,
-      H<E3, P, I2>,
-      H<E4, P, I3>,
-      H<E5, P, I4>,
-      H<E6, P, I5>,
-      H<E7, P, I6>,
-      H<E8, P, I7>,
+      H<E2, P, I> & M1,
+      H<E3, P, I2> & M2,
+      H<E4, P, I3> & M3,
+      H<E5, P, I4> & M4,
+      H<E6, P, I5> & M5,
+      H<E7, P, I6> & M6,
+      H<E8, P, I7> & M7,
       H<E9, P, I8, R>
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, P, I8, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I8,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+        | MergeTypedResponse<MR7>
+      >,
     BasePath
   >
 
@@ -512,19 +667,49 @@ export interface HandlerInterface<
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
+    E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, any> = H<E2, MergedPath, any>,
+    M2 extends H<E3, MergedPath, any> = H<E3, MergedPath, any>,
+    M3 extends H<E4, MergedPath, any> = H<E4, MergedPath, any>,
+    M4 extends H<E5, MergedPath, any> = H<E5, MergedPath, any>,
+    M5 extends H<E6, MergedPath, any> = H<E6, MergedPath, any>,
+    M6 extends H<E7, MergedPath, any> = H<E7, MergedPath, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>
   >(
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
       H<E8, MergedPath, I7, R>
     ]
-  ): HonoBase<E, S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponse<R>>, BasePath>
+  ): HonoBase<
+    E,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I7,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+      >,
+    BasePath
+  >
 
   // app.get(handler x 9)
   <
@@ -547,22 +732,54 @@ export interface HandlerInterface<
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    M4 extends H<E5, P, any> = H<E5, P, any>,
+    M5 extends H<E6, P, any> = H<E6, P, any>,
+    M6 extends H<E7, P, any> = H<E7, P, any>,
+    M7 extends H<E8, P, any> = H<E8, P, any>,
+    M8 extends H<E9, P, any> = H<E9, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>,
+    MR7 extends HandlerResponse<any> = ExtractHandlerResponse<M7>,
+    MR8 extends HandlerResponse<any> = ExtractHandlerResponse<M8>
   >(
     ...handlers: [
-      H<E2, P, I>,
-      H<E3, P, I2>,
-      H<E4, P, I3>,
-      H<E5, P, I4>,
-      H<E6, P, I5>,
-      H<E7, P, I6>,
-      H<E8, P, I7>,
-      H<E9, P, I8>,
+      H<E2, P, I> & M1,
+      H<E3, P, I2> & M2,
+      H<E4, P, I3> & M3,
+      H<E5, P, I4> & M4,
+      H<E6, P, I5> & M5,
+      H<E7, P, I6> & M6,
+      H<E8, P, I7> & M7,
+      H<E9, P, I8> & M8,
       H<E10, P, I9, R>
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, P, I9, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I9,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+        | MergeTypedResponse<MR7>
+        | MergeTypedResponse<MR8>
+      >,
     BasePath
   >
 
@@ -586,20 +803,53 @@ export interface HandlerInterface<
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
+    E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, any> = H<E2, MergedPath, any>,
+    M2 extends H<E3, MergedPath, any> = H<E3, MergedPath, any>,
+    M3 extends H<E4, MergedPath, any> = H<E4, MergedPath, any>,
+    M4 extends H<E5, MergedPath, any> = H<E5, MergedPath, any>,
+    M5 extends H<E6, MergedPath, any> = H<E6, MergedPath, any>,
+    M6 extends H<E7, MergedPath, any> = H<E7, MergedPath, any>,
+    M7 extends H<E8, MergedPath, any> = H<E8, MergedPath, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>,
+    MR7 extends HandlerResponse<any> = ExtractHandlerResponse<M7>
   >(
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
       H<E9, MergedPath, I8, R>
     ]
-  ): HonoBase<E, S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponse<R>>, BasePath>
+  ): HonoBase<
+    E,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I8,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+        | MergeTypedResponse<MR7>
+      >,
+    BasePath
+  >
 
   // app.get(handler x 10)
   <
@@ -624,23 +874,58 @@ export interface HandlerInterface<
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
+    // Middleware
+    M1 extends H<E2, P, any> = H<E2, P, any>,
+    M2 extends H<E3, P, any> = H<E3, P, any>,
+    M3 extends H<E4, P, any> = H<E4, P, any>,
+    M4 extends H<E5, P, any> = H<E5, P, any>,
+    M5 extends H<E6, P, any> = H<E6, P, any>,
+    M6 extends H<E7, P, any> = H<E7, P, any>,
+    M7 extends H<E8, P, any> = H<E8, P, any>,
+    M8 extends H<E9, P, any> = H<E9, P, any>,
+    M9 extends H<E10, P, any> = H<E10, P, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>,
+    MR7 extends HandlerResponse<any> = ExtractHandlerResponse<M7>,
+    MR8 extends HandlerResponse<any> = ExtractHandlerResponse<M8>,
+    MR9 extends HandlerResponse<any> = ExtractHandlerResponse<M9>
   >(
     ...handlers: [
-      H<E2, P, I>,
-      H<E3, P, I2>,
-      H<E4, P, I3>,
-      H<E5, P, I4>,
-      H<E6, P, I5>,
-      H<E7, P, I6>,
-      H<E8, P, I7>,
-      H<E9, P, I8>,
-      H<E10, P, I9>,
+      H<E2, P, I> & M1,
+      H<E3, P, I2> & M2,
+      H<E4, P, I3> & M3,
+      H<E5, P, I4> & M4,
+      H<E6, P, I5> & M5,
+      H<E7, P, I6> & M6,
+      H<E8, P, I7> & M7,
+      H<E9, P, I8> & M8,
+      H<E10, P, I9> & M9,
       H<E11, P, I10, R>
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, P, I10, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        P,
+        I10,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+        | MergeTypedResponse<MR7>
+        | MergeTypedResponse<MR8>
+        | MergeTypedResponse<MR9>
+      >,
     BasePath
   >
 
@@ -666,21 +951,57 @@ export interface HandlerInterface<
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
+    E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, any> = H<E2, MergedPath, any>,
+    M2 extends H<E3, MergedPath, any> = H<E3, MergedPath, any>,
+    M3 extends H<E4, MergedPath, any> = H<E4, MergedPath, any>,
+    M4 extends H<E5, MergedPath, any> = H<E5, MergedPath, any>,
+    M5 extends H<E6, MergedPath, any> = H<E6, MergedPath, any>,
+    M6 extends H<E7, MergedPath, any> = H<E7, MergedPath, any>,
+    M7 extends H<E8, MergedPath, any> = H<E8, MergedPath, any>,
+    M8 extends H<E9, MergedPath, any> = H<E9, MergedPath, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>,
+    MR7 extends HandlerResponse<any> = ExtractHandlerResponse<M7>,
+    MR8 extends HandlerResponse<any> = ExtractHandlerResponse<M8>
   >(
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
+      H<E9, MergedPath, I8> & M8,
       H<E10, MergedPath, I9, R>
     ]
-  ): HonoBase<E, S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<R>>, BasePath>
+  ): HonoBase<
+    E,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I9,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+        | MergeTypedResponse<MR7>
+        | MergeTypedResponse<MR8>
+      >,
+    BasePath
+  >
 
   // app.get(path, handler x10)
   <
@@ -706,22 +1027,61 @@ export interface HandlerInterface<
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
+    E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, any> = H<E2, MergedPath, any>,
+    M2 extends H<E3, MergedPath, any> = H<E3, MergedPath, any>,
+    M3 extends H<E4, MergedPath, any> = H<E4, MergedPath, any>,
+    M4 extends H<E5, MergedPath, any> = H<E5, MergedPath, any>,
+    M5 extends H<E6, MergedPath, any> = H<E6, MergedPath, any>,
+    M6 extends H<E7, MergedPath, any> = H<E7, MergedPath, any>,
+    M7 extends H<E8, MergedPath, any> = H<E8, MergedPath, any>,
+    M8 extends H<E9, MergedPath, any> = H<E9, MergedPath, any>,
+    M9 extends H<E10, MergedPath, any> = H<E10, MergedPath, any>,
+    // Middleware return type
+    MR1 extends HandlerResponse<any> = ExtractHandlerResponse<M1>,
+    MR2 extends HandlerResponse<any> = ExtractHandlerResponse<M2>,
+    MR3 extends HandlerResponse<any> = ExtractHandlerResponse<M3>,
+    MR4 extends HandlerResponse<any> = ExtractHandlerResponse<M4>,
+    MR5 extends HandlerResponse<any> = ExtractHandlerResponse<M5>,
+    MR6 extends HandlerResponse<any> = ExtractHandlerResponse<M6>,
+    MR7 extends HandlerResponse<any> = ExtractHandlerResponse<M7>,
+    MR8 extends HandlerResponse<any> = ExtractHandlerResponse<M8>,
+    MR9 extends HandlerResponse<any> = ExtractHandlerResponse<M9>
   >(
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
-      H<E10, MergedPath, I9>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
+      H<E9, MergedPath, I8> & M8,
+      H<E10, MergedPath, I9> & M9,
       H<E11, MergedPath, I10, R>
     ]
-  ): HonoBase<E, S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>, BasePath>
+  ): HonoBase<
+    E,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I10,
+        | MergeTypedResponse<R>
+        | MergeTypedResponse<MR1>
+        | MergeTypedResponse<MR2>
+        | MergeTypedResponse<MR3>
+        | MergeTypedResponse<MR4>
+        | MergeTypedResponse<MR5>
+        | MergeTypedResponse<MR6>
+        | MergeTypedResponse<MR7>
+        | MergeTypedResponse<MR8>
+        | MergeTypedResponse<MR9>
+      >,
+    BasePath
+  >
 
   // app.get(...handlers[])
   <
@@ -2055,6 +2415,15 @@ export type RemoveQuestion<T> = T extends `${infer R}?` ? R : T
 export type ExtractSchema<T> = UnionToIntersection<
   T extends HonoBase<infer _, infer S, any> ? S : never
 >
+
+export type ExtractSchemaForStatusCode<T, Status extends number> = {
+  [Path in keyof ExtractSchema<T>]: {
+    [Method in keyof ExtractSchema<T>[Path]]: Extract<
+      ExtractSchema<T>[Path][Method],
+      { status: Status }
+    >
+  }
+}
 
 export type ExtractHandlerResponse<T> = T extends (c: any, next: any) => Promise<infer R>
   ? R extends void

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -70,7 +70,7 @@ describe('Basic', () => {
     },
     validator('query', (value, c) => {
       type verify = Expect<Equal<Record<string, string | string[]>, typeof value>>
-      if (!value) {
+      if (!value.q) {
         return c.text('Invalid!', 400)
       }
     }),

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,4 +1,3 @@
-// Version 2
 import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
 import { HTTPException } from '../http-exception'
@@ -32,17 +31,17 @@ const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\
 
 export type ExtractValidationResponse<VF> = VF extends (value: any, c: any) => infer R
   ? R extends Promise<infer PR>
-    ? PR extends Response
-      ? PR
-      : PR extends TypedResponse<infer T, infer S, infer F>
+    ? PR extends TypedResponse<infer T, infer S, infer F>
       ? TypedResponse<T, S, F>
+      : PR extends Response
+      ? PR
       : PR extends undefined
       ? never // undefined → never
       : never // anything else → never
-    : R extends Response
-    ? R
     : R extends TypedResponse<infer T, infer S, infer F>
     ? TypedResponse<T, S, F>
+    : R extends Response
+    ? R
     : R extends undefined
     ? never // undefined → never
     : never // anything else → never
@@ -172,7 +171,7 @@ export const validator = <
 
     c.req.addValidatedData(target, res as never)
 
-    await next()
+    return await next() as ExtractValidationResponse<VF>
   }
 }
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,7 +1,13 @@
+// Version 2
 import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
 import { HTTPException } from '../http-exception'
-import type { Env, MiddlewareHandler, TypedResponse, ValidationTargets } from '../types'
+import type {
+  Env,
+  MiddlewareHandler,
+  TypedResponse,
+  ValidationTargets,
+} from '../types'
 import type { BodyData } from '../utils/body'
 import { bufferToFormData } from '../utils/buffer'
 
@@ -18,53 +24,73 @@ export type ValidationFunction<
 > = (
   value: InputType,
   c: Context<E, P>
-) => OutputType | Response | Promise<OutputType> | Promise<Response>
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ExcludeResponseType<T> = T extends Response & TypedResponse<any> ? never : T
+) => OutputType | TypedResponse | Promise<OutputType> | Promise<TypedResponse>
 
 const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
 const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
 const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+
+export type ExtractValidationResponse<VF> = VF extends (value: any, c: any) => infer R
+  ? R extends Promise<infer PR>
+    ? PR extends Response
+      ? PR
+      : PR extends TypedResponse<infer T, infer S, infer F>
+      ? TypedResponse<T, S, F>
+      : PR extends undefined
+      ? never // undefined → never
+      : never // anything else → never
+    : R extends Response
+    ? R
+    : R extends TypedResponse<infer T, infer S, infer F>
+    ? TypedResponse<T, S, F>
+    : R extends undefined
+    ? never // undefined → never
+    : never // anything else → never
+  : never // Can't extract → never
 
 export const validator = <
   InputType,
   P extends string,
   M extends string,
   U extends ValidationTargetByMethod<M>,
-  OutputType = ValidationTargets[U],
-  OutputTypeExcludeResponseType = ExcludeResponseType<OutputType>,
   P2 extends string = P,
+  // Capture the actual validation function as a type
+  VF extends (
+    value: unknown extends InputType ? ValidationTargets[U] : InputType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    c: Context<any, P2>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => any = (
+    value: unknown extends InputType ? ValidationTargets[U] : InputType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    c: Context<any, P2>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => any,
   V extends {
     in: {
       [K in U]: K extends 'json'
         ? unknown extends InputType
-          ? OutputTypeExcludeResponseType
+          ? ExtractValidatorOutput<VF>
           : InputType
-        : { [K2 in keyof OutputTypeExcludeResponseType]: ValidationTargets[K][K2] }
+        : { [K2 in keyof ExtractValidatorOutput<VF>]: ValidationTargets[K][K2] }
     }
-    out: { [K in U]: OutputTypeExcludeResponseType }
+    out: { [K in U]: ExtractValidatorOutput<VF> }
   } = {
     in: {
       [K in U]: K extends 'json'
         ? unknown extends InputType
-          ? OutputTypeExcludeResponseType
+          ? ExtractValidatorOutput<VF>
           : InputType
-        : { [K2 in keyof OutputTypeExcludeResponseType]: ValidationTargets[K][K2] }
+        : { [K2 in keyof ExtractValidatorOutput<VF>]: ValidationTargets[K][K2] }
     }
-    out: { [K in U]: OutputTypeExcludeResponseType }
+    out: { [K in U]: ExtractValidatorOutput<VF> }
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any
 >(
   target: U,
-  validationFunc: ValidationFunction<
-    unknown extends InputType ? ValidationTargets[U] : InputType,
-    OutputType,
-    E,
-    P2
-  >
-): MiddlewareHandler<E, P, V> => {
+  validationFunc: VF
+): MiddlewareHandler<E, P, V, ExtractValidationResponse<VF>> => {
   return async (c, next) => {
     let value = {}
     const contentType = c.req.header('Content-Type')
@@ -141,7 +167,7 @@ export const validator = <
     const res = await validationFunc(value as never, c as never)
 
     if (res instanceof Response) {
-      return res
+      return res as ExtractValidationResponse<VF>
     }
 
     c.req.addValidatedData(target, res as never)
@@ -149,3 +175,16 @@ export const validator = <
     await next()
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ExtractValidatorOutput<VF> = VF extends (value: any, c: any) => infer R
+  ? R extends Promise<infer PR>
+    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      PR extends Response | TypedResponse<any, any, any>
+      ? never
+      : PR
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    R extends Response | TypedResponse<any, any, any>
+    ? never
+    : R
+  : never

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,12 +1,7 @@
 import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
 import { HTTPException } from '../http-exception'
-import type {
-  Env,
-  MiddlewareHandler,
-  TypedResponse,
-  ValidationTargets,
-} from '../types'
+import type { Env, MiddlewareHandler, TypedResponse, ValidationTargets } from '../types'
 import type { BodyData } from '../utils/body'
 import { bufferToFormData } from '../utils/buffer'
 
@@ -171,7 +166,7 @@ export const validator = <
 
     c.req.addValidatedData(target, res as never)
 
-    return await next() as ExtractValidationResponse<VF>
+    return (await next()) as ExtractValidationResponse<VF>
   }
 }
 


### PR DESCRIPTION
This PR fixes #2719
It's somewhat based off this draft PR: #4252 (I copied majority of tests from there, thanks!)

After some more changes in validator middlewares (I already adjusted `@hono/zod-validator` and `@hono/valibot-validator`) it gives proper error codes through RPC.

The code here already works & should be passing all tests. The only outstanding thing I am aware of is adjusting types for `app.use`. From type like this:
```ts
<P extends string, MergedPath extends MergePath<BasePath, P>, E2 extends Env = E>(
  path: P,
  handler: MiddlewareHandler<E2, MergedPath, any>
): HonoBase<IntersectNonAnyTypes<[E, E2]>, ChangePathOfSchema<S, MergedPath>, BasePath>
```
into one that passes 4 params to MiddlewareHandler:
```ts
<P extends string, MergedPath extends MergePath<BasePath, P>, E2 extends Env = E>(
  path: P,
  handler: MiddlewareHandler<E2, MergedPath, any, any>
): HonoBase<IntersectNonAnyTypes<[E, E2]>, ChangePathOfSchema<S, MergedPath>, BasePath>
```

Without it `app.use` is complaining about invalid type when you try to pass a 'typed middleware' to it. I should be able to adjust this soon.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
