### PR TITLE
docs: fix JSDoc for .fetch() method

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -460,14 +460,14 @@ class Hono<
   }
 
   /**
-   * `.fetch()` will be entry point of your app.
+   * `.fetch()` will be the entry point of your app.
    *
    * @see {@link https://hono.dev/docs/api/hono#fetch}
    *
-   * @param {Request} request - request Object of request
-   * @param {Env} Env - env Object
-   * @param {ExecutionContext} - context of execution
-   * @returns {Response | Promise<Response>} response of request
+   * @param {Request} request - The Request object.
+   * @param {Env} Env - The environment bindings.
+   * @param {ExecutionContext} executionCtx - The execution context.
+   * @returns {Response | Promise<Response>} The response of the request.
    *
    */
   fetch: (


### PR DESCRIPTION
### Description
**The JSDoc comment for the `.fetch()` method in `hono-base.ts` had a few issues:**
- Missing article: `will be entry point` → `will be the entry point`
- The `@param` tag for `ExecutionContext` was missing the parameter name (`executionCtx`), which is required by the JSDoc spec
- The `@param` and `@returns` descriptions were inconsistent with the style used by other methods in the same file (e.g. `.route()`, `.basePath()`, `.onError()`)

This PR fixes these to match the conventions already established in the codebase.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### THANK YOU!