### PR TITLE
feat(helper/route): enable to get route path at specific index

### DIFF
--- a/src/helper/route/index.test.ts
+++ b/src/helper/route/index.test.ts
@@ -63,6 +63,11 @@ describe('routePath', () => {
 
     expect(routePath(c)).toBe('/:id')
 
+    expect(routePath(c, 0)).toBe('/:id')
+    expect(routePath(c, 1)).toBe('/:id/:name')
+    expect(routePath(c, -1)).toBe('/:id/:name')
+    expect(routePath(c, 2)).toBe('')
+
     c.req.routeIndex = 1
     expect(routePath(c)).toBe('/:id/:name')
   })
@@ -96,6 +101,12 @@ describe('baseRoutePath', () => {
 
     expect(baseRoutePath(c)).toBe('/')
 
+    expect(baseRoutePath(c, 0)).toBe('/')
+    expect(baseRoutePath(c, 1)).toBe('/sub')
+    expect(baseRoutePath(c, 2)).toBe('/:sub')
+    expect(baseRoutePath(c, -1)).toBe('/:sub')
+    expect(baseRoutePath(c, 3)).toBe('')
+
     c.req.routeIndex = 1
     expect(baseRoutePath(c)).toBe('/sub')
 
@@ -128,6 +139,11 @@ describe('basePath', () => {
 
     expect(basePath(c)).toBe('/')
     expect(basePath(c)).toBe('/') // cached value
+
+    expect(basePath(c, 0)).toBe('/')
+    expect(basePath(c, 1)).toBe('/sub')
+    expect(basePath(c, -1)).toBe('/sub')
+    expect(basePath(c, 2)).toBe('')
 
     c.req.routeIndex = 1
     expect(basePath(c)).toBe('/sub')


### PR DESCRIPTION
fixes #4196

Currently, only routes associated with handlers can be retrieved. This PR enables passing an optional `index` parameter (which has the same meaning as `Array.prototype.at(index)`), allowing `routePath(c, -1)` to retrieve the route that matched at the end.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
