### PR TITLE
feat(mime): specify charset parameter per MIME type

### DIFF
--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -9,12 +9,21 @@ describe('mime', () => {
   it('getMimeType', () => {
     expect(getMimeType('hello.txt')).toBe('text/plain; charset=utf-8')
     expect(getMimeType('hello.html')).toBe('text/html; charset=utf-8')
+    expect(getMimeType('hello.css')).toBe('text/css; charset=utf-8')
+    expect(getMimeType('hello.js')).toBe('text/javascript; charset=utf-8')
+    expect(getMimeType('hello.csv')).toBe('text/csv; charset=utf-8')
     expect(getMimeType('hello.json')).toBe('application/json')
     expect(getMimeType('favicon.ico')).toBe('image/x-icon')
     expect(getMimeType('good.morning.hello.gif')).toBe('image/gif')
     expect(getMimeType('site.webmanifest')).toBe('application/manifest+json')
     expect(getMimeType('goodmorninghellogif')).toBeUndefined()
     expect(getMimeType('indexjs.abcd')).toBeUndefined()
+  })
+
+  it('getMimeType - charset for XML-based types', () => {
+    expect(getMimeType('image.svg')).toBe('image/svg+xml; charset=utf-8')
+    expect(getMimeType('page.xhtml')).toBe('application/xhtml+xml; charset=utf-8')
+    expect(getMimeType('data.xml')).toBe('application/xml; charset=utf-8')
   })
 
   it('getMimeType with custom mime', () => {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -3,6 +3,20 @@
  * MIME utility.
  */
 
+const charsetTypes = new Set([
+  'css',
+  'csv',
+  'htm',
+  'html',
+  'ics',
+  'js',
+  'mjs',
+  'svg',
+  'txt',
+  'xhtml',
+  'xml',
+])
+
 export const getMimeType = (
   filename: string,
   mimes: Record<string, string> = baseMimes
@@ -13,7 +27,7 @@ export const getMimeType = (
     return
   }
   let mimeType = mimes[match[1]]
-  if (mimeType && mimeType.startsWith('text')) {
+  if (mimeType && charsetTypes.has(match[1])) {
     mimeType += '; charset=utf-8'
   }
   return mimeType


### PR DESCRIPTION
## Summary

- Replace the blanket `text/*` → `charset=utf-8` append in `getMimeType()` with a per-extension whitelist (`charsetTypes` Set)
- XML-based text types (`image/svg+xml`, `application/xhtml+xml`, `application/xml`) now correctly receive `charset=utf-8`
- Keeps `_baseMimes` values clean (no charset in const values) to preserve the `BaseMime` type used in JSX intrinsic elements and Context header typing
- `getExtension()` behavior is unchanged since `baseMimes` entries remain unmodified

## Changes

- **`src/utils/mime.ts`**: Add `charsetTypes` Set; replace `mimeType.startsWith('text')` check with `charsetTypes.has(match[1])`
- **`src/utils/mime.test.ts`**: Add tests for `css`, `js`, `csv` charset inclusion; add new test group for XML-based charset types (`svg`, `xhtml`, `xml`)

## Test plan

- [x] MIME utility tests pass (4/4)
- [x] Serve-static tests pass (18/18) — uses `getMimeType` internally
- [x] SSG tests pass (46/46) — uses `getExtension` internally
- [x] Format check passes

Closes #4510