### PR TITLE
Fix #4427 type regression by removing non-public export

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -190,7 +190,7 @@ interface JSONRespond {
  *
  * @returns {Response & TypedResponse<JSONParsed<T>, U, 'json'>} - The response after rendering the JSON object, typed with the provided object and status code types.
  */
-export type JSONRespondReturn<
+type JSONRespondReturn<
   T extends JSONValue | {} | InvalidJSONValue,
   U extends ContentfulStatusCode
 > = Response & TypedResponse<JSONParsed<T>, U, 'json'>


### PR DESCRIPTION
I think this fixes https://github.com/honojs/hono/issues/4427

Example test code:
```ts
import { createFactory } from 'hono/factory';
const factory = createFactory();
export const handlers = factory.createHandlers(c =>
	c.json({ ok: true }),
);

```

With the type exported (since v4.9.8), I was getting the error:

```
ts(2742): The inferred type of 'handlers' cannot be named without a reference to '../node_modules/hono/dist/types/context.js'. This is likely not portable. A type annotation is necessary.
```

By avoiding the export, there is no type error. Removing this export should not create any issues as far as I know, because it is not imported anywhere or publicly exposed outside hono itself.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
