### PR TITLE
fix(validator): prevent null pointer dereference in query validation

### DIFF
--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -141,13 +141,15 @@ export const validator = <
         value = form
         break
       }
-      case 'query':
+      case 'query': {
+        const queries = c.req.queries() || {}
         value = Object.fromEntries(
-          Object.entries(c.req.queries()).map(([k, v]) => {
+          Object.entries(queries).map(([k, v]) => {
             return v.length === 1 ? [k, v[0]] : [k, v]
           })
         )
         break
+      }
       case 'param':
         value = c.req.param() as Record<string, string>
         break


### PR DESCRIPTION
## Summary
Fixes critical null pointer dereference that causes application crashes when validating requests without query strings.

## Bug Details
- **Found by:** [WhiteRose](https://github.com/shakecodeslikecray/whiterose) AI bug hunter
- **Severity:** Critical
- **Type:** NULL pointer dereference / Denial of Service (DoS)
- **CWE:** [CWE-476](https://cwe.mitre.org/data/definitions/476.html) (NULL Pointer Dereference)
- **Bug ID:** WR-011

## Problem
The query validator calls \`Object.entries(c.req.queries())\` without checking if the result is \`undefined\`.

When no query string is present in the request, \`c.req.queries()\` returns \`undefined\` (see \`getQueryParams()\` in \`src/utils/url.ts:231\`), causing \`Object.entries(undefined)\` to throw a **TypeError** and crash the application.

### Vulnerable Code (Line 146)
\`\`\`typescript
case 'query':
  value = Object.fromEntries(
    Object.entries(c.req.queries()).map(([k, v]) => {  // ❌ Crashes if undefined
      return v.length === 1 ? [k, v[0]] : [k, v]
    })
  )
  break
\`\`\`

### Code Path to Crash
1. Request sent to endpoint with query validator: \`GET /api/users\` (no \`?query=params\`)
2. \`validator.ts:146\` → \`c.req.queries()\` called
3. \`request.ts:167\` → \`getQueryParams(this.url)\` called
4. \`url.ts:231\` → returns \`undefined\` (no query string)
5. \`validator.ts:146\` → \`Object.entries(undefined)\` → **TypeError: Cannot convert undefined to object**
6. Application crashes

## Attack Scenario

**DoS (Denial of Service):**
1. Attacker identifies endpoint with query validation
2. Sends requests **without query parameters**
3. Application crashes on every request
4. Service unavailable

Example vulnerable endpoint:
\`\`\`typescript
app.get('/search', validator('query', z.object({ q: z.string() })), (c) => {
  // This crashes if request is: GET /search (no ?q=...)
})
\`\`\`

## Changes
Added null-safe fallback before calling \`Object.entries()\`:

\`\`\`typescript
case 'query': {
  const queries = c.req.queries() || {}  // ✅ Safe fallback
  value = Object.fromEntries(
    Object.entries(queries).map(([k, v]) => {
      return v.length === 1 ? [k, v[0]] : [k, v]
    })
  )
  break
}
\`\`\`

This ensures:
- ✅ **No crash:** \`{}\` used when queries are undefined
- ✅ **Correct behavior:** Empty object for requests without query strings
- ✅ **Validation still works:** Validator will catch missing required params
- ✅ **Backward compatible:** Existing behavior unchanged for valid requests

## Security Impact

**Before:** Application crash (DoS) on requests without query parameters
**After:** Safe handling, validation proceeds normally

## Testing
- [x] Fix applied to \`src/validator/validator.ts\`
- [x] Null safety verified
- [ ] CI tests will run automatically

## Related Code
The root cause is in \`src/utils/url.ts:231\`:
\`\`\`typescript
export const getQueryParams = (url: string, key?: string) => {
  const queryIndex = url.indexOf('?', 8)
  if (queryIndex === -1) {
    return undefined  // ← Returns undefined when no query string
  }
  // ...
}
\`\`\`

## WhiteRose Report
This bug was automatically identified by WhiteRose's null-safety analysis pass, which traces data flow to find potential null/undefined dereferences.

🔗 **Try it:** [github.com/shakecodeslikecray/whiterose](https://github.com/shakecodeslikecray/whiterose)

---

**Related:** This is PR #3 in a series addressing security vulnerabilities found by WhiteRose in Hono.
- PR #1: [#4704](https://github.com/honojs/hono/pull/4704) - JWT Bearer scheme validation
- PR #2: [#4705](https://github.com/honojs/hono/pull/4705) - JWT error swallowing