### PR TITLE
fix(client): fix subject-verb agreement in fetchRP JSDoc

### DIFF
--- a/src/client/fetch-result-please.ts
+++ b/src/client/fetch-result-please.ts
@@ -7,7 +7,7 @@
 const nullBodyResponses = new Set([101, 204, 205, 304])
 
 /**
- * Smartly parses and return the consumable result from a fetch `Response`.
+ * Smartly parses and returns the consumable result from a fetch `Response`.
  *
  * Throwing a structured error if the response is not `ok`. ({@link DetailedError})
  */


### PR DESCRIPTION
Fixes a grammar error in the `fetchRP` function's JSDoc description.

## Changes

- Changed "Smartly parses and return" to "Smartly parses and returns" for correct subject-verb agreement

## Impact

Documentation only — no runtime changes.