### PR TITLE
fix(jsx): complete incomplete module description in dom/css

### DIFF
--- a/src/jsx/dom/css.ts
+++ b/src/jsx/dom/css.ts
@@ -1,6 +1,6 @@
 /**
  * @module
- * This module provides APIs that enable `hono/jsx/dom` to support.
+ * This module provides APIs that enable `hono/jsx/dom` to support CSS.
  */
 
 import type { FC, PropsWithChildren } from '../'


### PR DESCRIPTION
Fixes an incomplete sentence in the `@module` JSDoc description in `src/jsx/dom/css.ts`.

## Changes

- Changed "This module provides APIs that enable \`hono/jsx/dom\` to support." to "This module provides APIs that enable \`hono/jsx/dom\` to support CSS."

The original sentence was missing its object, making it grammatically incomplete.

## Impact

Documentation only — no runtime changes.