### PR TITLE
refactor(jwks): mark allowedAlgorithms, so the user can pass a `const…

### DIFF
--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -194,7 +194,7 @@ export const verifyWithJwks = async (
     keys?: HonoJsonWebKey[]
     jwks_uri?: string
     verification?: VerifyOptions
-    allowedAlgorithms: AsymmetricAlgorithm[]
+    allowedAlgorithms: readonly AsymmetricAlgorithm[]
   },
   init?: RequestInit
 ): Promise<JWTPayload> => {

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -83,7 +83,7 @@ export class JwtSymmetricAlgorithmNotAllowed extends Error {
 }
 
 export class JwtAlgorithmNotAllowed extends Error {
-  constructor(alg: string, allowedAlgorithms: string[]) {
+  constructor(alg: string, allowedAlgorithms: readonly string[]) {
     super(`algorithm "${alg}" is not in the allowed list: [${allowedAlgorithms.join(', ')}]`)
     this.name = 'JwtAlgorithmNotAllowed'
   }


### PR DESCRIPTION
Marks the parameter as readonly, to signal that the array wont be changed.

```js
const config = {
  allowedAlgorithms: ["RS256"],
} as const;

// error, because verifyWithJwks doesn't allow a const algorithm list
verifyWithJwks("foo", { allowedAlgorithms: config.allowedAlgorithms });
```

This works now. This change is non-breaking.