### PR TITLE
fix(linear-router): incorrect path matching

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -106,10 +106,14 @@ export const runTest = ({
     describe('Complex', () => {
       it('Named Param', async () => {
         router.add('GET', '/entry/:id', 'get entry')
-        const res = match('GET', '/entry/123')
+        let res = match('GET', '/entry/123')
+
         expect(res.length).toBe(1)
         expect(res[0].handler).toEqual('get entry')
         expect(res[0].params['id']).toBe('123')
+
+        res = match('GET', '/entry-123')
+        expect(res.length).toBe(0)
       })
 
       it('Wildcard', async () => {

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -66,43 +66,4 @@ describe('LinearRouter', () => {
       expect(res.length).toBe(0)
     })
   })
-
-  describe('Static vs parameterized', () => {
-    const router = new LinearRouter<string>()
-
-    router.add('GET', '/book/:slug', 'GET /book/:slug')
-    router.add('GET', '/boo/:slug', 'GET /boo/:slug')
-    router.add('GET', '/bo/:slug', 'GET /bo/:slug')
-    router.add('GET', '/book-now', 'GET /book-now')
-    router.add('GET', '/api/:version', 'GET /api/:version')
-    router.add('GET', '/api-v1', 'GET /api-v1')
-    router.add('GET', '/user/:id/posts/:postId', 'GET /user/:id/posts/:postId')
-    router.add('GET', '/user/admin/posts-all', 'GET /user/admin/posts-all')
-    router.add('GET', '/resources/:type/:id', 'GET /resources/:type/:id')
-    router.add('GET', '/resources-list/users-active', 'GET /resources-list/users-active')
-
-    it('GET /book-now', () => {
-      const [res] = router.match('GET', '/book-now')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('GET /book-now')
-    })
-
-    it('GET /api-v1', () => {
-      const [res] = router.match('GET', '/api-v1')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('GET /api-v1')
-    })
-
-    it('GET /user/admin/posts-all', () => {
-      const [res] = router.match('GET', '/user/admin/posts-all')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('GET /user/admin/posts-all')
-    })
-
-    it('GET /resources-list/users-active', () => {
-      const [res] = router.match('GET', '/resources-list/users-active')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('GET /resources-list/users-active')
-    })
-  })
 })

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -70,7 +70,6 @@ export class LinearRouter<T> implements Router<T> {
         } else if (hasLabel && !hasStar) {
           const params: Record<string, string> = Object.create(null)
           const parts = routePath.match(splitPathRe) as string[]
-          const pathParts = path.match(splitPathRe) || []
 
           const lastIndex = parts.length - 1
           for (let j = 0, pos = 0, len = parts.length; j < len; j++) {
@@ -80,6 +79,10 @@ export class LinearRouter<T> implements Router<T> {
 
             const part = parts[j]
             if (part.charCodeAt(1) === 58) {
+              if (path.charCodeAt(pos) !== 47) {
+                continue ROUTES_LOOP
+              }
+
               // /:label
               let name = part.slice(2)
               let value
@@ -113,7 +116,7 @@ export class LinearRouter<T> implements Router<T> {
               params[name] ||= value as string
             } else {
               const index = path.indexOf(part, pos)
-              if (pathParts.length < parts.length || index !== pos) {
+              if (index !== pos) {
                 continue ROUTES_LOOP
               }
               pos += part.length


### PR DESCRIPTION
Fix incorrect path matching in LinearRouter.

Examples of incorrect matches before fix:
```
GET /book-now
[
  [ 'GET /book/:slug', [Object: null prototype] { slug: 'now' } ],
  [ 'GET /boo/:slug', [Object: null prototype] { slug: '-now' } ],
  [ 'GET /bo/:slug', [Object: null prototype] { slug: 'k-now' } ],
  [ 'GET /book-now', [Object: null prototype] {} ]
]

GET /api-v1
[
  [ 'GET /api/:version', [Object: null prototype] { version: 'v1' } ],
  [ 'GET /api-v1', [Object: null prototype] {} ]
]

GET /user/admin/posts-all
[
  [
    'GET /user/:id/posts/:postId',
    [Object: null prototype] { id: 'admin', postId: 'all' }
  ],
  [ 'GET /user/admin/posts-all', [Object: null prototype] {} ]
]

GET /resources-list/users-active
[
  [
    'GET /resources/:type/:id',
    [Object: null prototype] { type: 'list', id: 'users-active' }
  ],
  [ 'GET /resources-list/users-active', [Object: null prototype] {} ]
]
```
After fix:
```
GET /book-now
[[ 'GET /book-now', [Object: null prototype] {} ]]

GET /api-v1
[[ 'GET /api-v1', [Object: null prototype] {} ]]

GET /user/admin/posts-all
[[ 'GET /user/admin/posts-all', [Object: null prototype] {} ]]

GET /resources-list/users-active
[[ 'GET /resources-list/users-active', [Object: null prototype] {} ]]
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
