### PR TITLE
fix(compose): preserve `c.req.routeIndex`  across `next()`

### DIFF
--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -16,7 +16,9 @@ describe('compose', () => {
 
   const a = async (c: Context, next: Next) => {
     c.set('log', 'log')
+    c.set('routeIndex-before-next', c.req.routeIndex)
     await next()
+    c.set('routeIndex-after-next', c.req.routeIndex)
   }
 
   const b = async (c: Context, next: Next) => {
@@ -47,6 +49,8 @@ describe('compose', () => {
     expect(context.get('log')).not.toBeNull()
     expect(context.get('log')).toBe('log message')
     expect(context.get('xxx')).toBe('yyy')
+    expect(context.get('routeIndex-before-next')).toBe(0)
+    expect(context.get('routeIndex-after-next')).toBe(0)
   })
   it('Response', async () => {
     const composed = compose(middleware)
@@ -244,7 +248,9 @@ describe('compose with Context - 500 error', () => {
     }
 
     const mHandler = async (_c: Context, next: Next) => {
+      _c.set('routeIndex-before-next', _c.req.routeIndex)
       await next()
+      _c.set('routeIndex-after-next', _c.req.routeIndex)
     }
 
     middleware.push(buildMiddlewareTuple(mHandler))
@@ -259,6 +265,8 @@ describe('compose with Context - 500 error', () => {
     expect(context.res.status).toBe(500)
     expect(await context.res.text()).toBe('onError')
     expect(context.finalized).toBe(true)
+    expect(context.get('routeIndex-before-next')).toBe(0)
+    expect(context.get('routeIndex-after-next')).toBe(0)
   })
 
   it('Error on handler - async', async () => {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -48,7 +48,10 @@ export const compose = <E extends Env = Env>(
 
       if (handler) {
         try {
-          res = await handler(context, () => dispatch(i + 1))
+          res = await handler(context, () => {
+            const routeIndex = context.req.routeIndex
+            return dispatch(i + 1).finally(() => (context.req.routeIndex = routeIndex))
+          })
         } catch (err) {
           if (err instanceof Error && onError) {
             context.error = err


### PR DESCRIPTION
Reference: https://github.com/honojs/hono/issues/4196#issuecomment-3317581222

This is a bug that has existed since quite early on. After calling `next()`, `param()` and `routePath()` were not returning the correct values. I believe this needs to be fixed.

Although this usage pattern is not very common, since it involves a change to the core behavior, I think it would be appropriate to merge this change during the next major version update.


### An app that can reproduce the bug

```ts
const app = new Hono()

app.use('/:all{.*}', async (c, next) => {
  console.log(routePath(c))
  await next()
  console.log(routePath(c)) // should be '/:all{.*}'
  console.log(c.req.param('all')) // should be the request path
})

app.get('/posts/:id', (c) => {
  return c.text(routePath(c))
})

export default app
```

### Expected result

* Outputs `/:all{.*}`, and the request path

### Actual result

* Outputs `/posts/:id`, and `undefined`

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code