### PR TITLE
fix(aws-lambda): add missing authorizer context types

### DIFF
--- a/src/adapter/aws-lambda/types.ts
+++ b/src/adapter/aws-lambda/types.ts
@@ -88,6 +88,9 @@ export interface ApiGatewayRequestContext {
   authorizer: {
     claims?: unknown
     scopes?: unknown
+    principalId?: string
+    integrationLatency?: number
+    [key: string]: unknown
   }
   domainName: string
   domainPrefix: string
@@ -114,6 +117,11 @@ interface Authorizer {
     userArn: string
     userId: string
   }
+  jwt?: {
+    claims: Record<string, string | number | boolean>
+    scopes?: string[]
+  }
+  lambda?: Record<string, unknown>
 }
 
 export interface ApiGatewayRequestContextV2 {


### PR DESCRIPTION
## Summary
- Add `lambda` and `jwt` authorizer types to `ApiGatewayRequestContextV2`'s `Authorizer` interface for HTTP API v2 Lambda and JWT authorizers
- Add `principalId`, `integrationLatency`, and index signature to `ApiGatewayRequestContext`'s authorizer for REST API custom authorizer support

Currently the `Authorizer` interface only includes `iam` authentication, which means users working with Lambda authorizers or JWT authorizers on HTTP API v2 need manual type workarounds.

Reference: [AWS API Gateway V2 Request Context](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)

Closes #3281