### PR TITLE
fix(cache): use console.warn for missing caches API warning

### DIFF
--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -68,7 +68,7 @@ export const cache = (options: {
   cacheableStatusCodes?: StatusCode[]
 }): MiddlewareHandler => {
   if (!globalThis.caches) {
-    console.log('Cache Middleware is not enabled because caches is not defined.')
+    console.warn('Cache Middleware is not enabled because caches is not defined.')
     return async (_c, next) => await next()
   }
 


### PR DESCRIPTION
When the Cache API is not available in the runtime, the cache middleware logs a message indicating it is disabled. This changes `console.log` to `console.warn` since it is a warning about degraded functionality, not informational output.

Using `console.warn` makes it easier to filter and identify these messages in production logs and matches the semantic intent of the message.