### PR TITLE
refactor(types): don't use recursion in `IntersectNonAnyTypes`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2468,9 +2468,117 @@ export type ExtractHandlerResponse<T> = T extends (c: any, next: any) => Promise
     : never
 
 type ProcessHead<T> = IfAnyThenEmptyObject<T extends Env ? (Env extends T ? {} : T) : T>
-export type IntersectNonAnyTypes<T extends any[]> = T extends [infer Head, ...infer Rest]
-  ? ProcessHead<Head> & IntersectNonAnyTypes<Rest>
-  : {}
+// Specialized overloads to reduce type instantiations
+export type IntersectNonAnyTypes<T extends any[]> = T extends [infer E1]
+  ? ProcessHead<E1>
+  : T extends [infer E1, infer E2]
+    ? ProcessHead<E1> & ProcessHead<E2>
+    : T extends [infer E1, infer E2, infer E3]
+      ? ProcessHead<E1> & ProcessHead<E2> & ProcessHead<E3>
+      : T extends [infer E1, infer E2, infer E3, infer E4]
+        ? ProcessHead<E1> & ProcessHead<E2> & ProcessHead<E3> & ProcessHead<E4>
+        : T extends [infer E1, infer E2, infer E3, infer E4, infer E5]
+          ? ProcessHead<E1> & ProcessHead<E2> & ProcessHead<E3> & ProcessHead<E4> & ProcessHead<E5>
+          : T extends [infer E1, infer E2, infer E3, infer E4, infer E5, infer E6]
+            ? ProcessHead<E1> &
+                ProcessHead<E2> &
+                ProcessHead<E3> &
+                ProcessHead<E4> &
+                ProcessHead<E5> &
+                ProcessHead<E6>
+            : T extends [infer E1, infer E2, infer E3, infer E4, infer E5, infer E6, infer E7]
+              ? ProcessHead<E1> &
+                  ProcessHead<E2> &
+                  ProcessHead<E3> &
+                  ProcessHead<E4> &
+                  ProcessHead<E5> &
+                  ProcessHead<E6> &
+                  ProcessHead<E7>
+              : T extends [
+                    infer E1,
+                    infer E2,
+                    infer E3,
+                    infer E4,
+                    infer E5,
+                    infer E6,
+                    infer E7,
+                    infer E8,
+                  ]
+                ? ProcessHead<E1> &
+                    ProcessHead<E2> &
+                    ProcessHead<E3> &
+                    ProcessHead<E4> &
+                    ProcessHead<E5> &
+                    ProcessHead<E6> &
+                    ProcessHead<E7> &
+                    ProcessHead<E8>
+                : T extends [
+                      infer E1,
+                      infer E2,
+                      infer E3,
+                      infer E4,
+                      infer E5,
+                      infer E6,
+                      infer E7,
+                      infer E8,
+                      infer E9,
+                    ]
+                  ? ProcessHead<E1> &
+                      ProcessHead<E2> &
+                      ProcessHead<E3> &
+                      ProcessHead<E4> &
+                      ProcessHead<E5> &
+                      ProcessHead<E6> &
+                      ProcessHead<E7> &
+                      ProcessHead<E8> &
+                      ProcessHead<E9>
+                  : T extends [
+                        infer E1,
+                        infer E2,
+                        infer E3,
+                        infer E4,
+                        infer E5,
+                        infer E6,
+                        infer E7,
+                        infer E8,
+                        infer E9,
+                        infer E10,
+                      ]
+                    ? ProcessHead<E1> &
+                        ProcessHead<E2> &
+                        ProcessHead<E3> &
+                        ProcessHead<E4> &
+                        ProcessHead<E5> &
+                        ProcessHead<E6> &
+                        ProcessHead<E7> &
+                        ProcessHead<E8> &
+                        ProcessHead<E9> &
+                        ProcessHead<E10>
+                    : T extends [
+                          infer E1,
+                          infer E2,
+                          infer E3,
+                          infer E4,
+                          infer E5,
+                          infer E6,
+                          infer E7,
+                          infer E8,
+                          infer E9,
+                          infer E10,
+                          infer E11,
+                        ]
+                      ? ProcessHead<E1> &
+                          ProcessHead<E2> &
+                          ProcessHead<E3> &
+                          ProcessHead<E4> &
+                          ProcessHead<E5> &
+                          ProcessHead<E6> &
+                          ProcessHead<E7> &
+                          ProcessHead<E8> &
+                          ProcessHead<E9> &
+                          ProcessHead<E10> &
+                          ProcessHead<E11>
+                      : {}
 
 ////////////////////////////////////////
 //////                            //////


### PR DESCRIPTION
Made `IntersectNonAnyTypes` not use recursion to improve TypeScript Type performance.

<img width="1106" height="1080" alt="CleanShot 2025-12-25 at 12 09 00@2x" src="https://github.com/user-attachments/assets/f0fc55c4-194d-4127-b1b5-116afcaa821c" />

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
