### PR TITLE
fix(vercel): add void return type and ctx param for Next.js 15 App Router compatibility

### DIFF
--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Hono } from '../../hono'
 
-export const handle =
-  (app: Hono<any, any, any>) =>
-  (req: Request): Response | Promise<Response> => {
+export function handle(
+  app: Hono<any, any, any>
+): (req: Request, ctx?: unknown) => Response | Promise<Response> | void {
+  return (req: Request, ctx?: unknown): Response | Promise<Response> | void => {
     return app.fetch(req)
   }
+}


### PR DESCRIPTION
## Summary

The `handle()` function in `hono/vercel` adapter was incompatible with Next.js 15 App Router route handler types.

Two type errors were reported:
1. Return type was `Response | Promise<Response>` but Next.js 15 expects `Response | void | Promise<Response | void>`
2. Handler was missing the optional `ctx` parameter that Next.js 15 passes

## Fix

- Added `void` to the return type union
- Added optional `ctx?: unknown` parameter to match Next.js 15 expectations

The runtime behavior is unchanged since `app.fetch(req)` always returns a Response (via notFoundHandler if needed).

## Test plan

- [ ] Verify `tsc --noEmit` passes in a Next.js 15 App Router project using the documented setup