### PR TITLE
docs: fix impaired -> inspired typo in benchmark READMEs

### DIFF
--- a/benchmarks/routers-deno/README.md
+++ b/benchmarks/routers-deno/README.md
@@ -18,7 +18,7 @@ For Deno:
 deno run --allow-read --allow-run src/bench.mts
 ```
 
-This project is heavily impaired by [delvedor/router-benchmark](https://github.com/delvedor/router-benchmark)
+This project is heavily inspired by [delvedor/router-benchmark](https://github.com/delvedor/router-benchmark)
 
 ## License
 

--- a/benchmarks/routers/README.md
+++ b/benchmarks/routers/README.md
@@ -31,7 +31,7 @@ For Bun:
 bun run bench:bun
 ```
 
-This project is heavily impaired by [delvedor/router-benchmark](https://github.com/delvedor/router-benchmark)
+This project is heavily inspired by [delvedor/router-benchmark](https://github.com/delvedor/router-benchmark)
 
 ## License
 


### PR DESCRIPTION
Fixes a recurring typo where 'inspired' was misspelled as 'impaired' in the benchmarks documentation.