### PR TITLE
feat(testing): add bufferResponse helper for async leak detection

### DIFF
--- a/src/helper/testing/index.test.ts
+++ b/src/helper/testing/index.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from '../../hono'
-import { testClient } from '.'
+import { testClient, bufferResponse } from '.'
 
 describe('hono testClient', () => {
   it('Should return the correct search result', async () => {
@@ -38,5 +38,42 @@ describe('hono testClient', () => {
     const app = new Hono().get('/ws', (c) => c.text('Fake response of a WebSocket'))
     // @ts-expect-error $ws is not typed correctly
     expect(() => testClient(app).ws.$ws()).not.toThrowError()
+  })
+})
+
+describe('bufferResponse', () => {
+  it('Should buffer text response body', async () => {
+    const app = new Hono().get('/text', (c) => c.text('hello'))
+    const res = await bufferResponse(app.request('/text'))
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+  })
+
+  it('Should buffer json response body', async () => {
+    const app = new Hono().get('/json', (c) => c.json({ message: 'ok' }))
+    const res = await bufferResponse(app.request('/json'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ message: 'ok' })
+  })
+
+  it('Should preserve status and headers', async () => {
+    const app = new Hono().get('/custom', (c) => {
+      c.header('X-Custom', 'test')
+      return c.text('created', 201)
+    })
+    const res = await bufferResponse(app.request('/custom'))
+    expect(res.status).toBe(201)
+    expect(res.headers.get('X-Custom')).toBe('test')
+  })
+
+  it('Should handle response with no body', async () => {
+    const app = new Hono().get('/empty', (c) => c.body(null, 204))
+    const res = await bufferResponse(app.request('/empty'))
+    expect(res.status).toBe(204)
+  })
+
+  it('Should accept a plain Response (non-Promise)', async () => {
+    const res = await bufferResponse(new Response('direct'))
+    expect(await res.text()).toBe('direct')
   })
 })

--- a/src/helper/testing/index.ts
+++ b/src/helper/testing/index.ts
@@ -25,3 +25,36 @@ export const testClient = <T extends Hono<any, Schema, string>>(
 
   return hc<typeof app, 'http://localhost'>('http://localhost', { ...options, fetch: customFetch })
 }
+
+/**
+ * Buffers the response body to prevent async leak detection false positives.
+ *
+ * Test runners with async leak detection (e.g. `vitest --detect-async-leaks`)
+ * flag the unconsumed `ReadableStream` body of Response objects created by
+ * `c.json()`, `c.text()`, etc. as leaked Promises.
+ *
+ * Use this helper to wrap `app.request()` calls in tests:
+ * ```ts
+ * import { bufferResponse } from 'hono/testing'
+ *
+ * const res = await bufferResponse(app.request('/api'))
+ * expect(res.status).toBe(200)
+ * ```
+ *
+ * @param response - A Response or Promise<Response> from `app.request()`
+ * @returns A new Response with the body buffered as an ArrayBuffer
+ */
+export const bufferResponse = async (
+  response: Response | Promise<Response>
+): Promise<Response> => {
+  const res = response instanceof Promise ? await response : response
+  if (!res.body || res.bodyUsed) {
+    return res
+  }
+  const body = await res.arrayBuffer()
+  return new Response(body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: new Headers(res.headers),
+  })
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `bufferResponse` test helper to `hono/testing` that prevents async leak detection false positives in test runners like `vitest --detect-async-leaks`.

This follows up on #4802, addressing the feedback that the fix should be **on the test side, not in Hono's core**.

## Problem

Test runners with async leak detection flag the unconsumed `ReadableStream` body of Response objects created by `c.json()`, `c.text()`, etc. as leaked Promises. This affects any project using Hono + vitest with `--detect-async-leaks`.

## Solution

A new `bufferResponse` helper exported from `hono/testing` that users can opt into:

```ts
import { bufferResponse } from 'hono/testing'

const res = await bufferResponse(app.request('/api'))
expect(res.status).toBe(200)
```

The helper:
- Reads the response body into an `ArrayBuffer` (no pending `ReadableStream`)
- Creates a new `Response` with the buffered body
- Preserves `status`, `statusText`, and `headers`
- Handles edge cases: no body, already consumed body, non-Promise responses

## What changed

- `src/helper/testing/index.ts` — Added `bufferResponse` export
- `src/helper/testing/index.test.ts` — 5 new tests covering text, JSON, custom status/headers, empty body, and plain Response inputs

## Impact

- **Zero core changes** — test-side helper only
- All existing tests pass
- 100% coverage on new code