### PR TITLE
fix(cors): reflect request origin when credentials enabled with wildcard origin

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -349,4 +349,52 @@ describe('CORS by Middleware', () => {
     expect(res2.headers.get('Access-Control-Allow-Origin')).toBe('*')
     expect(res2.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD')
   })
+
+  describe('Wildcard origin with credentials', () => {
+    const credApp = new Hono()
+
+    credApp.use(
+      '/api/*',
+      cors({
+        origin: '*',
+        credentials: true,
+      })
+    )
+
+    credApp.get('/api/abc', (c) => c.json({ success: true }))
+
+    it('reflects request origin instead of wildcard when credentials is true', async () => {
+      const res = await credApp.request('http://localhost/api/abc', {
+        headers: { Origin: 'http://example.com' },
+      })
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+      expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+    })
+
+    it('includes Vary: Origin header when credentials is true with wildcard', async () => {
+      const res = await credApp.request('http://localhost/api/abc', {
+        headers: { Origin: 'http://example.com' },
+      })
+
+      expect(res.headers.get('Vary')).toBe('Origin')
+    })
+
+    it('includes Vary: Origin on preflight when credentials is true with wildcard', async () => {
+      const req = new Request('http://localhost/api/abc', {
+        method: 'OPTIONS',
+        headers: { Origin: 'http://example.com' },
+      })
+      const res = await credApp.request(req)
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+      expect(res.headers.get('Vary')?.split(/\s*,\s*/)).toEqual(expect.arrayContaining(['Origin']))
+    })
+
+    it('does not set Allow-Origin when no Origin header is present and credentials is true', async () => {
+      const res = await credApp.request('http://localhost/api/abc')
+
+      expect(res.headers.has('Access-Control-Allow-Origin')).toBeFalsy()
+    })
+  })
 })

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -75,6 +75,9 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const findAllowOrigin = ((optsOrigin) => {
     if (typeof optsOrigin === 'string') {
       if (optsOrigin === '*') {
+        if (opts.credentials) {
+          return (origin: string) => origin || null
+        }
         return () => optsOrigin
       } else {
         return (origin: string) => (optsOrigin === origin ? origin : null)
@@ -115,7 +118,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
     }
 
     if (c.req.method === 'OPTIONS') {
-      if (opts.origin !== '*') {
+      if (opts.origin !== '*' || opts.credentials) {
         set('Vary', 'Origin')
       }
 
@@ -153,7 +156,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
     // Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard).
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-    if (opts.origin !== '*') {
+    if (opts.origin !== '*' || opts.credentials) {
       c.header('Vary', 'Origin', { append: true })
     }
   }


### PR DESCRIPTION
Closes #4811

## Summary

The CORS middleware currently allows `Access-Control-Allow-Origin: *` to be set alongside `Access-Control-Allow-Credentials: true`. Per the [Fetch spec](https://fetch.spec.whatwg.org/#http-access-control-allow-origin), `Access-Control-Allow-Origin` must not be `*` when the credentials mode is `include` -- browsers reject these responses.

This PR fixes the middleware to **reflect the request's `Origin` header** instead of returning `*` when both `origin: '*'` and `credentials: true` are configured. It also adds `Vary: Origin` in this case, since the response now varies per request origin.

## Changes

- `src/middleware/cors/index.ts`:
  - When `origin === '*'` and `credentials` is `true`, `findAllowOrigin` now returns the request origin instead of `'*'`
  - `Vary: Origin` is now set for both preflight and non-preflight responses when credentials are enabled with wildcard origin
- `src/middleware/cors/index.test.ts`:
  - Added 4 test cases for the wildcard + credentials scenario (origin reflection, Vary header, preflight, no-origin request)

## Behavior

| Config | Before | After |
|--------|--------|-------|
| `origin: '*', credentials: true` | `Allow-Origin: *` (spec violation) | `Allow-Origin: <request origin>` |
| `origin: '*', credentials: false` | `Allow-Origin: *` | `Allow-Origin: *` (unchanged) |
| `origin: 'example.com', credentials: true` | `Allow-Origin: example.com` | `Allow-Origin: example.com` (unchanged) |

## Test results

`bun run test` passes with **4199 passed, 33 skipped, 1 failed**.

The single failure (`src/client/utils.test.ts > parseResponse > should throw error matching snapshots`) is a **pre-existing snapshot mismatch on `main`** — verified by checking out `main` and running the same test:

```
# On main branch (no changes):
bun run test -- src/client/utils.test.ts
# FAIL  src/client/utils.test.ts > parseResponse > should throw error matching snapshots
# Tests  1 failed | 26 passed (27)
```

All 18 CORS tests pass, including the 4 new ones. Zero new failures introduced.