### PR TITLE
fix(validator): fix incomplete types and wrong tests

### DIFF
--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -9,8 +9,8 @@ import type {
   ErrorHandler,
   ExtractSchema,
   ExtractSchemaForStatusCode,
+  FormValue,
   MiddlewareHandler,
-  ParsedFormValue,
   TypedResponse,
   ValidationTargets,
 } from '../types'
@@ -954,7 +954,7 @@ it('With path parameters', () => {
       $put: {
         input: {
           form: {
-            title: ParsedFormValue | ParsedFormValue[]
+            title: FormValue | FormValue[]
           }
         } & {
           param: {
@@ -1000,7 +1000,7 @@ it('`on`', () => {
       $purge: {
         input: {
           form: {
-            tag: ParsedFormValue | ParsedFormValue[]
+            tag: FormValue | FormValue[]
           }
         } & {
           query: {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../context'
 import { getCookie } from '../helper/cookie'
 import { HTTPException } from '../http-exception'
-import type { Env, MiddlewareHandler, TypedResponse, ValidationTargets } from '../types'
+import type { Env, MiddlewareHandler, TypedResponse, ValidationTargets, FormValue } from '../types'
 import type { BodyData } from '../utils/body'
 import { bufferToFormData } from '../utils/buffer'
 
@@ -66,7 +66,7 @@ export const validator = <
         ? unknown extends InputType
           ? ExtractValidatorOutput<VF>
           : InputType
-        : { [K2 in keyof ExtractValidatorOutput<VF>]: ValidationTargets[K][K2] }
+        : { [K2 in keyof ExtractValidatorOutput<VF>]: ValidationTargets<FormValue>[K][K2] }
     }
     out: { [K in U]: ExtractValidatorOutput<VF> }
   } = {
@@ -75,7 +75,7 @@ export const validator = <
         ? unknown extends InputType
           ? ExtractValidatorOutput<VF>
           : InputType
-        : { [K2 in keyof ExtractValidatorOutput<VF>]: ValidationTargets[K][K2] }
+        : { [K2 in keyof ExtractValidatorOutput<VF>]: ValidationTargets<FormValue>[K][K2] }
     }
     out: { [K in U]: ExtractValidatorOutput<VF> }
   },


### PR DESCRIPTION
close: https://github.com/honojs/hono/issues/4520

This PR fixes the incomplete work from the PR I created a year ago. (https://github.com/honojs/hono/issues/3120)
I forgot to update the types for the input schemas such as `$get` and `$post`, and this mistake was caused by incorrect tests.
This PR should resolve everything. Sorry about that.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
