### PR TITLE
fix(cookie): deduplicate Set-Cookie headers by name

### DIFF
--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -371,11 +371,11 @@ describe('Cookie Middleware', () => {
       return c.text('Give cookie')
     })
 
-    it('Multiple values', async () => {
+    it('Multiple values with same name should deduplicate', async () => {
       const res = await app.request('http://localhost/set-cookie-multiple')
       expect(res.status).toBe(200)
       const header = res.headers.get('Set-Cookie')
-      expect(header).toBe('delicious_cookie=macha; Path=/, delicious_cookie=choco; Path=/')
+      expect(header).toBe('delicious_cookie=choco; Path=/')
     })
   })
 

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -97,8 +97,24 @@ export const generateCookie = (name: string, value: string, opt?: CookieOptions)
 }
 
 export const setCookie = (c: Context, name: string, value: string, opt?: CookieOptions): void => {
+  let cookieName = name
+  if (opt?.prefix === 'secure') {
+    cookieName = '__Secure-' + name
+  } else if (opt?.prefix === 'host') {
+    cookieName = '__Host-' + name
+  }
+
   const cookie = generateCookie(name, value, opt)
-  c.header('Set-Cookie', cookie, { append: true })
+  const headers = c.res.headers
+  const cookies = headers.getSetCookie?.() ?? []
+  headers.delete('Set-Cookie')
+  for (const existing of cookies) {
+    const existingName = existing.split('=')[0]
+    if (existingName !== cookieName) {
+      headers.append('Set-Cookie', existing)
+    }
+  }
+  headers.append('Set-Cookie', cookie)
 }
 
 export const generateSignedCookie = async (
@@ -134,8 +150,24 @@ export const setSignedCookie = async (
   secret: string | BufferSource,
   opt?: CookieOptions
 ): Promise<void> => {
+  let cookieName = name
+  if (opt?.prefix === 'secure') {
+    cookieName = '__Secure-' + name
+  } else if (opt?.prefix === 'host') {
+    cookieName = '__Host-' + name
+  }
+
   const cookie = await generateSignedCookie(name, value, secret, opt)
-  c.header('set-cookie', cookie, { append: true })
+  const headers = c.res.headers
+  const cookies = headers.getSetCookie?.() ?? []
+  headers.delete('Set-Cookie')
+  for (const existing of cookies) {
+    const existingName = existing.split('=')[0]
+    if (existingName !== cookieName) {
+      headers.append('Set-Cookie', existing)
+    }
+  }
+  headers.append('Set-Cookie', cookie)
 }
 
 export const deleteCookie = (c: Context, name: string, opt?: CookieOptions): string | undefined => {


### PR DESCRIPTION
## Summary

When `setCookie` or `setSignedCookie` is called multiple times with the same cookie name, all values were appended as separate `Set-Cookie` headers. This violates RFC 6265 and causes unpredictable browser behavior — the browser may accept any of the duplicate values.

This PR modifies both `setCookie` and `setSignedCookie` to remove existing `Set-Cookie` headers with the same cookie name before appending the new one, so only the last-set value is sent.

### Changes
- `setCookie`: Uses `getSetCookie()` to find and remove existing headers with the same cookie name before appending
- `setSignedCookie`: Same deduplication logic (previously used `c.header('set-cookie', cookie, { append: true })` which always appended)
- Updated test to verify deduplication behavior

### Example
```ts
setCookie(c, 'hello', 'world1')
setCookie(c, 'hello', 'world2')
// Before: Set-Cookie: hello=world1; Path=/, Set-Cookie: hello=world2; Path=/
// After:  Set-Cookie: hello=world2; Path=/
```

Closes #4445