### PR TITLE
fix(lambda-edge): base64 encode compressed response bodies

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -89,6 +89,36 @@ describe('handle', () => {
     expect(res.body).toBe('https://hono.dev/test-path')
   })
 
+  it('Should base64 encode compressed response body', async () => {
+    const app = new Hono()
+    app.get('/test-path', (c) => {
+      return new Response('compressed-data', {
+        headers: {
+          'content-type': 'text/html; charset=UTF-8',
+          'content-encoding': 'gzip',
+        },
+      })
+    })
+    const handler = handle(app)
+
+    const res = await handler(cloudFrontEdgeEvent)
+
+    expect(res.bodyEncoding).toBe('base64')
+  })
+
+  it('Should not base64 encode uncompressed text response', async () => {
+    const app = new Hono()
+    app.get('/test-path', (c) => {
+      return c.text('hello')
+    })
+    const handler = handle(app)
+
+    const res = await handler(cloudFrontEdgeEvent)
+
+    expect(res.bodyEncoding).toBeUndefined()
+    expect(res.body).toBe('hello')
+  })
+
   it('Should support multiple cookies', async () => {
     const app = new Hono()
     app.get('/test-path', (c) => {

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -137,7 +137,13 @@ export const handle = (
 }
 
 const createResult = async (res: Response): Promise<CloudFrontResult> => {
-  const isBase64Encoded = isContentTypeBinary(res.headers.get('content-type') || '')
+  let isBase64Encoded = isContentTypeBinary(res.headers.get('content-type') || '')
+  if (!isBase64Encoded) {
+    const contentEncoding = res.headers.get('content-encoding')
+    if (contentEncoding && /^(gzip|deflate|compress|br)/.test(contentEncoding)) {
+      isBase64Encoded = true
+    }
+  }
   const body = isBase64Encoded ? encodeBase64(await res.arrayBuffer()) : await res.text()
 
   return {


### PR DESCRIPTION
## Summary

- When using the `compress` middleware with the Lambda@Edge adapter, compressed response bodies (gzip, deflate, br) were returned as plain text instead of being Base64-encoded, causing CloudFront to serve empty or corrupted responses
- Now `createResult()` checks the `Content-Encoding` header in addition to `Content-Type` when deciding whether to Base64-encode the response body
- This matches the existing behavior of the `aws-lambda` adapter (which already has `isContentEncodingBinary`)

## Changes

- **`src/adapter/lambda-edge/handler.ts`**: Add `Content-Encoding` check in `createResult()` to set `isBase64Encoded = true` for compressed responses
- **`src/adapter/lambda-edge/handler.test.ts`**: Add tests for compressed and uncompressed response handling

## Test plan

- [x] Lambda-edge handler tests pass (6/6)
- [x] Format check passes

Closes #4254