### PR TITLE
fix(types): JSONParsed infer unknown values

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -194,21 +194,12 @@ interface JSONRespond {
  * @template T - The type of the JSON value or simplified unknown type.
  * @template U - The type of the status code.
  *
- * @returns {Response & TypedResponse<SimplifyDeepArray<T> extends JSONValue ? (JSONValue extends SimplifyDeepArray<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
+ * @returns {Response & TypedResponse<JSONParsed<T>, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
 type JSONRespondReturn<
   T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
   U extends ContentfulStatusCode
-> = Response &
-  TypedResponse<
-    SimplifyDeepArray<T> extends JSONValue
-      ? JSONValue extends SimplifyDeepArray<T>
-        ? never
-        : JSONParsed<T>
-      : never,
-    U,
-    'json'
-  >
+> = Response & TypedResponse<JSONParsed<T>, U, 'json'>
 
 /**
  * Interface representing a function that responds with HTML content.

--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -1,4 +1,4 @@
-import type { Equal, Expect, JSONParsed } from './types'
+import type { JSONParsed, JSONValue } from './types'
 
 describe('JSONParsed', () => {
   enum SampleEnum {
@@ -78,6 +78,11 @@ describe('JSONParsed', () => {
       type Expected = never
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
+    it('should convert bigint type to never', () => {
+      type Actual = JSONParsed<bigint>
+      type Expected = never
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
   })
 
   describe('array', () => {
@@ -154,6 +159,20 @@ describe('JSONParsed', () => {
     })
   })
 
+  describe('unknown', () => {
+    it('should convert unknown type to unknown', () => {
+      type Actual = JSONParsed<unknown>
+      type Expected = JSONValue
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+
+    it('Should convert unknown value to JSONValue', () => {
+      type Actual = JSONParsed<{ value: unknown }>
+      type Expected = { value: JSONValue }
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+  })
+
   describe('Set/Map', () => {
     it('should convert Set to empty object', () => {
       type Actual = JSONParsed<Set<number>>
@@ -199,19 +218,62 @@ describe('JSONParsed', () => {
       datetime: string
     }
     type Actual = JSONParsed<Post>
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type verify = Expect<Equal<Expected, Actual>>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
   })
 
   it('Should convert bigint to never', () => {
     type Post = {
       num: bigint
     }
-    type Expected = {
-      num: never
-    }
+    type Expected = never
     type Actual = JSONParsed<Post>
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type verify = Expect<Equal<Expected, Actual>>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  it('Should convert bigint when TError is provided', () => {
+    type Post = {
+      num: bigint
+    }
+    type Expected = {
+      num: JSONValue
+    }
+    type Actual = JSONParsed<Post, never>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  it('Should convert bigint[] to never', () => {
+    type Post = {
+      nums: bigint[]
+    }
+    type Expected = never
+    type Actual = JSONParsed<Post>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  it('Should convert bigint[] when TError is provided', () => {
+    type Post = {
+      num: bigint[]
+    }
+    type Expected = {
+      num: JSONValue[]
+    }
+    type Actual = JSONParsed<Post, never>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  it('Should parse bigint with a toJSON function', () => {
+    class SafeBigInt {
+      unsafe = BigInt('42')
+
+      toJSON() {
+        return {
+          unsafe: '42n',
+        }
+      }
+    }
+
+    type Actual = JSONParsed<SafeBigInt>
+    type Expected = { unsafe: string }
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
   })
 })


### PR DESCRIPTION
Changes `JSONParsed` so it will infer `unknown` values as `JSONValue`.

I also included handling for `bigint` so `JSONParsed` will be `never`, indicating that an error will be thrown.

fixes #4368 
