### PR TITLE
fix(context): throw for non-serializable json responses

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,16 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() should throw for undefined', () => {
+    expect(() => c.json(undefined)).toThrow(new TypeError('Value is not JSON serializable.'))
+  })
+
+  it('c.json() should stringify null', async () => {
+    const res = c.json(null)
+    expect(res.headers.get('Content-Type')).toMatch('application/json')
+    expect(await res.text()).toBe('null')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -290,6 +290,16 @@ const createResponseInstance = (
   init?: globalThis.ResponseInit
 ): Response => new Response(body, init)
 
+const serializeJSON = (value: unknown): string => {
+  const result = JSON.stringify(value)
+
+  if (result === undefined) {
+    throw new TypeError('Value is not JSON serializable.')
+  }
+
+  return result
+}
+
 export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
@@ -714,7 +724,7 @@ export class Context<
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
     return this.#newResponse(
-      JSON.stringify(object),
+      serializeJSON(object),
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## Summary
- make `c.json()` throw a `TypeError` when `JSON.stringify()` returns `undefined`
- avoid silently returning an empty string body for non-serializable values such as `undefined`
- add regression tests for `undefined` and preserve valid `null` serialization

Fixes #2343

## Test plan
- `bun x vitest run --config ./vitest.config.ts --project main src/context.test.ts`
- `bun x eslint src/context.ts src/context.test.ts`

Made with [Cursor](https://cursor.com)