### PR TITLE
feat: extend basePath() helper to accept Hono instances

### DIFF
--- a/src/helper/route/index.test.ts
+++ b/src/helper/route/index.test.ts
@@ -1,4 +1,5 @@
 import { Context } from '../../context'
+import { Hono } from '../../hono'
 import { matchedRoutes, routePath, baseRoutePath, basePath } from '.'
 
 const defaultContextOptions = {
@@ -215,5 +216,29 @@ describe('basePath', () => {
     })
 
     expect(basePath(c)).toBe('/sub-app-path/foo')
+  })
+})
+
+describe('basePath with Hono instance', () => {
+  it('should return "/" for a fresh Hono instance', () => {
+    const app = new Hono()
+    expect(basePath(app)).toBe('/')
+  })
+
+  it('should return the base path after basePath()', () => {
+    const app = new Hono().basePath('/api')
+    expect(basePath(app)).toBe('/api')
+  })
+
+  it('should return the merged path after chained basePath() calls', () => {
+    const app = new Hono().basePath('/api').basePath('/v1')
+    expect(basePath(app)).toBe('/api/v1')
+  })
+
+  it('should not affect the original instance', () => {
+    const app = new Hono()
+    const based = app.basePath('/api')
+    expect(basePath(app)).toBe('/')
+    expect(basePath(based)).toBe('/api')
   })
 })

--- a/src/helper/route/index.ts
+++ b/src/helper/route/index.ts
@@ -1,4 +1,5 @@
-import type { Context } from '../../context'
+import { Context } from '../../context'
+import type { HonoBase } from '../../hono-base'
 import { GET_MATCH_RESULT } from '../../request/constants'
 import type { RouterRoute } from '../../types'
 import { getPattern, splitRoutingPath } from '../../utils/url'
@@ -83,7 +84,7 @@ export const baseRoutePath = (c: Context, index?: number): string =>
   matchedRoutes(c).at(index ?? c.req.routeIndex)?.basePath ?? ''
 
 /**
- * Get the basePath with embedded parameters
+ * Get the basePath with embedded parameters, or the base path of a Hono instance.
  *
  * @param {Context} c - The context object
  * @param {number} index - The index of the root from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching root. Defaults to the current root index.
@@ -102,9 +103,27 @@ export const baseRoutePath = (c: Context, index?: number): string =>
  *
  * app.route('/:sub', subApp)
  * ```
+ *
+ * @example
+ * ```ts
+ * import { basePath } from 'hono/route'
+ *
+ * const subApp = new Hono()
+ * const path = basePath(subApp) // '/'
+ *
+ * const api = new Hono().basePath('/api')
+ * const apiPath = basePath(api) // '/api'
+ * ```
  */
 const basePathCacheMap: WeakMap<Context, Record<number, string>> = new WeakMap()
-export const basePath = (c: Context, index?: number): string => {
+export function basePath(app: HonoBase): string
+export function basePath(c: Context, index?: number): string
+export function basePath(c: Context | HonoBase, index?: number): string {
+  if (!(c instanceof Context)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (c as any)._basePath as string
+  }
+
   index ??= c.req.routeIndex
 
   const cache = basePathCacheMap.get(c) || []


### PR DESCRIPTION
## Summary

Extends the existing `basePath()` helper in `hono/route` to also accept a `Hono` instance, allowing libraries to read a Hono app's base path at setup time — without relying on the private `_basePath` property.

## Motivation

Currently, the only way to read a Hono instance's base path outside of a request handler is by accessing the private `_basePath` property. This is fragile — it is not part of the public API and could break without notice.

Libraries that integrate with Hono (such as [chanfana](https://github.com/cloudflare/chanfana), an OpenAPI schema generator) need to detect the base path to correctly generate API documentation and route schemas. Right now, chanfana reads `_basePath` defensively with runtime type guards ([see PR](https://github.com/cloudflare/chanfana/pull/306)), but a proper public API would be much better.

## Changes

- **`src/helper/route/index.ts`** — Added an overload to `basePath()` that accepts a `HonoBase` instance and returns its base path directly
- **`src/helper/route/index.test.ts`** — Added 4 tests for the new overload:
  - Returns `"/"` for a fresh instance
  - Returns the base path after `basePath()` 
  - Returns the merged path after chained `basePath()` calls
  - Original instance is unaffected after `basePath()` creates a clone

## Usage

```ts
import { basePath } from 'hono/route'

const app = new Hono().basePath('/api')
basePath(app) // '/api'

const v1 = app.basePath('/v1')
basePath(v1)  // '/api/v1'
basePath(app) // '/api' (unchanged)
```

The existing `basePath(c: Context)` handler behaviour is fully preserved.