### PR TITLE
fix(types): cannot `.use` non-returning async middleware

### DIFF
--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -324,7 +324,7 @@ export const createMiddleware = <
   E extends Env = any,
   P extends string = string,
   I extends Input = {},
-  R extends HandlerResponse<any> = Response
+  R extends HandlerResponse<any> = any
 >(
   middleware: MiddlewareHandler<E, P, I, R>
 ): MiddlewareHandler<E, P, I, R> => middleware


### PR DESCRIPTION
Resolves #4462

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Additional context

A simple fix for a weird TS behavior, aligning response declaration of `MiddlewareHandler` to be more similar to `Handler`