### PR TITLE
fix(logger): disable ANSI colors when stdout is not a TTY

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -23,7 +23,19 @@ export function getColorEnabled(): boolean {
           'NO_COLOR' in process?.env
         : false
 
-  return !isNoColor
+  if (isNoColor) {
+    return false
+  }
+
+  // Check if stdout is a TTY (Node.js / Deno)
+  if (typeof Deno?.stdout?.isTerminal === 'function') {
+    return Deno.stdout.isTerminal()
+  }
+  if (typeof process?.stdout?.isTTY === 'boolean') {
+    return process.stdout.isTTY
+  }
+
+  return true
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add TTY detection to `getColorEnabled()` so ANSI escape sequences are automatically disabled when output is not a terminal
- Supports Node.js (`process.stdout.isTTY`) and Deno (`Deno.stdout.isTerminal()`)
- `NO_COLOR` env var still takes precedence as the highest-priority override

This prevents garbled output in non-terminal environments like Cloudflare Workers logs, CI pipelines, and piped output, where ANSI escape codes are rendered as raw text.

Closes #3809