### PR TITLE
Allow middleware to redirect after downstream errors

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -64,7 +64,7 @@ export const compose = <E extends Env = Env>(
         }
       }
 
-      if (res && (context.finalized === false || isError)) {
+      if (res && (context.finalized === false || isError || context.error)) {
         context.res = res
       }
       return context


### PR DESCRIPTION
update compose so middleware can replace error responses when context.error is set, enabling patterns like c.redirect() after an error
add regression test covering the /hello?name=error scenario to ensure middleware can trigger a redirect post-error
captures the behavior reported in #4530 where redirects triggered in middleware were ignored after an error