### PR TITLE
fix(client): export `ApplyGlobalResponse` from `hono/client`

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -12,4 +12,5 @@ export type {
   ClientRequestOptions,
   ClientRequest,
   ClientResponse,
+  ApplyGlobalResponse,
 } from './types'


### PR DESCRIPTION
### The author should do the following, if applicable


I'm excited about `ApplyGlobalResponse` #4556 , released in v4.12.0.
When I tried it, I found that `dist/types/client/index.d.ts` was like this and the type were not included in the published artifact.



```typescript
/**
 * @module
 * The HTTP Client for Hono.
 */
export { hc } from './client';
export { parseResponse, DetailedError } from './utils';
export type { InferResponseType, InferRequestType, Fetch, ClientRequestOptions, ClientRequest, ClientResponse, } from './types';
```

This PR fixes that.

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
