### PR TITLE
fix: core error handling and routing consistency

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -50,9 +50,11 @@ export const compose = <E extends Env = Env>(
         try {
           res = await handler(context, () => dispatch(i + 1))
         } catch (err) {
-          if (err instanceof Error && onError) {
-            context.error = err
-            res = await onError(err, context)
+          if (onError) {
+            const error =
+              err instanceof Error ? err : new Error(typeof err === 'string' ? err : String(err))
+            context.error = error
+            res = await onError(error, context)
             isError = true
           } else {
             throw err

--- a/src/context.ts
+++ b/src/context.ts
@@ -703,8 +703,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -394,7 +394,10 @@ class Hono<
     if (err instanceof Error) {
       return this.errorHandler(err, c)
     }
-    throw err
+    return this.errorHandler(
+      new Error(typeof err === 'string' ? err : String(err)),
+      c
+    )
   }
 
   #dispatch(

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1374,8 +1374,11 @@ describe('Error handle', () => {
       return c.text('Custom Error Message', 500)
     })
 
-    it('Should throw Error if a non-Error object is thrown in a handler', async () => {
-      expect(() => app.request('/error-string')).toThrowError()
+    it('Should handle non-Error object thrown in a handler via onError', async () => {
+      const res = await app.request('/error-string')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toBe('Custom Error Message')
+      expect(res.headers.get('x-debug')).toBe('This is Error')
     })
 
     it('Custom Error Message', async () => {
@@ -2462,6 +2465,16 @@ describe('json', () => {
         message: 'Hello',
       })
     })
+  })
+
+  it('Should return 500 for non-serializable values like undefined', async () => {
+    const app = new Hono()
+    app.get('/json-undefined', (c) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return c.json(undefined as any)
+    })
+    const res = await app.request('/json-undefined')
+    expect(res.status).toBe(500)
   })
 })
 

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -282,6 +282,26 @@ describe('Special Wildcard deeply', () => {
   })
 })
 
+describe('Double star wildcard', () => {
+  const node = new Node()
+  node.insert('get', '/auth/**', 'match auth')
+  it('/auth/login', () => {
+    const [res] = node.search('get', '/auth/login')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('match auth')
+  })
+  it('/auth/signup', () => {
+    const [res] = node.search('get', '/auth/signup')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('match auth')
+  })
+  it('/auth', () => {
+    const [res] = node.search('get', '/auth')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('match auth')
+  })
+})
+
 describe('Default with wildcard', () => {
   const node = new Node()
   node.insert('ALL', '/api/*', 'fallback')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -44,7 +44,7 @@ export class Node<T> {
     const possibleKeys: string[] = []
 
     for (let i = 0, len = parts.length; i < len; i++) {
-      const p: string = parts[i]
+      const p: string = parts[i] === '**' ? '*' : parts[i]
       const nextP = parts[i + 1]
       const pattern = getPattern(p, nextP)
       const key = Array.isArray(pattern) ? pattern[0] : p


### PR DESCRIPTION
## Summary

Fixes for core error handling and router behavior consistency.

### Changes

- **context**: throw `TypeError` for non-serializable `c.json()` values — `JSON.stringify()` returns `undefined` for functions/undefined, silently producing an empty 200 response instead of triggering the error handler
- **compose/hono-base**: handle non-Error thrown values in `onError` — JavaScript allows throwing strings, objects, etc. These now get wrapped in `Error` instances so `onError` always fires
- **trie-router**: normalize `**` to `*` wildcard — TrieRouter treated `**` as a literal segment while RegExpRouter, LinearRouter, and PatternRouter all handled it as a wildcard

### Test plan

- [x] All existing core and router tests pass
- [x] New tests for non-serializable JSON and trie-router `**` normalization