### PR TITLE
fix(service-worker): make fire() consistent with handle() on 404 fallback

### DIFF
--- a/src/adapter/service-worker/index.ts
+++ b/src/adapter/service-worker/index.ts
@@ -12,7 +12,7 @@ import type { HandleOptions } from './handler'
  * This sets up `addEventListener('fetch', handle(app, options))` for the provided app.
  *
  * @param app - The Hono application instance
- * @param options - Options for handling requests (fetch defaults to undefined)
+ * @param options - Options for handling requests
  * @example
  * ```ts
  * import { Hono } from 'hono'
@@ -27,9 +27,7 @@ import type { HandleOptions } from './handler'
  */
 const fire = <E extends Env, S extends Schema, BasePath extends string>(
   app: Hono<E, S, BasePath>,
-  options: HandleOptions = {
-    fetch: undefined,
-  }
+  options?: HandleOptions
 ): void => {
   // @ts-expect-error addEventListener is not typed well in ServiceWorker-like contexts, see: https://github.com/microsoft/TypeScript/issues/14877
   addEventListener('fetch', handle(app, options))


### PR DESCRIPTION
## Summary
- `fire()` previously set `fetch: undefined` as default, causing it to NOT re-fetch on 404
- `handle()` defaults to `globalThis.fetch.bind(globalThis)`, which re-fetches on 404
- The docs state `fire()` is just a convenience wrapper around `handle()`, but they had different 404 behavior
- This fix removes the `{ fetch: undefined }` override in `fire()` so it inherits `handle()`'s defaults

## Changes
- `src/adapter/service-worker/index.ts`: Changed `options: HandleOptions = { fetch: undefined }` to `options?: HandleOptions`, letting `handle()`'s default parameter apply

## Test plan
- [x] All existing service-worker handler tests pass (5/5)
- [x] `bun run format:fix` passes
- [x] Users who want the old `fire()` behavior (no 404 fallback) can explicitly pass `{ fetch: undefined }`

Closes #4632