### PR TITLE
refactor(types): remove SimplifyDeepArray from json types

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -13,13 +13,7 @@ import type { ResponseHeader } from './utils/headers'
 import { HtmlEscapedCallbackPhase, resolveCallback } from './utils/html'
 import type { ContentfulStatusCode, RedirectStatusCode, StatusCode } from './utils/http-status'
 import type { BaseMime } from './utils/mime'
-import type {
-  InvalidJSONValue,
-  IsAny,
-  JSONParsed,
-  JSONValue,
-  SimplifyDeepArray,
-} from './utils/types'
+import type { InvalidJSONValue, IsAny, JSONParsed, JSONValue } from './utils/types'
 
 type HeaderRecord =
   | Record<'Content-Type', BaseMime>
@@ -174,7 +168,7 @@ interface TextRespond {
  */
 interface JSONRespond {
   <
-    T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
+    T extends JSONValue | {} | InvalidJSONValue,
     U extends ContentfulStatusCode = ContentfulStatusCode
   >(
     object: T,
@@ -182,7 +176,7 @@ interface JSONRespond {
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U>
   <
-    T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
+    T extends JSONValue | {} | InvalidJSONValue,
     U extends ContentfulStatusCode = ContentfulStatusCode
   >(
     object: T,
@@ -194,21 +188,12 @@ interface JSONRespond {
  * @template T - The type of the JSON value or simplified unknown type.
  * @template U - The type of the status code.
  *
- * @returns {Response & TypedResponse<SimplifyDeepArray<T> extends JSONValue ? (JSONValue extends SimplifyDeepArray<T> ? never : JSONParsed<T>) : never, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
+ * @returns {Response & TypedResponse<JSONParsed<T>, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
-type JSONRespondReturn<
-  T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
+export type JSONRespondReturn<
+  T extends JSONValue | {} | InvalidJSONValue,
   U extends ContentfulStatusCode
-> = Response &
-  TypedResponse<
-    SimplifyDeepArray<T> extends JSONValue
-      ? JSONValue extends SimplifyDeepArray<T>
-        ? never
-        : JSONParsed<T>
-      : never,
-    U,
-    'json'
-  >
+> = Response & TypedResponse<JSONParsed<T>, U, 'json'>
 
 /**
  * Interface representing a function that responds with HTML content.
@@ -704,7 +689,7 @@ export class Context<
    * ```
    */
   json: JSONRespond = <
-    T extends JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue,
+    T extends JSONValue | {} | InvalidJSONValue,
     U extends ContentfulStatusCode = ContentfulStatusCode
   >(
     object: T,


### PR DESCRIPTION
Simplifies return type of `ctx.json()` by removing `SimplifyDeepArray`

I may be missing something here.. but it appears to still work 🙈

The simplest way I could understand it was that

```ts
expectTypeOf<SimplifyDeepArray<unknown>>().toEqualTypeOf<{}>()
```

Or more specifically

```ts
type Old = Simplify<JSONValue | SimplifyDeepArray<unknown> | InvalidJSONValue>

type New = Simplify<JSONValue | {} | InvalidJSONValue>

type Actual = string | number | boolean | symbol | (JSONObject | JSONArray | JSONPrimitive)[] | {} | {
    [x: string]: object | JSONObject | JSONArray | JSONPrimitive | InvalidJSONValue;
} | {} | null | undefined

expectTypeOf<Old>().toEqualTypeOf<Actual>()

expectTypeOf<New>().toEqualTypeOf<Actual>()
```