### PR TITLE
fix(jsx): fix grammar in streaming module description

### DIFF
--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -1,6 +1,6 @@
 /**
  * @module
- * This module enables JSX to supports streaming Response.
+ * This module enables JSX to support streaming Response.
  */
 
 import { raw } from '../helper/html'


### PR DESCRIPTION
Fix grammar error in the `@module` JSDoc comment for `src/jsx/streaming.ts`.

`"enables JSX to supports streaming Response"` → `"enables JSX to support streaming Response"`