### PR TITLE
feat: add 'methodNotAllowed' handler for '405 Method Not Allowed' responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export type {
   ErrorHandler,
   Handler,
   MiddlewareHandler,
+  MethodNotAllowedHandler,
+  MethodNotAllowedResponse,
   Next,
   NotFoundResponse,
   NotFoundHandler,

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,23 @@ export type NotFoundHandler<E extends Env = any> = (
   ? NotFoundResponse | Promise<NotFoundResponse>
   : Response | Promise<Response>
 
+/**
+ * You can extend this interface to define a custom `c.methodNotAllowed()` Response type.
+ *
+ * @example
+ * declare module 'hono' {
+ *   interface MethodNotAllowedResponse extends Response, TypedResponse<string, 405, 'text'> {}
+ * }
+ */
+export interface MethodNotAllowedResponse {}
+
+export type MethodNotAllowedHandler<E extends Env = any> = (
+  c: Context<E>,
+  allowedMethods: string[]
+) => MethodNotAllowedResponse extends Response
+  ? MethodNotAllowedResponse | Promise<MethodNotAllowedResponse>
+  : Response | Promise<Response>
+
 export interface HTTPResponseError extends Error {
   getResponse: () => Response
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `app.methodNotAllowed()` handler that returns `405 Method Not Allowed` responses when a path exists but the HTTP method is not supported. This improves HTTP semantics by properly distinguishing between routes that don't exist (404) and routes that exist but don't support the requested method (405).

## Changes

- Added `MethodNotAllowedHandler` and `MethodNotAllowedResponse` types
- Added `methodNotAllowed()` method to `HonoBase` class
- Implemented `#findAllowedMethods()` helper to detect allowed methods for a path
- Updated `#dispatch()` to check for method not allowed when no route matches
- Added comprehensive test suite covering various scenarios
- Exported types from main index

## Behavior

- **Opt-in**: Feature is disabled by default (returns 404 as before)
- **When enabled**: Returns 405 with `Allow` header listing permitted methods
- **Backward compatible**: Existing behavior unchanged when handler is not set

## Example Usage

```typescript
const app = new Hono()

app.get('/hello', (c) => c.text('Hello'))

// Enable method not allowed handling
app.methodNotAllowed((c, allowedMethods) => {
  return c.text('405 Method Not Allowed', 405, {
    Allow: allowedMethods.join(', ').toUpperCase(),
  })
})

// POST /hello will now return 405 with Allow: GET
// GET /hello will return 200
// GET /nonexistent will return 404 (path doesn't exist)
```

## Testing

- [x] Added tests
- [x] All tests pass (`bun run test`)
- [x] Code formatted (`bun run format:fix`)
- [x] Linting passes (`bun run lint:fix`)
- [x] TSDoc added to public APIs

## Related

Closes #4633