### PR TITLE
Throw on non-serializable JSON responses

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,12 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() should throw for undefined', () => {
+    const json = () => c.json(undefined)
+    expect(json).toThrow(TypeError)
+    expect(json).toThrow('Value is not JSON serializable.')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable.')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## Summary
- make `c.json(undefined)` throw a consistent `TypeError`
- preserve the existing JSON response behavior for all serializable values
- add a regression test covering the undefined case

Fixes #2343

## Validation
- bunx vitest run src/context.test.ts
- bunx eslint src/context.ts src/context.test.ts

## Notes
- `bun install` was required in this checkout to restore the local vitest dependency tree