### PR TITLE
refactor: use protected methods instead of computed properties to allow `tree shaking`

### DIFF
--- a/src/router/reg-exp-router/matcher.ts
+++ b/src/router/reg-exp-router/matcher.ts
@@ -7,10 +7,9 @@ export type Matcher<T> = [RegExp, HandlerData<T>[], StaticMap<T>]
 export type MatcherMap<T> = Record<string, Matcher<T> | null>
 
 export const emptyParam: string[] = []
-export const buildAllMatchersKey = Symbol('buildAllMatchers')
 export function match<R extends Router<T>, T>(this: R, method: string, path: string): Result<T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const matchers: MatcherMap<T> = (this as any)[buildAllMatchersKey]()
+  const matchers: MatcherMap<T> = (this as any).buildAllMatchers()
 
   const match = ((method, path) => {
     const matcher = (matchers[method] || matchers[METHOD_NAME_ALL]) as Matcher<T>

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -6,7 +6,7 @@ import {
 } from '../../router'
 import { checkOptionalParameter } from '../../utils/url'
 import type { HandlerData, StaticMap, Matcher, MatcherMap } from './matcher'
-import { match, emptyParam, buildAllMatchersKey } from './matcher'
+import { match, emptyParam } from './matcher'
 import { PATH_ERROR } from './node'
 import type { ParamAssocArray } from './node'
 import { Trie } from './trie'
@@ -203,9 +203,9 @@ export class RegExpRouter<T> implements Router<T> {
     }
   }
 
-  match: typeof match<Router<T>, T> = match;
+  match: typeof match<Router<T>, T> = match
 
-  [buildAllMatchersKey](): MatcherMap<T> {
+  protected buildAllMatchers(): MatcherMap<T> {
     const matchers: MatcherMap<T> = Object.create(null)
 
     Object.keys(this.#routes!)


### PR DESCRIPTION
The presence of computed properties led to the determination that side effects were possible, resulting in larger bundled code.

#### file

```ts
import { PreparedRegExpRouter } from './src/router/reg-exp-router'
console.log(PreparedRegExpRouter)
```

#### bundle size

main branch

```
$ npx esbuild --bundle prr.ts | wc
     464    1619   15633
```

refactor/prepared-computed-property branch

```
$ npx esbuild --bundle import.ts | wc
      92     262    2790
```

### The author should do the following, if applicable

- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
