### PR TITLE
fix(hono/vercel): make handle() return type compatible with Next.js 15

### DIFF
--- a/src/adapter/vercel/handler.test.ts
+++ b/src/adapter/vercel/handler.test.ts
@@ -13,7 +13,7 @@ describe('Adapter for Next.js', () => {
     })
     const handler = handle(app)
     const req = new Request('http://localhost/api/author/hono')
-    const res = await handler(req)
+    const res = (await handler(req)) as Response
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       path: '/api/author/:name',

--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -1,8 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Hono } from '../../hono'
 
+/**
+ * Route handler type compatible with Next.js 15 App Router.
+ * Next.js 15 expects the return type to include `void` and
+ * the parameter to accept `NextRequest | Request`.
+ */
+export type NextRouteHandler = (
+  req: Request,
+  context?: unknown
+) => Response | void | Promise<Response | void>
+
 export const handle =
-  (app: Hono<any, any, any>) =>
+  (app: Hono<any, any, any>): NextRouteHandler =>
   (req: Request): Response | Promise<Response> => {
     return app.fetch(req)
   }


### PR DESCRIPTION
Fixes #4877

## Problem

Next.js 15 introduced stricter route handler type constraints that expect route handler exports to:
1. Accept `NextRequest | Request` as the first parameter
2. Return `Response | void | never | Promise<Response | void | never>`

The current `handle()` return type `(req: Request) => Response | Promise<Response>` fails TypeScript type checking when assigned to Next.js 15 App Router route handler exports because it lacks `void` in the return type union.

## Solution

- Widen the return type to include `void`: `Response | void | Promise<Response | void>`
- Export `NextRouteHandler` type for users who need it
- The runtime behavior is unchanged (the function still returns `Response | Promise<Response>`)
- The `context` parameter is optional to support Next.js 15 route handler signatures

## Changes

- `src/adapter/vercel/handler.ts`: Updated handle return type and exported `NextRouteHandler` type