### PR TITLE
fix(secure-headers): proposed features typo spelling mistake

### DIFF
--- a/src/middleware/secure-headers/permissions-policy.ts
+++ b/src/middleware/secure-headers/permissions-policy.ts
@@ -62,7 +62,7 @@ type StandardizedFeatures =
 type ProposedFeatures =
   | 'clipboardRead'
   | 'clipboardWrite'
-  | 'gemepad'
+  | 'gamepad'
   | 'sharedAutofill'
   | 'speakerSelection'
 


### PR DESCRIPTION
**fix: correct typo in secure-headers middleware permissions-policy.ts**

---

### 📝 Description
as [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/gamepad) see 'gemepad' should be 'gamepad'
There are **no functional changes** — only typo corrections in identifiers or comments.

---

### ✅ Checklist

- [ ] Add tests  
- [x] Run tests (`bun test`)  
- [x] `bun run format:fix && bun run lint:fix`  
- [ ] Add TSDoc/JSDoc documentation  

---

### 💬 Notes
- Verified all tests pass after changes.  
- No API, behavior, or logic modifications.
