### PR TITLE
fix(cors): reflect request origin when origin:"*" is combined with credentials:true

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -349,4 +349,45 @@ describe('CORS by Middleware', () => {
     expect(res2.headers.get('Access-Control-Allow-Origin')).toBe('*')
     expect(res2.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD')
   })
+
+  describe('CORS with origin * and credentials', () => {
+    const app = new Hono()
+
+    app.use(
+      '/api/*',
+      cors({
+        credentials: true,
+      })
+    )
+
+    app.get('/api/abc', (c) => c.json({ success: true }))
+
+    it('Should reflect request origin instead of * when credentials is true', async () => {
+      const req = new Request('http://localhost/api/abc', {
+        headers: { origin: 'http://example.com' },
+      })
+      const res = await app.request(req)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+      expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+      expect(res.headers.get('Vary')).toContain('Origin')
+    })
+
+    it('Preflight should reflect origin and set Vary when credentials is true', async () => {
+      const req = new Request('http://localhost/api/abc', {
+        method: 'OPTIONS',
+        headers: { origin: 'http://example.com' },
+      })
+      const res = await app.request(req)
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+      expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+      expect(res.headers.get('Vary')?.split(/\s*,\s*/)).toContain('Origin')
+    })
+
+    it('Should fall back to * when no Origin header and credentials is true', async () => {
+      const res = await app.request('http://localhost/api/abc')
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+    })
+  })
 })

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -75,6 +75,13 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const findAllowOrigin = ((optsOrigin) => {
     if (typeof optsOrigin === 'string') {
       if (optsOrigin === '*') {
+        // When credentials mode is used, the Fetch spec requires that
+        // Access-Control-Allow-Origin must not be '*'. Instead, we reflect
+        // the request origin back to the client.
+        // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#examples
+        if (opts.credentials) {
+          return (origin: string) => (origin ? origin : '*')
+        }
         return () => optsOrigin
       } else {
         return (origin: string) => (optsOrigin === origin ? origin : null)
@@ -115,7 +122,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
     }
 
     if (c.req.method === 'OPTIONS') {
-      if (opts.origin !== '*') {
+      if (opts.origin !== '*' || opts.credentials) {
         set('Vary', 'Origin')
       }
 
@@ -153,7 +160,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
     // Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard).
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-    if (opts.origin !== '*') {
+    if (opts.origin !== '*' || opts.credentials) {
       c.header('Vary', 'Origin', { append: true })
     }
   }


### PR DESCRIPTION
## Fixes #4811

### Problem

The CORS middleware sets `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials: true` when configured with `origin: "*"` (default) and `credentials: true`. Per the [Fetch spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#examples), browsers reject responses where `Access-Control-Allow-Origin` is `*` combined with credentials mode.

### Root Cause

In `middleware/cors/index.ts`, the `findAllowOrigin` function unconditionally returns `"*"` when `origin === "*"`, regardless of the `credentials` setting. When the Fetch spec requires credentials mode, the wildcard origin is invalid.

### Fix

When `origin === "*"` and `credentials === true`, the middleware now reflects the request `Origin` header back instead of `*`. When no Origin header is present (same-origin requests), it falls back to `*`. The `Vary: Origin` header is also set in both preflight and actual responses when this combination is used.

### Tests Added

- Reflects request origin when credentials + wildcard origin are combined
- Preflight reflects origin and sets Vary when credentials is true
- Falls back to `*` when no Origin header is present

### Verification

All 17 tests pass (14 existing + 3 new).

```sh
npx vitest run src/middleware/cors/index.test.ts
# ✓ 17 tests passed
```