### PR TITLE
fix(client): skip undefined values in form data serialization

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -447,6 +447,42 @@ describe('Form - Multiple Values', () => {
   })
 })
 
+describe('Form - Undefined Values', () => {
+  const server = setupServer(
+    http.post('http://localhost/form-undefined', async ({ request }) => {
+      const data = await request.formData()
+      return HttpResponse.json({
+        keys: [...data.keys()],
+        title: data.get('title'),
+        optional: data.get('optional'),
+      })
+    })
+  )
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  const client = hc('http://localhost/')
+
+  it('Should skip undefined values in form data', async () => {
+    // @ts-expect-error `client['form-undefined'].$post` is not typed
+    const res = await client['form-undefined'].$post({
+      form: {
+        title: 'Hello',
+        optional: undefined,
+      },
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({
+      keys: ['title'],
+      title: 'Hello',
+      optional: null,
+    })
+  })
+})
+
 describe('Infer the response/request type', () => {
   const app = new Hono()
   const route = app.get(

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -64,6 +64,9 @@ class ClientRequestImpl {
       if (args.form) {
         const form = new FormData()
         for (const [k, v] of Object.entries(args.form)) {
+          if (v === undefined) {
+            continue
+          }
           if (Array.isArray(v)) {
             for (const v2 of v) {
               form.append(k, v2)


### PR DESCRIPTION
Closes #4731

The RPC client serializes `undefined` form values as the literal string `"undefined"` via `FormData.append()`, while query parameters correctly skip `undefined` values.

This PR adds the same `undefined` check to the form data serialization loop in `ClientRequestImpl`, matching the existing behavior in `buildSearchParams`.

## Changes

- `src/client/client.ts`: Add `if (v === undefined) { continue }` guard in the form data loop
- `src/client/client.test.ts`: Add test verifying undefined form values are skipped