### PR TITLE
fix(aws-lambda): infer response type from event via overloads

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -197,16 +197,23 @@ type HandleOptions = {
 }
 
 type LambdaHandlerFunction = {
-  (event: APIGatewayProxyEvent, lambdaContext?: LambdaContext): Promise<APIGatewayProxyResult>
   (
     event: APIGatewayProxyEventV2,
     lambdaContext?: LambdaContext
   ): Promise<APIGatewayProxyResult & WithHeaders>
-  (event: ALBProxyEvent, lambdaContext?: LambdaContext): Promise<APIGatewayProxyResult>
   (
     event: LatticeProxyEventV2,
     lambdaContext?: LambdaContext
   ): Promise<APIGatewayProxyResult & WithHeaders>
+  (
+    event: LambdaEvent & { multiValueHeaders: Record<string, string[]> },
+    lambdaContext?: LambdaContext
+  ): Promise<APIGatewayProxyResult & WithMultiValueHeaders>
+  (
+    event: LambdaEvent & { multiValueHeaders?: undefined },
+    lambdaContext?: LambdaContext
+  ): Promise<APIGatewayProxyResult & WithHeaders>
+  (event: LambdaEvent, lambdaContext?: LambdaContext): Promise<APIGatewayProxyResult>
 }
 
 /**

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -196,6 +196,19 @@ type HandleOptions = {
   isContentTypeBinary: ((contentType: string) => boolean) | undefined
 }
 
+type LambdaHandlerFunction = {
+  (event: APIGatewayProxyEvent, lambdaContext?: LambdaContext): Promise<APIGatewayProxyResult>
+  (
+    event: APIGatewayProxyEventV2,
+    lambdaContext?: LambdaContext
+  ): Promise<APIGatewayProxyResult & WithHeaders>
+  (event: ALBProxyEvent, lambdaContext?: LambdaContext): Promise<APIGatewayProxyResult>
+  (
+    event: LatticeProxyEventV2,
+    lambdaContext?: LambdaContext
+  ): Promise<APIGatewayProxyResult & WithHeaders>
+}
+
 /**
  * Converts a Hono application to an AWS Lambda handler.
  *
@@ -239,17 +252,11 @@ type HandleOptions = {
 export const handle = <E extends Env = Env, S extends Schema = {}, BasePath extends string = '/'>(
   app: Hono<E, S, BasePath>,
   { isContentTypeBinary }: HandleOptions = { isContentTypeBinary: undefined }
-): (<L extends LambdaEvent>(
-  event: L,
-  lambdaContext?: LambdaContext
-) => Promise<
-  APIGatewayProxyResult &
-    (L extends { multiValueHeaders: Record<string, string[]> }
-      ? WithMultiValueHeaders
-      : WithHeaders)
->) => {
-  // @ts-expect-error FIXME: Fix return typing
-  return async (event, lambdaContext?) => {
+): LambdaHandlerFunction => {
+  const impl = async (
+    event: LambdaEvent,
+    lambdaContext?: LambdaContext
+  ): Promise<APIGatewayProxyResult> => {
     const processor = getProcessor(event)
 
     const req = processor.createRequest(event)
@@ -263,6 +270,7 @@ export const handle = <E extends Env = Env, S extends Schema = {}, BasePath exte
 
     return processor.createResult(event, res, { isContentTypeBinary })
   }
+  return impl as LambdaHandlerFunction
 }
 
 export abstract class EventProcessor<E extends LambdaEvent> {


### PR DESCRIPTION
## Summary

While reviewing the AWS Lambda adapter, I noticed `handle()` used a conditional return type guarded by `@ts-expect-error FIXME: Fix return typing`. Tracing the FIXME back to commit 0e4dfe58 (#3883), the author's goal was to *"Infer response type from event"* — narrowing to `WithHeaders` for events that cannot produce multi-value headers.

## The issue

The conditional `L extends { multiValueHeaders: Record<string, string[]> } ? WithMultiValueHeaders : WithHeaders` is vacuous. Every `LambdaEvent` member declares `multiValueHeaders` as optional (v1, ALB) or omits/undefines it (v2 which has `?: undefined`, Lattice which has no such field), so none satisfy the required-field extends constraint. The conditional always resolves to `WithHeaders` regardless of the input event type, and the `@ts-expect-error` on the implementation hides the mismatch between the declared return type and the actual value produced by `processor.createResult` (which at runtime may return either branch, based on `'multiValueHeaders' in event && event.multiValueHeaders`).

## The fix

Replace the conditional with per-event overloads that encode the real runtime guarantee. The overloads are ordered for resolution:

1. **v2 / Lattice** → `APIGatewayProxyResult & WithHeaders` — these event types never produce multi-value headers
2. **Any event with `multiValueHeaders` present** → `APIGatewayProxyResult & WithMultiValueHeaders` — the runtime uses multi-value headers when the event carries them
3. **Any event with `multiValueHeaders` absent/undefined** → `APIGatewayProxyResult & WithHeaders` — the runtime uses regular headers otherwise
4. **Generic `LambdaEvent` fallback** → the full `APIGatewayProxyResult` union — for callers whose event type is not statically known

This models the exact runtime behavior of `getProcessor` and `createResult`, so callers get the most precise return type the type system can express from their call-site argument.

The overload pattern matches `HonoRequest.param` in `src/request.ts:94-104`. The `as LambdaHandlerFunction` cast is the idiomatic TypeScript pattern for giving a `const` arrow function multiple call signatures — arrow functions cannot use stacked `function` declaration overloads.

No change in runtime behavior. The `@ts-expect-error FIXME: Fix return typing` directive is removed.

## Verification

- `bun tsc --build` — clean (the runtime-tests/lambda test file compiles without changes, since the overloads are precise enough for TypeScript to infer the correct return type from each test's inline event literal)
- `bun run test` — 4255 passed, 33 skipped, 0 failed
- `bun run build` — green (includes declaration emission and publint)
- `bun run format:fix && bun run lint:fix` — no changes needed
- Type-level narrowing also verified locally with an `@ts-expect-error`-style test file that imported the real `handle` from this branch and asserted the narrowing contract for all four event types (v2/Lattice narrow to `WithHeaders` without a discriminant; v1/ALB correctly require one when multiValueHeaders presence is unknown). Happy to contribute that as a follow-up if the team would like a regression guard in the test suite — kept this PR focused on the fix itself.

### The author should do the following, if applicable

- [ ] Add tests (type-level verification done locally; see note above)
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code (no new public API surface)