### PR TITLE
fix: allow middleware to override error responses with redirects

### DIFF
--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -777,7 +777,7 @@ describe('compose - middleware redirect after error', () => {
 
     const composed = compose(middleware, onError)
     const context = await composed(c)
-    
+
     expect(context.res).not.toBeNull()
     expect(context.res.status).toBe(302)
     expect(context.res.headers.get('Location')).toBe('/error-page')
@@ -808,7 +808,7 @@ describe('compose - middleware redirect after error', () => {
 
     const composed = compose(middleware, onError)
     const context = await composed(c)
-    
+
     expect(context.res).not.toBeNull()
     expect(context.res.status).toBe(500)
     expect(await context.res.text()).toBe('Error handled')

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -64,8 +64,12 @@ export const compose = <E extends Env = Env>(
         }
       }
 
-      if (res && (context.finalized === false || isError)) {
-        context.res = res
+      if (res) {
+        // Allow middleware to override error responses even after context is finalized
+        // This enables middleware to handle errors gracefully (e.g., redirecting)
+        if (context.finalized === false || isError || (context.error && res !== context.res)) {
+          context.res = res
+        }
       }
       return context
     }


### PR DESCRIPTION
This change enables middleware to handle errors gracefully by allowing them to return redirect responses even after the error handler has been invoked. Previously, when an error occurred in a downstream handler, the error handler's response would be set and finalized, preventing middleware from providing alternative responses like redirects.

The fix adds an additional condition in the compose function to check if there's an error and the returned response is different from the current context response. This allows middleware to override error responses while maintaining backward compatibility.

Fixes #4530

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
