### PR TITLE
tests: Fix test case of handlers without a path

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -248,10 +248,9 @@ describe('Register handlers without a path', () => {
       expect(await res.text()).toBe('Hello')
     })
 
-    it('GET http://localhost/anything is ok', async () => {
-      const res = await app.request('/')
-      expect(res.status).toBe(200)
-      expect(await res.text()).toBe('Hello')
+    it('GET http://localhost/anything is not found', async () => {
+      const res = await app.request('/anything')
+      expect(res.status).toBe(404)
     })
   })
 


### PR DESCRIPTION
# Description

While going through the tests, I noticed this small issue in `GET http://localhost/anything is not found` test, where the description says we are testing the route `/localhost/anything`, but the test was just checking for `/localhost`.

This PR aims to fix the test case to point to the correct URL.