### PR TITLE
feat(client): add `PickResponseByStatusCode` type

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -15,6 +15,7 @@ import type {
   InferRequestType,
   InferResponseType,
   ApplyGlobalResponse,
+  PickResponseByStatusCode,
 } from './types'
 
 class SafeBigInt {
@@ -1840,6 +1841,104 @@ describe('ApplyGlobalResponse Type Helper', () => {
     type ResponseType = InferResponseType<typeof req>
     type Expected = { users: string[] } | { error: string }
 
+    type verify = Expect<Equal<ResponseType, Expected>>
+  })
+})
+
+describe('PickResponseByStatusCode Type Helper', () => {
+  it('Should keep only specified status code responses', () => {
+    const app = new Hono().get('/api/users', (c) => {
+      try {
+        return c.json({ users: ['alice', 'bob'] }, 200)
+      } catch {
+        return c.json({ error: 'Internal Server Error' }, 500)
+      }
+    })
+
+    type AppSuccessOnly = PickResponseByStatusCode<typeof app, 200>
+
+    const client = hc<AppSuccessOnly>('http://localhost')
+    const req = client.api.users.$get
+
+    type ResponseType = InferResponseType<typeof req>
+    type Expected = { users: string[] }
+    type verify = Expect<Equal<ResponseType, Expected>>
+
+    type Res = Awaited<ReturnType<typeof req>>
+    type verifyOk = Expect<Equal<Res['ok'], true>>
+    type verifyStatus = Expect<Equal<Res['status'], 200>>
+  })
+
+  it('Should work with ApplyGlobalResponse', () => {
+    const app = new Hono().get('/api/users', (c) => {
+      try {
+        return c.json({ users: ['alice', 'bob'] }, 200)
+      } catch {
+        return c.json({ error: 'Not Found' }, 404)
+      }
+    })
+
+    type AppWithGlobalErrors = ApplyGlobalResponse<
+      typeof app,
+      {
+        401: { json: { error: string; message: string } }
+        500: { json: { error: string; message: string } }
+      }
+    >
+
+    type AppSuccessOnly = PickResponseByStatusCode<AppWithGlobalErrors, 200>
+
+    const client = hc<AppSuccessOnly>('http://localhost')
+    const req = client.api.users.$get
+
+    type ResponseType = InferResponseType<typeof req>
+    type Expected = { users: string[] }
+    type verify = Expect<Equal<ResponseType, Expected>>
+  })
+
+  it('Should work with route() paths', () => {
+    const users = new Hono().get('/users', (c) => {
+      try {
+        return c.json({ users: ['alice', 'bob'] }, 200)
+      } catch {
+        return c.json({ error: 'error' }, 500)
+      }
+    })
+    const app = new Hono().route('/api', users)
+
+    type AppSuccessOnly = PickResponseByStatusCode<typeof app, 200>
+
+    const client = hc<AppSuccessOnly>('http://localhost')
+    const req = client.api.users.$get
+
+    type ResponseType = InferResponseType<typeof req>
+    type Expected = { users: string[] }
+    type verify = Expect<Equal<ResponseType, Expected>>
+  })
+
+  it('Should pick multiple status codes', () => {
+    const app = new Hono().get('/api/users', (c) => {
+      try {
+        return c.json({ users: ['alice', 'bob'] }, 200)
+      } catch {
+        return c.json({ error: 'Bad Request' }, 400)
+      }
+    })
+
+    type AppWithGlobalErrors = ApplyGlobalResponse<
+      typeof app,
+      {
+        500: { json: { error: string } }
+      }
+    >
+
+    type AppFiltered = PickResponseByStatusCode<AppWithGlobalErrors, 200 | 400>
+
+    const client = hc<AppFiltered>('http://localhost')
+    const req = client.api.users.$get
+
+    type ResponseType = InferResponseType<typeof req>
+    type Expected = { users: string[] } | { error: string }
     type verify = Expect<Equal<ResponseType, Expected>>
   })
 })

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,4 +13,5 @@ export type {
   ClientRequest,
   ClientResponse,
   ApplyGlobalResponse,
+  PickResponseByStatusCode,
 } from './types'

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -361,3 +361,33 @@ export type ApplyGlobalResponse<App, Def extends GlobalResponseDefinition> =
       ? Hono<E, S, B>
       : never
     : never
+
+type PickRoute<R, U extends StatusCode> = R extends Endpoint
+  ? R extends { status: U }
+    ? R
+    : never
+  : R
+
+type PickSchema<D, U extends StatusCode> = {
+  [K in keyof D]: {
+    [M in keyof D[K]]: PickRoute<D[K][M], U>
+  }
+}
+
+/**
+ * Keep only specific status code responses from all routes of an app.
+ * Useful when error responses are handled centrally (e.g., via custom fetch)
+ * and you want the client to only expose success response types.
+ *
+ * @example
+ * ```ts
+ * type AppSuccessOnly = PickResponseByStatusCode<typeof app, 200>
+ * const client = hc<AppSuccessOnly>('http://localhost')
+ * ```
+ */
+export type PickResponseByStatusCode<App, U extends StatusCode> =
+  App extends HonoBase<infer E, infer _ extends Schema, infer B>
+    ? PickSchema<ExtractSchema<App>, U> extends infer S extends Schema
+      ? Hono<E, S, B>
+      : never
+    : never


### PR DESCRIPTION
Fixes #4590

Adding `PickResponseByStatusCode` to limit the status code for the Hono client in case of using a custom fetch that only returns a 200 response.

Usage:

```ts
type AppSuccessOnly = PickResponseByStatusCode<typeof app, 200>
const client = hc<AppSuccessOnly>('http://localhost')
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
