### PR TITLE
test(router): fix capturing group test using non-capturing regex

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -777,7 +777,7 @@ export const runTest = ({
     describe('Capture Group', () => {
       describe('Simple capturing group', () => {
         beforeEach(() => {
-          router.add('get', '/foo/:capture{(?:bar|baz)}', 'ok')
+          router.add('get', '/foo/:capture{(bar|baz)}', 'ok')
         })
 
         it('GET /foo/bar', () => {


### PR DESCRIPTION
## Summary

The 'Simple capturing group' test in `common.case.test.ts` was using `(?:bar|baz)` — a non-capturing group — making it identical to the 'Non-capturing group' test directly below it.

Changed the regex to `(bar|baz)` so the test actually exercises capturing group behavior as its name suggests.

Closes #1837