### PR TITLE
fix(request): Return 400 on invalid JSON request body issue #4711

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -249,7 +249,15 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    */
   json<T = any>(): Promise<T> {
-    return this.#cachedBody('text').then((text: string) => JSON.parse(text))
+    const cachedBody = this.#cachedBody('text')
+
+    return cachedBody.then((text: string) => {
+      try {
+        return JSON.parse(text) as T
+      } catch (e) {
+        throw new HTTPException(400, { message: 'Invalid JSON in request body', cause: e })
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
Handle JSON parse errors in HonoRequest.json(): the method now awaits the cached text, wraps JSON.parse in a try/catch, and throws an HTTPException(400) with message 'Invalid JSON in request body' and the original error as the cause. This prevents uncaught parse exceptions and returns a clear client error while preserving the cached-body behavior and generic typing.

### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
