### PR TITLE
fix(aws-lambda): improve regex for content type binary detection

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -93,6 +93,11 @@ describe('isContentTypeBinary', () => {
     expect(defaultIsContentTypeBinary('application/json')).toBe(false)
     expect(defaultIsContentTypeBinary('application/ld+json')).toBe(false)
     expect(defaultIsContentTypeBinary('application/json')).toBe(false)
+    expect(
+      defaultIsContentTypeBinary(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+      )
+    ).toBe(true)
   })
 })
 

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -564,9 +564,7 @@ const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => 
  * @returns True if the content type is binary, false otherwise.
  */
 export const defaultIsContentTypeBinary = (contentType: string): boolean => {
-  return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
-    contentType
-  )
+  return !/^text\/(?:plain|html|css|javascript|csv)|(?:\/|\+)(?:json|xml)(?:;|$)/.test(contentType)
 }
 
 export const isContentEncodingBinary = (contentEncoding: string | null) => {


### PR DESCRIPTION
The existing regular expression was somewhat broad in its matching, so I refined it to match only the intended patterns.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
