### PR TITLE
feat(cacherouter) add routing cache

### DIFF
--- a/src/router/cache-router/index.ts
+++ b/src/router/cache-router/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @module
+ * CacheRouter for Hono.
+ */
+
+export { CacheRouter } from './router'

--- a/src/router/cache-router/router.test.ts
+++ b/src/router/cache-router/router.test.ts
@@ -1,0 +1,14 @@
+import { runTest } from '../common.case.test'
+import { TrieRouter } from '../trie-router'
+import { CacheRouter } from './router'
+
+describe('SmartRouter', () => {
+  runTest({
+    newRouter: () =>
+      new CacheRouter({
+        router: new TrieRouter(),
+        maxCacheEntries: 10,
+        checkDiffOnAdd: false,
+      }),
+  })
+})

--- a/src/router/cache-router/router.ts
+++ b/src/router/cache-router/router.ts
@@ -18,12 +18,12 @@ export class CacheRouter<T> implements Router<T> {
   #checkDiffOnAdd: boolean
   /**
    * @param init
-   * @param init.router - The underlying router in CacheRouter internal.
-   * @param init.maxCacheEntries - Maximum number of cache entries. Must be positive number. the default is `100`.
+   * @param init.router - The underlying router used internally by CacheRouter.
+   * @param init.maxCacheEntries - Maximum number of cache entries. Must be a positive number. The default is `100`.
    * @param init.checkDiffOnAdd - Strategy for cache invalidation when `add()` method is called:
-   * - `true`: Remove only cache entries matching `method`. This is O(n) operation by cache amount and may impact performance
+   * - `true`: Remove only cache entries matching `method`. This is an O(n) operation and may impact performance
    * - `false`: Remove all cache. This is O(1).
-   * the default value is `false`.
+   * The default value is `false`.
    * @throws {TypeError} - `init.maxCacheEntries` is less than 1
    */
   constructor(init: { router: Router<T>; maxCacheEntries?: number; checkDiffOnAdd?: boolean }) {
@@ -31,7 +31,7 @@ export class CacheRouter<T> implements Router<T> {
     init.maxCacheEntries ??= 100
     if (init.maxCacheEntries < 1) {
       throw new TypeError(
-        'maxCacheEntries must be more or equal to 1. If you want unlimited caching,use `Infinity`.'
+        'maxCacheEntries must be greater than or equal to 1. If you want unlimited caching, use `Infinity`.'
       )
     }
     this.#maxCacheEntries = init.maxCacheEntries
@@ -60,14 +60,14 @@ export class CacheRouter<T> implements Router<T> {
     const id: CacheId = `${method}__${path}`
     const cachedResult = this.#cache.get(id)
     if (cachedResult) {
-      // case: found cache.
+      // Cache hit
 
       // move the cache to map tail for LRU(defer its eviction)
       this.#cache.delete(id)
       this.#cache.set(id, cachedResult)
       return cachedResult
     }
-    // case: not found cache.
+    // Cache miss
     const result = this.#router.match(method, path)
     if (this.#cache.size >= this.#maxCacheEntries) {
       // Evict the least recently used entry (LRU policy)

--- a/src/router/cache-router/router.ts
+++ b/src/router/cache-router/router.ts
@@ -1,0 +1,56 @@
+import { METHOD_NAME_ALL } from '../../router'
+import type { Result, Router } from '../../router'
+
+type CacheId = `${string}__${string}` // `${method}__${path}` e.g. `GET__/hello`
+
+export class CacheRouter<T> implements Router<T> {
+  name: string = 'CacheRouter'
+  #router: Router<T>
+  #maxCacheEntries: number
+  #cache: Map<CacheId, Result<T>>
+  #checkDiffOnAdd: boolean
+  constructor(init: { router: Router<T>; maxCacheEntries?: number; checkDiffOnAdd?: boolean }) {
+    this.#router = init.router
+    init.maxCacheEntries ??= 100
+    if (init.maxCacheEntries <= 0) {
+      throw new TypeError(
+        'maxCacheEnries must be positive. if you want to cache infinity,use `Infinity`.'
+      )
+    }
+    this.#maxCacheEntries = init.maxCacheEntries
+    this.#cache = new Map()
+    init.checkDiffOnAdd ??= false
+    this.#checkDiffOnAdd = init.checkDiffOnAdd
+  }
+  add(method: string, path: string, handler: T): void {
+    if (this.#checkDiffOnAdd) {
+      if (method === METHOD_NAME_ALL) {
+        this.#cache.clear()
+      } else {
+        for (const cacheId of this.#cache.keys()) {
+          const [cacheMethod] = cacheId.split('__')
+          if (cacheMethod === method) {
+            this.#cache.delete(cacheId)
+          }
+        }
+      }
+    } else {
+      this.#cache.clear()
+    }
+    this.#router.add(method, path, handler)
+  }
+  match(method: string, path: string): Result<T> {
+    const id: CacheId = `${method}__${path}`
+    const cacheOrUndefind = this.#cache.get(id)
+    if (cacheOrUndefind) {
+      return cacheOrUndefind
+    }
+    // case: not found cache.
+    const result = this.#router.match(method, path)
+    if (this.#cache.size >= this.#maxCacheEntries) {
+      this.#cache.delete(this.#cache.keys().next().value!) // delete first(old) cache
+    }
+    this.#cache.set(id, result)
+    return result
+  }
+}

--- a/src/router/cache-router/router.ts
+++ b/src/router/cache-router/router.ts
@@ -1,20 +1,37 @@
 import { METHOD_NAME_ALL } from '../../router'
 import type { Result, Router } from '../../router'
-
-type CacheId = `${string}__${string}` // `${method}__${path}` e.g. `GET__/hello`
-
+/**
+ * Cache Id Format
+ *
+ * Structure: `${method}__${path}` e.g. `"GET__/hello"`
+ */
+type CacheId = `${string}__${string}`
+/**
+ * Cache routing result.
+ * @template T - The type of the handler
+ */
 export class CacheRouter<T> implements Router<T> {
   name: string = 'CacheRouter'
   #router: Router<T>
   #maxCacheEntries: number
   #cache: Map<CacheId, Result<T>>
   #checkDiffOnAdd: boolean
+  /**
+   * @param init
+   * @param init.router - The underlying router in CacheRouter internal.
+   * @param init.maxCacheEntries - Maximum number of cache entries. Must be positive number. the default is `100`.
+   * @param init.checkDiffOnAdd - Strategy for cache invalidation when `add()` method is called:
+   * - `true`: Remove only cache entries matching `method`. This is O(n) operation by cache amount and may impact performance
+   * - `false`: Remove all cache. This is O(1).
+   * the default value is `false`.
+   * @throws {TypeError} - `init.maxCacheEntries` is less than 1
+   */
   constructor(init: { router: Router<T>; maxCacheEntries?: number; checkDiffOnAdd?: boolean }) {
     this.#router = init.router
     init.maxCacheEntries ??= 100
-    if (init.maxCacheEntries <= 0) {
+    if (init.maxCacheEntries < 1) {
       throw new TypeError(
-        'maxCacheEnries must be positive. if you want to cache infinity,use `Infinity`.'
+        'maxCacheEntries must be more or equal to 1. If you want unlimited caching,use `Infinity`.'
       )
     }
     this.#maxCacheEntries = init.maxCacheEntries
@@ -41,14 +58,20 @@ export class CacheRouter<T> implements Router<T> {
   }
   match(method: string, path: string): Result<T> {
     const id: CacheId = `${method}__${path}`
-    const cacheOrUndefind = this.#cache.get(id)
-    if (cacheOrUndefind) {
-      return cacheOrUndefind
+    const cachedResult = this.#cache.get(id)
+    if (cachedResult) {
+      // case: found cache.
+
+      // move the cache to map tail for LRU(defer its eviction)
+      this.#cache.delete(id)
+      this.#cache.set(id, cachedResult)
+      return cachedResult
     }
     // case: not found cache.
     const result = this.#router.match(method, path)
     if (this.#cache.size >= this.#maxCacheEntries) {
-      this.#cache.delete(this.#cache.keys().next().value!) // delete first(old) cache
+      // Evict the least recently used entry (LRU policy)
+      this.#cache.delete(this.#cache.keys().next().value!)
     }
     this.#cache.set(id, result)
     return result


### PR DESCRIPTION
## Overview
Add CacheRouter for cache routing Result.
- CacheRouter take router instance  on constructer
- this is LRU

## changes
- made cache-router directory and router.ts, index.ts, router.test.ts files.

## impact
- None

## Tests
- src/router/common.case.test.ts

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
