### PR TITLE
feat(context-storage): Add optional tryGetContext helper to context-storage middleware

### DIFF
--- a/src/middleware/context-storage/index.test.ts
+++ b/src/middleware/context-storage/index.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { contextStorage, getContext, getContextIfAny } from '.'
+import { contextStorage, getContext, tryGetContext } from '.'
 
 describe('Context Storage Middleware', () => {
   type Env = {
@@ -19,7 +19,7 @@ describe('Context Storage Middleware', () => {
     return c.text(getMessage())
   })
   app.get('/optional', (c) => {
-    const optionalContext = getContextIfAny<Env>()
+    const optionalContext = tryGetContext<Env>()
     return c.text(optionalContext?.var.message ?? 'no context')
   })
 
@@ -33,10 +33,10 @@ describe('Context Storage Middleware', () => {
   })
 
   it('Should return undefined when context is missing', () => {
-    expect(getContextIfAny<Env>()).toBeUndefined()
+    expect(tryGetContext<Env>()).toBeUndefined()
   })
 
-  it('Should get context when available via getContextIfAny', async () => {
+  it('Should get context when available via tryGetContext', async () => {
     const res = await app.request('/optional')
     expect(await res.text()).toBe('Hono is hot!!')
   })

--- a/src/middleware/context-storage/index.ts
+++ b/src/middleware/context-storage/index.ts
@@ -46,12 +46,12 @@ export const contextStorage = (): MiddlewareHandler => {
   }
 }
 
-export const getContextIfAny = <E extends Env = Env>(): Context<E> | undefined => {
+export const tryGetContext = <E extends Env = Env>(): Context<E> | undefined => {
   return asyncLocalStorage.getStore() as Context<E> | undefined
 }
 
 export const getContext = <E extends Env = Env>(): Context<E> => {
-  const context = getContextIfAny<E>()
+  const context = tryGetContext<E>()
   if (!context) {
     throw new Error('Context is not available')
   }


### PR DESCRIPTION
introduce getContextIfAny, which returns the stored context or undefined without throwing
make the existing getContext delegate to the softer helper so behavior stays unchanged when no context exists
expand the context-storage tests to cover both success and missing-context scenarios for the new helper