### PR TITLE
fix(context): throw TypeError for non-serializable values in c.json()

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,13 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() - throw TypeError for non-serializable value', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => c.json(undefined as any)).toThrow(TypeError)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => c.json(undefined as any)).toThrow('Value is not JSON serializable')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -703,8 +703,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## Summary

- `c.json()` now throws a `TypeError` when given a value that `JSON.stringify()` returns `undefined` for (e.g., `undefined`, bare functions, `Symbol`)
- Previously, these values silently produced an empty response body with a `Content-Type: application/json` header, which is confusing and incorrect
- This matches the behavior of Deno's `Response.json()` as suggested in the issue discussion

## Changes

- **`src/context.ts`**: Check `JSON.stringify()` result; throw `TypeError('Value is not JSON serializable')` if `undefined`
- **`src/context.test.ts`**: Add test case verifying the TypeError is thrown for non-serializable values

## Test plan

- [x] Existing context tests pass (58/58)
- [x] New test verifies `c.json(undefined)` throws `TypeError` with correct message
- [x] Format check passes

Closes #2343