### PR TITLE
refactor(types): export CORSOptions type from cors middleware

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -6,7 +6,7 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
-type CORSOptions = {
+export type CORSOptions = {
   origin:
     | string
     | string[]


### PR DESCRIPTION
With `CORSOptions` not being exported, it means that in TypeScript, it is not possible to create an object independently of the `cors` function and get fully aligned type safety. Yes, could just copy/paste, but the risk is Hono updates and there is drift.

For example

Currently, it looks like this and there is no type-safety and intellisense directly on the `corsConfig` object. It does get checked in the function, but having the error raised closest to the offending code is better.  In the example, it makes very little sense, but if one has a separate config file, and it is just an export, then the distance between the error and original code is far.
```
const corsConfig = {
  origin: corsOrigins,
  credentials: true,
};

app.use("/*", cors(corsConfig));
```

This fix allows this, which is just safer and easier to use
```
const corsConfig: CORSOptions = {
  origin: corsOrigins,
  credentials: true,
};

app.use("/*", cors(corsConfig));
```

There are no unit tests added, since it is an export of a type and any unit test would be testing TS works... not system logic.

## Checklist

- [x] Tests pass: npx vitest --run src/adapter/cloudflare-workers/websocket.test.ts 
- [x] Tests pass: npx vitest --run src/adapter/cloudflare-workers/conninfo.test.ts
- [x] TypeScript: npx tsc --noEmit — zero errors
- [x] Formatting: bun run format:fix — no changes needed
- [x] Linting: bun run lint:fix — zero errors (only pre-existing warnings)