### PR TITLE
feat(cache): add `onCacheNotAvailable` option

### DIFF
--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -416,6 +416,37 @@ describe('Cache Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe(null)
   })
+
+  it('Should call onCacheNotAvailable when caches is not defined', async () => {
+    vi.stubGlobal('caches', undefined)
+    const spy = vi.fn()
+    const app = new Hono()
+    app.use(cache({ cacheName: 'my-app-v1', onCacheNotAvailable: spy }))
+    app.get('/', (c) => {
+      return c.text('cached')
+    })
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(spy).toHaveBeenCalledOnce()
+    vi.unstubAllGlobals()
+  })
+
+  it('Should suppress default log when onCacheNotAvailable is false', async () => {
+    vi.stubGlobal('caches', undefined)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const app = new Hono()
+    app.use(cache({ cacheName: 'my-app-v1', onCacheNotAvailable: false }))
+    app.get('/', (c) => {
+      return c.text('cached')
+    })
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(logSpy).not.toHaveBeenCalledWith(
+      'Cache Middleware is not enabled because caches is not defined.'
+    )
+    logSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
 })
 
 describe('Cache Skipping Logic', () => {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -45,6 +45,7 @@ const shouldSkipCache = (res: Response) => {
  * @param {string | string[]} [options.vary] - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
  * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
  * @param {number[]} [options.cacheableStatusCodes=[200]] - An array of status codes that can be cached.
+ * @param {Function | false} [options.onCacheNotAvailable] - A callback invoked when `globalThis.caches` is not available. By default, a message is logged to the console. Set to `false` to suppress the log, or provide a custom function.
  * @returns {MiddlewareHandler} The middleware handler function.
  * @throws {Error} If the `vary` option includes "*".
  *
@@ -66,9 +67,16 @@ export const cache = (options: {
   vary?: string | string[]
   keyGenerator?: (c: Context) => Promise<string> | string
   cacheableStatusCodes?: StatusCode[]
+  onCacheNotAvailable?: (() => void) | false
 }): MiddlewareHandler => {
   if (!globalThis.caches) {
-    console.log('Cache Middleware is not enabled because caches is not defined.')
+    if (options.onCacheNotAvailable === false) {
+      // suppress log
+    } else if (options.onCacheNotAvailable) {
+      options.onCacheNotAvailable()
+    } else {
+      console.log('Cache Middleware is not enabled because caches is not defined.')
+    }
     return async (_c, next) => await next()
   }
 


### PR DESCRIPTION
This PR introduces `onCacheNotAvailable` to Cache Middleware.

By default, it logs a message with `console.log` if the `caches` are not found in the global scope. But some users want to prevent logging or customize the behavior. In that case, `onCacheNotAvailable` is useful:

```ts
app.use(
  cache({
    cacheName: 'my-app-v1',
    onCacheNotAvailable: () => {
      console.log('Custom log: Cache API is not available.')
    },
  })
)
```

Or to prevent logging:

```ts
app.use(
  cache({
    cacheName: 'my-app-v1',
    onCacheNotAvailable: false,
  })
)
```

Relevant to #4871

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
