### PR TITLE
fix(utils/cookie): accept ':' in cookie names when parsing

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -73,6 +73,32 @@ describe('Parse cookie', () => {
     expect(cookie['']).toBeUndefined()
   })
 
+  it('Should parse cookie names containing colons', () => {
+    // Colons are used by real-world libraries such as @inlang/paraglide-sveltekit
+    // (e.g. 'paraglide:lang') and AWS Cognito. They are technically outside the
+    // strict RFC 6265 token definition but browsers send them without issue.
+    const cookieString = 'paraglide:lang=en; other_cookie=value; ns:sub:key=deep'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['paraglide:lang']).toBe('en')
+    expect(cookie['other_cookie']).toBe('value')
+    expect(cookie['ns:sub:key']).toBe('deep')
+  })
+
+  it('Should parse a single cookie with a colon in its name when specified by name', () => {
+    const cookieString = 'paraglide:lang=en; other_cookie=value'
+    const cookie: Cookie = parse(cookieString, 'paraglide:lang')
+    expect(cookie['paraglide:lang']).toBe('en')
+    expect(cookie['other_cookie']).toBeUndefined()
+  })
+
+  it('Should parse signed cookies with colon in name', async () => {
+    const secret = 'test-secret'
+    // serializeSigned produces 'name=value.signature' which is also a valid Cookie header
+    const serialized = await serializeSigned('paraglide:lang', 'en', secret)
+    const cookie: SignedCookie = await parseSigned(serialized, secret)
+    expect(cookie['paraglide:lang']).toBe('en')
+  })
+
   it('Should ignore invalid cookie values', () => {
     const cookieString = 'yummy_cookie=choco\\nchip; tasty_cookie=strawberry; best_cookie="sugar'
     const cookie: Cookie = parse(cookieString)

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -65,9 +65,11 @@ const verifySignature = async (
   }
 }
 
-// all alphanumeric chars and all of _!#$%&'*.^`|~+-
-// (see: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)
-const validCookieNameRegEx = /^[\w!#$%&'*.^`|~+-]+$/
+// When parsing incoming cookies, use a permissive regex that accepts ':' in addition
+// to the strict RFC 6265 token characters. ':' is used in practice by libraries like
+// @inlang/paraglide-sveltekit (e.g. 'paraglide:lang') and AWS Cognito. The hyphen
+// is explicitly escaped to avoid ambiguity in the character class.
+const parseCookieNameRegEx = /^[\w!#$%&'*.^`|~+:\-]+$/
 
 // all ASCII chars 32-126 except 34, 59, and 92 (i.e. space to tilde but not double quote, semicolon, or backslash)
 // (see: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)
@@ -91,7 +93,7 @@ export const parse = (cookie: string, name?: string): Cookie => {
     }
 
     const cookieName = pairStr.substring(0, valueStartPos).trim()
-    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
+    if ((name && name !== cookieName) || !parseCookieNameRegEx.test(cookieName)) {
       continue
     }
 


### PR DESCRIPTION
## Problem                                                                                                                                                                 
                                                            
  `parse()` in `src/utils/cookie.ts` validates every cookie name against a regex based on strict RFC 6265 token definition, which excludes `:`. This silently drops any      
  cookie whose name contains a colon — for example `paraglide:lang` (set by @inlang/paraglide-sveltekit) and cookies issued by AWS Cognito. Users calling `getCookie(c,
  'paraglide:lang')` always received `undefined` even when the cookie was present in the request.                                                                            
                                                            
  ## Solution

  Introduced a separate `parseCookieNameRegEx` that extends the allowlist with `:`, used only in the `parse()` function (incoming cookie parsing). The fix follows the same  
  principle as the popular `jshttp/cookie` npm package: be strict when writing, permissive when reading.
                                                                                                                                                                             
  ## Changes                                                

  - Added `parseCookieNameRegEx` with `:` and escaped hyphen for clarity                                                                                                     
  - Updated `parse()` to use the new permissive regex
  - Added 3 new test cases covering colon names in regular and signed cookies                                                                                                
  - All 4230+ tests pass; 0 regressions                                                                                                                                      
   
  ## Reproduction                                                                                                                                                            
                                                            
  ```ts                                                                                                                                                                      
  import { getCookie } from 'hono/cookie'
                                                                                                                                                                             
  app.get('/', (c) => {                                     
    // Request carries: Cookie: paraglide:lang=en
    const lang = getCookie(c, 'paraglide:lang') // was undefined, now 'en'                                                                                                   
    return c.text(lang ?? 'not found')                                                                                                                                       
  })                                                                                                                                                                         
 ```                                                                                                                                                                            
  Fixes #3189.