### PR TITLE
fix: add JSX type for hono/jsx/dom

### DIFF
--- a/src/jsx/dom/jsx-dev-runtime.ts
+++ b/src/jsx/dom/jsx-dev-runtime.ts
@@ -4,6 +4,7 @@
  */
 
 import type { JSXNode, Props } from '../base'
+export type { JSX } from '../base'
 import * as intrinsicElementTags from './intrinsic-element/components'
 
 export const jsxDEV = (tag: string | Function, props: Props, key?: string): JSXNode => {

--- a/src/jsx/dom/jsx-runtime.ts
+++ b/src/jsx/dom/jsx-runtime.ts
@@ -5,3 +5,4 @@
 
 export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
 export { jsxDEV as jsxs } from './jsx-dev-runtime'
+export type { JSX } from './jsx-dev-runtime'


### PR DESCRIPTION
close #4533 


Issues:

```
> hono-jsx-dom-types-repro@0.0.0 build /Users/sotaro/Dev/github.com/ssssota/hono-jsx-dom-types-repro
> tsc && vite build

src/main.tsx:8:10 - error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.

8   return <h1>Hello</h1>;
           ~~~~

src/main.tsx:8:19 - error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.

8   return <h1>Hello</h1>;
                    ~~~~~
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
