### PR TITLE
fix(jsx): use console.error for streaming errors

### DIFF
--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -165,7 +165,7 @@ export const renderToReadableStream = (
           callbacks.push(
             promise
               .catch((err) => {
-                console.log(err)
+                console.error(err)
                 onError(err)
                 return ''
               })


### PR DESCRIPTION
## Summary
- The catch handler in JSX streaming was using `console.log` to output errors during promise resolution
- Changed to `console.error` to properly signal error severity and follow standard error logging conventions

## Changes
- `src/jsx/streaming.ts`: `console.log(err)` → `console.error(err)` in the streaming promise catch handler