### PR TITLE
fix(service-worker): make `fire()` fallback behavior consistent with `handle()`

### DIFF
--- a/src/adapter/service-worker/index.ts
+++ b/src/adapter/service-worker/index.ts
@@ -27,9 +27,7 @@ import type { HandleOptions } from './handler'
  */
 const fire = <E extends Env, S extends Schema, BasePath extends string>(
   app: Hono<E, S, BasePath>,
-  options: HandleOptions = {
-    fetch: undefined,
-  }
+  options?: HandleOptions
 ): void => {
   // @ts-expect-error addEventListener is not typed well in ServiceWorker-like contexts, see: https://github.com/microsoft/TypeScript/issues/14877
   addEventListener('fetch', handle(app, options))


### PR DESCRIPTION
Fixes #4632

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
