### PR TITLE
fix(cache): log "caches is not defined" only once

### DIFF
--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -403,18 +403,31 @@ describe('Cache Middleware', () => {
     expect(res.headers.get('cache-control')).not.toBe('max-age=10')
   })
 
-  it('Should not be enabled if caches is not defined', async () => {
+  it('Should not be enabled if caches is not defined and should log only once', async () => {
     vi.stubGlobal('caches', undefined)
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
     const app = new Hono()
     app.use(cache({ cacheName: 'my-app-v1', cacheControl: 'max-age=10' }))
+    cache({ cacheName: 'extra-1' })
+    cache({ cacheName: 'extra-2' })
     app.get('/', (c) => {
       return c.text('cached')
     })
+
     expect(caches).toBeUndefined()
     const res = await app.request('/')
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe(null)
+
+    const logCalls = spy.mock.calls.filter(
+      (args) => args[0] === 'Cache Middleware is not enabled because caches is not defined.'
+    )
+    expect(logCalls).toHaveLength(1)
+
+    spy.mockRestore()
+    vi.unstubAllGlobals()
   })
 })
 

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -59,6 +59,8 @@ const shouldSkipCache = (res: Response) => {
  * )
  * ```
  */
+let cacheNotDefinedLogged = false
+
 export const cache = (options: {
   cacheName: string | ((c: Context) => Promise<string> | string)
   wait?: boolean
@@ -68,7 +70,10 @@ export const cache = (options: {
   cacheableStatusCodes?: StatusCode[]
 }): MiddlewareHandler => {
   if (!globalThis.caches) {
-    console.log('Cache Middleware is not enabled because caches is not defined.')
+    if (!cacheNotDefinedLogged) {
+      console.log('Cache Middleware is not enabled because caches is not defined.')
+      cacheNotDefinedLogged = true
+    }
     return async (_c, next) => await next()
   }
 


### PR DESCRIPTION
The log is repeated for every `cache()` call when `globalThis.caches` is not available. This PR ensures the message is logged only once.

```bash
$ vite

  VITE v8.0.0  ready in 675 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
Cache Middleware is not enabled because caches is not defined.
(repeats...)
Using vars defined in .env
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code (N/A)