### PR TITLE
feat(cookie): add AES-256-GCM encrypted cookie support

### DIFF
--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -526,6 +526,24 @@ describe('Cookie Middleware', () => {
         expect(await res.text()).toBe('INVALID')
       })
 
+      it('should return false when encrypted value is copied to a different cookie name', async () => {
+        const app2 = new Hono()
+        app2.get('/get', async (c) => {
+          const value = await getEncryptedCookie(c, secret, 'other_cookie')
+          return c.text(value === false ? 'INVALID' : 'UNEXPECTED')
+        })
+
+        const setRes = await app.request('http://localhost/set-encrypted-cookie')
+        const setCookieHeader = setRes.headers.get('Set-Cookie')
+        // take the encrypted value from secret_cookie and assign it to other_cookie
+        const encryptedValue = setCookieHeader!.split(';')[0].split('=').slice(1).join('=')
+
+        const getRes = await app2.request('http://localhost/get', {
+          headers: { Cookie: `other_cookie=${encryptedValue}` },
+        })
+        expect(await getRes.text()).toBe('INVALID')
+      })
+
       it('should return false for wrong secret', async () => {
         const app2 = new Hono()
         app2.get('/get', async (c) => {

--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -2,10 +2,13 @@ import { Hono } from '../../hono'
 import {
   deleteCookie,
   getCookie,
+  getEncryptedCookie,
   getSignedCookie,
   setCookie,
+  setEncryptedCookie,
   setSignedCookie,
   generateCookie,
+  generateEncryptedCookie,
   generateSignedCookie,
 } from '.'
 
@@ -454,6 +457,192 @@ describe('Cookie Middleware', () => {
     })
   })
 
+  describe('Encrypted cookie', () => {
+    const secret = 'secret encryption key'
+
+    describe('Set and get encrypted cookie', () => {
+      const app = new Hono()
+
+      app.get('/set-encrypted-cookie', async (c) => {
+        await setEncryptedCookie(c, 'secret_cookie', 'hidden-value', secret)
+        return c.text('Set encrypted cookie')
+      })
+
+      app.get('/get-encrypted-cookie', async (c) => {
+        const value = await getEncryptedCookie(c, secret, 'secret_cookie')
+        return c.text(typeof value === 'string' ? value : value === false ? 'INVALID' : 'NOT_FOUND')
+      })
+
+      app.get('/get-encrypted-cookie-all', async (c) => {
+        const cookies = await getEncryptedCookie(c, secret)
+        const value = cookies['secret_cookie']
+        return c.text(typeof value === 'string' ? value : value === false ? 'INVALID' : 'NOT_FOUND')
+      })
+
+      it('should set an encrypted cookie', async () => {
+        const res = await app.request('http://localhost/set-encrypted-cookie')
+        expect(res.status).toBe(200)
+        const header = res.headers.get('Set-Cookie')
+        expect(header).toBeTruthy()
+        // encrypted value should not contain the plaintext
+        expect(header).not.toContain('hidden-value')
+        expect(header).toContain('secret_cookie=')
+      })
+
+      it('should round-trip set and get an encrypted cookie', async () => {
+        const setRes = await app.request('http://localhost/set-encrypted-cookie')
+        const setCookieHeader = setRes.headers.get('Set-Cookie')
+        expect(setCookieHeader).toBeTruthy()
+
+        // extract cookie value from Set-Cookie header
+        const cookieValue = setCookieHeader!.split(';')[0]
+
+        const getRes = await app.request('http://localhost/get-encrypted-cookie', {
+          headers: { Cookie: cookieValue },
+        })
+        expect(await getRes.text()).toBe('hidden-value')
+      })
+
+      it('should round-trip with getEncryptedCookie (all cookies)', async () => {
+        const setRes = await app.request('http://localhost/set-encrypted-cookie')
+        const setCookieHeader = setRes.headers.get('Set-Cookie')
+        const cookieValue = setCookieHeader!.split(';')[0]
+
+        const getRes = await app.request('http://localhost/get-encrypted-cookie-all', {
+          headers: { Cookie: cookieValue },
+        })
+        expect(await getRes.text()).toBe('hidden-value')
+      })
+
+      it('should return undefined when cookie is missing', async () => {
+        const res = await app.request('http://localhost/get-encrypted-cookie')
+        expect(await res.text()).toBe('NOT_FOUND')
+      })
+
+      it('should return false for tampered cookie', async () => {
+        const res = await app.request('http://localhost/get-encrypted-cookie', {
+          headers: { Cookie: 'secret_cookie=tampered-value' },
+        })
+        expect(await res.text()).toBe('INVALID')
+      })
+
+      it('should return false for wrong secret', async () => {
+        const app2 = new Hono()
+        app2.get('/get', async (c) => {
+          const value = await getEncryptedCookie(c, 'wrong-secret', 'secret_cookie')
+          return c.text(value === false ? 'INVALID' : 'UNEXPECTED')
+        })
+
+        const setRes = await app.request('http://localhost/set-encrypted-cookie')
+        const setCookieHeader = setRes.headers.get('Set-Cookie')
+        const cookieValue = setCookieHeader!.split(';')[0]
+
+        const getRes = await app2.request('http://localhost/get', {
+          headers: { Cookie: cookieValue },
+        })
+        expect(await getRes.text()).toBe('INVALID')
+      })
+    })
+
+    describe('Encrypted cookie with prefix', () => {
+      const app = new Hono()
+
+      app.get('/set-encrypted-secure-prefix', async (c) => {
+        await setEncryptedCookie(c, 'secret_cookie', 'hidden-value', secret, {
+          prefix: 'secure',
+        })
+        return c.text('Set encrypted secure prefix cookie')
+      })
+
+      app.get('/get-encrypted-secure-prefix', async (c) => {
+        const value = await getEncryptedCookie(c, secret, 'secret_cookie', 'secure')
+        return c.text(typeof value === 'string' ? value : 'NOT_FOUND')
+      })
+
+      app.get('/set-encrypted-host-prefix', async (c) => {
+        await setEncryptedCookie(c, 'secret_cookie', 'hidden-value', secret, {
+          prefix: 'host',
+          domain: 'example.com', // this will be ignored
+          path: '/foo', // this will be ignored
+          secure: false, // this will be ignored
+        })
+        return c.text('Set encrypted host prefix cookie')
+      })
+
+      app.get('/get-encrypted-host-prefix', async (c) => {
+        const value = await getEncryptedCookie(c, secret, 'secret_cookie', 'host')
+        return c.text(typeof value === 'string' ? value : 'NOT_FOUND')
+      })
+
+      it('should set encrypted cookie with secure prefix', async () => {
+        const res = await app.request('http://localhost/set-encrypted-secure-prefix')
+        const header = res.headers.get('Set-Cookie')
+        expect(header).toContain('__Secure-secret_cookie=')
+        expect(header).toContain('Secure')
+      })
+
+      it('should round-trip encrypted cookie with secure prefix', async () => {
+        const setRes = await app.request('http://localhost/set-encrypted-secure-prefix')
+        const setCookieHeader = setRes.headers.get('Set-Cookie')
+        const cookieValue = setCookieHeader!.split(';')[0]
+
+        const getRes = await app.request('http://localhost/get-encrypted-secure-prefix', {
+          headers: { Cookie: cookieValue },
+        })
+        expect(await getRes.text()).toBe('hidden-value')
+      })
+
+      it('should set encrypted cookie with host prefix', async () => {
+        const res = await app.request('http://localhost/set-encrypted-host-prefix')
+        const header = res.headers.get('Set-Cookie')
+        expect(header).toContain('__Host-secret_cookie=')
+        expect(header).toContain('Secure')
+        expect(header).not.toContain('Domain=')
+      })
+
+      it('should round-trip encrypted cookie with host prefix', async () => {
+        const setRes = await app.request('http://localhost/set-encrypted-host-prefix')
+        const setCookieHeader = setRes.headers.get('Set-Cookie')
+        const cookieValue = setCookieHeader!.split(';')[0]
+
+        const getRes = await app.request('http://localhost/get-encrypted-host-prefix', {
+          headers: { Cookie: cookieValue },
+        })
+        expect(await getRes.text()).toBe('hidden-value')
+      })
+    })
+
+    describe('Encrypted cookie with options', () => {
+      const app = new Hono()
+
+      app.get('/set-encrypted-cookie-complex', async (c) => {
+        await setEncryptedCookie(c, 'secret_cookie', 'hidden-value', secret, {
+          path: '/',
+          secure: true,
+          domain: 'example.com',
+          httpOnly: true,
+          maxAge: 1000,
+          expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
+          sameSite: 'Strict',
+        })
+        return c.text('Set encrypted cookie with options')
+      })
+
+      it('should set encrypted cookie with all options', async () => {
+        const res = await app.request('http://localhost/set-encrypted-cookie-complex')
+        const header = res.headers.get('Set-Cookie')
+        expect(header).toContain('secret_cookie=')
+        expect(header).toContain('Max-Age=1000')
+        expect(header).toContain('Domain=example.com')
+        expect(header).toContain('Path=/')
+        expect(header).toContain('HttpOnly')
+        expect(header).toContain('Secure')
+        expect(header).toContain('SameSite=Strict')
+        expect(header).not.toContain('hidden-value')
+      })
+    })
+  })
+
   describe('Generate cookie', () => {
     it('should generate a cookie', () => {
       const cookie = generateCookie('delicious_cookie', 'macha')
@@ -496,6 +685,36 @@ describe('Cookie Middleware', () => {
       expect(cookie).toBe(
         'delicious_cookie=macha.diubJPY8O7hI1pLa42QSfkPiyDWQ0I4DnlACH%2FN2HaA%3D; Domain=example.com; Path=/; HttpOnly; Secure'
       )
+    })
+
+    it('should generate an encrypted cookie', async () => {
+      const cookie = await generateEncryptedCookie(
+        'secret_cookie',
+        'hidden-value',
+        'secret encryption key'
+      )
+      expect(cookie).toContain('secret_cookie=')
+      expect(cookie).toContain('Path=/')
+      expect(cookie).not.toContain('hidden-value')
+    })
+
+    it('should generate an encrypted cookie with options', async () => {
+      const cookie = await generateEncryptedCookie(
+        'secret_cookie',
+        'hidden-value',
+        'secret encryption key',
+        {
+          path: '/',
+          secure: true,
+          httpOnly: true,
+          domain: 'example.com',
+        }
+      )
+      expect(cookie).toContain('secret_cookie=')
+      expect(cookie).toContain('Domain=example.com')
+      expect(cookie).toContain('HttpOnly')
+      expect(cookie).toContain('Secure')
+      expect(cookie).not.toContain('hidden-value')
     })
   })
 })

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -4,8 +4,21 @@
  */
 
 import type { Context } from '../../context'
-import { parse, parseSigned, serialize, serializeSigned } from '../../utils/cookie'
-import type { Cookie, CookieOptions, CookiePrefixOptions, SignedCookie } from '../../utils/cookie'
+import {
+  parse,
+  parseEncrypted,
+  parseSigned,
+  serialize,
+  serializeEncrypted,
+  serializeSigned,
+} from '../../utils/cookie'
+import type {
+  Cookie,
+  CookieOptions,
+  CookiePrefixOptions,
+  EncryptedCookie,
+  SignedCookie,
+} from '../../utils/cookie'
 
 interface GetCookie {
   (c: Context, key: string): string | undefined
@@ -135,6 +148,82 @@ export const setSignedCookie = async (
   opt?: CookieOptions
 ): Promise<void> => {
   const cookie = await generateSignedCookie(name, value, secret, opt)
+  c.header('set-cookie', cookie, { append: true })
+}
+
+interface GetEncryptedCookie {
+  (c: Context, secret: string | BufferSource, key: string): Promise<string | undefined | false>
+  (c: Context, secret: string | BufferSource): Promise<EncryptedCookie>
+  (
+    c: Context,
+    secret: string | BufferSource,
+    key: string,
+    prefixOptions?: CookiePrefixOptions
+  ): Promise<string | undefined | false>
+}
+
+export const getEncryptedCookie: GetEncryptedCookie = async (
+  c,
+  secret,
+  key?,
+  prefix?: CookiePrefixOptions
+) => {
+  const cookie = c.req.raw.headers.get('Cookie')
+  if (typeof key === 'string') {
+    if (!cookie) {
+      return undefined
+    }
+    let finalKey = key
+    if (prefix === 'secure') {
+      finalKey = '__Secure-' + key
+    } else if (prefix === 'host') {
+      finalKey = '__Host-' + key
+    }
+    const obj = await parseEncrypted(cookie, secret, finalKey)
+    return obj[finalKey]
+  }
+  if (!cookie) {
+    return {}
+  }
+  const obj = await parseEncrypted(cookie, secret)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return obj as any
+}
+
+export const generateEncryptedCookie = async (
+  name: string,
+  value: string,
+  secret: string | BufferSource,
+  opt?: CookieOptions
+): Promise<string> => {
+  let cookie
+  if (opt?.prefix === 'secure') {
+    cookie = await serializeEncrypted('__Secure-' + name, value, secret, {
+      path: '/',
+      ...opt,
+      secure: true,
+    })
+  } else if (opt?.prefix === 'host') {
+    cookie = await serializeEncrypted('__Host-' + name, value, secret, {
+      ...opt,
+      path: '/',
+      secure: true,
+      domain: undefined,
+    })
+  } else {
+    cookie = await serializeEncrypted(name, value, secret, { path: '/', ...opt })
+  }
+  return cookie
+}
+
+export const setEncryptedCookie = async (
+  c: Context,
+  name: string,
+  value: string,
+  secret: string | BufferSource,
+  opt?: CookieOptions
+): Promise<void> => {
+  const cookie = await generateEncryptedCookie(name, value, secret, opt)
   c.header('set-cookie', cookie, { append: true })
 }
 

--- a/src/helper/cookie/index.ts
+++ b/src/helper/cookie/index.ts
@@ -162,6 +162,17 @@ interface GetEncryptedCookie {
   ): Promise<string | undefined | false>
 }
 
+/**
+ * Get an encrypted cookie value. Returns the decrypted plaintext,
+ * `undefined` if the cookie doesn't exist, or `false` if decryption fails.
+ * @example
+ * ```ts
+ * app.get('/read', async (c) => {
+ *   const value = await getEncryptedCookie(c, secret, 'session')
+ *   // value: string | undefined | false
+ * })
+ * ```
+ */
 export const getEncryptedCookie: GetEncryptedCookie = async (
   c,
   secret,
@@ -190,6 +201,10 @@ export const getEncryptedCookie: GetEncryptedCookie = async (
   return obj as any
 }
 
+/**
+ * Generate an encrypted cookie string without setting it on the response.
+ * Useful for testing or manual header manipulation.
+ */
 export const generateEncryptedCookie = async (
   name: string,
   value: string,
@@ -216,6 +231,16 @@ export const generateEncryptedCookie = async (
   return cookie
 }
 
+/**
+ * Set an encrypted cookie using AES-256-GCM.
+ * The cookie value is encrypted and the plaintext is not visible in the cookie header.
+ * @example
+ * ```ts
+ * app.get('/write', async (c) => {
+ *   await setEncryptedCookie(c, 'session', 'user-data', secret)
+ * })
+ * ```
+ */
 export const setEncryptedCookie = async (
   c: Context,
   name: string,

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -7,6 +7,7 @@ import { decodeURIComponent_, tryDecode } from './url'
 
 export type Cookie = Record<string, string>
 export type SignedCookie = Record<string, string | false>
+export type EncryptedCookie = Record<string, string | false>
 
 type PartitionedCookieConstraint =
   | { partitioned: true; secure: true }
@@ -60,6 +61,65 @@ const verifySignature = async (
       signature[i] = signatureBinStr.charCodeAt(i)
     }
     return await crypto.subtle.verify(algorithm, secret, signature, new TextEncoder().encode(value))
+  } catch {
+    return false
+  }
+}
+
+const encryptionAlgorithm = 'AES-GCM'
+const IV_LENGTH = 12
+const TAG_LENGTH_BIT = 128
+const HKDF_INFO = new TextEncoder().encode('hono-encrypted-cookie')
+
+const getEncryptionKey = async (secret: string | BufferSource): Promise<CryptoKey> => {
+  const secretBuf = typeof secret === 'string' ? new TextEncoder().encode(secret) : secret
+  const keyMaterial = await crypto.subtle.importKey('raw', secretBuf, 'HKDF', false, ['deriveKey'])
+  return await crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(), info: HKDF_INFO },
+    keyMaterial,
+    { name: encryptionAlgorithm, length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+const encrypt = async (value: string, secret: string | BufferSource): Promise<string> => {
+  const key = await getEncryptionKey(secret)
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+  const encoded = new TextEncoder().encode(value)
+  const cipherBuf = await crypto.subtle.encrypt(
+    { name: encryptionAlgorithm, iv, tagLength: TAG_LENGTH_BIT },
+    key,
+    encoded
+  )
+  const combined = new Uint8Array(IV_LENGTH + cipherBuf.byteLength)
+  combined.set(iv, 0)
+  combined.set(new Uint8Array(cipherBuf), IV_LENGTH)
+  return btoa(String.fromCharCode(...combined))
+}
+
+const decrypt = async (
+  base64Encrypted: string,
+  secret: string | BufferSource
+): Promise<string | false> => {
+  try {
+    const key = await getEncryptionKey(secret)
+    const binStr = atob(base64Encrypted)
+    const combined = new Uint8Array(binStr.length)
+    for (let i = 0; i < binStr.length; i++) {
+      combined[i] = binStr.charCodeAt(i)
+    }
+    if (combined.length < IV_LENGTH + TAG_LENGTH_BIT / 8) {
+      return false
+    }
+    const iv = combined.slice(0, IV_LENGTH)
+    const ciphertext = combined.slice(IV_LENGTH)
+    const decrypted = await crypto.subtle.decrypt(
+      { name: encryptionAlgorithm, iv, tagLength: TAG_LENGTH_BIT },
+      key,
+      ciphertext
+    )
+    return new TextDecoder().decode(decrypted)
   } catch {
     return false
   }
@@ -240,5 +300,32 @@ export const serializeSigned = async (
   const signature = await makeSignature(value, secret)
   value = `${value}.${signature}`
   value = encodeURIComponent(value)
+  return _serialize(name, value, opt)
+}
+
+export const parseEncrypted = async (
+  cookie: string,
+  secret: string | BufferSource,
+  name?: string
+): Promise<EncryptedCookie> => {
+  const parsedCookie: EncryptedCookie = {}
+
+  for (const [key, value] of Object.entries(parse(cookie, name))) {
+    const decoded = decodeURIComponent_(value)
+    const decrypted = await decrypt(decoded, secret)
+    parsedCookie[key] = decrypted
+  }
+
+  return parsedCookie
+}
+
+export const serializeEncrypted = async (
+  name: string,
+  value: string,
+  secret: string | BufferSource,
+  opt: CookieOptions = {}
+): Promise<string> => {
+  const encrypted = await encrypt(value, secret)
+  value = encodeURIComponent(encrypted)
   return _serialize(name, value, opt)
 }

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -303,6 +303,11 @@ export const serializeSigned = async (
   return _serialize(name, value, opt)
 }
 
+/**
+ * Parse encrypted cookies from a cookie header string.
+ * Uses AES-256-GCM decryption with HKDF-SHA256 key derivation.
+ * Returns `false` for cookies that fail decryption (tampered or wrong key).
+ */
 export const parseEncrypted = async (
   cookie: string,
   secret: string | BufferSource,
@@ -319,6 +324,10 @@ export const parseEncrypted = async (
   return parsedCookie
 }
 
+/**
+ * Serialize a cookie value with AES-256-GCM encryption.
+ * The cookie value is encrypted using a random IV and encoded as base64.
+ */
 export const serializeEncrypted = async (
   name: string,
   value: string,

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -92,11 +92,7 @@ const uint8ArrayToBase64 = (buf: Uint8Array): string => {
   return btoa(binary)
 }
 
-const encrypt = async (
-  value: string,
-  cookieName: string,
-  key: CryptoKey
-): Promise<string> => {
+const encrypt = async (value: string, cookieName: string, key: CryptoKey): Promise<string> => {
   const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
   const encoded = new TextEncoder().encode(value)
   const aad = new TextEncoder().encode(cookieName)

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -69,13 +69,14 @@ const verifySignature = async (
 const encryptionAlgorithm = 'AES-GCM'
 const IV_LENGTH = 12
 const TAG_LENGTH_BIT = 128
+const HKDF_SALT = new TextEncoder().encode('hono-encrypted-cookie-salt-v1')
 const HKDF_INFO = new TextEncoder().encode('hono-encrypted-cookie')
 
 const getEncryptionKey = async (secret: string | BufferSource): Promise<CryptoKey> => {
   const secretBuf = typeof secret === 'string' ? new TextEncoder().encode(secret) : secret
   const keyMaterial = await crypto.subtle.importKey('raw', secretBuf, 'HKDF', false, ['deriveKey'])
   return await crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(), info: HKDF_INFO },
+    { name: 'HKDF', hash: 'SHA-256', salt: HKDF_SALT, info: HKDF_INFO },
     keyMaterial,
     { name: encryptionAlgorithm, length: 256 },
     false,
@@ -83,27 +84,39 @@ const getEncryptionKey = async (secret: string | BufferSource): Promise<CryptoKe
   )
 }
 
-const encrypt = async (value: string, secret: string | BufferSource): Promise<string> => {
-  const key = await getEncryptionKey(secret)
+const uint8ArrayToBase64 = (buf: Uint8Array): string => {
+  let binary = ''
+  for (let i = 0; i < buf.length; i++) {
+    binary += String.fromCharCode(buf[i])
+  }
+  return btoa(binary)
+}
+
+const encrypt = async (
+  value: string,
+  cookieName: string,
+  key: CryptoKey
+): Promise<string> => {
   const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
   const encoded = new TextEncoder().encode(value)
+  const aad = new TextEncoder().encode(cookieName)
   const cipherBuf = await crypto.subtle.encrypt(
-    { name: encryptionAlgorithm, iv, tagLength: TAG_LENGTH_BIT },
+    { name: encryptionAlgorithm, iv, tagLength: TAG_LENGTH_BIT, additionalData: aad },
     key,
     encoded
   )
   const combined = new Uint8Array(IV_LENGTH + cipherBuf.byteLength)
   combined.set(iv, 0)
   combined.set(new Uint8Array(cipherBuf), IV_LENGTH)
-  return btoa(String.fromCharCode(...combined))
+  return uint8ArrayToBase64(combined)
 }
 
 const decrypt = async (
   base64Encrypted: string,
-  secret: string | BufferSource
+  cookieName: string,
+  key: CryptoKey
 ): Promise<string | false> => {
   try {
-    const key = await getEncryptionKey(secret)
     const binStr = atob(base64Encrypted)
     const combined = new Uint8Array(binStr.length)
     for (let i = 0; i < binStr.length; i++) {
@@ -114,8 +127,9 @@ const decrypt = async (
     }
     const iv = combined.slice(0, IV_LENGTH)
     const ciphertext = combined.slice(IV_LENGTH)
+    const aad = new TextEncoder().encode(cookieName)
     const decrypted = await crypto.subtle.decrypt(
-      { name: encryptionAlgorithm, iv, tagLength: TAG_LENGTH_BIT },
+      { name: encryptionAlgorithm, iv, tagLength: TAG_LENGTH_BIT, additionalData: aad },
       key,
       ciphertext
     )
@@ -314,11 +328,15 @@ export const parseEncrypted = async (
   name?: string
 ): Promise<EncryptedCookie> => {
   const parsedCookie: EncryptedCookie = {}
+  const key = await getEncryptionKey(secret)
 
-  for (const [key, value] of Object.entries(parse(cookie, name))) {
-    const decoded = decodeURIComponent_(value)
-    const decrypted = await decrypt(decoded, secret)
-    parsedCookie[key] = decrypted
+  for (const [cookieName, value] of Object.entries(parse(cookie, name))) {
+    try {
+      const decoded = decodeURIComponent_(value)
+      parsedCookie[cookieName] = await decrypt(decoded, cookieName, key)
+    } catch {
+      parsedCookie[cookieName] = false
+    }
   }
 
   return parsedCookie
@@ -334,7 +352,8 @@ export const serializeEncrypted = async (
   secret: string | BufferSource,
   opt: CookieOptions = {}
 ): Promise<string> => {
-  const encrypted = await encrypt(value, secret)
+  const key = await getEncryptionKey(secret)
+  const encrypted = await encrypt(value, name, key)
   value = encodeURIComponent(encrypted)
   return _serialize(name, value, opt)
 }


### PR DESCRIPTION
Closes #4817

## Summary

- Add `setEncryptedCookie`, `getEncryptedCookie`, `generateEncryptedCookie` helpers using AES-256-GCM encryption via Web Crypto API
- Add `serializeEncrypted`, `parseEncrypted` low-level utils with `EncryptedCookie` type
- API mirrors existing signed cookie pattern (`setSignedCookie` / `getSignedCookie`)

### Crypto design

| Concern | Choice |
|---|---|
| Algorithm | AES-256-GCM (`crypto.subtle`) |
| Key derivation | HKDF-SHA256 with app-specific salt |
| IV | Random 12 bytes per encryption |
| Auth tag | 128-bit (full strength) |
| AAD | Cookie name bound as additional data |
| Cookie format | `base64(iv \|\| ciphertext \|\| authTag)` |

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

## Test plan

- [x] Round-trip set/get encrypted cookie (single key and all cookies)
- [x] Missing cookie returns `undefined`
- [x] Tampered cookie returns `false`
- [x] Wrong secret returns `false`
- [x] Copying encrypted value to different cookie name returns `false` (AAD binding)
- [x] Secure and host prefix round-trips
- [x] Cookie options (domain, httpOnly, maxAge, expires, sameSite)
- [x] `generateEncryptedCookie` with and without options
- [x] All 29 existing cookie tests still pass