### PR TITLE
fix(context): throw TypeError when c.json() receives a non-serializable value

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,17 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws TypeError for non-serializable values', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => c.json(undefined as any)).toThrow(TypeError)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => c.json(undefined as any)).toThrow('Value is not JSON serializable')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => c.json(Symbol('s') as any)).toThrow(TypeError)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => c.json((() => {}) as any)).toThrow(TypeError)
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
Fixes #2343.

\`JSON.stringify\` returns \`undefined\` for values that can't be serialized: \`undefined\` itself, symbols, and functions. When \`c.json()\` received one of these, it passed \`undefined\` to \`new Response()\`. That call behaves differently by runtime: empty string in Bun, the literal string \`"undefined"\` in Cloudflare Workers, a thrown error in Node.js.

The fix follows the approach @yusukebe pointed to from Deno's implementation: stringify first, then throw \`TypeError\` if the result is \`undefined\`.

\`\`\`ts
const body = JSON.stringify(object)
if (body === undefined) {
  throw new TypeError('Value is not JSON serializable')
}
\`\`\`

This is a technically breaking change for apps that pass non-serializable values to \`c.json()\` and silently depend on the empty-body behavior, but those apps already have a bug.

## Checklist

- [x] Add tests
- [x] Run tests (58/58 pass)
- [x] \`bun run format:fix && bun run lint:fix\`