### PR TITLE
feat(pretty-json): support force option

### DIFF
--- a/src/middleware/pretty-json/index.test.ts
+++ b/src/middleware/pretty-json/index.test.ts
@@ -55,4 +55,22 @@ describe('JSON pretty by Middleware', () => {
     const nonPrettyText = await (await app.request('?pretty')).text()
     expect(nonPrettyText).toBe('{"message":"Hono!"}')
   })
+
+  it('Should force pretty JSON output when force option is true', async () => {
+    const app = new Hono()
+    app.use('*', prettyJSON({ force: true }))
+    app.get('/', (c) => {
+      return c.json({ message: 'Hono!' })
+    })
+
+    const resWithoutQuery = await (await app.request('http://localhost/')).text()
+    expect(resWithoutQuery).toBe(`{
+  "message": "Hono!"
+}`)
+
+    const resWithQuery = await (await app.request('http://localhost/?pretty')).text()
+    expect(resWithQuery).toBe(`{
+  "message": "Hono!"
+}`)
+  })
 })

--- a/src/middleware/pretty-json/index.ts
+++ b/src/middleware/pretty-json/index.ts
@@ -17,6 +17,12 @@ interface PrettyOptions {
    * @default 'pretty'
    */
   query?: string
+
+  /**
+   * Force prettification of JSON responses regardless of query parameters.
+   * @default false
+   */
+  force?: boolean
 }
 
 /**
@@ -40,7 +46,7 @@ interface PrettyOptions {
 export const prettyJSON = (options?: PrettyOptions): MiddlewareHandler => {
   const targetQuery = options?.query ?? 'pretty'
   return async function prettyJSON(c, next) {
-    const pretty = c.req.query(targetQuery) || c.req.query(targetQuery) === ''
+    const pretty = options?.force || c.req.query(targetQuery) || c.req.query(targetQuery) === ''
     await next()
     if (pretty && c.res.headers.get('Content-Type')?.startsWith('application/json')) {
       const obj = await c.res.json()


### PR DESCRIPTION
This PR adds a `force` option to `pretty-json` for users who want all responses to be pretty printed, ie. don't want to add `?pretty=1` to all queries and don't want to use a 3rd party or hand-rolled middleware.

usage:

```js
app.use('*', prettyJSON({ force: true }))
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code