### PR TITLE
fix(jwt): fix formatting in JWT error messages

### DIFF
--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -56,7 +56,7 @@ export class JwtTokenIssuedAt extends Error {
 
 export class JwtTokenIssuer extends Error {
   constructor(expected: string | RegExp, iss: string | null) {
-    super(`expected issuer "${expected}", got ${iss ? `"${iss}"` : 'none'} `)
+    super(`expected issuer "${expected}", got ${iss ? `"${iss}"` : 'none'}`)
     this.name = 'JwtTokenIssuer'
   }
 }
@@ -91,7 +91,7 @@ export class JwtAlgorithmNotAllowed extends Error {
 
 export class JwtTokenSignatureMismatched extends Error {
   constructor(token: string) {
-    super(`token(${token}) signature mismatched`)
+    super(`token (${token}) signature mismatched`)
     this.name = 'JwtTokenSignatureMismatched'
   }
 }


### PR DESCRIPTION
Fix formatting inconsistencies in JWT error messages:

- **JwtTokenSignatureMismatched**: Add missing space between `token` and parenthesized token value to match the formatting used in `JwtTokenNotBefore` and `JwtTokenExpired` (e.g., `token (xxx) signature mismatched` instead of `token(xxx) signature mismatched`)
- **JwtTokenIssuer**: Remove trailing space at end of error message