### PR TITLE
perf(aws-lambda): optimize header parsing to reduce micro-allocations

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -413,17 +413,20 @@ export class EventV2Processor extends EventProcessor<APIGatewayProxyEventV2> {
   protected getHeaders(event: APIGatewayProxyEventV2): Headers {
     const headers = new Headers()
     this.getCookies(event, headers)
-    if (event.headers) {
-      for (const [k, v] of Object.entries(event.headers)) {
-        if (v) {
-          headers.set(k, v)
+    const eventHeaders = event.headers
+    if (eventHeaders) {
+      for (const k in eventHeaders) {
+        if (Object.prototype.hasOwnProperty.call(eventHeaders, k)) {
+          const v = eventHeaders[k]
+          if (v) {
+            headers.set(k, v)
+          }
         }
       }
     }
     return headers
   }
 }
-
 const v2Processor: EventV2Processor = new EventV2Processor()
 
 export class EventV1Processor extends EventProcessor<APIGatewayProxyEvent> {


### PR DESCRIPTION
## Description

This PR optimizes the getHeaders method in the AWS Lambda adapter. By switching from Object.entries() to a for...in loop with a safety check, we avoid the overhead of creating intermediate arrays for every request.
In high-throughput serverless environments, reducing these "micro-allocations" significantly lowers Garbage Collection (GC) pressure and minimizes latency jitter.

## Performance Details

benchmark                   avg (min … max)       p75 / p99
------------------------------------------- -------------------------------
Current (Object.entries)       1.26 µs/iter       1.20 µs / 2.30 µs
Optimized (for...in)         851.85 ns/iter     860.13 ns / 954.57 ns

Summary:
  Optimized (for...in) is 1.48x faster than Current (Object.entries)

## Testing

    [x] Benchmark Validation: Verified with mitata (results above).

    [x] Functional Testing: Ran the full Hono test suite.

    [x] Runtime Verification: Verified that globalThis.Headers is correctly populated.

    [x] Logic Safety: Added hasOwnProperty check to ensure we only process own properties of the event.headers object.
