### PR TITLE
fix(cookie): relax cookie name validation during parsing

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -73,6 +73,13 @@ describe('Parse cookie', () => {
     expect(cookie['']).toBeUndefined()
   })
 
+  it('Should parse cookie names with non-RFC characters like colons', () => {
+    const cookieString = 'paraglide:lang=en; test=ok'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['paraglide:lang']).toBe('en')
+    expect(cookie['test']).toBe('ok')
+  })
+
   it('Should ignore invalid cookie values', () => {
     const cookieString = 'yummy_cookie=choco\\nchip; tasty_cookie=strawberry; best_cookie="sugar'
     const cookie: Cookie = parse(cookieString)

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -65,9 +65,13 @@ const verifySignature = async (
   }
 }
 
-// all alphanumeric chars and all of _!#$%&'*.^`|~+-
-// (see: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)
+// RFC 6265 cookie-name token chars for serialization (strict)
 const validCookieNameRegEx = /^[\w!#$%&'*.^`|~+-]+$/
+
+// Lenient cookie name validation for parsing: accept any non-empty name
+// that doesn't contain control chars, spaces, '=', ';', or ','
+// This allows real-world cookie names like 'paraglide:lang'
+const validCookieNameLoose = /^[^\x00-\x1f\x7f =;,\\]+$/
 
 // all ASCII chars 32-126 except 34, 59, and 92 (i.e. space to tilde but not double quote, semicolon, or backslash)
 // (see: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)
@@ -91,7 +95,7 @@ export const parse = (cookie: string, name?: string): Cookie => {
     }
 
     const cookieName = pairStr.substring(0, valueStartPos).trim()
-    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
+    if ((name && name !== cookieName) || !validCookieNameLoose.test(cookieName)) {
       continue
     }
 


### PR DESCRIPTION
## Summary
- Add a lenient cookie name regex for parsing (consuming) cookies that accepts real-world cookie names containing characters like `:` (e.g. `paraglide:lang`)
- Keep the strict RFC 6265 regex for cookie serialization (producing cookies)
- The lenient regex only rejects control characters, spaces, `=`, `;`, `,`, and `\`

This follows the same approach used by popular cookie libraries like `jshttp/cookie` (used by Express/Koa, 50M+ weekly downloads) which don't validate cookie names during parsing at all.

Closes #3189