### PR TITLE
fix(sse): handle `\r` and `\r\n` line endings in writeSSE

### DIFF
--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -18,7 +18,7 @@ export class SSEStreamingApi extends StreamingApi {
   async writeSSE(message: SSEMessage) {
     const data = await resolveCallback(message.data, HtmlEscapedCallbackPhase.Stringify, false, {})
     const dataLines = (data as string)
-      .split('\n')
+      .split(/\r\n|\r|\n/)
       .map((line) => {
         return `data: ${line}`
       })


### PR DESCRIPTION
Close #4028

According to the SSE specification, lines can end with `\r`, `\n`, or `\r\n`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] ~~Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code~~
