### PR TITLE
fix(types): infer response type from last handler in app.on 9-/10-handler overloads

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -401,6 +401,53 @@ describe('OnHandlerInterface', () => {
     }
     type verify = Expect<Equal<Expected, Actual>>
   })
+
+  test('app.on(method, path, ...10 handlers) - last handler response type should be inferred', () => {
+    const noop: MiddlewareHandler = async (_c, next) => {
+      await next()
+    }
+    const route = app.on('GET', '/x10', noop, noop, noop, noop, noop, noop, noop, noop, noop, (c) =>
+      c.json({ success: true })
+    )
+    type Actual = ExtractSchema<typeof route>['/x10']['$get']['output']
+    type Expected = { success: true }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  test('app.on(method[], path, ...9 handlers) - last handler response type should be inferred', () => {
+    const noop: MiddlewareHandler = async (_c, next) => {
+      await next()
+    }
+    const route = app.on(['GET'], '/x9-arr', noop, noop, noop, noop, noop, noop, noop, noop, (c) =>
+      c.json({ success: true })
+    )
+    type Actual = ExtractSchema<typeof route>['/x9-arr']['$get']['output']
+    type Expected = { success: true }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  test('app.on(method[], path, ...10 handlers) - last handler response type should be inferred', () => {
+    const noop: MiddlewareHandler = async (_c, next) => {
+      await next()
+    }
+    const route = app.on(
+      ['GET'],
+      '/x10-arr',
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      (c) => c.json({ success: true })
+    )
+    type Actual = ExtractSchema<typeof route>['/x10-arr']['$get']['output']
+    type Expected = { success: true }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
 })
 
 describe('TypedResponse', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1790,7 +1790,7 @@ export interface OnHandlerInterface<
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -2095,7 +2095,7 @@ export interface OnHandlerInterface<
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<R>>,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -2143,7 +2143,7 @@ export interface OnHandlerInterface<
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<HandlerResponse<any>>>,
+    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>,
     BasePath,
     MergePath<BasePath, P>
   >


### PR DESCRIPTION
## Summary

The 9- and 10-handler overloads of `OnHandlerInterface` declared a type parameter `R` on the final handler position but **discarded it from the schema computation**, hardcoding `MergeTypedResponse<HandlerResponse<any>>` instead. As a result, the inferred `output` collapses to `{} | Promise<void>` and `outputFormat` to `string` regardless of what the response handler actually returns, so the RPC client resolves `r.json()` as `Promise<unknown>`.

This is a write-omission that was introduced in #1735 (2023-11) and carried through subsequent refactors without being noticed — the surrounding x1–x8 overloads are all using `MergeTypedResponse<R>` correctly.

## Affected overloads

This affects only the x9 / x10 overloads of `OnHandlerInterface`.
The x1–x8 overloads already use `MergeTypedResponse<R>` correctly.

## Reproduction

```ts
import { Hono } from 'hono'
import { hc } from 'hono/client'

const noop = async (_c: any, next: any) => { await next() }

const app = new Hono().on(
  ['GET'], '/api/users/:id',
  noop, noop, noop, noop, noop, noop, noop, noop, noop, // 9 middlewares
  (c) => c.json({ id: '1', name: 'Alice' })             // response handler
)

const client = hc<typeof app>('/')
const data = await client.api.users[':id']
  .$get({ param: { id: '1' } })
  .then((r) => r.json())

// Before this PR: data is `unknown`
// After this PR:  data is `{ id: string; name: string }`
```

Reducing the chain to **8 handlers** makes the inference work correctly even on `main`, because the x8 overload is not affected by the bug. This bizarre cliff at the x9 boundary is the symptom.

## Fix

3-line change in `src/types.ts`:

```diff
- S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<HandlerResponse<any>>>,
+ S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>,
```

`R` was already declared in the type parameter list and properly captured by the last `H<E11, MergedPath, I10, R>` element of the handler tuple — only the schema computation was failing to use it.

## Test plan

Added 3 regression tests under `describe('OnHandlerInterface', ...)` in `src/types.test.ts`, one per fixed overload. Each test passes 9 or 10 handlers and asserts that the schema's `output` matches the response handler's return type.

These tests fail on `main` (the schema's `output` is `{} | Promise<void>`) and pass after this fix.

- [x] `bun run format:fix && bun run lint:fix`
- [x] `bun run test` (full type check + vitest)
- [x] Added regression tests covering all 3 fixed overloads

## Related history

This is **not related** to honojs/hono#3485 / the `.then()` arrow-function inference issue, which is a separate TypeScript-level limitation in `H = Handler | MiddlewareHandler` union inference. This PR fixes an unrelated, mechanical write-omission.

| commit | date | note |
|---|---|---|
| [b80895a](https://github.com/honojs/hono/commit/b80895a8) — feat(types): Support types until 10 handlers (#1735) | 2023-11-28 | introduced the hardcoded `HandlerResponse<any>` in the new x9 / x10 overloads |
| [9732a7b](https://github.com/honojs/hono/commit/9732a7ba) — feat(types): improve `ToSchema` & WebSocket Helper types (#2588) | 2024-05-03 | renamed `MergeTypedResponseData` → `MergeTypedResponse`, hardcode preserved |
| [37c3809](https://github.com/honojs/hono/commit/37c3809c) — fix(types): fix app.on method array type inference (#4578) | 2025-12-14 | adjacent fix (`Ms[number]` → `M`), hardcode preserved |


I am using a translation tool. I apologize if any of my expressions cause misunderstanding.