### PR TITLE
feat(core,router): expose Context and add LinearRouter.matchRoute utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,11 @@ export type {
 /**
  * Types for context, context variable map, context renderer, and execution context.
  */
-export type { Context, ContextVariableMap, ContextRenderer, ExecutionContext } from './context'
+export type { ContextVariableMap, ContextRenderer, ExecutionContext } from './context'
+/**
+ * Context class for request handling and response generation.
+ */
+export { Context } from './context'
 /**
  * Type for HonoRequest.
  */

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -1,6 +1,6 @@
-import { UnsupportedPathError } from '../../router';
-import { runTest } from '../common.case.test';
-import { LinearRouter } from './router';
+import { UnsupportedPathError } from '../../router'
+import { runTest } from '../common.case.test'
+import { LinearRouter } from './router'
 
 describe('LinearRouter', () => {
   runTest({
@@ -124,7 +124,10 @@ describe('LinearRouter', () => {
       })
 
       it('should match multiple parameters', () => {
-        const result = LinearRouter.matchRoute('/users/123/posts/456', '/users/:userId/posts/:postId')
+        const result = LinearRouter.matchRoute(
+          '/users/123/posts/456',
+          '/users/:userId/posts/:postId'
+        )
         expect(result).not.toBeNull()
         expect(result!.params).toEqual({ userId: '123', postId: '456' })
         expect(result!.paramIndexMap).toEqual({ userId: 0, postId: 1 })
@@ -169,7 +172,10 @@ describe('LinearRouter', () => {
       })
 
       it('should match parameter with custom pattern', () => {
-        const result = LinearRouter.matchRoute('/files/image.jpg', '/files/:filename{[^/]+\\.[a-z]+}')
+        const result = LinearRouter.matchRoute(
+          '/files/image.jpg',
+          '/files/:filename{[^/]+\\.[a-z]+}'
+        )
         expect(result).not.toBeNull()
         expect(result!.params).toEqual({ filename: 'image.jpg' })
       })
@@ -177,13 +183,19 @@ describe('LinearRouter', () => {
 
     describe('Complex patterns', () => {
       it('should match mixed static and dynamic segments', () => {
-        const result = LinearRouter.matchRoute('/api/v1/users/123/profile', '/api/v1/users/:id/profile')
+        const result = LinearRouter.matchRoute(
+          '/api/v1/users/123/profile',
+          '/api/v1/users/:id/profile'
+        )
         expect(result).not.toBeNull()
         expect(result!.params).toEqual({ id: '123' })
       })
 
       it('should match multiple parameters with static segments', () => {
-        const result = LinearRouter.matchRoute('/api/users/123/posts/456/comments', '/api/users/:userId/posts/:postId/comments')
+        const result = LinearRouter.matchRoute(
+          '/api/users/123/posts/456/comments',
+          '/api/users/:userId/posts/:postId/comments'
+        )
         expect(result).not.toBeNull()
         expect(result!.params).toEqual({ userId: '123', postId: '456' })
         expect(result!.paramIndexMap).toEqual({ userId: 0, postId: 1 })

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -1,6 +1,6 @@
-import { UnsupportedPathError } from '../../router'
-import { runTest } from '../common.case.test'
-import { LinearRouter } from './router'
+import { UnsupportedPathError } from '../../router';
+import { runTest } from '../common.case.test';
+import { LinearRouter } from './router';
 
 describe('LinearRouter', () => {
   runTest({
@@ -64,6 +64,167 @@ describe('LinearRouter', () => {
     it('GET /products/list', () => {
       const [res] = router.match('GET', '/products/list')
       expect(res.length).toBe(0)
+    })
+  })
+
+  describe('Static matchRoute method', () => {
+    describe('Exact path matching', () => {
+      it('should match exact paths', () => {
+        const result = LinearRouter.matchRoute('/users', '/users')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({})
+        expect(result!.paramIndexMap).toEqual({})
+        expect(result!.paramStash).toEqual([])
+      })
+
+      it('should match exact paths with trailing slash', () => {
+        const result = LinearRouter.matchRoute('/users/', '/users')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({})
+      })
+
+      it('should not match different paths', () => {
+        const result = LinearRouter.matchRoute('/users', '/books')
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('Wildcard matching', () => {
+      it('should match single wildcard', () => {
+        const result = LinearRouter.matchRoute('/anything', '*')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({})
+      })
+
+      it('should match wildcard with slash', () => {
+        const result = LinearRouter.matchRoute('/anything/else', '/*')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({})
+      })
+
+      it('should match wildcard patterns without labels', () => {
+        const result = LinearRouter.matchRoute('/api/v1/users', '/api/*/users')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({})
+      })
+
+      it('should not match incomplete wildcard patterns', () => {
+        const result = LinearRouter.matchRoute('/api/users', '/api/*/v1/users')
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('Parameter matching', () => {
+      it('should match single parameter', () => {
+        const result = LinearRouter.matchRoute('/users/123', '/users/:id')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ id: '123' })
+        expect(result!.paramIndexMap).toEqual({ id: 0 })
+        expect(result!.paramStash).toEqual(['123'])
+      })
+
+      it('should match multiple parameters', () => {
+        const result = LinearRouter.matchRoute('/users/123/posts/456', '/users/:userId/posts/:postId')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ userId: '123', postId: '456' })
+        expect(result!.paramIndexMap).toEqual({ userId: 0, postId: 1 })
+        expect(result!.paramStash).toEqual(['123', '456'])
+      })
+
+      it('should match parameter at end of path', () => {
+        const result = LinearRouter.matchRoute('/users/john', '/users/:name')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ name: 'john' })
+      })
+
+      it('should not match when parameter is missing', () => {
+        const result = LinearRouter.matchRoute('/users/', '/users/:id')
+        expect(result).toBeNull()
+      })
+
+      it('should not match when path has extra segments', () => {
+        const result = LinearRouter.matchRoute('/users/123/extra', '/users/:id')
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('Pattern matching with regex', () => {
+      it('should match parameter with digit pattern', () => {
+        const result = LinearRouter.matchRoute('/products/123', '/products/:id{\\d+}')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ id: '123' })
+        expect(result!.paramIndexMap).toEqual({ id: 0 })
+        expect(result!.paramStash).toEqual(['123'])
+      })
+
+      it('should not match parameter with wrong pattern', () => {
+        const result = LinearRouter.matchRoute('/products/abc', '/products/:id{\\d+}')
+        expect(result).toBeNull()
+      })
+
+      it('should match parameter with word pattern', () => {
+        const result = LinearRouter.matchRoute('/categories/electronics', '/categories/:name{\\w+}')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ name: 'electronics' })
+      })
+
+      it('should match parameter with custom pattern', () => {
+        const result = LinearRouter.matchRoute('/files/image.jpg', '/files/:filename{[^/]+\\.[a-z]+}')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ filename: 'image.jpg' })
+      })
+    })
+
+    describe('Complex patterns', () => {
+      it('should match mixed static and dynamic segments', () => {
+        const result = LinearRouter.matchRoute('/api/v1/users/123/profile', '/api/v1/users/:id/profile')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ id: '123' })
+      })
+
+      it('should match multiple parameters with static segments', () => {
+        const result = LinearRouter.matchRoute('/api/users/123/posts/456/comments', '/api/users/:userId/posts/:postId/comments')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({ userId: '123', postId: '456' })
+        expect(result!.paramIndexMap).toEqual({ userId: 0, postId: 1 })
+        expect(result!.paramStash).toEqual(['123', '456'])
+      })
+
+      it('should not match when static segments differ', () => {
+        const result = LinearRouter.matchRoute('/api/v2/users/123', '/api/v1/users/:id')
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('Edge cases', () => {
+      it('should handle empty path segments', () => {
+        const result = LinearRouter.matchRoute('/', '/')
+        expect(result).not.toBeNull()
+        expect(result!.params).toEqual({})
+      })
+
+      it('should handle root path matching', () => {
+        const result = LinearRouter.matchRoute('/', '/')
+        expect(result).not.toBeNull()
+      })
+
+      it('should not match when path is too short', () => {
+        const result = LinearRouter.matchRoute('/api', '/api/users/:id')
+        expect(result).toBeNull()
+      })
+
+      it('should handle special characters in static segments', () => {
+        const result = LinearRouter.matchRoute('/api-v1/users_123', '/api-v1/users_123')
+        expect(result).not.toBeNull()
+      })
+    })
+
+    describe('Unsupported patterns', () => {
+      it('should throw UnsupportedPathError for mixed labels and wildcards', () => {
+        expect(() => {
+          LinearRouter.matchRoute('/users/123/files', '/users/:id/*')
+        }).toThrowError(UnsupportedPathError)
+      })
     })
   })
 })

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -1,4 +1,4 @@
-import type { Params, Result, Router } from '../../router'
+import type { Params, Result, Router, ParamIndexMap, ParamStash } from '../../router'
 import { METHOD_NAME_ALL, UnsupportedPathError } from '../../router'
 import { checkOptionalParameter } from '../../utils/url'
 
@@ -24,117 +24,163 @@ export class LinearRouter<T> implements Router<T> {
 
   match(method: string, path: string): Result<T> {
     const handlers: [T, Params][] = []
-    ROUTES_LOOP: for (let i = 0, len = this.#routes.length; i < len; i++) {
+    for (let i = 0, len = this.#routes.length; i < len; i++) {
       const [routeMethod, routePath, handler] = this.#routes[i]
       if (routeMethod === method || routeMethod === METHOD_NAME_ALL) {
-        if (routePath === '*' || routePath === '/*') {
+        const matchResult = LinearRouter.matchRoute(path, routePath)
+        if (matchResult) {
+          handlers.push([handler, matchResult.params])
+        } else if (routePath === '*' || routePath === '/*') {
           handlers.push([handler, emptyParams])
-          continue
-        }
-
-        const hasStar = routePath.indexOf('*') !== -1
-        const hasLabel = routePath.indexOf(':') !== -1
-        if (!hasStar && !hasLabel) {
-          if (routePath === path || routePath + '/' === path) {
-            handlers.push([handler, emptyParams])
-          }
-        } else if (hasStar && !hasLabel) {
-          const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
-          const parts = (endsWithStar ? routePath.slice(0, -2) : routePath).split(splitByStarRe)
-
-          const lastIndex = parts.length - 1
-          for (let j = 0, pos = 0, len = parts.length; j < len; j++) {
-            const part = parts[j]
-            const index = path.indexOf(part, pos)
-            if (index !== pos) {
-              continue ROUTES_LOOP
-            }
-            pos += part.length
-            if (j === lastIndex) {
-              if (
-                !endsWithStar &&
-                pos !== path.length &&
-                !(pos === path.length - 1 && path.charCodeAt(pos) === 47)
-              ) {
-                continue ROUTES_LOOP
-              }
-            } else {
-              const index = path.indexOf('/', pos)
-              if (index === -1) {
-                continue ROUTES_LOOP
-              }
-              pos = index
-            }
-          }
-          handlers.push([handler, emptyParams])
-        } else if (hasLabel && !hasStar) {
-          const params: Record<string, string> = Object.create(null)
-          const parts = routePath.match(splitPathRe) as string[]
-
-          const lastIndex = parts.length - 1
-          for (let j = 0, pos = 0, len = parts.length; j < len; j++) {
-            if (pos === -1 || pos >= path.length) {
-              continue ROUTES_LOOP
-            }
-
-            const part = parts[j]
-            if (part.charCodeAt(1) === 58) {
-              // /:label
-              let name = part.slice(2)
-              let value
-
-              if (name.charCodeAt(name.length - 1) === 125) {
-                // :label{pattern}
-                const openBracePos = name.indexOf('{')
-                const next = parts[j + 1]
-                const lookahead = next && next[1] !== ':' && next[1] !== '*' ? `(?=${next})` : ''
-                const pattern = name.slice(openBracePos + 1, -1) + lookahead
-                const restPath = path.slice(pos + 1)
-                const match = new RegExp(pattern, 'd').exec(restPath) as RegExpMatchArrayWithIndices
-                if (!match || match.indices[0][0] !== 0 || match.indices[0][1] === 0) {
-                  continue ROUTES_LOOP
-                }
-                name = name.slice(0, openBracePos)
-                value = restPath.slice(...match.indices[0])
-                pos += match.indices[0][1] + 1
-              } else {
-                let endValuePos = path.indexOf('/', pos + 1)
-                if (endValuePos === -1) {
-                  if (pos + 1 === path.length) {
-                    continue ROUTES_LOOP
-                  }
-                  endValuePos = path.length
-                }
-                value = path.slice(pos + 1, endValuePos)
-                pos = endValuePos
-              }
-
-              params[name] ||= value as string
-            } else {
-              const index = path.indexOf(part, pos)
-              if (index !== pos) {
-                continue ROUTES_LOOP
-              }
-              pos += part.length
-            }
-
-            if (j === lastIndex) {
-              if (
-                pos !== path.length &&
-                !(pos === path.length - 1 && path.charCodeAt(pos) === 47)
-              ) {
-                continue ROUTES_LOOP
-              }
-            }
-          }
-
-          handlers.push([handler, params])
-        } else if (hasLabel && hasStar) {
-          throw new UnsupportedPathError()
         }
       }
     }
 
     return [handlers]
+  }
+
+  /**
+   * Static method to match a path against a route pattern.
+   * This is the same matching logic used internally by the LinearRouter.
+   *
+   * @param path - The actual path to match
+   * @param routePath - The route pattern (e.g., '/user/:id/:action')
+   * @returns Object containing paramIndexMap, paramStash, and params, or null if no match
+   */
+  static matchRoute(
+    path: string,
+    routePath: string
+  ): {
+    paramIndexMap: ParamIndexMap
+    paramStash: ParamStash
+    params: Params
+  } | null {
+    const params: Params = Object.create(null)
+    const paramIndexMap: ParamIndexMap = Object.create(null)
+    const paramStash: ParamStash = []
+
+    if (routePath === '*' || routePath === '/*') {
+      return { paramIndexMap, paramStash, params }
+    }
+
+    const hasStar = routePath.indexOf('*') !== -1
+    const hasLabel = routePath.indexOf(':') !== -1
+
+    if (!hasStar && !hasLabel) {
+      if (routePath === path || routePath + '/' === path) {
+        return { paramIndexMap, paramStash, params }
+      }
+      return null
+    }
+
+    if (hasStar && !hasLabel) {
+      const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
+      const parts = (endsWithStar ? routePath.slice(0, -2) : routePath).split(splitByStarRe)
+
+      const lastIndex = parts.length - 1
+      for (let j = 0, pos = 0, len = parts.length; j < len; j++) {
+        const part = parts[j]
+        const index = path.indexOf(part, pos)
+        if (index !== pos) {
+          return null
+        }
+        pos += part.length
+
+        if (j === lastIndex) {
+          if (
+            !endsWithStar &&
+            pos !== path.length &&
+            !(pos === path.length - 1 && path.charCodeAt(pos) === 47)
+          ) {
+            return null
+          }
+        } else {
+          const index = path.indexOf('/', pos)
+          if (index === -1) {
+            return null
+          }
+          pos = index
+        }
+      }
+      return { paramIndexMap, paramStash, params }
+    }
+
+    if (hasLabel && !hasStar) {
+      const parts = routePath.match(splitPathRe) as string[]
+
+      if (!parts) {
+        return null
+      }
+
+      let paramIndex = 0
+      let pos = 0
+
+      for (let j = 0; j < parts.length; j++) {
+        if (pos === -1 || pos >= path.length) {
+          return null
+        }
+
+        const part = parts[j]
+
+        if (part.charCodeAt(1) === 58) {
+          // /:label
+          let name = part.slice(2)
+          let value: string
+
+          if (name.charCodeAt(name.length - 1) === 125) {
+            // :label{pattern}
+            const openBracePos = name.indexOf('{')
+            const next = parts[j + 1]
+            const lookahead = next && next[1] !== ':' && next[1] !== '*' ? `(?=${next})` : ''
+            const pattern = name.slice(openBracePos + 1, -1) + lookahead
+            const restPath = path.slice(pos + 1)
+            const match = new RegExp(pattern, 'd').exec(restPath) as RegExpMatchArrayWithIndices
+
+            if (!match || match.indices[0][0] !== 0 || match.indices[0][1] === 0) {
+              return null
+            }
+
+            name = name.slice(0, openBracePos)
+            value = restPath.slice(...match.indices[0])
+            pos += match.indices[0][1] + 1
+          } else {
+            let endValuePos = path.indexOf('/', pos + 1)
+            if (endValuePos === -1) {
+              if (pos + 1 === path.length) {
+                return null
+              }
+              endValuePos = path.length
+            }
+            value = path.slice(pos + 1, endValuePos)
+            pos = endValuePos
+          }
+
+          params[name] ||= value
+          paramIndexMap[name] = paramIndex
+          paramStash[paramIndex] = value
+          paramIndex++
+        } else {
+          const index = path.indexOf(part, pos)
+          if (index !== pos) {
+            return null
+          }
+          pos += part.length
+        }
+
+        if (j === parts.length - 1) {
+          if (pos !== path.length && !(pos === path.length - 1 && path.charCodeAt(pos) === 47)) {
+            return null
+          }
+        }
+      }
+
+      return { paramIndexMap, paramStash, params }
+    }
+
+    if (hasLabel && hasStar) {
+      throw new UnsupportedPathError()
+    }
+
+    return null
   }
 }


### PR DESCRIPTION
This PR introduces two public APIs that were previously internal.
It also resolves #4409.

* `Context` class - exported from `index.ts` for advanced use cases (testing, unified request handling, extensions).

* `LinearRouter.matchRoute` static method

  * Abstraction of the internal matching logic.
  * Allows for comprehensive testing and reusability of route-matching behavior.
  * Covers exact paths, wildcards, parameters, regex patterns, edge cases, and unsupported patterns.
---

### The author should do the following, if applicable

* [x] Add tests
* [x] Run tests
* [x] `bun run format:fix && bun run lint:fix` to format the code
* [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code