### PR TITLE
fix: handle non-Error thrown values in onError

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -50,9 +50,11 @@ export const compose = <E extends Env = Env>(
         try {
           res = await handler(context, () => dispatch(i + 1))
         } catch (err) {
-          if (err instanceof Error && onError) {
-            context.error = err
-            res = await onError(err, context)
+          if (onError) {
+            const error =
+              err instanceof Error ? err : new Error(typeof err === 'string' ? err : String(err))
+            context.error = error
+            res = await onError(error, context)
             isError = true
           } else {
             throw err

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -394,7 +394,10 @@ class Hono<
     if (err instanceof Error) {
       return this.errorHandler(err, c)
     }
-    throw err
+    return this.errorHandler(
+      new Error(typeof err === 'string' ? err : String(err)),
+      c
+    )
   }
 
   #dispatch(

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1374,8 +1374,11 @@ describe('Error handle', () => {
       return c.text('Custom Error Message', 500)
     })
 
-    it('Should throw Error if a non-Error object is thrown in a handler', async () => {
-      expect(() => app.request('/error-string')).toThrowError()
+    it('Should handle non-Error object thrown in a handler via onError', async () => {
+      const res = await app.request('/error-string')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toBe('Custom Error Message')
+      expect(res.headers.get('x-debug')).toBe('This is Error')
     })
 
     it('Custom Error Message', async () => {


### PR DESCRIPTION
## Summary

When a handler throws a non-Error value (e.g. `throw 'something'`), `app.onError()` was not invoked. The throw propagated as an unhandled rejection, making it impossible to catch errors from third-party libraries that throw strings or other non-Error values.

This PR wraps non-Error thrown values in an `Error` instance before passing them to `onError`, so all thrown values are handled consistently.

### Changes
- `compose.ts`: Removed `instanceof Error` guard — now wraps non-Error values in `new Error()` before calling `onError`
- `hono-base.ts`: Updated `#handleError` to wrap non-Error values instead of re-throwing
- Updated test to verify non-Error throws are handled by `onError`

### Example
```ts
app.get('/error', () => {
  throw 'something went wrong' // non-Error value
})

app.onError((err, c) => {
  // Previously: never called for non-Error throws
  // Now: err.message === 'something went wrong'
  return c.text(err.message, 500)
})
```

Closes #667