### PR TITLE
Fix `parseResponse` not parsing json in react native

### DIFF
--- a/src/client/fetch-result-please.ts
+++ b/src/client/fetch-result-please.ts
@@ -12,9 +12,19 @@ const nullBodyResponses = new Set([101, 204, 205, 304])
  * Throwing a structured error if the response is not `ok`. ({@link DetailedError})
  */
 export async function fetchRP(fetchRes: Response | Promise<Response>): Promise<any> {
-  const _fetchRes = (await fetchRes) as unknown as Response & { _data: any }
+  const _fetchRes = (await fetchRes) as unknown as Response & {
+    _data: any;
+    /**
+     * @description BodyInit property from whatwg-fetch polyfill
+     *
+     * @link https://github.com/JakeChampion/fetch/blob/main/fetch.js#L238
+     */
+    _bodyInit?: any;
+  };
 
-  const hasBody = _fetchRes.body && !nullBodyResponses.has(_fetchRes.status)
+  const hasBody =
+    (_fetchRes.body || _fetchRes._bodyInit) &&
+    !nullBodyResponses.has(_fetchRes.status);
 
   if (hasBody) {
     const responseType = detectResponseType(_fetchRes)

--- a/src/client/fetch-result-please.ts
+++ b/src/client/fetch-result-please.ts
@@ -13,18 +13,17 @@ const nullBodyResponses = new Set([101, 204, 205, 304])
  */
 export async function fetchRP(fetchRes: Response | Promise<Response>): Promise<any> {
   const _fetchRes = (await fetchRes) as unknown as Response & {
-    _data: any;
+    _data: any
     /**
      * @description BodyInit property from whatwg-fetch polyfill
      *
      * @link https://github.com/JakeChampion/fetch/blob/main/fetch.js#L238
      */
-    _bodyInit?: any;
-  };
+    _bodyInit?: any
+  }
 
   const hasBody =
-    (_fetchRes.body || _fetchRes._bodyInit) &&
-    !nullBodyResponses.has(_fetchRes.status);
+    (_fetchRes.body || _fetchRes._bodyInit) && !nullBodyResponses.has(_fetchRes.status)
 
   if (hasBody) {
     const responseType = detectResponseType(_fetchRes)


### PR DESCRIPTION
React native uses [`whatwg-fetch`](https://github.com/JakeChampion/fetch) polyfill to implement fetch and currently `parseResponse` checks existence of `response.body` in order to parse it, but this polyfill does not implement `body` property, so check fails. However it implements `_bodyInit` (https://github.com/JakeChampion/fetch/blob/main/fetch.js#L238) and some other internal properties we can check to ensure response body exists.

I added check of `_bodyInit` and it started parsing json responses as expected. I do not add tests for this case, but if its desirable I can do this.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
