### PR TITLE
fix: setCookie should deduplicate cookies with the same name

### DIFF
--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -98,7 +98,24 @@ export const generateCookie = (name: string, value: string, opt?: CookieOptions)
 
 export const setCookie = (c: Context, name: string, value: string, opt?: CookieOptions): void => {
   const cookie = generateCookie(name, value, opt)
-  c.header('Set-Cookie', cookie, { append: true })
+  
+  // Remove existing cookies with the same name to avoid duplicates
+  // This ensures only the latest value is sent
+  const existingCookies = c.res.headers.getSetCookie()
+  const filteredCookies = existingCookies.filter((existingCookie) => {
+    // Parse the existing cookie to get its name
+    const existingName = existingCookie.split('=')[0]?.trim()
+    return existingName !== name
+  })
+  
+  // Clear all Set-Cookie headers and re-add filtered ones
+  c.res.headers.delete('Set-Cookie')
+  for (const existingCookie of filteredCookies) {
+    c.res.headers.append('Set-Cookie', existingCookie)
+  }
+  
+  // Add the new cookie
+  c.res.headers.append('Set-Cookie', cookie)
 }
 
 export const generateSignedCookie = async (


### PR DESCRIPTION
Fixes #4445

## Problem
When calling `setCookie()` multiple times with the same name, Hono was sending multiple `Set-Cookie` headers instead of only the latest value.

```js
setCookie(c, 'hello', 'world1')
setCookie(c, 'hello', 'world2')
setCookie(c, 'hello', 'world3')
```

**Before (Bug):**
```
set-cookie: hello=world1; Path=/
set-cookie: hello=world2; Path=/
set-cookie: hello=world3; Path=/
```

This wastes bandwidth and can cause client parsing errors.

## Solution
Modified `setCookie()` to remove all existing cookies with the same name before adding the new one.

**After (Fixed):**
```
set-cookie: hello=world3; Path=/
```

Only the latest value is sent, which is the expected behavior.

## Changes
- Modified `src/helper/cookie/index.ts`
- Added deduplication logic in `setCookie()`
- Uses `getSetCookie()` to filter existing cookies
- Ensures only one cookie per name is sent

## Behavior
Now calling `setCookie()` multiple times with the same name works correctly:
- The last call's value is the only one sent
- Matches standard cookie behavior where assignments override
- Prevents duplicate `Set-Cookie` headers