### PR TITLE
fix(types): fix 4.9.8 regression

### DIFF
--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -60,6 +60,11 @@ describe('JSONParsed', () => {
       type Expected = { a: number }
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
+    it('should convert invalid type with { toJSON() => T to T', () => {
+      type Actual = JSONParsed< bigint & { toJSON(): string }>
+      type Expected = string
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
   })
 
   describe('invalid types', () => {

--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -61,7 +61,7 @@ describe('JSONParsed', () => {
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
     it('should convert invalid type with { toJSON() => T to T', () => {
-      type Actual = JSONParsed< bigint & { toJSON(): string }>
+      type Actual = JSONParsed<bigint & { toJSON(): string }>
       type Expected = string
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -54,11 +54,9 @@ export type JSONValue = JSONObject | JSONArray | JSONPrimitive
  * which defaults to `bigint | ReadonlyArray<bigint>`.
  * You can set it to `never` to disable this check.
  */
-export type JSONParsed<T, TError = bigint | ReadonlyArray<bigint>> = T extends TError
-  ? never
-  : T extends {
-      toJSON(): infer J
-    }
+export type JSONParsed<T, TError = bigint | ReadonlyArray<bigint>> = T extends {
+  toJSON(): infer J
+}
   ? (() => J) extends () => JSONPrimitive
     ? J
     : (() => J) extends () => { toJSON(): unknown }
@@ -83,7 +81,9 @@ export type JSONParsed<T, TError = bigint | ReadonlyArray<bigint>> = T extends T
           : JSONParsed<T[K], TError>
       }
   : T extends unknown
-  ? JSONValue
+  ? T extends TError
+    ? never
+    : JSONValue
   : never
 
 /**


### PR DESCRIPTION
After 4.9.8, the error checking in the `JSONParsed` utility function, short circuits any checking for the `toJSON` function. The error checking was moved to the unknown case. This fixes cases where an invalid type like `bigint` has a global override to `toJSON`.

e.g.
```typescript
declare global {
  interface BigInt {
    toJSON(): string;
  }
}
// expected
type should_be_string = JSONParsed<bigint>;
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
