### PR TITLE
feat(request): return new Request with cached body in raw getter

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -267,6 +267,24 @@ describe('Body methods with caching', () => {
     expect(await req.text()).toEqual(text)
   })
 
+  test('req.raw.json() should work after req.json() is called', async () => {
+    const data = { foo: 'bar' }
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      })
+    )
+
+    // First call to req.json() - consumes the body
+    const firstResult = await req.json()
+    expect(firstResult).toEqual(data)
+
+    // Second call to req.raw.json() - should work with cached body
+    const secondResult = await req.raw.json()
+    expect(secondResult).toEqual(data)
+  })
+
   test('req.arrayBuffer()', async () => {
     const buffer = new TextEncoder().encode('{"foo":"bar"}').buffer
     const req = new HonoRequest(

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { GET_MATCH_RESULT } from './request/constants'
 import type { Result } from './router'
 import type {
@@ -28,6 +27,7 @@ type BodyCache = Partial<Body & { parsedBody: BodyData }>
 const tryDecodeURIComponent = (str: string) => tryDecode(str, decodeURIComponent_)
 
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
+  private _raw: Request
   /**
    * `.raw` can get the raw Request object.
    *
@@ -42,8 +42,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * })
    * ```
    */
-  raw: Request
-
+  raw!: Request
   #validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
   #matchResult: Result<[unknown, RouterRoute]>
   routeIndex: number = 0
@@ -67,10 +66,29 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     path: string = '/',
     matchResult: Result<[unknown, RouterRoute]> = [[]]
   ) {
-    this.raw = request
+    this._raw = request
     this.path = path
     this.#matchResult = matchResult
     this.#validatedData = {}
+    const self = this
+    Object.defineProperty(this, 'raw', {
+      get() {
+        if (self._raw.bodyUsed) {
+          const body = self.#getAnyCachedBody()
+          if (body) {
+            return new Request(self._raw, {
+              ...self._raw,
+              body,
+            })
+          }
+        }
+        return self._raw
+      },
+      set(req: Request) {
+        self._raw = req
+      },
+      enumerable: true,
+    })
   }
 
   /**
@@ -209,7 +227,18 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     return (this.bodyCache.parsedBody ??= await parseBody(this, options))
   }
 
-  #cachedBody = (key: keyof Body) => {
+  #getAnyCachedBody = () => {
+    const anyCachedKey = Object.keys(this.bodyCache)[0]
+    if (anyCachedKey) {
+      let body = this.bodyCache[anyCachedKey as keyof Body]
+      if (anyCachedKey === 'json') {
+        body = JSON.stringify(body)
+      }
+      return body
+    }
+  }
+
+  #cachedBody = async (key: keyof Body) => {
     const { bodyCache, raw } = this
     const cachedBody = bodyCache[key]
 
@@ -217,17 +246,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
       return cachedBody
     }
 
-    const anyCachedKey = Object.keys(bodyCache)[0]
-    if (anyCachedKey) {
-      return (bodyCache[anyCachedKey as keyof Body] as Promise<BodyInit>).then((body) => {
-        if (anyCachedKey === 'json') {
-          body = JSON.stringify(body)
-        }
-        return new Response(body)[key]()
-      })
-    }
-
-    return (bodyCache[key] = raw[key]())
+    const body = this.#getAnyCachedBody()
+    return body ? new Response(body)[key]() : (bodyCache[key] = await raw[key]())
   }
 
   /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -70,6 +70,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     this.path = path
     this.#matchResult = matchResult
     this.#validatedData = {}
+    /* eslint-disable @typescript-eslint/no-this-alias */
     const self = this
     Object.defineProperty(this, 'raw', {
       get() {


### PR DESCRIPTION
This PR will fix the problem that we wanted to resolve with #4382.

### Problem

The following code will cause the error:

```ts
import { Hono } from 'hono'

const app = new Hono()

app.post('/', async (c) => {
  const data = await c.req.json()
  await c.req.raw.json() // Body already used!
  return c.json(data)
})

export default app
```

<img width="1254" height="424" alt="CleanShot 2025-09-23 at 17 17 54@2x" src="https://github.com/user-attachments/assets/ea95ed2f-c6fc-4bbb-9d70-f7f4661d71c2" />

This is because when you do `c.req.raw`, the body to be used is already consumed. This is explained in https://github.com/honojs/hono/pull/4382#issue-3370569516.

### Solution

In this PR, it will create a new Request object with a cached body when `c.req.raw` is called. The reason why it does not use getter/setter and uses `Object.defineProperty` is that if it were to use getter/setter, it would fail with the spread syntax `{...c.req}`.

### Caveat

The code size will be increased.

The performance may degrade, but it's small.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
