### PR TITLE
feat(hono-base): introduce `~env` type-only attribute in `Hono` class

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -556,8 +556,7 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
    *     c.var.logger("log message");
    *   })
    */
-  ['~env']: E = undefined as unknown as E;
-  ['~schema']: S = undefined as unknown as S
+  ['~env']: E = undefined as unknown as E
 }
 
 export { Hono as HonoBase }


### PR DESCRIPTION
# Problem

https://github.com/honojs/middleware/issues/637

Can not call `.use()` from `OpenAPIHono` (zod-openapi) without changing the return type into a general `Hono` instance

```ts
// == logger-middleware.ts
// Adds a variable `logger` to `c.var` in the middleware
type Logger = () => ...
export const loggerMiddleware = createMiddleware<{ Variables: { logger: Logger } }>(...);
```

```ts
// == index.ts
// Initialize an OpenAPIHono instance (zod-openapi middleware)
export const baseApp = new OpenAPIHono();
export const baseAppWithMiddlewares = baseApp
  .use(loggerMiddleware())
  // Because we called .use(), the return type is now
  // `Hono<{ Variables: { logger: Logger } }>` instead of `OpenAPIHono`
```

```ts
// == auth.ts
// ❌ Can not call openapi() because baseAppWithMiddlewares is now a more basic `Hono` instance
const authRoutes = baseAppWithMiddlewares
  .openapi(someRoute, someHandler)

// ❌ `c.var.logger` is not available via TypeScript, although in runtime it should be there
const authRoutes = baseApp
  .openapi(someRoute, (c) => { c.var.logger("...") } ) // error
```

# Current solution

People tried adding custom Env to the OpenAPIHono instance

```ts
// == index.ts

// Defining your own Variables
type Variables = {
  logger: Logger
}

export const baseApp = new OpenAPIHono<{ Variables: Variables }>();
export const baseAppWithMiddlewares = baseApp
  .use(loggerMiddleware())
```

```ts
// == auth.ts
// ✅ `c.var.logger` is now available

const authRoutes = baseApp
  .openapi(someRoute, (c) => { c.var.logger("...") } ) // inferred correctly
```

Others also used approach like extending the interface `ContextVariableMap` and use type augmentation (like in `hono/request-id` middleware). But both methods have the same issue:

⚠️ Accidentally changing/removing `.use(loggerMiddleware())` in index.ts will risk it being broken on runtime.

# Solution

By introducing new attribute `~env` in Hono class, we can get the inferred `Env` types from Hono instance that has been added using `.use(middleware)`

The naming `~env` and `~schema` (prefixed with tilde) was choosen to [de-prioritize it in autocompletion](https://x.com/colinhacks/status/1816860780459073933). By contrast, an underscore-prefixed property would show up before properties/methods with alphanumeric names. As this is mostly just a type-only thing, I also made it return undefined.

```ts
// == index.ts

// No need to define your own Variables
// No need to augment ContextVariableMap, just use the real thing

const _baseApp = new OpenAPIHono();
export const baseAppWithMiddlewares = _baseApp
  .use(loggerMiddleware())

type BaseAppEnv = (typeof baseAppWithMiddlewares)['~env']

// THE POINT:
// - Export the original `_baseApp`, but still
// - Retain the inferred end result types from baseAppWithMiddlewares
export const baseApp = _baseApp as OpenAPIHono<BaseAppEnv>
```

```ts
// == auth.ts
// ✅ `c.var.logger` is now available
const authRoutes = baseApp
  .openapi(someRoute, (c) => { c.var.logger("...") } ) // inferred correctly

```

I'm not sure what kind of tests to add here, as it only forwards the generics `E` and `S` in Hono class, and contains no runtime code.

~To complement the expose of `~env`, I also added `~schema`, so people can get both generics.~ Seems that exposing schema would make type inference too deep.