### PR TITLE
refactor(middleware/logger): add return type annotations

### DIFF
--- a/src/middleware/logger/index.ts
+++ b/src/middleware/logger/index.ts
@@ -12,7 +12,7 @@ enum LogPrefix {
   Error = 'xxx',
 }
 
-const humanize = (times: string[]) => {
+const humanize = (times: string[]): string => {
   const [delimiter, separator] = [',', '.']
 
   const orderTimes = times.map((v) => v.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1' + delimiter))
@@ -20,12 +20,12 @@ const humanize = (times: string[]) => {
   return orderTimes.join(separator)
 }
 
-const time = (start: number) => {
+const time = (start: number): string => {
   const delta = Date.now() - start
   return humanize([delta < 1000 ? delta + 'ms' : Math.round(delta / 1000) + 's'])
 }
 
-const colorStatus = async (status: number) => {
+const colorStatus = async (status: number): Promise<string> => {
   const colorEnabled = await getColorEnabledAsync()
   if (colorEnabled) {
     switch ((status / 100) | 0) {
@@ -54,7 +54,7 @@ async function log(
   path: string,
   status: number = 0,
   elapsed?: string
-) {
+): Promise<void> {
   const out =
     prefix === LogPrefix.Incoming
       ? `${prefix} ${method} ${path}`


### PR DESCRIPTION
## Summary

Added the missing return type annotations to internal helper functions in the logger middleware. This change improves code readability and provides slightly better type inference performance.

This PR follows the same pattern as #4591.

### Changes

- `humanize`: added `: string`
- `time`: added `: string`
- `colorStatus`: added `: Promise<string>`
- `log`: added `: Promise<void>`

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code