### PR TITLE
fix(jsx): fix typo in renderToReadableStream comment

### DIFF
--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -147,7 +147,7 @@ export const renderToReadableStream = (
     async start(controller) {
       try {
         if (content instanceof JSXNode) {
-          // aJSXNode.toString() returns a string or Promise<string> and string is already escaped
+          // A JSXNode.toString() returns a string or Promise<string> and string is already escaped
           content = content.toString() as HtmlEscapedString | Promise<HtmlEscapedString>
         }
         const context = typeof content === 'object' ? content : {}


### PR DESCRIPTION
Fixes a typo in an inline comment in `renderToReadableStream`.

## Changes

- Changed `// aJSXNode.toString()` to `// A JSXNode.toString()` — the lowercase "a" was concatenated with "JSXNode", making it hard to read.

## Impact

Comment only — no runtime changes.