### PR TITLE
feat(middleware): allow overriding timeout in subroutes

### DIFF
--- a/src/middleware/timeout/index.test.ts
+++ b/src/middleware/timeout/index.test.ts
@@ -18,6 +18,7 @@ describe('Timeout API', () => {
   const exception500: HTTPExceptionFunction = (context: Context) =>
     new HTTPException(500, { message: `Internal Server Error at ${context.req.path}` })
   app.use('/slow-endpoint/error', timeout(1200, exception500))
+  app.use('/slow-endpoint/replace', timeout(1300))
   app.use('/normal-endpoint', timeout(1000))
 
   app.get('/slow-endpoint', async (c) => {
@@ -32,6 +33,11 @@ describe('Timeout API', () => {
 
   app.get('/slow-endpoint/error', async (c) => {
     await new Promise((resolve) => setTimeout(resolve, 1300))
+    return c.text('This should not show up')
+  })
+
+  app.get('/slow-endpoint/replace', timeout(1100), async (c) => {
+    await new Promise((resolve) => setTimeout(resolve, 1200))
     return c.text('This should not show up')
   })
 
@@ -59,6 +65,13 @@ describe('Timeout API', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(500)
     expect(await res.text()).toContain('Internal Server Error at /slow-endpoint/error')
+  })
+
+  it('Old timeout should be replaced', async () => {
+    const res = await app.request('http://localhost/slow-endpoint/replace')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(504)
+    expect(await res.text()).toContain('Gateway Timeout')
   })
 
   it('No Timeout should pass', async () => {

--- a/src/middleware/timeout/index.test.ts
+++ b/src/middleware/timeout/index.test.ts
@@ -18,7 +18,7 @@ describe('Timeout API', () => {
   const exception500: HTTPExceptionFunction = (context: Context) =>
     new HTTPException(500, { message: `Internal Server Error at ${context.req.path}` })
   app.use('/slow-endpoint/error', timeout(1200, exception500))
-  app.use('/slow-endpoint/replace', timeout(1300))
+  app.use('/slow-endpoint/override', timeout(1300))
   app.use('/normal-endpoint', timeout(1000))
 
   app.get('/slow-endpoint', async (c) => {
@@ -36,7 +36,7 @@ describe('Timeout API', () => {
     return c.text('This should not show up')
   })
 
-  app.get('/slow-endpoint/replace', timeout(1100), async (c) => {
+  app.get('/slow-endpoint/override', timeout(1100), async (c) => {
     await new Promise((resolve) => setTimeout(resolve, 1200))
     return c.text('This should not show up')
   })
@@ -67,8 +67,8 @@ describe('Timeout API', () => {
     expect(await res.text()).toContain('Internal Server Error at /slow-endpoint/error')
   })
 
-  it('Old timeout should be replaced', async () => {
-    const res = await app.request('http://localhost/slow-endpoint/replace')
+  it('Old timeout should be overriden', async () => {
+    const res = await app.request('http://localhost/slow-endpoint/override')
     expect(res).not.toBeNull()
     expect(res.status).toBe(504)
     expect(await res.text()).toContain('Gateway Timeout')

--- a/src/middleware/timeout/index.ts
+++ b/src/middleware/timeout/index.ts
@@ -33,6 +33,13 @@ const defaultTimeoutException = new HTTPException(504, {
  *   await someLongRunningFunction()
  *   return c.text('Completed within time limit')
  * })
+ *
+ * app.use('/user', timeout(5000)) // Set a generic timeout for all user routes
+ *
+ * app.use('/user/export', timeout(30000), async (c, next) => {
+ *   await someLongRunningFunction()
+ *   return c.text('Completed within 30 seconds')
+ * })
  * ```
  */
 export const timeout = (

--- a/src/middleware/timeout/index.ts
+++ b/src/middleware/timeout/index.ts
@@ -38,13 +38,17 @@ const defaultTimeoutException = new HTTPException(504, {
 export const timeout = (
   duration: number,
   exception: HTTPExceptionFunction | HTTPException = defaultTimeoutException
-): MiddlewareHandler => {
+): MiddlewareHandler<{ Variables: { timeoutTimer: number | undefined } }> => {
   return async function timeout(context, next) {
-    let timer: number | undefined
+    let timer = context.get('timeoutTimer')
+    if (timer !== undefined) {
+      clearTimeout(timer)
+    }
     const timeoutPromise = new Promise<void>((_, reject) => {
       timer = setTimeout(() => {
         reject(typeof exception === 'function' ? exception(context) : exception)
       }, duration) as unknown as number
+      context.set('timeoutTimer', timer)
     })
 
     try {
@@ -52,6 +56,7 @@ export const timeout = (
     } finally {
       if (timer !== undefined) {
         clearTimeout(timer)
+        context.set('timeoutTimer', undefined)
       }
     }
   }


### PR DESCRIPTION
This PR allows users to override upstream route timeouts. This enables users to set a general, application-wide timeout while configuring specific exceptions for long-running routes.

### Key Changes
- Uses `context.get/set` to store `timeoutTimer`, ensuring any existing timer is cleared before a new one is created.
- Updates the middleware handler type to include `Variables.timeoutTimer`.
- Adds a test route and assertions to verify that the previous timeout is successfully overridden.

### Questions/comments
- I'm not sure about exposing the timer with variables. It allows users manipulate it but at the same time it can pollute variable space. Do I need to change it to an internal namespace?
- Do I need to fetch timeoutTimer from variables after next() function?

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
