### PR TITLE
fix(csrf): fix comment grammar in validation functions

### DIFF
--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -105,7 +105,7 @@ export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
   })(options?.origin)
   const isAllowedOrigin = async (origin: string | undefined, c: Context) => {
     if (origin === undefined) {
-      // denied always when origin header is not present
+      // deny when origin header is not present
       return false
     }
     return await originHandler(origin, c)
@@ -125,7 +125,7 @@ export const csrf = (options?: CSRFOptions): MiddlewareHandler => {
   })(options?.secFetchSite)
   const isAllowedSecFetchSite = async (secFetchSite: string | undefined, c: Context) => {
     if (secFetchSite === undefined) {
-      // denied always when sec-fetch-site header is not present
+      // deny when sec-fetch-site header is not present
       return false
     }
     // type guard to check if the value is a valid SecFetchSite


### PR DESCRIPTION
Fixes grammar in two inline comments in the CSRF middleware.

## Changes

- Changed "denied always when origin header is not present" to "deny when origin header is not present"
- Changed "denied always when sec-fetch-site header is not present" to "deny when sec-fetch-site header is not present"

The imperative form ("deny") matches the function's action and is consistent with common code comment style.

## Impact

Comments only — no runtime changes.