### PR TITLE
refactor: use `unique symbol` for more accurate typing.

### DIFF
--- a/src/request/constants.ts
+++ b/src/request/constants.ts
@@ -1,1 +1,1 @@
-export const GET_MATCH_RESULT: symbol = Symbol()
+export const GET_MATCH_RESULT = Symbol()


### PR DESCRIPTION
fixes #4640

Explicitly annotating with `: symbol` causes type widening, converting the inferred `unique symbol` type to a general `symbol` type. By removing the type annotation, TypeScript automatically infers `unique symbol` for const declarations initialized with Symbol().
