### PR TITLE
chore: update typescript to v6

### DIFF
--- a/benchmarks/routers/tsconfig.json
+++ b/benchmarks/routers/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "esModuleInterop": true,
     "module": "NodeNext"
   },
   "include": ["./src"]

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "hono",
@@ -26,7 +25,7 @@
         "pkg-pr-new": "^0.0.53",
         "prettier": "3.7.4",
         "publint": "0.3.15",
-        "typescript": "^5.9.2",
+        "typescript": "^6.0.0",
         "undici": "^6.21.3",
         "vite-plugin-fastly-js-compute": "^0.4.2",
         "vitest": "^3.2.4",
@@ -1403,7 +1402,7 @@
 
     "type-fest": ["type-fest@4.26.1", "", {}, "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "typescript-eslint": ["typescript-eslint@8.56.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.1", "@typescript-eslint/parser": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -677,7 +677,7 @@
     "pkg-pr-new": "^0.0.53",
     "prettier": "3.7.4",
     "publint": "0.3.15",
-    "typescript": "^5.9.2",
+    "typescript": "^6.0.0",
     "undici": "^6.21.3",
     "vite-plugin-fastly-js-compute": "^0.4.2",
     "vitest": "^3.2.4",

--- a/perf-measures/type-check/scripts/tsconfig.json
+++ b/perf-measures/type-check/scripts/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   }
 }

--- a/perf-measures/type-check/tsconfig.build.json
+++ b/perf-measures/type-check/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "exclude": ["dist", "scripts"],
   "references": [

--- a/src/helper/websocket/index.ts
+++ b/src/helper/websocket/index.ts
@@ -48,7 +48,7 @@ export type WSReadyState = 0 | 1 | 2 | 3
  * An argument for WSContext class
  */
 export interface WSContextInit<T = unknown> {
-  send(data: string | ArrayBuffer | Uint8Array, options: SendOptions): void
+  send(data: string | ArrayBuffer | Uint8Array<ArrayBuffer>, options: SendOptions): void
   close(code?: number, reason?: string): void
 
   raw?: T

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "declaration": true,
     "moduleResolution": "Bundler",
     "outDir": "${configDir}/dist",
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,8 @@
     "rootDir": "./src/",
     "outDir": "./dist/types/",
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This PR updates TypeScript to v6 and adjusts config for the new defaults.

- Add explicit `types` fields (v6 defaults to `types: []`)
- Constrain `BufferSource` type to `ArrayBuffer`
- Drop `esModuleInterop` true by default

> [!NOTE]
> TS v6 benchmarks ran a bit slower, which is expected - v6 is mostly a preparations release with stricter checks ahead of v7.
>
> Benchmarks using `tsgo` and today's TS v7 release show roughly 2× lower memory usage and almost 3× faster type-checking on Mac M3.

### TS 7.0 readiness
- `tsc --stableTypeOrdering --noEmit` - passes with no issues
- `tsgo --noEmit` with TS _7.0.0-dev.20260324.1_ - passes with no issues (full type-check with the native Go compiler)
- `tsgo -p tsconfig.build.json` - passes with no issues (successfully generates `d.ts` files)
- `tsgo --build` - 4 errors in tests code regarding overload resolution


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
