### PR TITLE
docs(ip-restriction): add clear JSDoc examples and param types

### DIFF
--- a/src/middleware/ip-restriction/index.ts
+++ b/src/middleware/ip-restriction/index.ts
@@ -121,9 +121,45 @@ export interface IPRestrictionRules {
 }
 
 /**
- * IP Restriction Middleware
+ * IP Restriction Middleware for Hono.
  *
- * @param getIP function to get IP Address
+ * @see {@link https://hono.dev/docs/middleware/builtin/ip-restriction}
+ *
+ * @param {GetConnInfo | ((c: Context) => string)} getIP - A function to retrieve the client IP address. Use `getConnInfo` from the appropriate runtime adapter.
+ * @param {IPRestrictionRules} rules - An object with optional `denyList` and `allowList` arrays of IP rules. Each rule can be a static IP, a CIDR range, or a custom function.
+ * @param {(remote: { addr: string; type: AddressType }, c: Context) => Response | Promise<Response>} [onError] - Optional custom handler invoked when a request is blocked. Defaults to returning a 403 Forbidden response.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono'
+ * import { ipRestriction } from 'hono/ip-restriction'
+ * import { getConnInfo } from 'hono/cloudflare-workers'
+ *
+ * const app = new Hono()
+ *
+ * app.use(
+ *   '*',
+ *   ipRestriction(getConnInfo, {
+ *     // Block a specific IP and an entire subnet
+ *     denyList: ['192.168.0.5', '10.0.0.0/8'],
+ *     // Only allow requests from localhost and a private range
+ *     allowList: ['127.0.0.1', '::1', '192.168.1.0/24'],
+ *   })
+ * )
+ *
+ * // With a custom error handler
+ * app.use(
+ *   '/admin/*',
+ *   ipRestriction(
+ *     getConnInfo,
+ *     { allowList: ['203.0.113.0/24'] },
+ *     (remote, c) => c.text(`Access denied for ${remote.addr}`, 403)
+ *   )
+ * )
+ *
+ * app.get('/', (c) => c.text('Hello!'))
+ * ```
  */
 export const ipRestriction = (
   getIP: GetIPAddr,


### PR DESCRIPTION
This PR adds a comprehensive `@example` block and fully documents the `@param` and `@returns` tags for the `ipRestriction` middleware. This will help developers understand how to correctly configure its `allowList`/`denyList` and custom `onError` handler right from their IDE.

- Adds exhaustive `@param` documentation
- Adds `@example` showcasing complex CIDR/IP combinations and a custom error handler
- Adds `@see` linking directly to the Hono ip-restriction docs

Addresses the current lack of IDE context for this specific middleware.