### PR TITLE
refactor(context): fix the `as` position

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -683,13 +683,11 @@ export class Context<
     arg?: ContentfulStatusCode | ResponseOrInit,
     headers?: HeaderRecord
   ): ReturnType<TextRespond> => {
-    return this.#useFastPath() && !arg && !headers
-      ? (new Response(text) as ReturnType<TextRespond>)
-      : (this.#newResponse(
-          text,
-          arg,
-          setDefaultContentType(TEXT_PLAIN, headers)
-        ) as ReturnType<TextRespond>)
+    return (
+      this.#useFastPath() && !arg && !headers
+        ? new Response(text)
+        : this.#newResponse(text, arg, setDefaultContentType(TEXT_PLAIN, headers))
+    ) as ReturnType<TextRespond>
   }
 
   /**


### PR DESCRIPTION
Just for readability.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
