### PR TITLE
refactor(jwt): reduce the size of the code generated by minification

### DIFF
--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -148,20 +148,13 @@ export const verify = async (
     }
 
     const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud]
-    const matched = audiences.some((payloadAud): boolean => {
-      if (aud instanceof RegExp && aud.test(payloadAud)) {
-        return true
-      } else if (typeof aud === 'string') {
-        if (payloadAud === aud) {
-          return true
-        }
-      } else if (Array.isArray(aud)) {
-        if (aud.includes(payloadAud)) {
-          return true
-        }
-      }
-      return false
-    })
+    const matched = audiences.some((payloadAud): boolean =>
+      aud instanceof RegExp
+        ? aud.test(payloadAud)
+        : typeof aud === 'string'
+        ? payloadAud === aud
+        : Array.isArray(aud) && aud.includes(payloadAud)
+    )
     if (!matched) {
       throw new JwtTokenAudience(aud, payload.aud)
     }


### PR DESCRIPTION
This refactoring aims to reduce the size of the code generated by minification.

* e53a89cf0b00a00e4330cdf0ea8bbe4b82476f5e : This is simply an omission of redundant conditions.
* 5d3ca90724afba40bb1bfb3a5cbfe0788d82f13d : After placing it in an object, referencing it via key makes minify less effective, so I'll stop putting it in an object.
* eeaf13d5422f24aa3207a7e8694269a756a908ed :  Simplify conditional branching with ternary operators
    * Some people might find this a bit hard to read, but it's not overly complex, and considering the code reduction it achieves, I think it's a good approach.

#### before

```
$ npx esbuild --minify dist/utils/jwt/jwt.js | wc
      1     152    2885
```

#### after

```
% npx esbuild --minify dist/utils/jwt/jwt.js | wc
       1     150    2715
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
