### PR TITLE
fix(validator): no return in middleware

### DIFF
--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -166,7 +166,7 @@ export const validator = <
 
     c.req.addValidatedData(target, res as never)
 
-    return (await next()) as ExtractValidationResponse<VF>
+    await next()
   }
 }
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

We may not have returned a response yet. In RSSHub, we have a wrapped handler, https://github.com/DIYgod/RSSHub/blob/680abcc00820876176d34cd47c3c13a37ad564dd/lib/registry.ts#L193-L210, and I tried to add a validator. https://github.com/DIYgod/RSSHub/pull/20584 This will result in unexpected errors. Please tell me if I did anything wrong.

~~BTW, can we have the standard validator accept a nullable schema? In that case, validation can be skipped.~~ I can pass an empty middleware.

And is it possible to restrict the schema type to the parameter defined in the path (Is there a type utils for this in Hono?) This is how I wrote it now.

```
type ParamObjectFromPath<P extends string> = P extends `${string}:${infer Param}/${infer Rest}`
    ? Param extends `${infer Name}?`
        ? { [K in Name]?: string } & ParamObjectFromPath<`/${Rest}`>
        : { [K in Param]: string } & ParamObjectFromPath<`/${Rest}`>
    : P extends `${string}:${infer Param}`
      ? Param extends `${infer Name}?`
          ? { [K in Name]?: string }
          : { [K in Param]: string }
      : Record<string, never>;
```
