### PR TITLE
feat: adds support for hmr

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -374,12 +374,46 @@ class Hono<E extends Env = Env, S extends Schema = {}, BasePath extends string =
     return this
   }
 
+  /**
+   * Add a route to the router.
+   *
+   * Replaces an existing route if the method and path are the same.
+   * Rebuilds the router if a route is replaced.
+   *
+   * Otherwise, adds the route to the router and the routes array.
+   * @param method - HTTP method
+   * @param path - Path for the route
+   * @param handler - Handler for the route
+   */
   #addRoute(method: string, path: string, handler: H) {
     method = method.toUpperCase()
     path = mergePath(this._basePath, path)
     const r: RouterRoute = { basePath: this._basePath, path, method, handler }
-    this.router.add(method, path, [handler, r])
-    this.routes.push(r)
+
+    const existingIndex = this.routes.findIndex(
+      (route) => route.method === method && route.path === path
+    )
+
+    if (existingIndex !== -1) {
+      this.routes[existingIndex] = r
+      this.#rebuildRouter()
+    } else {
+      this.router.add(method, path, [handler, r])
+      this.routes.push(r)
+    }
+  }
+
+  #rebuildRouter() {
+    if ('clear' in this.router && typeof this.router.clear === 'function') {
+      this.router.clear()
+    } else {
+      const RouterClass = this.router.constructor as new () => Router<[H, RouterRoute]>
+      this.router = new RouterClass()
+    }
+
+    this.routes.forEach((route) => {
+      this.router.add(route.method, route.path, [route.handler, route])
+    })
   }
 
   #handleError(err: unknown, c: Context<E>) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,6 +49,11 @@ export interface Router<T> {
    * @returns The result of the match.
    */
   match(method: string, path: string): Result<T>
+
+  /**
+   * Clears all routes from the router.
+   */
+  clear?(): void
 }
 
 /**

--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -871,5 +871,79 @@ export const runTest = ({
         expect(res[0].handler).toBe('all')
       })
     })
+
+    describe('Clear method', () => {
+      it('should clear all routes', () => {
+        router.add('GET', '/hello', 'handler1')
+        router.add('POST', '/world', 'handler2')
+
+        let res = match('GET', '/hello')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toBe('handler1')
+
+        res = match('POST', '/world')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toBe('handler2')
+
+        if ('clear' in router && typeof router.clear === 'function') {
+          router.clear()
+
+          res = match('GET', '/hello')
+          expect(res.length).toBe(0)
+
+          res = match('POST', '/world')
+          expect(res.length).toBe(0)
+        }
+      })
+
+      it('should allow adding new routes after clear', () => {
+        router.add('GET', '/old', 'oldHandler')
+        let res = match('GET', '/old')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toBe('oldHandler')
+
+        if ('clear' in router && typeof router.clear === 'function') {
+          router.clear()
+          router.add('GET', '/new', 'newHandler')
+
+          res = match('GET', '/old')
+          expect(res.length).toBe(0)
+
+          res = match('GET', '/new')
+          expect(res.length).toBe(1)
+          expect(res[0].handler).toBe('newHandler')
+        }
+      })
+
+      it('should handle complex routes after clear', () => {
+        router.add('GET', '/users/:id', 'user')
+        router.add('POST', '/api/*', 'apiMiddleware')
+        router.add('ALL', '*', 'globalMiddleware')
+
+        let res = match('GET', '/users/123')
+        expect(res.length).toBeGreaterThan(0)
+
+        res = match('POST', '/api/posts')
+        expect(res.length).toBeGreaterThan(0)
+
+        if ('clear' in router && typeof router.clear === 'function') {
+          router.clear()
+
+          res = match('GET', '/users/123')
+          expect(res.length).toBe(0)
+
+          res = match('POST', '/api/posts')
+          expect(res.length).toBe(0)
+
+          res = match('DELETE', '/anything')
+          expect(res.length).toBe(0)
+
+          router.add('GET', '/fresh', 'freshHandler')
+          res = match('GET', '/fresh')
+          expect(res.length).toBe(1)
+          expect(res[0].handler).toBe('freshHandler')
+        }
+      })
+    })
   })
 }

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -137,4 +137,8 @@ export class LinearRouter<T> implements Router<T> {
 
     return [handlers]
   }
+
+  clear(): void {
+    this.#routes = []
+  }
 }

--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -57,4 +57,8 @@ export class PatternRouter<T> implements Router<T> {
 
     return [handlers]
   }
+
+  clear(): void {
+    this.#routes = []
+  }
 }

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -273,4 +273,9 @@ export class RegExpRouter<T> implements Router<T> {
       return buildMatcherFromPreprocessedRoutes(routes)
     }
   }
+
+  clear(): void {
+    this.#middleware = { [METHOD_NAME_ALL]: Object.create(null) }
+    this.#routes = { [METHOD_NAME_ALL]: Object.create(null) }
+  }
 }

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -25,4 +25,8 @@ export class TrieRouter<T> implements Router<T> {
   match(method: string, path: string): Result<T> {
     return this.#node.search(method, path)
   }
+
+  clear(): void {
+    this.#node = new Node()
+  }
 }


### PR DESCRIPTION
Reference: https://github.com/honojs/vite-plugins/issues/274

This PR attempts to address the way Hono adds new routes, which prevents proper HMR from working with toolkits like Vite. This PR introduces a new method for each router — `clear` — which will properly tear down the router while its running and adds a new `rebuildRouter` method, which will rebuild the router. 

This allows for a more intelligent smart diff comparison, rather than what happened with the previous HMR attempt, which caused issues because of how Hono attempts to add new routes and breaking because the route already exists.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
