### PR TITLE
fix: normalize nested Windows file paths

### DIFF
--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -43,6 +43,15 @@ describe('getFilePathWithoutDefaultDocument', () => {
     expect(
       getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./..foo../bar.txt') })
     ).toBe('..foo../bar.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./foo/bar/baz.txt') })
+    ).toBe('foo/bar/baz.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({
+        filename: slashToBackslash('./foo/bar/baz.txt'),
+        root: 'public',
+      })
+    ).toBe('public/foo/bar/baz.txt')
   })
 })
 

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -43,7 +43,7 @@ export const getFilePathWithoutDefaultDocument = (
   filename = filename.replace(/^\.?[\/\\]/, '')
 
   // foo\bar.txt => foo/bar.txt
-  filename = filename.replace(/\\/, '/')
+  filename = filename.replace(/\\/g, '/')
 
   // assets/ => assets
   root = root.replace(/\/$/, '')


### PR DESCRIPTION

**Repo:** honojs/hono (⭐ 23000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +10/-1

## What
This change fixes `getFilePathWithoutDefaultDocument()` so it normalizes every Windows-style path separator in the incoming filename instead of only the first one. It also adds focused tests covering nested Windows-style paths, both with and without a configured root.

## Why
The previous implementation used a non-global backslash replacement, which could leave mixed separators in nested paths such as `foo\\bar\\baz.txt`. Since this utility is used to build normalized asset paths, returning partially normalized paths is an avoidable cross-platform bug. The added tests make that expectation explicit.

## Testing
I verified the final diff by inspection. I could not run the repo’s Vitest target locally because this checkout does not have dependencies installed and `bun`/`bunx` are unavailable in the environment.

## Risk
Low / The change is a one-line normalization fix in a utility function with narrow, additive test coverage.
