### PR TITLE
refactor(types): delete type `NotSpecified` and `StrictVerifyOptions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2348,9 +2348,6 @@ export type ExtractHandlerResponse<T> = T extends (c: any, next: any) => Promise
     : never
   : never
 
-// Special type to indicate "not specified"
-type NotSpecified = { readonly __notSpecified: unique symbol }
-
 type ProcessHead<T> = IfAnyThenEmptyObject<T extends Env ? (Env extends T ? {} : T) : T>
 export type IntersectNonAnyTypes<T extends any[]> = T extends [infer Head, ...infer Rest]
   ? ProcessHead<Head> & IntersectNonAnyTypes<Rest>

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -89,14 +89,6 @@ export type VerifyOptionsWithAlg = {
   alg?: SignatureAlgorithm
 } & VerifyOptions
 
-type StrictVerifyOptions = {
-  iss?: string | RegExp
-  nbf: boolean
-  exp: boolean
-  iat: boolean
-  aud?: string | string[] | RegExp
-}
-
 export const verify = async (
   token: string,
   publicKey: SignatureKey,


### PR DESCRIPTION
When I was watching [this PR](https://github.com/honojs/hono/pull/4523/files#:~:text=Unchanged%20files%20with%20check%20annotations),  I awared there were `declared but never used.` errors. So I delete type declared but never used.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
