### PR TITLE
fix(trie-router): treat ** wildcard the same as *

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -814,3 +814,73 @@ describe('Node with initial method and handler', () => {
     expect(res[0][0]).toEqual('hello handler')
   })
 })
+
+describe('Double star wildcard (**)', () => {
+  describe('Basic', () => {
+    const node = new Node()
+    node.insert('get', '/auth/**', 'auth handler')
+    it('/auth/hello', () => {
+      const [res] = node.search('get', '/auth/hello')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('auth handler')
+    })
+    it('/auth/hello/world', () => {
+      const [res] = node.search('get', '/auth/hello/world')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('auth handler')
+    })
+    it('/auth', () => {
+      const [res] = node.search('get', '/auth')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('auth handler')
+    })
+  })
+
+  describe('Should behave the same as single star (*)', () => {
+    const nodeSingle = new Node()
+    nodeSingle.insert('get', '/api/*', 'single star')
+
+    const nodeDouble = new Node()
+    nodeDouble.insert('get', '/api/**', 'double star')
+
+    const paths = ['/api', '/api/users', '/api/users/123']
+    for (const path of paths) {
+      it(`${path} should match both single and double star`, () => {
+        const [resSingle] = nodeSingle.search('get', path)
+        const [resDouble] = nodeDouble.search('get', path)
+        expect(resSingle.length).toBe(resDouble.length)
+      })
+    }
+  })
+
+  describe('With multiple methods', () => {
+    const node = new Node()
+    node.insert('get', '/auth/**', 'get auth')
+    node.insert('post', '/auth/**', 'post auth')
+    it('GET /auth/hello', () => {
+      const [res] = node.search('get', '/auth/hello')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('get auth')
+    })
+    it('POST /auth/hello', () => {
+      const [res] = node.search('post', '/auth/hello')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('post auth')
+    })
+  })
+
+  describe('Top-level double star', () => {
+    const node = new Node()
+    node.insert('get', '**', 'match all')
+    it('/', () => {
+      const [res] = node.search('get', '/')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('match all')
+    })
+    it('/foo/bar', () => {
+      const [res] = node.search('get', '/foo/bar')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('match all')
+    })
+  })
+})

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -51,7 +51,7 @@ export class Node<T> {
     const possibleKeys: string[] = []
 
     for (let i = 0, len = parts.length; i < len; i++) {
-      const p: string = parts[i]
+      const p: string = parts[i] === '**' ? '*' : parts[i]
       const nextP = parts[i + 1]
       const pattern = getPattern(p, nextP)
       const key = Array.isArray(pattern) ? pattern[0] : p


### PR DESCRIPTION
Fixes #4623

## Problem

TrieRouter returns 404 for routes defined with `/**` (double-star wildcard), while RegExpRouter, PatternRouter, and LinearRouter all match them correctly as equivalent to `/*`.

For example:
```ts
const app = new Hono({ router: new TrieRouter() })
app.on(['POST', 'GET'], '/auth/**', (c) => c.json({}))
// GET /auth/hello → 404 ❌
