### PR TITLE
docs: improve grammar in contributing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The migration guide is available on [docs/MIGRATION.md](docs/MIGRATION.md).
 Contributions Welcome! You can contribute in the following ways.
 
 - Create an Issue - Propose a new feature. Report a bug.
-- Pull Request - Fix a bug and typo. Refactor the code.
-- Create third-party middleware - Instruct below.
+- Pull Request - Fix a bug or typo. Refactor the code.
+- Create third-party middleware - See instructions below.
 - Share - Share your thoughts on the Blog, X, and others.
 - Make your application - Please try to use Hono.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,8 +4,8 @@ Contributions Welcome! We will be glad for your help.
 You can contribute in the following ways.
 
 - Create an Issue - Propose a new feature. Report a bug.
-- Pull Request - Fix a bug and typo. Refactor the code.
-- Create third-party middleware - Instruct below.
+- Pull Request - Fix a bug or typo. Refactor the code.
+- Create third-party middleware - See instructions below.
 - Share - Share your thoughts on the Blog, X, and others.
 - Make your application - Please try to use Hono.
 


### PR DESCRIPTION
This PR fixes a couple of minor grammar issues in `README.md` and `docs/CONTRIBUTING.md`.

- Changed "Fix a bug and typo" to "Fix a bug or typo".
- Changed "Instruct below" to "See instructions below".