### PR TITLE
fix(request-id): validation accepts `=`

### DIFF
--- a/src/middleware/request-id/index.test.ts
+++ b/src/middleware/request-id/index.test.ts
@@ -29,6 +29,19 @@ describe('Request ID Middleware', () => {
     expect(await res.text()).toBe('hono-is-hot')
   })
 
+  it('Should return custom request id with all valid characters', async () => {
+    const validRequestId = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_='
+    const res = await app.request('http://localhost/requestId', {
+      headers: {
+        'X-Request-Id': validRequestId,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Request-Id')).toBe(validRequestId)
+    expect(await res.text()).toBe(validRequestId)
+  })
+
   it('Should return random request id without using request header', async () => {
     const res = await app.request('http://localhost/requestId', {
       headers: {

--- a/src/middleware/request-id/request-id.ts
+++ b/src/middleware/request-id/request-id.ts
@@ -46,7 +46,7 @@ export const requestId = ({
   return async function requestId(c, next) {
     // If `headerName` is empty string, req.header will return the object
     let reqId = headerName ? c.req.header(headerName) : undefined
-    if (!reqId || reqId.length > limitLength || /[^\w\-]/.test(reqId)) {
+    if (!reqId || reqId.length > limitLength || /[^\w\-=]/.test(reqId)) {
       reqId = generator(c)
     }
 


### PR DESCRIPTION
closes #4477 

The middleware validation accepts `=` to use a Base64 string like AWS request id.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
