### PR TITLE
fix(method-override): handle Content-Type with charset parameter

### DIFF
--- a/src/middleware/method-override/index.test.ts
+++ b/src/middleware/method-override/index.test.ts
@@ -95,6 +95,23 @@ describe('Method Override Middleware', () => {
         expect(data.contentType).toBe('application/x-www-form-urlencoded')
       })
 
+      it('Should override POST to DELETE - with charset in Content-Type', async () => {
+        const params = new URLSearchParams()
+        params.append('message', 'Hello')
+        params.append('_method', 'DELETE')
+        const res = await app.request('/posts', {
+          body: params,
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+          },
+          method: 'POST',
+        })
+        expect(res.status).toBe(200)
+        const data = await res.json()
+        expect(data.method).toBe('DELETE')
+        expect(data.message).toBe('Hello')
+      })
+
       it('Should override POST to PATCH - not found', async () => {
         const form = new FormData()
         form.append('message', 'Hello')

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -89,7 +89,7 @@ export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandle
         }
       }
       // Content-Type is `application/x-www-form-urlencoded`
-      if (contentType === 'application/x-www-form-urlencoded') {
+      if (contentType?.startsWith('application/x-www-form-urlencoded')) {
         const params = await parseBody<Record<string, string>>(clonedRequest)
         const method = params[methodFormName]
         if (method) {


### PR DESCRIPTION
Fixes #4892

The `method-override` middleware checked Content-Type with an exact match (`=== 'application/x-www-form-urlencoded'`), but browsers and libraries like Hotwired Turbo automatically append a charset (e.g. `application/x-www-form-urlencoded;charset=UTF-8`) when sending URLSearchParams as the request body.

Changed to `startsWith` to match the pattern already used for `multipart/form-data`.