### PR TITLE
feat(compose): `app.onError` handles a non-Error object

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -50,9 +50,13 @@ export const compose = <E extends Env = Env>(
         try {
           res = await handler(context, () => dispatch(i + 1))
         } catch (err) {
-          if (err instanceof Error && onError) {
-            context.error = err
-            res = await onError(err, context)
+          if (onError) {
+            const error =
+              err instanceof Error
+                ? err
+                : new Error(typeof err === 'string' ? err : undefined, { cause: err })
+            context.error = error
+            res = await onError(error, context)
             isError = true
           } else {
             throw err


### PR DESCRIPTION
Resolves #667

The original code is https://github.com/honojs/hono/issues/667#issuecomment-3301249718 by @usualoma 

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
