### PR TITLE
refactor(lambda): simplify streaming handler and remove type workaround

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -151,7 +151,6 @@ declare const awslambda: {
   }
 }
 
-
 export const streamHandle = <
   E extends Env = Env,
   S extends Schema = {},

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -135,6 +135,23 @@ const streamToNodeStream = async (
   writer.end()
 }
 
+declare const awslambda: {
+  streamifyResponse: (
+    handler: (
+      event: LambdaEvent,
+      responseStream: NodeJS.WritableStream,
+      context: LambdaContext
+    ) => Promise<void>
+  ) => Handler
+  HttpResponseStream: {
+    from: (
+      stream: NodeJS.WritableStream,
+      metadata: { statusCode: number; headers: Record<string, string>; cookies: string[] }
+    ) => NodeJS.WritableStream
+  }
+}
+
+
 export const streamHandle = <
   E extends Env = Env,
   S extends Schema = {},


### PR DESCRIPTION
found this while going through codebase
<img width="430" height="40" alt="image" src="https://github.com/user-attachments/assets/c4ba94f2-22b6-4c58-ac05-e096a361dc45" />

```typescript

declare const awslambda: {
  streamifyResponse: (
    handler: (
      event: LambdaEvent,
      responseStream: NodeJS.WritableStream,
      context: LambdaContext
    ) => Promise<void>
  ) => Handler
  HttpResponseStream: {
    from: (
      stream: NodeJS.WritableStream,
      metadata: { statusCode: number; headers: Record<string, string>; cookies: string[] }
    ) => NodeJS.WritableStream
  }
}
```
This ensures 
streamHandle
 is fully type-safe.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
