### PR TITLE
refactor: use `unique symbol` for more accurate typing.

### DIFF
--- a/src/request/constants.ts
+++ b/src/request/constants.ts
@@ -1,1 +1,1 @@
-export const GET_MATCH_RESULT: symbol = Symbol()
+export const GET_MATCH_RESULT: unique symbol = Symbol()


### PR DESCRIPTION
fixes #4640

Fixes compilation error in consuming code where computed property names 
require explicit `unique symbol` type.

Requires TypeScript 2.7+ (January 2018).