### PR TITLE
fix(timing): use c.header() to handle immutable response headers

### DIFF
--- a/src/middleware/timing/index.test.ts
+++ b/src/middleware/timing/index.test.ts
@@ -103,6 +103,35 @@ describe('Server-Timing API', () => {
     consoleWarnSpy.mockRestore()
   })
 
+  describe('Should handle immutable response headers', () => {
+    it('Should set Server-Timing header even when response is a new Response object', async () => {
+      const immutableApp = new Hono()
+      immutableApp.use('*', timing())
+      immutableApp.get('/', () => {
+        return new Response('ok', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      })
+
+      const res = await immutableApp.request('http://localhost/')
+      expect(res.status).toBe(200)
+      expect(res.headers.has('server-timing')).toBeTruthy()
+      expect(res.headers.get('server-timing')?.includes('total;dur=')).toBeTruthy()
+    })
+
+    it('Should set Timing-Allow-Origin even when response is a new Response object', async () => {
+      const immutableApp = new Hono()
+      immutableApp.use('*', timing({ crossOrigin: true }))
+      immutableApp.get('/', () => {
+        return new Response('ok')
+      })
+
+      const res = await immutableApp.request('http://localhost/')
+      expect(res.headers.has('server-timing')).toBeTruthy()
+      expect(res.headers.get('timing-allow-origin')).toBe('*')
+    })
+  })
+
   describe('Should handle crossOrigin setting', async () => {
     it('Should do nothing when crossOrigin is falsy', async () => {
       const crossOriginApp = new Hono()

--- a/src/middleware/timing/timing.ts
+++ b/src/middleware/timing/timing.ts
@@ -108,16 +108,15 @@ export const timing = (config?: TimingOptions): MiddlewareHandler => {
     const enabled = typeof options.enabled === 'function' ? options.enabled(c) : options.enabled
 
     if (enabled) {
-      c.res.headers.append('Server-Timing', headers.join(','))
+      c.header('Server-Timing', headers.join(','), { append: true })
 
       const crossOrigin =
         typeof options.crossOrigin === 'function' ? options.crossOrigin(c) : options.crossOrigin
 
       if (crossOrigin) {
-        c.res.headers.append(
-          'Timing-Allow-Origin',
-          typeof crossOrigin === 'string' ? crossOrigin : '*'
-        )
+        c.header('Timing-Allow-Origin', typeof crossOrigin === 'string' ? crossOrigin : '*', {
+          append: true,
+        })
       }
     }
   }


### PR DESCRIPTION
## Summary

The `timing` middleware directly accessed `c.res.headers.append()` after `await next()`, which throws `TypeError: Can't modify immutable headers` on runtimes where the response headers become immutable after finalization (e.g., Cloudflare Workers).

This switches to using `c.header()` with `{ append: true }`, which already handles this case by creating a new `Response` with mutable headers when `c.finalized` is true (see `context.ts` L505-508). This follows the same pattern used by the CORS middleware.

## Changes

- Replace `c.res.headers.append('Server-Timing', ...)` with `c.header('Server-Timing', ..., { append: true })`
- Replace `c.res.headers.append('Timing-Allow-Origin', ...)` with `c.header('Timing-Allow-Origin', ..., { append: true })`
- Add test cases verifying headers are set correctly when the handler returns a `new Response()` directly

## Checklist

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format code
- [x] Add TSDoc/JSDoc to document code (no new public APIs added)

Closes #4454