### PR TITLE
fix(lambda-edge): handle malformed CloudFront events gracefully

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -89,6 +89,19 @@ describe('handle', () => {
     expect(res.body).toBe('https://hono.dev/test-path')
   })
 
+  it('Should return 500 for malformed CloudFront event', async () => {
+    const app = new Hono()
+    app.get('/test-path', (c) => c.text('ok'))
+    const handler = handle(app)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const malformedEvent = { Records: [] } as any
+    const res = await handler(malformedEvent)
+
+    expect(res.status).toBe('500')
+    expect(res.body).toContain('Unable to handle CloudFront event')
+  })
+
   it('Should support multiple cookies', async () => {
     const app = new Hono()
     app.get('/test-path', (c) => {

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -122,17 +122,25 @@ export const handle = (
   callback?: Callback
 ) => Promise<CloudFrontResult>) => {
   return async (event, context?, callback?) => {
-    const res = await app.fetch(createRequest(event), {
-      event,
-      context,
-      callback: (err: Error | null, result?: CloudFrontResult | CloudFrontRequest) => {
-        callback?.(err, result)
-      },
-      config: event.Records[0].cf.config,
-      request: event.Records[0].cf.request,
-      response: event.Records[0].cf.response,
-    })
-    return createResult(res)
+    try {
+      const res = await app.fetch(createRequest(event), {
+        event,
+        context,
+        callback: (err: Error | null, result?: CloudFrontResult | CloudFrontRequest) => {
+          callback?.(err, result)
+        },
+        config: event.Records[0].cf.config,
+        request: event.Records[0].cf.request,
+        response: event.Records[0].cf.response,
+      })
+      return createResult(res)
+    } catch (e) {
+      return {
+        status: '500',
+        statusDescription: 'Internal Server Error',
+        body: `Error: Unable to handle CloudFront event: ${e instanceof Error ? e.message : 'Unknown error'}`,
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- When testing Lambda@Edge via the AWS Console with dummy event data, the handler crashes with an unhandled TypeError because it accesses `event.Records[0].cf` without validation
- Now the handler wraps event processing in a try-catch, returning a 500 response with a descriptive error message instead of throwing

## Changes

- **`src/adapter/lambda-edge/handler.ts`**: Wrap handler body in try-catch, return `{ status: '500', body: 'Error: ...' }` on failure
- **`src/adapter/lambda-edge/handler.test.ts`**: Add test for malformed event handling

## Test plan

- [x] Lambda-edge handler tests pass (5/5)
- [x] Format check passes

Closes #4417