### PR TITLE
feat(types): Add exports field to ExecutionContext

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -44,6 +44,11 @@ export interface ExecutionContext {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props: any
+  /**
+   * For compatibility with Wrangler 4.x.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  exports?: any
 }
 
 /**


### PR DESCRIPTION
## Summary
Add `exports` property to `ExecutionContext` for Cloudflare Workers

## Related
- Fixes #4493 
- https://developers.cloudflare.com/workers/runtime-apis/context/#exports

## Note
To Autocomplete with Wrangler's generated types, we should declare the type like:
```ts
import 'hono'

declare module 'hono' {
  interface ExecutionContext {
    readonly exports: Cloudflare.Exports
  }
}
```

## The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
