### PR TITLE
fix(url): strip fragment identifiers from path in getPath()

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -105,6 +105,22 @@ describe('url', () => {
       expect(path).toBe('/hello/hey')
     })
 
+    it('getPath - strip fragment identifiers', () => {
+      let path = getPath(new Request('https://example.com/hello#fragment'))
+      expect(path).toBe('/hello')
+      path = getPath(new Request('https://example.com/hello/hey#section'))
+      expect(path).toBe('/hello/hey')
+      path = getPath(new Request('https://example.com/hello?name=foo#fragment'))
+      expect(path).toBe('/hello')
+      path = getPath(new Request('https://example.com/#top'))
+      expect(path).toBe('/')
+    })
+
+    it('getPath - strip fragment with percent encoding', () => {
+      const path = getPath(new Request('https://example.com/%E7%82%8E#fragment'))
+      expect(path).toBe('/\u708e')
+    })
+
     it('getPath - with trailing slash', () => {
       let path = getPath(new Request('https://example.com/hello/'))
       expect(path).toBe('/hello/')

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -113,11 +113,14 @@ export const getPath = (request: Request): string => {
       // '%'
       // If the path contains percent encoding, use `indexOf()` to find '?' and return the result immediately.
       // Although this is a performance disadvantage, it is acceptable since we prefer cases that do not include percent encoding.
-      const queryIndex = url.indexOf('?', i)
-      const path = url.slice(start, queryIndex === -1 ? undefined : queryIndex)
+      let separator = url.indexOf('?', i)
+      if (separator === -1) {
+        separator = url.indexOf('#', i)
+      }
+      const path = url.slice(start, separator === -1 ? undefined : separator)
       return tryDecodeURI(path.includes('%25') ? path.replace(/%25/g, '%2525') : path)
-    } else if (charCode === 63) {
-      // '?'
+    } else if (charCode === 63 || charCode === 35) {
+      // '?' or '#'
       break
     }
   }


### PR DESCRIPTION
## Summary

Service Workers receive the full URL including fragment identifiers (e.g., `/users/#section`), unlike traditional servers where browsers strip fragments before sending requests. This caused Hono's route matcher to treat `#` as a regular character, leading to incorrect route parameter parsing (e.g., `id = "#user-list"` instead of a 404/correct match).

This implements the approach suggested by @usualoma in the issue discussion: update `getPath()` to treat `#` as a path terminator alongside `?`, both in the fast-path character loop and the percent-encoding fallback path.

## Changes

- In the fast-path loop: break on charCode `35` (`#`) in addition to `63` (`?`)
- In the percent-encoding fallback: check for `#` when `?` is not found
- Added test cases for fragment stripping with and without percent encoding

## Checklist

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format code
- [x] Add TSDoc/JSDoc to document code (no new public APIs added)

Closes #4440