### PR TITLE
fix(service-worker): Update service-worker fire() to accept generic variants of Hono app instance

### DIFF
--- a/src/adapter/service-worker/index.ts
+++ b/src/adapter/service-worker/index.ts
@@ -3,6 +3,7 @@
  * @module
  */
 import type { Hono } from '../../hono'
+import type { Env, Schema } from '../../types'
 import { handle } from './handler'
 import type { HandleOptions } from './handler'
 
@@ -24,8 +25,8 @@ import type { HandleOptions } from './handler'
  * fire(app)
  * ```
  */
-const fire = (
-  app: Hono,
+const fire = <E extends Env, S extends Schema, BasePath extends string>(
+  app: Hono<E, S, BasePath>,
   options: HandleOptions = {
     fetch: undefined,
   }


### PR DESCRIPTION
This PR adds generic parameters to `fire()` in `hono/service-worker` to accept generic variants.

```typescript
import { Hono } from 'hono/quick'
import { fire } from 'hono/service-worker'

type Env = {
  Variables: {
    // ...
  },
}

const app = new Hono<Env>()

// ...

fire(app)
```

Without this fix, the above code gives this TypeScript error:
```
% npx tsc --noEmit
src/index.ts:69:6 - error TS2345: Argument of type 'Hono<Env, BlankSchema, "/">' is not assignable to parameter of type 'Hono<BlankEnv, BlankSchema, "/">'.
  The types of 'get(...).get' are incompatible between these types.
    Type 'HandlerInterface<Env, "get", { [x: string]: { $get: { input: any; output: {}; outputFormat: string; status: StatusCode; }; }; }, "/">' is not assignable to type 'HandlerInterface<{}, "get", { [x: string]: { $get: { input: any; output: {}; outputFormat: string; status: StatusCode; }; }; }, "/">'.
      Types of parameters 'handlers' and 'handlers' are incompatible.
        Type 'H<{}, any, any, any>' is not assignable to type 'H<Env, any, any, any>'.
          Type 'Handler<{}, any, any, any>' is not assignable to type 'H<Env, any, any, any>'.
            Type 'Handler<{}, any, any, any>' is not assignable to type 'Handler<Env, any, any, any>'.
              Types of parameters 'c' and 'c' are incompatible.
                Type 'Context<Env, any, any>' is not assignable to type 'Context<{}, any, any>'.
                  Property 'Variables' is missing in type '{}' but required in type 'Env'.

69 fire(app)
        ~~~
```

This PR enables `Hono<Env>` to be passed to `fire()` successfully.

### The author should do the following, if applicable

- [ ] Add tests - this is only for type system, not sure how to add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code - N/A
