### PR TITLE
feat(basic-auth): set authenticated username in context

### DIFF
--- a/src/middleware/basic-auth/index.ts
+++ b/src/middleware/basic-auth/index.ts
@@ -8,8 +8,17 @@ import { HTTPException } from '../../http-exception'
 import type { MiddlewareHandler } from '../../types'
 import { auth } from '../../utils/basic-auth'
 import { timingSafeEqual } from '../../utils/buffer'
+import type {} from '../..'
 
 type MessageFunction = (c: Context) => string | object | Promise<string | object>
+
+export type BasicAuthVariables = {
+  basicAuthUsername: string
+}
+
+declare module '../..' {
+  interface ContextVariableMap extends BasicAuthVariables {}
+}
 
 type BasicAuthOptions =
   | {
@@ -88,6 +97,7 @@ export const basicAuth = (
     if (requestUser) {
       if (verifyUserInOptions) {
         if (await options.verifyUser(requestUser.username, requestUser.password, ctx)) {
+          ctx.set('basicAuthUsername', requestUser.username)
           await next()
           return
         }
@@ -98,6 +108,7 @@ export const basicAuth = (
             timingSafeEqual(user.password, requestUser.password, options.hashFunction),
           ])
           if (usernameEqual && passwordEqual) {
+            ctx.set('basicAuthUsername', requestUser.username)
             await next()
             return
           }


### PR DESCRIPTION
## Summary
- After successful basic auth verification, the authenticated username is now available to downstream handlers via `c.get('basicAuthUsername')`
- Works for both the `username/password` option and the `verifyUser` callback option
- Exports `BasicAuthVariables` type and augments `ContextVariableMap`, following the same pattern as the JWT middleware (`jwtPayload`) and request-id middleware (`requestId`)

## Changes
- `src/middleware/basic-auth/index.ts`: Added `ctx.set('basicAuthUsername', requestUser.username)` before `await next()` on both successful auth paths. Added `BasicAuthVariables` type export and `ContextVariableMap` module augmentation.
- `src/middleware/basic-auth/index.test.ts`: Added 3 test cases covering username/password auth, verifyUser auth, and failed auth scenarios.

## Usage
```ts
import { Hono } from 'hono'
import { basicAuth } from 'hono/basic-auth'

const app = new Hono()

app.use('/auth/*', basicAuth({ username: 'admin', password: 'secret' }))

app.get('/auth/profile', (c) => {
  const username = c.get('basicAuthUsername')
  return c.json({ user: username })
})
```

## Test plan
- [x] Username is set in context after successful username/password auth
- [x] Username is set in context after successful verifyUser auth
- [x] Username is not set when auth fails (401 returned before handler)
- [x] All existing basic-auth tests pass (16/16)
- [x] `bun run format:fix && bun run lint:fix` pass

Closes #4192