### PR TITLE
fix(jsx): self-close wrapped empty tags

### DIFF
--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -27,4 +27,10 @@ describe('cloneElement', () => {
     expect(element.toString()).toBe('<div>Hello</div>')
     expect(clonedElement.toString()).toBe('<div>World</div>')
   })
+
+  it('should self-close a wrapped empty tag', () => {
+    const Hr = ({ ...props }) => <hr {...props} />
+    const element = <Hr />
+    expect(element.toString()).toBe('<hr/>')
+  })
 })

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -245,10 +245,12 @@ class JSXFunctionNode extends JSXNode {
   override toStringToBuffer(buffer: StringBufferWithCallbacks): void {
     const { children } = this
 
-    const res = (this.tag as Function).call(null, {
-      ...this.props,
-      children: children.length <= 1 ? children[0] : children,
-    })
+    const props = { ...this.props }
+    if (children.length) {
+      props.children = children.length === 1 ? children[0] : children
+    }
+
+    const res = (this.tag as Function).call(null, props)
 
     if (typeof res === 'boolean' || res == null) {
       // boolean or null or undefined


### PR DESCRIPTION
Fix `JSXFunctionNode.prototype.toStringToBuffer` to leave `children` prop unset if there are no children.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
