### PR TITLE
fix(validator): make query params always return string[] for consistency

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -323,7 +323,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
   it('Should get 200 response - query', async () => {
     const res = await client.search.$get({
       query: {
-        q: 'foobar',
+        q: ['foobar'],
         tag: ['a', 'b'],
         // @ts-expect-error
         filter: undefined,
@@ -413,8 +413,8 @@ describe('Basic - $url()', () => {
     expect(
       client.content.search.$url({
         query: {
-          page: '123',
-          limit: '20',
+          page: ['123'],
+          limit: ['20'],
         },
       }).href
     ).toBe('http://fake/content/search?page=123&limit=20')
@@ -1061,7 +1061,7 @@ describe('$url() with a query option', () => {
   it('Should return the correct path - /posts?filter=test', async () => {
     const url = client.posts.$url({
       query: {
-        filter: 'test',
+        filter: ['test'],
       },
     })
     expect(url.search).toBe('?filter=test')
@@ -1571,7 +1571,7 @@ describe('Custom buildSearchParams', () => {
 
   it('Should use custom buildSearchParams for query serialization', async () => {
     const client = hc<AppType>('http://localhost', { buildSearchParams: customBuildSearchParams })
-    const res = await client.search.$get({ query: { q: 'test', tags: ['tag1', 'tag2', 'tag3'] } })
+    const res = await client.search.$get({ query: { q: ['test'], tags: ['tag1', 'tag2', 'tag3'] } })
     const data = await res.json()
 
     expect(res.status).toBe(200)
@@ -1580,7 +1580,7 @@ describe('Custom buildSearchParams', () => {
 
   it('Should use default buildSearchParams when custom one is not provided', async () => {
     const client = hc<AppType>('http://localhost')
-    const res = await client.search.$get({ query: { q: 'test', tags: ['tag1', 'tag2'] } })
+    const res = await client.search.$get({ query: { q: ['test'], tags: ['tag1', 'tag2'] } })
     const data = await res.json()
 
     expect(res.status).toBe(200)
@@ -1589,14 +1589,14 @@ describe('Custom buildSearchParams', () => {
 
   it('Should use custom buildSearchParams in $url() method', () => {
     const client = hc<AppType>('http://localhost', { buildSearchParams: customBuildSearchParams })
-    const url = client.search.$url({ query: { q: 'test', tags: ['tag1', 'tag2'] } })
+    const url = client.search.$url({ query: { q: ['test'], tags: ['tag1', 'tag2'] } })
 
     expect(url.href).toBe('http://localhost/search?q=test&tags%5B%5D=tag1&tags%5B%5D=tag2')
   })
 
   it('Should use default buildSearchParams in $url() when custom one is not provided', () => {
     const client = hc<AppType>('http://localhost')
-    const url = client.search.$url({ query: { q: 'test', tags: ['tag1', 'tag2'] } })
+    const url = client.search.$url({ query: { q: ['test'], tags: ['tag1', 'tag2'] } })
 
     expect(url.href).toBe('http://localhost/search?q=test&tags=tag1&tags=tag2')
   })

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -229,7 +229,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
     .get(
       '/search',
       validator('query', () => {
-        return {} as { q: string; tag: string[]; filter: string }
+        return {} as { q: string[]; tag: string[]; filter: string[] }
       }),
       (c) => {
         return c.json({
@@ -382,7 +382,7 @@ describe('Basic - $url()', () => {
   const content = new Hono().get(
     '/search',
     validator('query', () => {
-      return { page: '1', limit: '10' }
+      return { page: ['1'], limit: ['10'] }
     }),
     (c) => c.text('Search')
   )
@@ -494,8 +494,8 @@ describe('Infer the response/request type', () => {
 
     type Actual = InferRequestType<typeof req>
     type Expected = {
-      age: string | string[]
-      name: string | string[]
+      age: string[]
+      name: string[]
     }
     type verify = Expect<Equal<Expected, Actual['query']>>
   })
@@ -913,11 +913,11 @@ describe('Infer the response types from middlewares', () => {
     .get(
       '/',
       validator('query', (input, c) => {
-        if (!input.page || typeof input.page !== 'string') {
+        if (!input.page || input.page.length === 0 || typeof input.page[0] !== 'string') {
           return c.json({ error: 'Bad request' as const }, 400)
         }
 
-        return input as { page: string }
+        return { page: input.page[0] }
       }),
       async (c) => {
         const query = c.req.valid('query')
@@ -1529,7 +1529,7 @@ describe('Custom buildSearchParams', () => {
   const route = app.get(
     '/search',
     validator('query', () => {
-      return {} as { q: string; tags: string[] }
+      return {} as { q: string[]; tags: string[] }
     }),
     (c) => {
       return c.json({

--- a/src/helper/factory/index.test.ts
+++ b/src/helper/factory/index.test.ts
@@ -135,7 +135,7 @@ describe('createHandler', () => {
     const handlers = factory.createHandlers(
       validator('query', () => {
         return {
-          page: '1',
+          page: ['1'],
         }
       }),
       (c) => {
@@ -154,7 +154,7 @@ describe('createHandler', () => {
         {
           in: {
             query: {
-              page: string
+              page: string[]
             }
           }
         },
@@ -188,7 +188,7 @@ describe('createHandler', () => {
       }),
       validator('query', () => {
         return {
-          page: '1',
+          page: ['1'],
         }
       }),
       validator('json', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2394,7 +2394,7 @@ export type ParsedFormValue = string | File
 export type ValidationTargets<T extends FormValue = ParsedFormValue, P extends string = string> = {
   json: any
   form: Record<string, T | T[]>
-  query: Record<string, string | string[]>
+  query: Record<string, string[]>
   param: Record<P, P extends `${infer _}?` ? string | undefined : string>
   header: Record<RequestHeader | CustomHeader, string>
   cookie: Record<string, string>

--- a/src/validator/utils.test.ts
+++ b/src/validator/utils.test.ts
@@ -26,15 +26,15 @@ describe('InferInput', () => {
     }>()
   })
 
-  it('should convert string to string | string[] for query', () => {
+  it('should convert string to string[] for query', () => {
     expectTypeOf<InferInput<{ page: string }, 'query'>>().toEqualTypeOf<{
-      page: string | string[]
+      page: string[]
     }>()
   })
 
-  it('should convert number to string | string[] for query', () => {
+  it('should convert number to string[] for query', () => {
     expectTypeOf<InferInput<{ page: number }, 'query'>>().toEqualTypeOf<{
-      page: string | string[]
+      page: string[]
     }>()
   })
 
@@ -50,9 +50,9 @@ describe('InferInput', () => {
     }>()
   })
 
-  it('should convert unknown to string | string[] for query (coerce support)', () => {
+  it('should convert unknown to string[] for query (coerce support)', () => {
     expectTypeOf<InferInput<{ page: unknown }, 'query'>>().toEqualTypeOf<{
-      page: string | string[]
+      page: string[]
     }>()
   })
 

--- a/src/validator/utils.ts
+++ b/src/validator/utils.ts
@@ -34,7 +34,7 @@ type InferInputInner<
       : Target extends 'form'
         ? T | T[]
         : Target extends 'query'
-          ? string | string[]
+          ? string[]
           : Target extends 'param'
             ? string
             : Target extends 'header'

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -70,8 +70,8 @@ describe('Basic', () => {
       await next()
     },
     validator('query', (value, c) => {
-      type verify = Expect<Equal<Record<string, string | string[]>, typeof value>>
-      if (!value.q) {
+      type verify = Expect<Equal<Record<string, string[]>, typeof value>>
+      if (!value.q || value.q.length === 0) {
         return c.text('Invalid!', 400)
       }
     }),
@@ -685,12 +685,12 @@ describe('Validator middleware with Zod validates query params', () => {
 
   const schema = z.object({
     page: z
-      .string()
+      .array(z.string())
       .refine((v) => {
-        return !isNaN(Number(v))
+        return v.length === 1 && !isNaN(Number(v[0]))
       })
       .transform((v) => {
-        return Number(v)
+        return Number(v[0])
       }),
     tag: z.array(z.string()),
   })
@@ -1004,7 +1004,7 @@ it('`on`', () => {
           }
         } & {
           query: {
-            q: string | string[]
+            q: string[]
           }
         }
         output: {
@@ -1280,7 +1280,7 @@ describe('Transform', () => {
         $get: {
           input: {
             query: {
-              page: string | string[]
+              page: string[]
             }
           }
           output: {
@@ -1327,7 +1327,7 @@ describe('Transform', () => {
         $get: {
           input: {
             query: {
-              page: string | string[]
+              page: string[]
               orderBy: 'asc' | 'desc'
               ordreByWithdefault?: 'asc' | 'desc' | undefined
             }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -142,11 +142,7 @@ export const validator = <
         break
       }
       case 'query':
-        value = Object.fromEntries(
-          Object.entries(c.req.queries()).map(([k, v]) => {
-            return v.length === 1 ? [k, v[0]] : [k, v]
-          })
-        )
+        value = c.req.queries()
         break
       case 'param':
         value = c.req.param() as Record<string, string>


### PR DESCRIPTION
# Summary

- Fixes query parameter validator having inconsistent types: single values were string, multiple values were string[]
- Now query parameters always return string[] for consistency
- This aligns with the behavior of c.req.queries() which always returns arrays

# Changes

- validator.ts: Use c.req.queries() directly instead of converting single values to strings
- types.ts: Change ValidationTargets['query'] from Record<string, string | string[]> to Record<string, string[]>
- validator/utils.ts: Update InferInput query type to string[]

# Related

- #4103 