### PR TITLE
fix(utils/url): make _getQueryParam search behind question mark

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -247,8 +247,9 @@ describe('url', () => {
       })
       expect(getQueryParam('http://example.com/?pretty', 'pretty')).toBe('')
       expect(getQueryParam('http://example.com/?pretty', 'prtt')).toBe(undefined)
-      expect(getQueryParam('http://example.com/&name=sam?name=tom', 'name')).toBe('tom')
       expect(getQueryParam('http://example.com/?name=sam&name=tom', 'name')).toBe('sam')
+      expect(getQueryParam('http://example.com/&name=sam?name=tom', 'name')).toBe('tom')
+      expect(getQueryParam('http://example.com/&name=sam', 'name')).toBe(undefined)
       expect(getQueryParam('http://example.com/?name=sam&name=tom')).toEqual({
         name: 'sam',
       })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -221,7 +221,7 @@ const _getQueryParam = (
     if (keyIndex === -1) {
       return undefined
     }
-    if (url.slice(keyIndex + 1, keyIndex + key.length + 1) !== key) {
+    if (!url.startsWith(key, keyIndex + 1)) {
       keyIndex = url.indexOf(`&${key}`, keyIndex + 1)
     }
     while (keyIndex !== -1) {


### PR DESCRIPTION
Original implementation would search in substrings presented without or before `?`, which should be parse as path instead.
This PR fixes that.

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
