### PR TITLE
fix(accept): replace regex split to mitigate ReDoS

### DIFF
--- a/src/utils/accept.test.ts
+++ b/src/utils/accept.test.ts
@@ -17,6 +17,11 @@ describe('parseAccept Comprehensive Tests', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(parseAccept(null as any)).toEqual([])
     })
+
+    test('handles whitespace-only header', () => {
+      expect(parseAccept('   ')).toEqual([])
+      expect(parseAccept(' \t\n ')).toEqual([])
+    })
   })
 
   describe('Quality Values', () => {
@@ -154,6 +159,48 @@ describe('parseAccept Comprehensive Tests', () => {
           q: 0.3,
         },
       ])
+    })
+
+    test('skips invalid param without swallowing next media type', () => {
+      const header = 'a;foo, b;q=0.5'
+      const result = parseAccept(header)
+      expect(result).toEqual([
+        { type: 'a', params: {}, q: 1 },
+        { type: 'b', params: { q: '0.5' }, q: 0.5 },
+      ])
+    })
+
+    test('skips malformed quoted param tail without creating bogus media type', () => {
+      const header = 'a;foo="x"bar,b'
+      const result = parseAccept(header)
+      expect(result).toEqual([
+        { type: 'a', params: {}, q: 1 },
+        { type: 'b', params: {}, q: 1 },
+      ])
+    })
+
+    test('parses params after quoted value with trailing whitespace', () => {
+      const header = 'a;foo="x" ;q=0.5,b;q=0.4'
+      const result = parseAccept(header)
+      expect(result).toEqual([
+        { type: 'a', params: { foo: 'x', q: '0.5' }, q: 0.5 },
+        { type: 'b', params: { q: '0.4' }, q: 0.4 },
+      ])
+    })
+
+    test('handles quoted param followed immediately by comma', () => {
+      const header = 'a;foo="x",b'
+      const result = parseAccept(header)
+      expect(result).toEqual([
+        { type: 'a', params: { foo: 'x' }, q: 1 },
+        { type: 'b', params: {}, q: 1 },
+      ])
+    })
+
+    test('skips empty media type that starts with semicolon', () => {
+      const header = ';q=0.5,b;q=0.4'
+      const result = parseAccept(header)
+      expect(result).toEqual([{ type: 'b', params: { q: '0.4' }, q: 0.4 }])
     })
   })
 

--- a/src/utils/accept.ts
+++ b/src/utils/accept.ts
@@ -4,137 +4,237 @@ export interface Accept {
   q: number
 }
 
-/**
- * Parse an Accept header into an array of objects with type, parameters, and quality score.
- * @param acceptHeader The Accept header string
- * @returns An array of parsed Accept values
- */
+const isWhitespace = (char: number): boolean =>
+  char === 32 || char === 9 || char === 10 || char === 13
+
+const consumeWhitespace = (acceptHeader: string, startIndex: number): number => {
+  while (startIndex < acceptHeader.length) {
+    if (!isWhitespace(acceptHeader.charCodeAt(startIndex))) {
+      break
+    }
+    startIndex++
+  }
+  return startIndex
+}
+
+const ignoreTrailingWhitespace = (acceptHeader: string, startIndex: number): number => {
+  while (startIndex > 0) {
+    if (!isWhitespace(acceptHeader.charCodeAt(startIndex - 1))) {
+      break
+    }
+    startIndex--
+  }
+  return startIndex
+}
+
+const skipInvalidParam = (acceptHeader: string, startIndex: number): [number, boolean] => {
+  while (startIndex < acceptHeader.length) {
+    const char = acceptHeader.charCodeAt(startIndex)
+    if (char === 59) {
+      // ';' => next param
+      return [startIndex + 1, true]
+    }
+    if (char === 44) {
+      // ',' => next accept value
+      return [startIndex + 1, false]
+    }
+    startIndex++
+  }
+  return [startIndex, false]
+}
+
+const skipInvalidAcceptValue = (acceptHeader: string, startIndex: number): number => {
+  let i = startIndex
+  let inQuotes = false
+  while (i < acceptHeader.length) {
+    const char = acceptHeader.charCodeAt(i)
+    if (inQuotes && char === 92) {
+      // '\' => escape
+      i++
+    } else if (char === 34) {
+      // '"' => toggle quotes
+      inQuotes = !inQuotes
+    } else if (!inQuotes && char === 44) {
+      // ',' => next accept value
+      return i + 1
+    }
+    i++
+  }
+  return i
+}
+
+const getNextParam = (
+  acceptHeader: string,
+  startIndex: number
+): [number, string | undefined, string | undefined, boolean] => {
+  startIndex = consumeWhitespace(acceptHeader, startIndex)
+  let i = startIndex
+  let key: string | undefined
+  let value: string | undefined
+  let hasNext = false
+  while (i < acceptHeader.length) {
+    const char = acceptHeader.charCodeAt(i)
+    if (char === 61) {
+      // '=' => end of key
+      key = acceptHeader.slice(startIndex, ignoreTrailingWhitespace(acceptHeader, i))
+      i++
+      break
+    }
+    if (char === 59) {
+      // ';' => invalid empty param, continue parsing params
+      return [i + 1, undefined, undefined, true]
+    }
+    if (char === 44) {
+      // ',' => invalid empty param, move to next accept value
+      return [i + 1, undefined, undefined, false]
+    }
+    i++
+  }
+  if (key === undefined) {
+    return [i, undefined, undefined, false]
+  }
+
+  i = consumeWhitespace(acceptHeader, i)
+  if (acceptHeader.charCodeAt(i) === 61) {
+    // '=' is invalid as a value, so return undefined
+    const skipResult = skipInvalidParam(acceptHeader, i + 1)
+    return [skipResult[0], key, undefined, skipResult[1]]
+  }
+
+  let inQuotes = false
+  const paramStartIndex = i
+  while (i < acceptHeader.length) {
+    const char = acceptHeader.charCodeAt(i)
+
+    if (inQuotes && char === 92) {
+      // '\' => escape
+      i++
+    } else if (char === 34) {
+      // '"' => start of quotes
+      if (inQuotes) {
+        let nextIndex = consumeWhitespace(acceptHeader, i + 1)
+        const nextChar = acceptHeader.charCodeAt(nextIndex)
+        if (nextIndex < acceptHeader.length && !(nextChar === 59 || nextChar === 44)) {
+          // not ';' or ',' => invalid trailing chars
+          const skipResult = skipInvalidParam(acceptHeader, nextIndex)
+          return [skipResult[0], key, undefined, skipResult[1]]
+        }
+        value = acceptHeader.slice(paramStartIndex + 1, i)
+        if (value.includes('\\')) {
+          value = value.replace(/\\(.)/g, '$1')
+        }
+        if (nextChar === 44) {
+          // ',' => end of accept value
+          return [nextIndex + 1, key, value, false]
+        }
+        if (nextChar === 59) {
+          // ';' => has next param
+          hasNext = true
+          nextIndex++
+        }
+        i = nextIndex
+        break
+      }
+      inQuotes = true
+    } else if (!inQuotes && (char === 59 || char === 44)) {
+      // ';' or ',' => end of value
+      value = acceptHeader.slice(paramStartIndex, ignoreTrailingWhitespace(acceptHeader, i))
+      if (char === 59) {
+        // ';' => has next param
+        hasNext = true
+      }
+      i++
+      break
+    }
+    i++
+  }
+  return [
+    i,
+    key,
+    value ?? acceptHeader.slice(paramStartIndex, ignoreTrailingWhitespace(acceptHeader, i)),
+    hasNext,
+  ]
+}
+
+const getNextAcceptValue = (
+  acceptHeader: string,
+  startIndex: number
+): [number, Accept | undefined] => {
+  const accept: Accept = {
+    type: '',
+    params: {},
+    q: 1,
+  }
+  startIndex = consumeWhitespace(acceptHeader, startIndex)
+  let i = startIndex
+  while (i < acceptHeader.length) {
+    const char = acceptHeader.charCodeAt(i)
+    if (char === 59 || char === 44) {
+      // ';' or ',' => end of type
+      accept.type = acceptHeader.slice(startIndex, ignoreTrailingWhitespace(acceptHeader, i))
+      i++
+      if (char === 44) {
+        // ',' => end of value
+        return [i, accept.type ? accept : undefined]
+      }
+      if (!accept.type) {
+        return [skipInvalidAcceptValue(acceptHeader, i), undefined]
+      }
+      break // parse params
+    }
+    i++
+  }
+  if (!accept.type) {
+    accept.type = acceptHeader.slice(
+      startIndex,
+      ignoreTrailingWhitespace(acceptHeader, acceptHeader.length)
+    )
+    return [acceptHeader.length, accept.type ? accept : undefined]
+  }
+
+  let param: string | undefined
+  let value: string | undefined
+  let hasNext: boolean
+  while (i < acceptHeader.length) {
+    ;[i, param, value, hasNext] = getNextParam(acceptHeader, i)
+    if (param && value) {
+      accept.params[param] = value
+    }
+    if (!hasNext) {
+      break
+    }
+  }
+
+  return [i, accept] as [number, Accept]
+}
+
 export const parseAccept = (acceptHeader: string): Accept[] => {
   if (!acceptHeader) {
     return []
   }
 
-  const acceptValues = splitByDelimiterOutsideQuotes(acceptHeader, ',').map((value, index) => ({
-    value,
-    index,
-  }))
-
-  return acceptValues
-    .map(parseAcceptValue)
-    .filter((item): item is Accept & { index: number } => Boolean(item))
-    .sort(sortByQualityAndIndex)
-    .map(({ type, params, q }) => ({ type, params, q }))
-}
-
-const splitByDelimiterOutsideQuotes = (value: string, delimiter: string): string[] => {
-  const parts: string[] = []
-  let current = ''
-  let inQuotes = false
-  let escaped = false
-
-  for (let i = 0; i < value.length; i++) {
-    const char = value[i]
-
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
+  const values: Accept[] = []
+  let i = 0
+  let accept: Accept | undefined
+  let requiresSort = false // in many cases, accept values are already sorted by quality (e.g. "text/html, application/json;q=0.9, */*;q=0.8")
+  let lastAccept: Accept | undefined
+  while (i < acceptHeader.length) {
+    ;[i, accept] = getNextAcceptValue(acceptHeader, i)
+    if (accept) {
+      accept.q = parseQuality(accept.params.q)
+      values.push(accept)
+      if (lastAccept && lastAccept.q < accept.q) {
+        // find higher quality accept value, so we need to sort
+        requiresSort = true
+      }
+      lastAccept = accept
     }
-
-    if (char === '\\' && inQuotes) {
-      current += char
-      escaped = true
-      continue
-    }
-
-    if (char === '"') {
-      inQuotes = !inQuotes
-      current += char
-      continue
-    }
-
-    if (char === delimiter && !inQuotes) {
-      parts.push(current)
-      current = ''
-      continue
-    }
-
-    current += char
+  }
+  if (requiresSort) {
+    values.sort((a, b) => b.q - a.q)
   }
 
-  parts.push(current)
-  return parts
-}
-
-const parseAcceptValue = ({ value, index }: { value: string; index: number }) => {
-  const parts = splitByDelimiterOutsideQuotes(value.trim(), ';').map((s) => s.trim())
-  const type = parts[0]
-  if (!type) {
-    return null
-  }
-
-  const params = parseParams(parts.slice(1))
-  const q = parseQuality(params.q)
-
-  return { type, params, q, index }
-}
-
-const parseParams = (paramParts: string[]): Record<string, string> => {
-  return paramParts.reduce<Record<string, string>>((acc, param) => {
-    const separatorIndex = param.indexOf('=')
-    if (separatorIndex <= 0) {
-      return acc
-    }
-
-    const key = param.slice(0, separatorIndex).trim()
-    const rawVal = param.slice(separatorIndex + 1).trim()
-    if (!key || !rawVal) {
-      return acc
-    }
-
-    const val = parseParamValue(rawVal)
-    if (val !== null) {
-      acc[key] = val
-    }
-
-    return acc
-  }, {})
-}
-
-const parseParamValue = (value: string): string | null => {
-  if (value[0] !== '"') {
-    return value.includes('=') ? null : value
-  }
-
-  return parseQuotedString(value)
-}
-
-const parseQuotedString = (value: string): string | null => {
-  let unescaped = ''
-  let escaped = false
-
-  for (let i = 1; i < value.length; i++) {
-    const char = value[i]
-
-    if (escaped) {
-      unescaped += char
-      escaped = false
-      continue
-    }
-
-    if (char === '\\') {
-      escaped = true
-      continue
-    }
-
-    if (char === '"') {
-      return value.slice(i + 1).trim() ? null : unescaped
-    }
-
-    unescaped += char
-  }
-
-  return null
+  return values
 }
 
 const parseQuality = (qVal?: string): number => {
@@ -163,12 +263,4 @@ const parseQuality = (qVal?: string): number => {
   }
 
   return num
-}
-
-const sortByQualityAndIndex = (a: Accept & { index: number }, b: Accept & { index: number }) => {
-  const qDiff = b.q - a.q
-  if (qDiff !== 0) {
-    return qDiff
-  }
-  return a.index - b.index
 }


### PR DESCRIPTION
## Summary
In proxy configurations without header size limits, this can cause real impact.

## Proof
```bash
curl http://127.0.0.1:3000/ \                                                                                                                                                                                                                                                                       
    -H "Accept-Language: $(node -e "process.stdout.write('a;'.repeat(16000) + '\"')")"
```

```json
[                                                                                                                                                                                                                                                                                     
 {"segments": 4000, "time": 12.8},
 {"segments": 8000, "time": 51.07},                                                                                                                                                                                                                                           
 {"segments": 16000, "time": 203.52}                                                                                                                                                                                                                                          
]
```

```ts
import {
    Hono
} from 'hono'
import {
    languageDetector
} from 'hono/language'

async function main() {
    const app = new Hono()
    app.use('*', languageDetector({
        supportedLanguages: ['en', 'ja'],
        fallbackLanguage: 'en'
    }))
    app.get('/', (c) => c.text(String(c.get('language'))))

    const run = async (segments: number) => {
        const v = 'a;'.repeat(segments) + '"'
        const req = new Request('http://localhost/', {
            headers: {
                'accept-language': v
            },
        })

        const t0 = performance.now()
        const res = await app.request(req)
        await res.text()
        return {
            segments,
            time: Number((performance.now() - t0).toFixed(2))
        }
    }

    const a = await run(4000)
    const b = await run(8000)
    const c = await run(16000)

    console.log(JSON.stringify([
        a,
        b,
        c
    ], null, 2))
}

main().catch(console.error)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
