### PR TITLE
fix(trie-router): normalize ** to * wildcard for consistent routing

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -282,6 +282,26 @@ describe('Special Wildcard deeply', () => {
   })
 })
 
+describe('Double star wildcard', () => {
+  const node = new Node()
+  node.insert('get', '/auth/**', 'match auth')
+  it('/auth/login', () => {
+    const [res] = node.search('get', '/auth/login')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('match auth')
+  })
+  it('/auth/signup', () => {
+    const [res] = node.search('get', '/auth/signup')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('match auth')
+  })
+  it('/auth', () => {
+    const [res] = node.search('get', '/auth')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('match auth')
+  })
+})
+
 describe('Default with wildcard', () => {
   const node = new Node()
   node.insert('ALL', '/api/*', 'fallback')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -44,7 +44,7 @@ export class Node<T> {
     const possibleKeys: string[] = []
 
     for (let i = 0, len = parts.length; i < len; i++) {
-      const p: string = parts[i]
+      const p: string = parts[i] === '**' ? '*' : parts[i]
       const nextP = parts[i + 1]
       const pattern = getPattern(p, nextP)
       const key = Array.isArray(pattern) ? pattern[0] : p


### PR DESCRIPTION
## Summary
- TrieRouter treated `**` as a literal path segment instead of a wildcard, causing routes like `/auth/**` to return 404
- Other routers (RegExpRouter, LinearRouter, PatternRouter) already handled `**` correctly
- Normalizes `**` to `*` during route insertion in TrieRouter's `insert()` method

## Changes
- `src/router/trie-router/node.ts`: Normalize `**` to `*` in the parts loop
- `src/router/trie-router/node.test.ts`: Added "Double star wildcard" test suite

Closes #4623