### PR TITLE
fix(ip-restriction): add explicit radix to parseInt for CIDR prefix

### DIFF
--- a/src/middleware/ip-restriction/index.ts
+++ b/src/middleware/ip-restriction/index.ts
@@ -57,7 +57,7 @@ const buildMatcher = (
         }
 
         const isIPv4 = type === 'IPv4'
-        const prefix = parseInt(separatedRule[1])
+        const prefix = parseInt(separatedRule[1], 10)
 
         if (isIPv4 ? prefix === 32 : prefix === 128) {
           // this rule is a static rule


### PR DESCRIPTION
## Summary

Add explicit radix `10` to `parseInt(separatedRule[1])` in the IP restriction middleware's CIDR prefix parser.

## Problem

`parseInt()` without a radix parameter relies on implicit base detection. While modern engines default to base 10, the [ESLint `radix` rule](https://eslint.org/docs/latest/rules/radix) flags this as a best-practice violation. In security-critical code like IP restriction CIDR parsing, explicit intent prevents any ambiguity.

## Change

```diff
- const prefix = parseInt(separatedRule[1])
+ const prefix = parseInt(separatedRule[1], 10)
```

`src/middleware/ip-restriction/index.ts` line 60 — the only `parseInt` call in the codebase without an explicit radix.

## Test plan

- [ ] Existing IP restriction tests pass
- [ ] CIDR rules like `192.168.0.0/24` and `::1/128` continue to work correctly