### PR TITLE
fix(request): remove `parseBody` from bodyCache to prevent TypeError

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -354,6 +354,48 @@ describe('Body methods with caching', () => {
       expect(async () => await req.blob()).not.toThrow()
     })
 
+    describe('should not break body methods after parseBody() with non-form content-type', () => {
+      const createReq = () =>
+        new HonoRequest(
+          new Request('http://localhost', {
+            method: 'POST',
+            body: JSON.stringify({ event: 'push' }),
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+
+      it('text()', async () => {
+        const req = createReq()
+        await req.parseBody()
+        expect(await req.text()).toBe(JSON.stringify({ event: 'push' }))
+      })
+
+      it('json()', async () => {
+        const req = createReq()
+        await req.parseBody()
+        expect(await req.json()).toEqual({ event: 'push' })
+      })
+
+      it('arrayBuffer()', async () => {
+        const req = createReq()
+        await req.parseBody()
+        expect(await req.arrayBuffer()).toBeInstanceOf(ArrayBuffer)
+      })
+
+      it('blob()', async () => {
+        const req = createReq()
+        await req.parseBody()
+        expect(await req.blob()).toBeInstanceOf(Blob)
+      })
+
+      it('formData()', async () => {
+        const req = createReq()
+        await req.parseBody()
+        // application/json is not a valid formData content-type, so this should throw
+        expect(req.formData()).rejects.toThrow()
+      })
+    })
+
     describe('Return type', () => {
       let req: HonoRequest
       beforeEach(() => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -24,7 +24,7 @@ type Body = {
   blob: Blob
   formData: FormData
 }
-type BodyCache = Partial<Body & { parsedBody: BodyData }>
+type BodyCache = Partial<Body>
 
 type OptionalRequestInitProperties = 'window' | 'priority'
 type RequiredRequestInit = Required<Omit<RequestInit, OptionalRequestInitProperties>> & {
@@ -214,7 +214,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   ): Promise<T>
   async parseBody<T extends BodyData>(options?: Partial<ParseBodyOptions>): Promise<T>
   async parseBody(options?: Partial<ParseBodyOptions>) {
-    return (this.bodyCache.parsedBody ??= await parseBody(this, options))
+    return parseBody(this, options)
   }
 
   #cachedBody = (key: keyof Body) => {


### PR DESCRIPTION
Fixes #4806

I realized `bodyCache.parsedBody` in Hono Request is unnecessary, and this change will fix #4806.

`parseBody` uses `formData` inside, so it might already be cached:

https://github.com/honojs/hono/blob/fe689eceb7834db653a64ecae5f8d203d9c23b9a/src/utils/body.ts#L125


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
