### PR TITLE
docs(CONTRIBUTING): use bun instead of yarn in local development setup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ If you want to do it, create the issue about your middleware.
 ## Local Development
 
 ```bash
-git clone git@github.com:honojs/hono.git && cd hono/.devcontainer && yarn install --frozen-lockfile
+git clone git@github.com:honojs/hono.git && cd hono/.devcontainer && bun install --frozen-lockfile
 docker compose up -d --build
 docker compose exec hono bash
 ```


### PR DESCRIPTION
I found that the "Local Development" section of `CONTRIBUTING.md` still uses `yarn install`, even though the project has moved to Bun as its package manager.

This PR updates it to use `bun install --frozen-lockfile` for consistency with the rest of the project.