### PR TITLE
docs(bun/websocket): Fixed a typo in hono/bun deprecation message and updated test.

### DIFF
--- a/src/adapter/bun/websocket.test.ts
+++ b/src/adapter/bun/websocket.test.ts
@@ -119,9 +119,9 @@ describe('upgradeWebSocket()', () => {
 })
 
 describe('createBunWebSocket()', () => {
-  it('Should create a BunWebSocket', () => {
-    const { upgradeWebSocket, websocket } = createBunWebSocket()
-    expect(upgradeWebSocket).toBe(upgradeWebSocket)
-    expect(websocket).toBe(websocket)
+  it('Should return upgradeWebSocket and websocket', () => {
+    const result = createBunWebSocket()
+    expect(result.upgradeWebSocket).toBe(upgradeWebSocket)
+    expect(result.websocket).toBe(websocket)
   })
 })

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -94,7 +94,7 @@ export const websocket: BunWebSocketHandler<BunWebSocketData> = {
 }
 
 /**
- * @deprecated Import `createWebSocket` and `websocket` directly from `hono/bun` instead.
+ * @deprecated Import `upgradeWebSocket` and `websocket` directly from `hono/bun` instead.
  * @returns A function to create a Bun WebSocket handler.
  */
 export const createBunWebSocket = <T>(): CreateWebSocket<T> => ({


### PR DESCRIPTION
Fix typo in createBunWebSocket deprecation message

The deprecation notice incorrectly referenced createWebSocket which doesn't exist. Changed to upgradeWebSocket which is the actual export users should migrate to.

Also fixed the test assertion which was comparing variables to themselves instead of verifying the factory returns the correct exports.

Tests pass: `bun run vitest run src/adapter/bun/websocket.test.ts`