### PR TITLE
fix(types): remove DOM type dependencies from ClientResponse and request method

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -129,8 +129,7 @@ export interface ClientResponse<
   T,
   U extends number = StatusCode,
   F extends ResponseFormat = ResponseFormat,
->
-  extends globalThis.Response {
+> {
   readonly body: ReadableStream | null
   readonly bodyUsed: boolean
   ok: U extends SuccessStatusCode
@@ -138,12 +137,15 @@ export interface ClientResponse<
     : U extends Exclude<StatusCode, SuccessStatusCode>
       ? false
       : boolean
+  redirected: boolean
   status: U
   statusText: string
+  type: 'basic' | 'cors' | 'default' | 'error' | 'opaque' | 'opaqueredirect'
   headers: Headers
   url: string
   redirect(url: string, status: number): Response
   clone(): Response
+  bytes(): Promise<Uint8Array<ArrayBuffer>>
   json(): F extends 'text' ? Promise<never> : F extends 'json' ? Promise<T> : Promise<unknown>
   text(): F extends 'text' ? (T extends string ? Promise<T> : Promise<never>) : Promise<string>
   blob(): Promise<Blob>

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -491,7 +491,7 @@ class Hono<
    * @see https://hono.dev/docs/api/hono#request
    */
   request = (
-    input: RequestInfo | URL,
+    input: Request | string | URL,
     requestInit?: RequestInit,
     Env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext


### PR DESCRIPTION
## Summary

- Remove `extends globalThis.Response` from `ClientResponse` interface in `src/client/types.ts`, adding `redirected`, `type`, and `bytes()` properties inline so the interface remains structurally compatible with `Response`
- Replace `RequestInfo | URL` with `Request | string | URL` in `Hono.request()` method signature in `src/hono-base.ts` (semantically identical since `RequestInfo = Request | string` in DOM lib)

## Motivation

Hono's type declarations depend on DOM-only types (`globalThis.Response`, `RequestInfo`) that are unavailable in non-DOM TypeScript environments (e.g. Bun with `types: ["bun"]`, Node without DOM lib). Projects using `skipLibCheck: false` in these environments hit `TS2304` errors when importing from hono.

Related issues: #1200, #3312, #3750

## Changes

### `src/client/types.ts`

`ClientResponse` already redeclares all `Response` members inline. Removing the `extends globalThis.Response` clause and adding three previously-inherited properties (`redirected`, `type`, `bytes()`) makes the interface self-contained and structurally compatible with `Response` without requiring DOM types.

### `src/hono-base.ts`

`RequestInfo` is defined as `Request | string` in `lib.dom.d.ts`. Expanding it inline to `Request | string | URL` removes the DOM dependency while being semantically identical.

## Checklist

- [x] Added tests (no new runtime behavior; existing 4097 tests all pass)
- [x] Ran tests (`vitest --run` — 144/144 files, 4097/4097 tests pass)
- [x] `bun run format:fix && bun run lint:fix` (0 errors, 50 warnings — identical to baseline)
- [x] `tsc --noEmit` — 0 errors
- [x] `bun run build` — CJS + ESM + declarations all build successfully
- [x] `editorconfig-checker` — pass

Closes #3750
