### PR TITLE
fix: JSX streaming and documentation fixes

### DIFF
--- a/src/client/fetch-result-please.ts
+++ b/src/client/fetch-result-please.ts
@@ -7,7 +7,7 @@
 const nullBodyResponses = new Set([101, 204, 205, 304])
 
 /**
- * Smartly parses and return the consumable result from a fetch `Response`.
+ * Smartly parses and returns the consumable result from a fetch `Response`.
  *
  * Throwing a structured error if the response is not `ok`. ({@link DetailedError})
  */

--- a/src/jsx/dom/css.ts
+++ b/src/jsx/dom/css.ts
@@ -1,6 +1,6 @@
 /**
  * @module
- * This module provides APIs that enable `hono/jsx/dom` to support.
+ * This module provides APIs that enable `hono/jsx/dom` to support CSS.
  */
 
 import type { FC, PropsWithChildren } from '../'

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -1,6 +1,6 @@
 /**
  * @module
- * This module enables JSX to supports streaming Response.
+ * This module enables JSX to support streaming Response.
  */
 
 import { raw } from '../helper/html'
@@ -147,7 +147,7 @@ export const renderToReadableStream = (
     async start(controller) {
       try {
         if (content instanceof JSXNode) {
-          // aJSXNode.toString() returns a string or Promise<string> and string is already escaped
+          // A JSXNode.toString() returns a string or Promise<string> and string is already escaped
           content = content.toString() as HtmlEscapedString | Promise<HtmlEscapedString>
         }
         const context = typeof content === 'object' ? content : {}
@@ -165,7 +165,7 @@ export const renderToReadableStream = (
           callbacks.push(
             promise
               .catch((err) => {
-                console.log(err)
+                console.error(err)
                 onError(err)
                 return ''
               })


### PR DESCRIPTION
## Summary

Fixes for JSX streaming log level and documentation/comment quality.

### Changes

- **streaming**: use `console.error` for streaming render errors instead of `console.log`
- **streaming**: fix grammar in `@module` JSDoc (`supports` -> `support`)
- **streaming**: fix typo in `renderToReadableStream` comment (`aJSXNode` -> `A JSXNode`)
- **jsx/dom/css**: complete incomplete module description (`to support.` -> `to support CSS.`)
- **client**: fix subject-verb agreement in `fetchRP` JSDoc (`return` -> `returns`)

### Test plan

- [x] All existing JSX and streaming tests pass
- No behavioral changes — logging level fix and documentation only