### PR TITLE
fix(aws-lambda): sanitize non-ASCII header values to prevent ByteString errors

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -289,4 +289,80 @@ describe('EventProcessor.createRequest', () => {
       header2: 'value1,value2',
     })
   })
+
+  describe('non-ASCII header value processing', () => {
+    it('Should correctly process ALB request with non-ASCII header values', async () => {
+      const event: LambdaEvent = {
+        headers: {
+          'content-type': 'application/json',
+          'cf-ipcity': 'São Paulo', // City name with non-ASCII characters
+          'x-custom-city': 'Москва', // Cyrillic characters
+        },
+        httpMethod: 'GET',
+        path: '/',
+        body: null,
+        isBase64Encoded: false,
+        requestContext: {
+          elb: {
+            targetGroupArn:
+              'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/lambda-279XGJDqGZ5rsrHC2Fjr/49e9d65c45c6791a',
+          },
+        },
+      }
+
+      const processor = getProcessor(event)
+      const request = processor.createRequest(event)
+
+      expect(request.method).toBe('GET')
+      expect(request.url).toBe('https://undefined/')
+      expect(request.headers.get('cf-ipcity')).toBeDefined()
+      expect(request.headers.get('x-custom-city')).toBeDefined()
+    })
+
+    it('Should correctly process ALB request with non-ASCII multi-value header values', async () => {
+      const event: LambdaEvent = {
+        multiValueHeaders: {
+          'content-type': ['application/json'],
+          'cf-ipcity': ['São Paulo', 'München'], // City names with non-ASCII characters
+        },
+        httpMethod: 'GET',
+        path: '/',
+        body: null,
+        isBase64Encoded: false,
+        requestContext: {
+          elb: {
+            targetGroupArn:
+              'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/lambda-279XGJDqGZ5rsrHC2Fjr/49e9d65c45c6791a',
+          },
+        },
+      }
+
+      const processor = getProcessor(event)
+      const request = processor.createRequest(event)
+
+      expect(request.method).toBe('GET')
+      expect(request.url).toBe('https://undefined/')
+      expect(request.headers.get('cf-ipcity')).toBeDefined()
+      expect(request.headers.get('cf-ipcity')).toContain(';')
+    })
+
+    it('Should correctly process APIGateway v1 request with non-ASCII header values', async () => {
+      const event: LambdaEvent = {
+        ...baseV1Event,
+        headers: {
+          'content-type': 'application/json',
+          'cf-ipcity': 'São Paulo', // City name with non-ASCII characters
+          'x-custom-city': 'Москва', // Cyrillic characters
+        },
+      }
+
+      const processor = getProcessor(event)
+      const request = processor.createRequest(event)
+
+      expect(request.method).toBe('GET')
+      expect(request.url).toBe('https://id.execute-api.us-east-1.amazonaws.com/my/path')
+      expect(request.headers.get('cf-ipcity')).toBeDefined()
+      expect(request.headers.get('x-custom-city')).toBeDefined()
+    })
+  })
 })

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -16,16 +16,7 @@ function sanitizeHeaderValue(value: string): string {
   if (!hasNonAscii) {
     return value
   }
-
-  try {
-    // Convert UTF-8 string to bytes and interpret as Latin-1
-    const utf8Bytes = new TextEncoder().encode(value)
-    return new TextDecoder('latin1').decode(utf8Bytes)
-  } catch {
-    // Fallback: remove non-ASCII characters
-    // eslint-disable-next-line no-control-regex
-    return value.replace(/[^\x00-\x7F]/g, '')
-  }
+  return encodeURIComponent(value)
 }
 
 export type LambdaEvent = APIGatewayProxyEvent | APIGatewayProxyEventV2 | ALBProxyEvent

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -11,6 +11,7 @@ import type {
 
 function sanitizeHeaderValue(value: string): string {
   // Check if the value contains non-ASCII characters (char codes > 127)
+  // eslint-disable-next-line no-control-regex
   const hasNonAscii = /[^\x00-\x7F]/.test(value)
   if (!hasNonAscii) {
     return value
@@ -22,6 +23,7 @@ function sanitizeHeaderValue(value: string): string {
     return new TextDecoder('latin1').decode(utf8Bytes)
   } catch {
     // Fallback: remove non-ASCII characters
+    // eslint-disable-next-line no-control-regex
     return value.replace(/[^\x00-\x7F]/g, '')
   }
 }


### PR DESCRIPTION
Fixes #4432

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
