### PR TITLE
feat(trailing-slash): add `alwaysRedirect` option to support wildcard routes

### DIFF
--- a/src/middleware/trailing-slash/index.test.ts
+++ b/src/middleware/trailing-slash/index.test.ts
@@ -87,9 +87,9 @@ describe('Resolve trailing slash', () => {
     })
   })
 
-  describe('trimTrailingSlash middleware with eager option', () => {
+  describe('trimTrailingSlash middleware with alwaysRedirect option', () => {
     const app = new Hono()
-    app.use('*', trimTrailingSlash({ eager: true }))
+    app.use('*', trimTrailingSlash({ alwaysRedirect: true }))
 
     app.get('/', async (c) => {
       return c.text('ok')
@@ -255,9 +255,9 @@ describe('Resolve trailing slash', () => {
     })
   })
 
-  describe('appendTrailingSlash middleware with eager option', () => {
+  describe('appendTrailingSlash middleware with alwaysRedirect option', () => {
     const app = new Hono()
-    app.use('*', appendTrailingSlash({ eager: true }))
+    app.use('*', appendTrailingSlash({ alwaysRedirect: true }))
 
     app.get('/', async (c) => {
       return c.text('ok')

--- a/src/middleware/trailing-slash/index.ts
+++ b/src/middleware/trailing-slash/index.ts
@@ -13,7 +13,7 @@ type TrimTrailingSlashOptions = {
    * If `false` (default), it will only redirect when the route is not found (404).
    * @default false
    */
-  eager?: boolean
+  alwaysRedirect?: boolean
 }
 
 /**
@@ -34,16 +34,16 @@ type TrimTrailingSlashOptions = {
  *
  * @example
  * ```ts
- * // With eager option for wildcard routes
+ * // With alwaysRedirect option for wildcard routes
  * const app = new Hono()
  *
- * app.use(trimTrailingSlash({ eager: true }))
+ * app.use(trimTrailingSlash({ alwaysRedirect: true }))
  * app.get('/my-path/*', (c) => c.text('Wildcard route'))
  * ```
  */
 export const trimTrailingSlash = (options?: TrimTrailingSlashOptions): MiddlewareHandler => {
   return async function trimTrailingSlash(c, next) {
-    if (options?.eager) {
+    if (options?.alwaysRedirect) {
       if (
         (c.req.method === 'GET' || c.req.method === 'HEAD') &&
         c.req.path !== '/' &&
@@ -59,7 +59,7 @@ export const trimTrailingSlash = (options?: TrimTrailingSlashOptions): Middlewar
     await next()
 
     if (
-      !options?.eager &&
+      !options?.alwaysRedirect &&
       c.res.status === 404 &&
       (c.req.method === 'GET' || c.req.method === 'HEAD') &&
       c.req.path !== '/' &&
@@ -81,7 +81,7 @@ type AppendTrailingSlashOptions = {
    * If `false` (default), it will only redirect when the route is not found (404).
    * @default false
    */
-  eager?: boolean
+  alwaysRedirect?: boolean
 }
 
 /**
@@ -102,16 +102,16 @@ type AppendTrailingSlashOptions = {
  *
  * @example
  * ```ts
- * // With eager option for wildcard routes
+ * // With alwaysRedirect option for wildcard routes
  * const app = new Hono()
  *
- * app.use(appendTrailingSlash({ eager: true }))
+ * app.use(appendTrailingSlash({ alwaysRedirect: true }))
  * app.get('/my-path/*', (c) => c.text('Wildcard route'))
  * ```
  */
 export const appendTrailingSlash = (options?: AppendTrailingSlashOptions): MiddlewareHandler => {
   return async function appendTrailingSlash(c, next) {
-    if (options?.eager) {
+    if (options?.alwaysRedirect) {
       if ((c.req.method === 'GET' || c.req.method === 'HEAD') && c.req.path.at(-1) !== '/') {
         const url = new URL(c.req.url)
         url.pathname += '/'
@@ -123,7 +123,7 @@ export const appendTrailingSlash = (options?: AppendTrailingSlashOptions): Middl
     await next()
 
     if (
-      !options?.eager &&
+      !options?.alwaysRedirect &&
       c.res.status === 404 &&
       (c.req.method === 'GET' || c.req.method === 'HEAD') &&
       c.req.path.at(-1) !== '/'


### PR DESCRIPTION
Resolves #3407

Add ~`strict`~ `alwaysRedirect` option to `trimTrailingSlash` and `appendTrailingSlash` middleware.                 
                                                                                                   
When ~`strict: true`~ `alwaysRedirect:true`, the middleware redirects before executing handlers, which fixes the issue where trailing slash handling doesn't work with wildcard routes (`*`).                           
                                                                                                   
  ```ts                                                                                            
app.use(trimTrailingSlash({ alwaysRedirect: true }))
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
