### PR TITLE
doc(jwt): mark `options.secret` as required in JSDoc

### DIFF
--- a/src/middleware/jwt/jwt.ts
+++ b/src/middleware/jwt/jwt.ts
@@ -25,7 +25,7 @@ export type JwtVariables<T = any> = {
  * @see {@link https://hono.dev/docs/middleware/builtin/jwt}
  *
  * @param {object} options - The options for the JWT middleware.
- * @param {SignatureKey} [options.secret] - A value of your secret key.
+ * @param {SignatureKey} options.secret - A value of your secret key.
  * @param {string} [options.cookie] - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
  * @param {SignatureAlgorithm} options.alg - An algorithm type that is used for verifying (required). Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
  * @param {string} [options.headerName='Authorization'] - The name of the header to look for the JWT token. Default is 'Authorization'.


### PR DESCRIPTION
This PR updates the annotation to make `options.secret` required.

## Changes

- Updated JSDoc in `src/middleware/jwt/jwt.ts`
  - `@param {SignatureKey} [options.secret]`
  - -> `@param {SignatureKey} options.secret`

- Documentation-only change
- No runtime behavior changes

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
