### PR TITLE
fix(trie-router): support double wildcard ** as alias for single wildcard *

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -861,6 +861,24 @@ export const runTest = ({
       })
     })
 
+    describe('Double wildcard **', () => {
+      beforeEach(() => {
+        router.add('GET', '/auth/**', 'double wildcard')
+      })
+
+      it('GET /auth/login should match /auth/**', async () => {
+        const res = match('GET', '/auth/login')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('double wildcard')
+      })
+
+      it('GET /auth/a/b/c should match /auth/**', async () => {
+        const res = match('GET', '/auth/a/b/c')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('double wildcard')
+      })
+    })
+
     describe('Unknown method', () => {
       beforeEach(() => {
         router.add('GET', '/', 'index')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -54,7 +54,7 @@ export class Node<T> {
       const p: string = parts[i]
       const nextP = parts[i + 1]
       const pattern = getPattern(p, nextP)
-      const key = Array.isArray(pattern) ? pattern[0] : p
+      const key = pattern === '*' ? '*' : Array.isArray(pattern) ? pattern[0] : p
 
       if (key in curNode.#children) {
         curNode = curNode.#children[key]

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -57,6 +57,10 @@ export const getPattern = (label: string, next?: string): Pattern | null => {
     return '*'
   }
 
+  if (label === '**') {
+    return '*'
+  }
+
   const match = label.match(/^\:([^\{\}]+)(?:\{(.+)\})?$/)
   if (match) {
     const cacheKey = `${label}#${next}`


### PR DESCRIPTION
Fixes #4623

The TrieRouter treated `**` as a literal path segment while other routers (RegExpRouter, PatternRouter, LinearRouter) correctly treated it as a wildcard. This caused routes like `/auth/**` to return 404 when using TrieRouter or SmartRouter (which defaults to TrieRouter).

**Root cause:** The `getPattern()` function only recognized `*` as a wildcard, not `**`. And in `Node.insert()`, the child node key was always the raw path segment (`**`), not the normalized wildcard key (`*`). During search, the code looks for `node.#children["*"]` to find wildcard matches, but the node was stored under `node.#children["**"]`.

**Fix (2 changes):**
1. `getPattern()`: Return `*` pattern for `**` label (same as `*`)
2. `Node.insert()`: Use `*` as child key when the pattern is a wildcard, so `**` segments create the same child node as `*` segments

All 532 router tests pass (7 test files), including 2 new tests for double wildcard behavior.