### PR TITLE
fix(utils/mime): Normalize input extension to lowercase before MIME check

### DIFF
--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -15,6 +15,7 @@ describe('mime', () => {
     expect(getMimeType('site.webmanifest')).toBe('application/manifest+json')
     expect(getMimeType('goodmorninghellogif')).toBeUndefined()
     expect(getMimeType('indexjs.abcd')).toBeUndefined()
+    expect(getMimeType('IMAGE.JPG')).toBe('image/jpeg')
   })
 
   it('getMimeType with custom mime', () => {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -12,7 +12,7 @@ export const getMimeType = (
   if (!match) {
     return
   }
-  let mimeType = mimes[match[1]]
+  let mimeType = mimes[match[1].toLowerCase()]
   if (mimeType && mimeType.startsWith('text')) {
     mimeType += '; charset=utf-8'
   }


### PR DESCRIPTION
When a filename with an upper/mixed-case extension is provided to getMimeType, it currently returns an undefined value which causes the static middleware to return a Content-Type of `application/octet-stream`. This PR normalizes upper/mixed-case file extensions during the check so that they can be properly matched to the MIME type map.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
