### PR TITLE
docs: align CODE_OF_CONDUCT.md wording with Contributor Covenant

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -14,8 +14,8 @@ diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contribute to a positive environment for our
-community includes:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences


### PR DESCRIPTION
## Summary

I noticed a slight difference in wording between this project's CODE_OF_CONDUCT.md and the original [Contributor Covenant v2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).

**Current (lines 17-18):**
> Examples of behavior that contribute to a positive environment for our community includes:

**Contributor Covenant original:**
> Examples of behavior that contributes to a positive environment for our community include:

This PR aligns the wording with the original. If this was an intentional variation, please feel free to close this PR.