### PR TITLE
fix: throw TypeError when c.json() receives a non-serializable value

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,11 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws TypeError for undefined', () => {
+    expect(() => c.json(undefined as never)).toThrow(TypeError)
+    expect(() => c.json(undefined as never)).toThrow('Value is not JSON serializable')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## Summary

Fixes #2343

`JSON.stringify()` returns `undefined` for values like `undefined`, functions, and symbols. Previously, this `undefined` was passed to `new Response()`, which silently produced an empty string body with `200 OK` — masking bugs in user code.

```ts
// Before: returns Response with body "" and 200 OK — silent data loss
c.json(undefined)

// After: throws TypeError("Value is not JSON serializable")
c.json(undefined)
```

## Approach

Follows the same pattern as [Deno's `Response.json()` implementation](https://github.com/denoland/deno/blob/0d43a63636c97886c10c6b8ce05fdb67cd2d8b91/ext/web/00_infra.js#L382-L388), as suggested by @yusukebe in the discussion:

```ts
const body = JSON.stringify(object)
if (body === undefined) {
  throw new TypeError('Value is not JSON serializable')
}
```

This catches all non-serializable values (`undefined`, `Function`, `Symbol`) with a single `=== undefined` check after stringify — minimal performance impact, no pre-validation needed.

## Why `TypeError` and not a custom error?

- Matches the Web Platform behavior (`Response.json(undefined)` throws `TypeError` in Deno and Node.js)
- `TypeError` is the standard error type for invalid argument types in JavaScript

## Test plan

- [x] Added test: `c.json(undefined)` throws `TypeError` with message "Value is not JSON serializable"
- [x] All 58 existing context tests pass