### PR TITLE
fix(context): throw TypeError for non-serializable c.json() values

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -703,8 +703,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2463,6 +2463,16 @@ describe('json', () => {
       })
     })
   })
+
+  it('Should return 500 for non-serializable values like undefined', async () => {
+    const app = new Hono()
+    app.get('/json-undefined', (c) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return c.json(undefined as any)
+    })
+    const res = await app.request('/json-undefined')
+    expect(res.status).toBe(500)
+  })
 })
 
 describe('Optional parameters', () => {


### PR DESCRIPTION
## Summary
- `JSON.stringify()` returns `undefined` for values like `undefined` or functions, which caused `c.json()` to silently return an empty body with a `200` status and `application/json` content type
- Now throws a `TypeError('Value is not JSON serializable')` so the error handler properly returns a `500` response

## Changes
- `src/context.ts`: Added check after `JSON.stringify(object)` — if result is `undefined`, throw `TypeError`
- `src/hono.test.ts`: Added test verifying `c.json(undefined)` triggers a 500 response

Closes #2343