### PR TITLE
perf(types): check `JSONPrimitive` first in `JSONParsed`

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -50,18 +50,16 @@ export type JSONValue = JSONObject | JSONArray | JSONPrimitive
  * which defaults to `bigint | ReadonlyArray<bigint>`.
  * You can set it to `never` to disable this check.
  */
-export type JSONParsed<T, TError = bigint | ReadonlyArray<bigint>> = T extends {
-  toJSON(): infer J
-}
-  ? (() => J) extends () => JSONPrimitive
-    ? J
-    : (() => J) extends () => { toJSON(): unknown }
-      ? {}
-      : JSONParsed<J, TError>
-  : T extends JSONPrimitive
-    ? T
-    : T extends InvalidJSONValue
-      ? never
+export type JSONParsed<T, TError = bigint | ReadonlyArray<bigint>> = T extends JSONPrimitive
+  ? T
+  : T extends InvalidJSONValue
+    ? never
+    : T extends { toJSON(): infer J }
+      ? (() => J) extends () => JSONPrimitive
+        ? J
+        : (() => J) extends () => { toJSON(): unknown }
+          ? {}
+          : JSONParsed<J, TError>
       : T extends ReadonlyArray<unknown>
         ? { [K in keyof T]: JSONParsed<InvalidToNull<T[K]>, TError> }
         : T extends Set<unknown> | Map<unknown, unknown> | Record<string, never>


### PR DESCRIPTION
Check `JSONPrimitive` first, since it's used more often.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
