### PR TITLE
fix(context): revert PR #4707

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -667,10 +667,6 @@ export class Context<
     headers?: HeaderRecord
   ): ReturnType<BodyRespond> => this.#newResponse(data, arg, headers) as ReturnType<BodyRespond>
 
-  #useFastPath(): boolean {
-    return !this.#preparedHeaders && !this.#status && !this.finalized
-  }
-
   /**
    * `.text()` can render text as `Content-Type:text/plain`.
    *
@@ -688,8 +684,8 @@ export class Context<
     arg?: ContentfulStatusCode | ResponseOrInit,
     headers?: HeaderRecord
   ): ReturnType<TextRespond> => {
-    return this.#useFastPath() && !arg && !headers
-      ? (createResponseInstance(text) as ReturnType<TextRespond>)
+    return !this.#preparedHeaders && !this.#status && !arg && !headers && !this.finalized
+      ? (new Response(text) as ReturnType<TextRespond>)
       : (this.#newResponse(
           text,
           arg,
@@ -717,15 +713,11 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
-    return (
-      this.#useFastPath() && !arg && !headers
-        ? Response.json(object)
-        : this.#newResponse(
-            JSON.stringify(object),
-            arg,
-            setDefaultContentType('application/json', headers)
-          )
-    ) as JSONRespondReturn<T, U>
+    return this.#newResponse(
+      JSON.stringify(object),
+      arg,
+      setDefaultContentType('application/json', headers)
+    ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any
   }
 
   html: HTMLRespond = (


### PR DESCRIPTION
We added the fast path for `c.json()` in #4707. It uses `Response.json()` in the fast path. It seems good, but sometimes the behavior of `Response.json()` differs across runtimes. For example, `c.json(undefined)`. The result, the PR #4756, is created.

Now, I revert the PR #4707 and disable the fast path for `c.json()`. We can keep the fast path logic without `Response.json()`, but if so, the bundle size will increase slightly. For now, revert.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
