### PR TITLE
fix(jwt): support single-line PEM keys

### DIFF
--- a/src/utils/jwt/jws.ts
+++ b/src/utils/jwt/jws.ts
@@ -48,7 +48,7 @@ export async function verifying(
 }
 
 function pemToBinary(pem: string): Uint8Array<ArrayBuffer> {
-  return decodeBase64(pem.replace(/-+(BEGIN|END).*/g, '').replace(/\s/g, ''))
+  return decodeBase64(pem.replace(/-+(BEGIN|END).*?-+/g, '').replace(/\s/g, ''))
 }
 
 async function importPrivateKey(key: SignatureKey, alg: KeyImporterAlgorithm): Promise<CryptoKey> {

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -1587,7 +1587,7 @@ describe('PEM parsing', async () => {
   const base64Key = Buffer.from(exported).toString('base64')
   const privateKey = `-----BEGIN PRIVATE KEY-----\n${base64Key}\n-----END PRIVATE KEY-----`
 
-  it('should sign with a normal private PEM key', async () => {
+  it('should sign & verify with a normal private PEM key', async () => {
     const payload = { sub: '123' }
 
     const token = await JWT.sign(payload, privateKey, 'EdDSA')
@@ -1596,31 +1596,12 @@ describe('PEM parsing', async () => {
     expect(verified).toEqual(payload)
   })
 
-  it('should verify with a normal private PEM key', async () => {
-    const payload = { sub: '123' }
-
-    const token = await JWT.sign(payload, privateKey, 'EdDSA')
-    const verified = await JWT.verify(token, privateKey, 'EdDSA')
-
-    expect(verified).toEqual(payload)
-  })
-
-  it('should sign with a single-line private PEM key', async () => {
+  it('should sign & verify with a single-line private PEM key', async () => {
     const singleLinePrivateKey = privateKey.replace(/\n/g, '')
     const payload = { sub: '123' }
 
     const token = await JWT.sign(payload, singleLinePrivateKey, 'EdDSA')
     const verified = await JWT.verify(token, privateKey, 'EdDSA')
-
-    expect(verified).toEqual(payload)
-  })
-
-  it('should verify with a single-line private PEM key', async () => {
-    const singleLinePrivateKey = privateKey.replace(/\n/g, '')
-    const payload = { sub: '123' }
-
-    const token = await JWT.sign(payload, privateKey, 'EdDSA')
-    const verified = await JWT.verify(token, singleLinePrivateKey, 'EdDSA')
 
     expect(verified).toEqual(payload)
   })

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -1573,3 +1573,55 @@ describe('JWT decode token format validation', () => {
     expect(header.typ).toBe('JWT')
   })
 })
+
+describe('PEM parsing', async () => {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: 'Ed25519',
+    },
+    true,
+    ['sign', 'verify']
+  )
+
+  const exported = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey)
+  const base64Key = Buffer.from(exported).toString('base64')
+  const privateKey = `-----BEGIN PRIVATE KEY-----\n${base64Key}\n-----END PRIVATE KEY-----`
+
+  it('should sign with a normal private PEM key', async () => {
+    const payload = { sub: '123' }
+
+    const token = await JWT.sign(payload, privateKey, 'EdDSA')
+    const verified = await JWT.verify(token, privateKey, 'EdDSA')
+
+    expect(verified).toEqual(payload)
+  })
+
+  it('should verify with a normal private PEM key', async () => {
+    const payload = { sub: '123' }
+
+    const token = await JWT.sign(payload, privateKey, 'EdDSA')
+    const verified = await JWT.verify(token, privateKey, 'EdDSA')
+
+    expect(verified).toEqual(payload)
+  })
+
+  it('should sign with a single-line private PEM key', async () => {
+    const singleLinePrivateKey = privateKey.replace(/\n/g, '')
+    const payload = { sub: '123' }
+
+    const token = await JWT.sign(payload, singleLinePrivateKey, 'EdDSA')
+    const verified = await JWT.verify(token, privateKey, 'EdDSA')
+
+    expect(verified).toEqual(payload)
+  })
+
+  it('should verify with a single-line private PEM key', async () => {
+    const singleLinePrivateKey = privateKey.replace(/\n/g, '')
+    const payload = { sub: '123' }
+
+    const token = await JWT.sign(payload, privateKey, 'EdDSA')
+    const verified = await JWT.verify(token, singleLinePrivateKey, 'EdDSA')
+
+    expect(verified).toEqual(payload)
+  })
+})


### PR DESCRIPTION
The JWT PEM cleanup used a greedy boundary regex. For compact PEM values where  the header, body, and footer are stored on one line, the regex removed the entire key body, causing WebCrypto to throw `DataError: Invalid PKCS8 input`.
This updates PEM cleanup to remove only PEM boundary markers and whitespace, preserving the base64 body for both multiline and single-line PEM strings.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
