### PR TITLE
fix(cookie): remove throwing on Max-Age/Expires > 400 days

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -240,26 +240,20 @@ describe('Set cookie', () => {
     expect(serialized).toBe('great_cookie=banana')
   })
 
-  it('Should throw Error cookie with maxAge grater than 400days', () => {
-    expect(() => {
-      serialize('great_cookie', 'banana', {
-        maxAge: 3600 * 24 * 401,
-      })
-    }).toThrowError(
-      'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
-    )
+  it('Should allow cookie with maxAge greater than 400 days', () => {
+    const maxAge = 3600 * 24 * 401
+    const serialized = serialize('great_cookie', 'banana', {
+      maxAge,
+    })
+    expect(serialized).toBe(`great_cookie=banana; Max-Age=${maxAge}`)
   })
 
-  it('Should throw Error cookie with expires grater than 400days', () => {
-    const now = Date.now()
-    const day401 = new Date(now + 1000 * 3600 * 24 * 401)
-    expect(() => {
-      serialize('great_cookie', 'banana', {
-        expires: day401,
-      })
-    }).toThrowError(
-      'Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.'
-    )
+  it('Should allow cookie with expires greater than 400 days', () => {
+    const day401 = new Date(Date.now() + 1000 * 3600 * 24 * 401)
+    const serialized = serialize('great_cookie', 'banana', {
+      expires: day401,
+    })
+    expect(serialized).toBe(`great_cookie=banana; Expires=${day401.toUTCString()}`)
   })
 
   it('Should throw Error Partitioned cookie without Secure attributes', () => {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -162,12 +162,6 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt && typeof opt.maxAge === 'number' && opt.maxAge >= 0) {
-    if (opt.maxAge > 34560000) {
-      // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.6.2
-      throw new Error(
-        'Cookies Max-Age SHOULD NOT be greater than 400 days (34560000 seconds) in duration.'
-      )
-    }
     cookie += `; Max-Age=${opt.maxAge | 0}`
   }
 
@@ -180,12 +174,6 @@ const _serialize = (name: string, value: string, opt: CookieOptions = {}): strin
   }
 
   if (opt.expires) {
-    if (opt.expires.getTime() - Date.now() > 34560000_000) {
-      // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.5
-      throw new Error(
-        'Cookies Expires SHOULD NOT be greater than 400 days (34560000 seconds) in the future.'
-      )
-    }
     cookie += `; Expires=${opt.expires.toUTCString()}`
   }
 


### PR DESCRIPTION
## Summary

Removes the `throw new Error()` when setting a cookie with `Max-Age` > 400 days or `Expires` > 400 days in the future.

RFC 6265bis section 5.5/5.6.2 uses **SHOULD NOT** (not MUST NOT) for this limit. The current behavior of throwing an error is too strict and breaks third-party libraries like Supabase Auth that set long-lived session cookies.

The browser is the appropriate enforcer — it will silently clamp the value. Hono as a server framework should not prevent the `Set-Cookie` header from being sent.

### Changes
- Removed the `maxAge > 34560000` check and throw in `_serialize()`
- Removed the `expires > 400 days` check and throw in `_serialize()`
- Updated tests to verify large values are accepted instead of thrown

Closes #2762