### PR TITLE
chore: update Zod import examples to use namespace imports

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -129,7 +129,7 @@ const app = new Hono<{ Bindings: Bindings }>()
 At the next major version, Validator Middleware will be changed with "breaking changes". Therefore, the current Validator Middleware will be deprecated; please use 3rd-party Validator libraries such as [Zod](https://zod.dev) or [TypeBox](https://github.com/sinclairzx81/typebox).
 
 ```ts
-import { z } from 'zod'
+import * as z from 'zod'
 
 //...
 

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { ZodSchema } from 'zod'
-import { z } from 'zod'
+import * as z from 'zod'
 import type { Context } from '../context'
 import { Hono } from '../hono'
 import { HTTPException } from '../http-exception'
@@ -35,7 +34,7 @@ type InferValidatorResponse<VF> = VF extends (value: any, c: any) => infer R
 
 // Reference implementation for only testing
 const zodValidator = <
-  T extends ZodSchema,
+  T extends z.ZodSchema,
   E extends {},
   P extends string,
   Target extends keyof ValidationTargets,


### PR DESCRIPTION
Update Zod import examples to use namespace imports (`import * as z from 'zod'`) to align with the [official Zod documentation](https://zod.dev/packages/zod).

## Changes

- `src/validator/validator.test.ts`: Consolidate `import type { ZodSchema }` and `import { z }` into `import * as z from 'zod'`, update `ZodSchema` references to `z.ZodSchema`
- `docs/MIGRATION.md`: Update Zod import example to namespace import style

## Related

- honojs/middleware#1738
- honojs/website#731

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code