### PR TITLE
fix(jsx): normalize SVG attributes on the <svg> root element

### DIFF
--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -34,3 +34,13 @@ describe('cloneElement', () => {
     expect(element.toString()).toBe('<hr/>')
   })
 })
+
+describe('createElement', () => {
+  it('should preserve the SVG element shape', () => {
+    const ref = { current: null }
+    const element = jsx('svg', { ref }) as unknown as JSXNode
+    expect(element.tag).toBe('svg')
+    expect(element.type).toBe('svg')
+    expect(element.ref).toBe(ref)
+  })
+})

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -335,7 +335,20 @@ export const jsxFn = (
       props,
       children
     )
-  } else if (tag === 'svg' || tag === 'head') {
+  } else if (tag === 'svg') {
+    nameSpaceContext ||= createContext('')
+    return new JSXFunctionNode(
+      nameSpaceContext,
+      {
+        value: tag,
+        // The `<svg>` element itself belongs to the SVG namespace it
+        // establishes, so its own attributes must render inside the provider.
+        // Otherwise SSR skips kebab-case normalization on e.g. `<svg strokeWidth>`.
+        children: new JSXNode(tag, props, children),
+      },
+      []
+    )
+  } else if (tag === 'head') {
     nameSpaceContext ||= createContext('')
     return new JSXNode(tag, props, [
       new JSXFunctionNode(

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -177,7 +177,7 @@ export class JSXNode implements HtmlEscaped {
     buffer[0] += `<${tag}`
 
     const normalizeKey: (key: string) => string =
-      nameSpaceContext && useContext(nameSpaceContext) === 'svg'
+      tag === 'svg' || (nameSpaceContext && useContext(nameSpaceContext) === 'svg')
         ? (key) => toSVGAttributeName(normalizeIntrinsicElementKey(key))
         : (key) => normalizeIntrinsicElementKey(key)
     for (let [key, v] of Object.entries(props)) {
@@ -335,20 +335,7 @@ export const jsxFn = (
       props,
       children
     )
-  } else if (tag === 'svg') {
-    nameSpaceContext ||= createContext('')
-    return new JSXFunctionNode(
-      nameSpaceContext,
-      {
-        value: tag,
-        // The `<svg>` element itself belongs to the SVG namespace it
-        // establishes, so its own attributes must render inside the provider.
-        // Otherwise SSR skips kebab-case normalization on e.g. `<svg strokeWidth>`.
-        children: new JSXNode(tag, props, children),
-      },
-      []
-    )
-  } else if (tag === 'head') {
+  } else if (tag === 'svg' || tag === 'head') {
     nameSpaceContext ||= createContext('')
     return new JSXNode(tag, props, [
       new JSXFunctionNode(

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -746,6 +746,13 @@ describe('SVG', () => {
     expect(template.toString()).toBe('<svg><g viewBox="0 0 10 10"></g></svg>')
   })
 
+  it('should normalize kebab-case attributes on the <svg> root element', () => {
+    const template = <svg {...{ strokeWidth: '1.5', strokeLinecap: 'round' }} viewBox='0 0 16 16' />
+    expect(template.toString()).toBe(
+      '<svg stroke-width="1.5" stroke-linecap="round" viewBox="0 0 16 16"></svg>'
+    )
+  })
+
   describe('attribute', () => {
     describe('camelCase', () => {
       test.each`


### PR DESCRIPTION
### Summary

`<svg strokeWidth="1.5">` was output as-is by SSR, but the DOM renderer
converted it to `stroke-width`. This broke icon libraries that set stroke/fill
attributes on the `<svg>` root, and it caused SSR and DOM to produce different
HTML for the same JSX (hydration mismatch).

After this PR, both SSR and DOM output `<svg stroke-width="1.5" ...>`.

### Reproduction

```tsx
app.get('/', (c) => {

  const icon = (
    <svg stroke="currentColor" strokeWidth="1.5" viewBox="0 0 32 32">
      <path d="M1 1L8 8" />
    </svg>
  )

  return c.render(<span>{icon}</span>)
})
```

###  Investigation

- Icon libraries put presentation attributes on the <svg> root so child paths can inherit them.
  -  Example from Heroicons:
https://github.com/tailwindlabs/heroicons/blob/master/optimized/24/outline/pencil-square.svg
- React also converts strokeWidth → stroke-width on the root
  -  checked with react-dom/server@18.3.1 renderToStaticMarkup
- HTML spec: when the parser sees a <svg> start tag, it inserts "a foreign element for the token, with SVG namespace". The <svg> element
itself is in the SVG namespace, not only its children:
https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody:adjust-svg-attributes

###  Root cause

The factory put only the children of <svg> inside the namespace provider:  `svg > Provider > children`

When SSR rendered the <svg>'s own attributes, useContext(nameSpaceContext) returned the default "" instead of "svg", so toSVGAttributeName was skipped:

https://github.com/honojs/hono/blob/f774f8df49e7ec7e205f15c5076a37132c515ebf/src/jsx/base.ts#L179-L182

###  Fix

Put the <svg> element itself inside the provider too: `Provider > svg > children`

---

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
