### PR TITLE
fix(types): preserve handler response typing in createHandlers

### DIFF
--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from 'vitest'
 import { hc } from '../../client'
 import type { ClientRequest } from '../../client/types'
 import { Hono } from '../../index'
-import type { Env, ExtractSchema, MiddlewareHandler, ToSchema, TypedResponse } from '../../types'
+import type { Env, ExtractSchema, H, MiddlewareHandler, ToSchema, TypedResponse } from '../../types'
 import type { ContentfulStatusCode } from '../../utils/http-status'
 import type { Equal, Expect } from '../../utils/types'
 import { validator } from '../../validator'
@@ -332,6 +332,25 @@ describe('createHandler', () => {
           foo9: c.get('foo9'),
         })
       })
+    })
+  })
+
+  describe('Types - Multiple Handlers', () => {
+    const factory = createFactory()
+
+    const [handler1, handler2] = factory.createHandlers(
+      (c) => c.json({ first: 1 }),
+      (c) => c.json({ second: 'second' as const })
+    )
+
+    type ExtractOutput<R> = R extends H<any, any, any, TypedResponse<infer Inner>> ? Inner : never
+
+    type Handler1Output = ExtractOutput<typeof handler1>
+    type Handler2Output = ExtractOutput<typeof handler2>
+
+    it('Should allow multiple handlers with independent return types', () => {
+      expectTypeOf<Handler1Output>().toEqualTypeOf<{ first: number }>()
+      expectTypeOf<Handler2Output>().toEqualTypeOf<{ second: 'second' }>()
     })
   })
 })

--- a/src/helper/factory/index.ts
+++ b/src/helper/factory/index.ts
@@ -27,12 +27,13 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I extends Input = {},
     I2 extends Input = I,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>
-  ): [H<E2, P, I, R>, H<E3, P, I2, R>]
+    handler2: H<E3, P, I2, R2>
+  ): [H<E2, P, I, R>, H<E3, P, I2, R2>]
 
   // handler x3
   <
@@ -40,14 +41,16 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I2 extends Input = I,
     I3 extends Input = I & I2,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>
-  ): [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>]
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>
+  ): [H<E2, P, I, R>, H<E3, P, I2, R2>, H<E4, P, I3, R3>]
 
   // handler x4
   <
@@ -56,16 +59,19 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I3 extends Input = I & I2,
     I4 extends Input = I & I2 & I3,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>
-  ): [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>, H<E5, P, I4, R>]
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>
+  ): [H<E2, P, I, R>, H<E3, P, I2, R2>, H<E4, P, I3, R3>, H<E5, P, I4, R4>]
 
   // handler x5
   <
@@ -75,6 +81,10 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I4 extends Input = I & I2 & I3,
     I5 extends Input = I & I2 & I3 & I4,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
+    R5 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
@@ -82,11 +92,11 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>,
-    handler5: H<E6, P, I5, R>
-  ): [H<E2, P, I, R>, H<E3, P, I2, R>, H<E4, P, I3, R>, H<E5, P, I4, R>, H<E6, P, I5, R>]
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>,
+    handler5: H<E6, P, I5, R5>
+  ): [H<E2, P, I, R>, H<E3, P, I2, R2>, H<E4, P, I3, R3>, H<E5, P, I4, R4>, H<E6, P, I5, R5>]
 
   // handler x6
   <
@@ -97,6 +107,11 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I5 extends Input = I & I2 & I3 & I4,
     I6 extends Input = I & I2 & I3 & I4 & I5,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
+    R5 extends HandlerResponse<any> = any,
+    R6 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
@@ -105,18 +120,18 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>,
-    handler5: H<E6, P, I5, R>,
-    handler6: H<E7, P, I6, R>
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>,
+    handler5: H<E6, P, I5, R5>,
+    handler6: H<E7, P, I6, R6>
   ): [
     H<E2, P, I, R>,
-    H<E3, P, I2, R>,
-    H<E4, P, I3, R>,
-    H<E5, P, I4, R>,
-    H<E6, P, I5, R>,
-    H<E7, P, I6, R>
+    H<E3, P, I2, R2>,
+    H<E4, P, I3, R3>,
+    H<E5, P, I4, R4>,
+    H<E6, P, I5, R5>,
+    H<E7, P, I6, R6>
   ]
 
   // handler x7
@@ -129,6 +144,12 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I6 extends Input = I & I2 & I3 & I4 & I5,
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
+    R5 extends HandlerResponse<any> = any,
+    R6 extends HandlerResponse<any> = any,
+    R7 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
@@ -138,20 +159,20 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>,
-    handler5: H<E6, P, I5, R>,
-    handler6: H<E7, P, I6, R>,
-    handler7: H<E8, P, I7, R>
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>,
+    handler5: H<E6, P, I5, R5>,
+    handler6: H<E7, P, I6, R6>,
+    handler7: H<E8, P, I7, R7>
   ): [
     H<E2, P, I, R>,
-    H<E3, P, I2, R>,
-    H<E4, P, I3, R>,
-    H<E5, P, I4, R>,
-    H<E6, P, I5, R>,
-    H<E7, P, I6, R>,
-    H<E8, P, I7, R>
+    H<E3, P, I2, R2>,
+    H<E4, P, I3, R3>,
+    H<E5, P, I4, R4>,
+    H<E6, P, I5, R5>,
+    H<E7, P, I6, R6>,
+    H<E8, P, I7, R7>
   ]
 
   // handler x8
@@ -165,6 +186,13 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I7 extends Input = I & I2 & I3 & I4 & I5 & I6,
     I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
+    R5 extends HandlerResponse<any> = any,
+    R6 extends HandlerResponse<any> = any,
+    R7 extends HandlerResponse<any> = any,
+    R8 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
@@ -175,22 +203,22 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>,
-    handler5: H<E6, P, I5, R>,
-    handler6: H<E7, P, I6, R>,
-    handler7: H<E8, P, I7, R>,
-    handler8: H<E9, P, I8, R>
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>,
+    handler5: H<E6, P, I5, R5>,
+    handler6: H<E7, P, I6, R6>,
+    handler7: H<E8, P, I7, R7>,
+    handler8: H<E9, P, I8, R8>
   ): [
     H<E2, P, I, R>,
-    H<E3, P, I2, R>,
-    H<E4, P, I3, R>,
-    H<E5, P, I4, R>,
-    H<E6, P, I5, R>,
-    H<E7, P, I6, R>,
-    H<E8, P, I7, R>,
-    H<E9, P, I8, R>
+    H<E3, P, I2, R2>,
+    H<E4, P, I3, R3>,
+    H<E5, P, I4, R4>,
+    H<E6, P, I5, R5>,
+    H<E7, P, I6, R6>,
+    H<E8, P, I7, R7>,
+    H<E9, P, I8, R8>
   ]
 
   // handler x9
@@ -205,6 +233,14 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I8 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7,
     I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
+    R5 extends HandlerResponse<any> = any,
+    R6 extends HandlerResponse<any> = any,
+    R7 extends HandlerResponse<any> = any,
+    R8 extends HandlerResponse<any> = any,
+    R9 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
@@ -216,14 +252,14 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>,
-    handler5: H<E6, P, I5, R>,
-    handler6: H<E7, P, I6, R>,
-    handler7: H<E8, P, I7, R>,
-    handler8: H<E9, P, I8, R>,
-    handler9: H<E10, P, I9, R>
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>,
+    handler5: H<E6, P, I5, R5>,
+    handler6: H<E7, P, I6, R6>,
+    handler7: H<E8, P, I7, R7>,
+    handler8: H<E9, P, I8, R8>,
+    handler9: H<E10, P, I9, R9>
   ): [
     H<E2, P, I, R>,
     H<E3, P, I2, R>,
@@ -249,6 +285,15 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     I9 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8,
     I10 extends Input = I & I2 & I3 & I4 & I5 & I6 & I7 & I8 & I9,
     R extends HandlerResponse<any> = any,
+    R2 extends HandlerResponse<any> = any,
+    R3 extends HandlerResponse<any> = any,
+    R4 extends HandlerResponse<any> = any,
+    R5 extends HandlerResponse<any> = any,
+    R6 extends HandlerResponse<any> = any,
+    R7 extends HandlerResponse<any> = any,
+    R8 extends HandlerResponse<any> = any,
+    R9 extends HandlerResponse<any> = any,
+    R10 extends HandlerResponse<any> = any,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
@@ -261,26 +306,26 @@ export interface CreateHandlersInterface<E extends Env, P extends string> {
     E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>
   >(
     handler1: H<E2, P, I, R>,
-    handler2: H<E3, P, I2, R>,
-    handler3: H<E4, P, I3, R>,
-    handler4: H<E5, P, I4, R>,
-    handler5: H<E6, P, I5, R>,
-    handler6: H<E7, P, I6, R>,
-    handler7: H<E8, P, I7, R>,
-    handler8: H<E9, P, I8, R>,
-    handler9: H<E10, P, I9, R>,
-    handler10: H<E11, P, I10, R>
+    handler2: H<E3, P, I2, R2>,
+    handler3: H<E4, P, I3, R3>,
+    handler4: H<E5, P, I4, R4>,
+    handler5: H<E6, P, I5, R5>,
+    handler6: H<E7, P, I6, R6>,
+    handler7: H<E8, P, I7, R7>,
+    handler8: H<E9, P, I8, R8>,
+    handler9: H<E10, P, I9, R9>,
+    handler10: H<E11, P, I10, R10>
   ): [
     H<E2, P, I, R>,
-    H<E3, P, I2, R>,
-    H<E4, P, I3, R>,
-    H<E5, P, I4, R>,
-    H<E6, P, I5, R>,
-    H<E7, P, I6, R>,
-    H<E8, P, I7, R>,
-    H<E9, P, I8, R>,
-    H<E10, P, I9, R>,
-    H<E11, P, I10, R>
+    H<E3, P, I2, R2>,
+    H<E4, P, I3, R3>,
+    H<E5, P, I4, R4>,
+    H<E6, P, I5, R5>,
+    H<E7, P, I6, R6>,
+    H<E8, P, I7, R7>,
+    H<E9, P, I8, R8>,
+    H<E10, P, I9, R9>,
+    H<E11, P, I10, R10>
   ]
 }
 


### PR DESCRIPTION
Fixes #4489 

This PR fixes incorrect type inference in _factory.createHandlers_ when multiple handlers are provided.
Currently, the response type of the first handler is enforced across all handlers, breaking type safety.

Example code:

```ts
const factory = createFactory()

const handler = factory.createHandlers(
  (c) => c.json({example1: 0}),
  (c) => c.json({example2: 0}),
)
```

Bug:

```
Property 'example1' is missing in type '{ example2: number; }' but required in type '{ example1: number; }'.
```

After this fix the type is inferred correctly:

```ts
[H<Env, string, {}, JSONRespondReturn<{
    example1: number;
}, ContentfulStatusCode>>, H<{}, string, {}, JSONRespondReturn<{
    example2: number;
}, ContentfulStatusCode>>]
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
