### PR TITLE
test(utils/jwt): add missing algorithm types in jwa.test.ts

### DIFF
--- a/src/utils/jwt/jwa.test.ts
+++ b/src/utils/jwt/jwa.test.ts
@@ -8,6 +8,13 @@ describe('Types', () => {
     expect('RS256' as AlgorithmTypes).toBe(AlgorithmTypes.RS256)
     expect('RS384' as AlgorithmTypes).toBe(AlgorithmTypes.RS384)
     expect('RS512' as AlgorithmTypes).toBe(AlgorithmTypes.RS512)
+    expect('PS256' as AlgorithmTypes).toBe(AlgorithmTypes.PS256)
+    expect('PS384' as AlgorithmTypes).toBe(AlgorithmTypes.PS384)
+    expect('PS512' as AlgorithmTypes).toBe(AlgorithmTypes.PS512)
+    expect('ES256' as AlgorithmTypes).toBe(AlgorithmTypes.ES256)
+    expect('ES384' as AlgorithmTypes).toBe(AlgorithmTypes.ES384)
+    expect('ES512' as AlgorithmTypes).toBe(AlgorithmTypes.ES512)
+    expect('EdDSA' as AlgorithmTypes).toBe(AlgorithmTypes.EdDSA)
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

fixes #4606
