### PR TITLE
fix(cookie): use consistent header casing in setSignedCookie

### DIFF
--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -135,7 +135,7 @@ export const setSignedCookie = async (
   opt?: CookieOptions
 ): Promise<void> => {
   const cookie = await generateSignedCookie(name, value, secret, opt)
-  c.header('set-cookie', cookie, { append: true })
+  c.header('Set-Cookie', cookie, { append: true })
 }
 
 export const deleteCookie = (c: Context, name: string, opt?: CookieOptions): string | undefined => {


### PR DESCRIPTION
`setSignedCookie` used lowercase `'set-cookie'` while `setCookie` used properly cased `'Set-Cookie'`. Although HTTP headers are case-insensitive per RFC 7230, this inconsistency could cause issues with header deduplication in some environments and is inconsistent with the rest of the codebase.

This aligns the casing to match `setCookie` and all other `Set-Cookie` usages in Hono.