### PR TITLE
fix(vercel): fix handle() return type for Next.js 15 App router

### DIFF
--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -3,6 +3,6 @@ import type { Hono } from '../../hono'
 
 export const handle =
   (app: Hono<any, any, any>) =>
-  (req: Request): Response | Promise<Response> => {
+  (req: Request): Response | void | Promise<Response | void> => {
     return app.fetch(req)
   }


### PR DESCRIPTION
Fixes #4877

**What this PR does:**
Updates the return type of the Vercel `handle()` function to include `void` (and `Promise<Response | void>`). This is required because Next.js 15 App Router expects route handlers to optionally return void.
