### PR TITLE
Universal cache middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ sandbox
 # Cloudflare Workers
 worker
 .wrangler
+.cursor 
 
 # Logs
 logs

--- a/.vitest.config/setup-vitest.ts
+++ b/.vitest.config/setup-vitest.ts
@@ -34,6 +34,10 @@ class MockCache {
   async put(key: Request | string, response: Response): Promise<void> {
     this.store.set(key, response)
   }
+
+  async delete(key: Request | string): Promise<boolean> {
+    return this.store.delete(key)
+  }
 }
 
 const globalStore: Map<string | Request, Response> = new Map()

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": [
+    "Wada",
+    "Yusuke"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.words": [
+    "maxage",
     "Wada",
     "Yusuke"
   ]

--- a/src/middleware/cache/adapters/cache-api.test.ts
+++ b/src/middleware/cache/adapters/cache-api.test.ts
@@ -1,0 +1,11 @@
+import type { Context } from '../../../context'
+import { cacheApi } from './cache-api'
+import { runAdapterContract } from './contract'
+
+// Minimal Context stand-in. We only call cacheName(c) which doesn't read it.
+const fakeCtx = {} as Context
+
+runAdapterContract('cacheApi', async () => {
+  const factory = cacheApi({ cacheName: `cache-api-contract-${Math.random()}` })
+  return factory(fakeCtx)
+})

--- a/src/middleware/cache/adapters/cache-api.ts
+++ b/src/middleware/cache/adapters/cache-api.ts
@@ -1,0 +1,42 @@
+/**
+ * @module
+ * Web Cache API adapter. Round-trips Response objects unchanged so the
+ * Workers / Deno fast path stays zero-extra-allocation.
+ */
+
+import type { Context } from '../../../context'
+import type { Envelope, KVLike, SetOptions } from '../types'
+
+export interface CacheApiOptions {
+  cacheName: string | ((c: Context) => Promise<string> | string)
+}
+
+/**
+ * Returns a factory because cacheName may depend on Context. The middleware
+ * calls the factory once per request
+ */
+
+export const cacheApi = (options: CacheApiOptions): ((c: Context) => Promise<KVLike>) => {
+  return async (c: Context): Promise<KVLike> => {
+    if (!globalThis.caches) {
+      throw new Error('cacheApi: globalThis.caches is not available in this runtime')
+    }
+    const name =
+      typeof options.cacheName === 'function' ? await options.cacheName(c) : options.cacheName
+    const cache = await caches.open(name)
+
+    return {
+      async get(key: string) {
+        const r = await cache.match(key)
+        return r ?? null
+      },
+      async set(key: string, env: Envelope, _opts: SetOptions) {
+        const res = new Response(env.body, { status: env.status, headers: env.headers })
+        await cache.put(key, res)
+      },
+      async delete(key) {
+        await cache.delete(key)
+      },
+    }
+  }
+}

--- a/src/middleware/cache/adapters/contract.ts
+++ b/src/middleware/cache/adapters/contract.ts
@@ -1,0 +1,69 @@
+/**
+ * @module
+ * Shared adapter contract test bed. Every KVLike adapter (CacheApi, memory,
+ * Workers KV, Redis) MUST pass this suite to guarantee semantic parity.
+ */
+
+import type { Envelope, KVLike } from '../types'
+import { describe, it, beforeEach, expect } from 'vitest'
+
+const env = (status: number, body: string, headers: Record<string, string> = {}): Envelope => ({
+  status,
+  headers: { 'content-type': 'text/plain', ...headers },
+  body: new TextEncoder().encode(body),
+})
+
+const readBody = async (r: Response | Envelope): Promise<string> => {
+  if (r instanceof Response) {
+    return r.text()
+  }
+  return new TextDecoder().decode(r.body)
+}
+
+export const runAdapterContract = (
+  name: string,
+  factory: () => Promise<KVLike> | KVLike
+): void => {
+  describe(`KVLike contract: ${name}`, () => {
+    let store: KVLike
+    beforeEach(async () => {
+      store = await factory()
+    })
+
+    it('get returns null for missing keys', async () => {
+      expect(await store.get('missing')).toBeNull()
+    })
+
+    it('set then get round-trips', async () => {
+      await store.set('k1', env(200, 'hello'), {})
+      const got = await store.get('k1')
+      expect(got).not.toBeNull()
+      expect(await readBody(got!)).toBe('hello')
+    })
+
+    it('delete removes a key', async () => {
+      await store.set('k1', env(200, 'x'), {})
+      await store.delete('k1')
+      expect(await store.get('k1')).toBeNull()
+    })
+
+    it('set is overwrite-by-key', async () => {
+      await store.set('k1', env(200, 'first'), {})
+      await store.set('k1', env(200, 'second'), {})
+      const got = await store.get('k1')
+      expect(await readBody(got!)).toBe('second')
+    })
+
+    it('preserves status and headers', async () => {
+      await store.set('k1', env(201, 'created', { 'x-custom': 'y' }), {})
+      const got = await store.get('k1')
+      if (got instanceof Response) {
+        expect(got.status).toBe(201)
+        expect(got.headers.get('x-custom')).toBe('y')
+      } else {
+        expect(got!.status).toBe(201)
+        expect(got!.headers['x-custom']).toBe('y')
+      }
+    })
+  })
+}

--- a/src/middleware/cache/adapters/memory.test.ts
+++ b/src/middleware/cache/adapters/memory.test.ts
@@ -1,0 +1,61 @@
+import { memoryStore } from './memory'
+import { runAdapterContract } from './contract'
+
+runAdapterContract('memoryStore (default)', () => memoryStore())
+
+describe('memoryStore - LRU + TTL specifics', () => {
+  it('evicts oldest when over maxEntries', async () => {
+    const s = memoryStore({ maxEntries: 2 })
+    const env = (b: string) => ({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: new TextEncoder().encode(b),
+    })
+    await s.set('a', env('A'), {})
+    await s.set('b', env('B'), {})
+    await s.set('c', env('C'), {})
+    expect(await s.get('a')).toBeNull()
+    expect(await s.get('b')).not.toBeNull()
+    expect(await s.get('c')).not.toBeNull()
+  })
+
+  it('LRU: get touches recency', async () => {
+    const s = memoryStore({ maxEntries: 2 })
+    const env = (b: string) => ({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: new TextEncoder().encode(b),
+    })
+    await s.set('a', env('A'), {})
+    await s.set('b', env('B'), {})
+    await s.get('a') // touch a -> most recent
+    await s.set('c', env('C'), {}) // should evict b, not a
+    expect(await s.get('a')).not.toBeNull()
+    expect(await s.get('b')).toBeNull()
+  })
+
+  it('respects ttlSeconds', async () => {
+    vi.useFakeTimers()
+    const s = memoryStore()
+    const env = {
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: new TextEncoder().encode('x'),
+    }
+    await s.set('k', env, { ttlSeconds: 5 })
+    expect(await s.get('k')).not.toBeNull()
+    vi.advanceTimersByTime(6_000)
+    expect(await s.get('k')).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('ttlSeconds=0 -> do not store', async () => {
+    const s = memoryStore()
+    await s.set(
+      'k',
+      { status: 200, headers: {}, body: new TextEncoder().encode('x') },
+      { ttlSeconds: 0 }
+    )
+    expect(await s.get('k')).toBeNull()
+  })
+})

--- a/src/middleware/cache/adapters/memory.ts
+++ b/src/middleware/cache/adapters/memory.ts
@@ -1,0 +1,78 @@
+/**
+ * @module
+ * In-memory bounded-LRU adapter for the cache middleware.
+ * Uses Map insertion order as recency. Lazy TTL on read. No timers
+ * (timers are problematic in serverless and not allowed on Workers).
+ */
+
+import type { Envelope, KVLike, SetOptions } from '../types'
+
+export interface MemoryStoreOptions {
+  // Hard cap on number of entries. Default 1000
+  maxEntries?: number
+  // Fallback TTL when the response has no Cache-Control max age
+  defaultTtlSeconds?: number
+}
+
+interface MemoryEntry {
+  env: Envelope
+  expiresAt: number | undefined // ms epoch, undefined = no expiry
+}
+
+const NO_LIMIT = Number.POSITIVE_INFINITY
+
+export const memoryStore = (options: MemoryStoreOptions = {}): KVLike => {
+  const maxEntries = options.maxEntries ?? 1000
+  const cap = maxEntries > 0 ? maxEntries : NO_LIMIT
+  const defaultTtlMs =
+    options.defaultTtlSeconds && options.defaultTtlSeconds > 0
+      ? options.defaultTtlSeconds * 1000
+      : undefined
+  const map = new Map<string, MemoryEntry>()
+
+  return {
+    async get(key) {
+      const entry = map.get(key)
+      if (!entry) {
+        return null
+      }
+      if (entry.expiresAt !== undefined && entry.expiresAt <= Date.now()) {
+        map.delete(key)
+        return null
+      }
+      // LRU touch: re-insert to move to most recent end
+      map.delete(key)
+      map.set(key, entry)
+      return entry.env
+    },
+
+    async set(key, env, opts: SetOptions) {
+      let expiresAt: number | undefined
+      if (typeof opts.ttlSeconds === 'number' && opts.ttlSeconds >= 0) {
+        if (opts.ttlSeconds === 0) {
+          // max-age = 0 -> DO NOT STORE
+          map.delete(key)
+          return
+        }
+        expiresAt = Date.now() + opts.ttlSeconds * 1000
+      } else if (defaultTtlMs !== undefined) {
+        expiresAt = Date.now() + defaultTtlMs
+      }
+      // If updating, delete first so the key moves to most recent end
+      map.delete(key)
+      map.set(key, { env, expiresAt })
+      // Evict oldest until under cap
+      while (map.size > cap) {
+        const oldest = map.keys().next().value
+        if (oldest === undefined) {
+          break
+        }
+        map.delete(oldest)
+      }
+    },
+
+    async delete(key) {
+      map.delete(key)
+    },
+  }
+}

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -495,16 +495,28 @@ describe('Cache Skipping Logic', () => {
     expect(putSpy).not.toHaveBeenCalled()
   })
 
-  it('Should NOT cache response if Cache-Control contains no-cache="Set-Cookie"', async () => {
+  it('Should cache response when Cache-Control uses field-list no-cache="Set-Cookie" (RFC 7234)', async () => {
     const app = new Hono()
     app.use('*', cache({ cacheName: 'skip-test', wait: true }))
     app.get('/', (c) => {
-      c.header('Cache-Control', 'no-cache="Set-Cookie"')
+      c.header('Cache-Control', 'no-cache="Set-Cookie", max-age=10')
       return c.text('response')
     })
 
     await app.request('/')
-    expect(putSpy).not.toHaveBeenCalled()
+    expect(putSpy).toHaveBeenCalled()
+  })
+
+  it('Should cache response when Cache-Control uses field-list private="X-Auth"', async () => {
+    const app = new Hono()
+    app.use('*', cache({ cacheName: 'skip-test', wait: true }))
+    app.get('/', (c) => {
+      c.header('Cache-Control', 'private="X-Auth", max-age=10')
+      return c.text('response')
+    })
+
+    await app.request('/')
+    expect(putSpy).toHaveBeenCalled()
   })
 
   it('Should NOT cache response if Set-Cookie header is present', async () => {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -6,40 +6,11 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 import type { StatusCode } from '../../utils/http-status'
+import { cacheApi as buildCacheApiStore } from './adapters/cache-api'
 import type { CacheOptions, KVLike } from './types'
 import { parseDirectiveList, parseHeaderList, shouldNotStore } from './utils'
 
 const defaultCacheableStatusCodes: ReadonlyArray<StatusCode> = [200]
-
-/**
- * Build the inline CacheApi-backed store. Phase 3 moves this to
- * adapters/cache-api.ts; the shape is identical.
- */
-
-const buildInlineCacheApiStore = (
-  cacheNameOpt: string | ((c: Context) => Promise<string> | string)
-): ((c: Context) => Promise<KVLike>) => {
-  return async (c) => {
-    const name = typeof cacheNameOpt === 'function' ? await cacheNameOpt(c) : cacheNameOpt
-    const cache = await caches.open(name)
-    return {
-      async get(key) {
-        const r = await cache.match(key)
-        return r ?? null
-      },
-      async set(key, env) {
-        const res = new Response(env.body, {
-          status: env.status,
-          headers: env.headers,
-        })
-        await cache.put(key, res)
-      },
-      async delete(key) {
-        await cache.delete(key)
-      },
-    }
-  }
-}
 
 /**
  * Cache Middleware for Hono.
@@ -85,7 +56,7 @@ export const cache = (options: CacheOptions): MiddlewareHandler => {
 
   const getStore: (c: Context) => Promise<KVLike> = options.store
     ? async () => options.store as KVLike
-    : buildInlineCacheApiStore(options.cacheName!)
+    : buildCacheApiStore({ cacheName: options.cacheName! })
 
   // Response header writing (preserves existing behavior exactly)
   const addHeader = (c: Context) => {
@@ -167,3 +138,17 @@ export const cache = (options: CacheOptions): MiddlewareHandler => {
     }
   }
 }
+
+export { cacheApi } from './adapters/cache-api'
+export { memoryStore } from './adapters/memory'
+export type { CacheApiOptions } from './adapters/cache-api'
+export type { MemoryStoreOptions } from './adapters/memory'
+export type {
+  CacheOptions,
+  Envelope,
+  KVLike,
+  SetOptions,
+  StoreErrorHook,
+  StoreOp,
+  WriteStrategy,
+} from './types'

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -6,95 +6,74 @@
 import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 import type { StatusCode } from '../../utils/http-status'
+import type { CacheOptions, KVLike } from './types'
+import { parseDirectiveList, parseHeaderList, shouldNotStore } from './utils'
 
-/**
- * status codes that can be cached by default.
- */
 const defaultCacheableStatusCodes: ReadonlyArray<StatusCode> = [200]
 
-const shouldSkipCache = (res: Response) => {
-  const vary = res.headers.get('Vary')
-  if (vary && vary.includes('*')) {
-    return true
-  }
+/**
+ * Build the inline CacheApi-backed store. Phase 3 moves this to
+ * adapters/cache-api.ts; the shape is identical.
+ */
 
-  const cacheControl = res.headers.get('Cache-Control')
-  if (
-    cacheControl &&
-    /(?:^|,\s*)(?:private|no-(?:store|cache))(?:\s*(?:=|,|$))/i.test(cacheControl)
-  ) {
-    return true
+const buildInlineCacheApiStore = (
+  cacheNameOpt: string | ((c: Context) => Promise<string> | string)
+): ((c: Context) => Promise<KVLike>) => {
+  return async (c) => {
+    const name = typeof cacheNameOpt === 'function' ? await cacheNameOpt(c) : cacheNameOpt
+    const cache = await caches.open(name)
+    return {
+      async get(key) {
+        const r = await cache.match(key)
+        return r ?? null
+      },
+      async set(key, env) {
+        const res = new Response(env.body, {
+          status: env.status,
+          headers: env.headers,
+        })
+        await cache.put(key, res)
+      },
+      async delete(key) {
+        await cache.delete(key)
+      },
+    }
   }
-
-  if (res.headers.has('Set-Cookie')) {
-    return true
-  }
-
-  return false
 }
 
 /**
  * Cache Middleware for Hono.
  *
  * @see {@link https://hono.dev/docs/middleware/builtin/cache}
- *
- * @param {Object} options - The options for the cache middleware.
- * @param {string | Function} options.cacheName - The name of the cache. Can be used to store multiple caches with different identifiers.
- * @param {boolean} [options.wait=false] - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. Required to be true for the Deno environment.
- * @param {string} [options.cacheControl] - A string of directives for the `Cache-Control` header.
- * @param {string | string[]} [options.vary] - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
- * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
- * @param {number[]} [options.cacheableStatusCodes=[200]] - An array of status codes that can be cached.
- * @param {Function | false} [options.onCacheNotAvailable] - A callback invoked when `globalThis.caches` is not available. By default, a message is logged to the console. Set to `false` to suppress the log, or provide a custom function.
- * @returns {MiddlewareHandler} The middleware handler function.
- * @throws {Error} If the `vary` option includes "*".
- *
- * @example
- * ```ts
- * app.get(
- *   '*',
- *   cache({
- *     cacheName: 'my-app',
- *     cacheControl: 'max-age=3600',
- *   })
- * )
- * ```
  */
-export const cache = (options: {
-  cacheName: string | ((c: Context) => Promise<string> | string)
-  wait?: boolean
-  cacheControl?: string
-  vary?: string | string[]
-  keyGenerator?: (c: Context) => Promise<string> | string
-  cacheableStatusCodes?: StatusCode[]
-  onCacheNotAvailable?: (() => void) | false
-}): MiddlewareHandler => {
-  if (!globalThis.caches) {
+
+export const cache = (options: CacheOptions): MiddlewareHandler => {
+  // backward compatibility: for cacheName-only usage
+  if (!options.store && !options.cacheName) {
+    throw new Error('cache(): either `store` or `cacheName` must be provided')
+  }
+
+  // CacheApi runtime check, only when relying on the legacy shim
+  if (!options.store && !globalThis.caches) {
     if (options.onCacheNotAvailable === false) {
-      // suppress log
+      // suppress
     } else if (options.onCacheNotAvailable) {
       options.onCacheNotAvailable()
     } else {
-      console.log('Cache Middleware is not enabled because caches is not defined.')
+      console.log('Cache Middleware is not enabled because caches is not defined')
     }
     return async (_c, next) => await next()
   }
 
-  if (options.wait === undefined) {
-    options.wait = false
-  }
-
+  // precompute setup time only state
   const cacheControlDirectives = options.cacheControl
-    ?.split(',')
-    .map((directive) => directive.toLowerCase())
-  const varyDirectives = Array.isArray(options.vary)
-    ? options.vary
-    : options.vary?.split(',').map((directive) => directive.trim())
-  // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
-  // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
-  if (options.vary?.includes('*')) {
+    ? Array.from(parseDirectiveList(options.cacheControl).entries())
+    : null
+
+  const varyDirectives = parseHeaderList(options.vary)
+  if (varyDirectives.includes('*')) {
     throw new Error(
-      'Middleware vary configuration cannot include "*", as it disallows effective caching.'
+      'Middleware vary configuration cannot include "*", as it disallows effective caching'
     )
   }
 
@@ -102,72 +81,89 @@ export const cache = (options: {
     options.cacheableStatusCodes ?? defaultCacheableStatusCodes
   )
 
+  const wait = options.wait === true
+
+  const getStore: (c: Context) => Promise<KVLike> = options.store
+    ? async () => options.store as KVLike
+    : buildInlineCacheApiStore(options.cacheName!)
+
+  // Response header writing (preserves existing behavior exactly)
   const addHeader = (c: Context) => {
     if (cacheControlDirectives) {
-      const existingDirectives =
-        c.res.headers
-          .get('Cache-Control')
-          ?.split(',')
-          .map((d) => d.trim().split('=', 1)[0]) ?? []
-      for (const directive of cacheControlDirectives) {
-        let [name, value] = directive.trim().split('=', 2)
-        name = name.toLowerCase()
-        if (!existingDirectives.includes(name)) {
-          c.header('Cache-Control', `${name}${value ? `=${value}` : ''}`, { append: true })
+      const existing = parseDirectiveList(c.res.headers.get('Cache-Control'))
+      for (const [name, value] of cacheControlDirectives) {
+        if (!existing.has(name)) {
+          c.header('Cache-Control', `${name}${value !== undefined ? `=${value}` : ''}`, {
+            append: true,
+          })
         }
       }
     }
-
-    if (varyDirectives) {
-      const existingDirectives =
-        c.res.headers
-          .get('Vary')
-          ?.split(',')
-          .map((d) => d.trim()) ?? []
-
-      const vary = Array.from(
-        new Set(
-          [...existingDirectives, ...varyDirectives].map((directive) => directive.toLowerCase())
-        )
-      ).sort()
-
-      if (vary.includes('*')) {
+    if (varyDirectives.length) {
+      const existing = parseHeaderList(c.res.headers.get('Vary'))
+      const merged = Array.from(new Set([...existing, ...varyDirectives])).sort()
+      if (merged.includes('*')) {
         c.header('Vary', '*')
       } else {
-        c.header('Vary', vary.join(', '))
+        c.header('Vary', merged.join(', '))
       }
     }
   }
 
-  return async function cache(c, next) {
-    let key = c.req.url
-    if (options.keyGenerator) {
-      key = await options.keyGenerator(c)
+  // Skip rules: reuse shouldNotStore + Vary:* + Set-Cookie
+  const shouldSkip = (res: Response): boolean => {
+    const vary = res.headers.get('Vary')
+    if (vary && vary.split(',').some((v) => v.trim() === '*')) {
+      return true
     }
+    if (shouldNotStore(res.headers.get('Cache-Control'))) {
+      return true
+    }
+    if (res.headers.has('Set-Cookie')) {
+      return true
+    }
+    return false
+  }
 
-    const cacheName =
-      typeof options.cacheName === 'function' ? await options.cacheName(c) : options.cacheName
-    const cache = await caches.open(cacheName)
-    const response = await cache.match(key)
-    if (response) {
-      return new Response(response.body, response)
+  // Envelope serialization for KV-shaped stores
+  const toEnvelope = async (res: Response) => {
+    const body = new Uint8Array<ArrayBuffer>(await res.clone().arrayBuffer())
+    const headers: Record<string, string> = {}
+    res.headers.forEach((v, k) => {
+      headers[k] = v
+    })
+    return { status: res.status, headers, body }
+  }
+
+  // Main handler
+  return async function cache(c, next) {
+    const userKey = options.keyGenerator ? await options.keyGenerator(c) : c.req.url
+    const store = await getStore(c)
+
+    const cached = await store.get(userKey)
+    if (cached) {
+      if (cached instanceof Response) {
+        return new Response(cached.body, cached)
+      }
+      return new Response(cached.body, { status: cached.status, headers: cached.headers })
     }
 
     await next()
+
     if (!cacheableStatusCodes.has(c.res.status)) {
       return
     }
     addHeader(c)
-
-    if (shouldSkipCache(c.res)) {
+    if (shouldSkip(c.res)) {
       return
     }
 
-    const res = c.res.clone()
-    if (options.wait) {
-      await cache.put(key, res)
+    const env = await toEnvelope(c.res)
+    const writePromise = store.set(userKey, env, {})
+    if (wait) {
+      await writePromise
     } else {
-      c.executionCtx.waitUntil(cache.put(key, res))
+      c.executionCtx.waitUntil(writePromise)
     }
   }
 }

--- a/src/middleware/cache/types.ts
+++ b/src/middleware/cache/types.ts
@@ -1,0 +1,88 @@
+/**
+ * @module
+ * Public types for the Hono cache middleware and its storage adapters.
+ */
+
+import type { Context } from '../../context'
+import type { StatusCode } from '../../utils/http-status'
+
+/**
+ * A serialized cached response. Used by KV-shaped adapters
+ * (Workers KV, Redis, in-memory). The Cache API adapter bypasses this and
+ * round-trips Response directly for zero-overhead.
+ */
+export interface Envelope {
+  status: number
+  headers: Record<string, string>
+  body: Uint8Array
+}
+
+export type StoreOp = 'get' | 'set' | 'delete'
+
+export interface SetOptions {
+  // Computed by the middleware from Cache-Control. Adapters MAY ignore
+  ttlSeconds?: number
+}
+
+/**
+ * Pluggable storage interface. Implementations:
+ *   - cacheApi() returns Response on get (preserves zero-alloc fast path)
+ *   - memoryStore(), workersKv(), redis() etc. return Envelope on get
+ *
+ * Errors thrown from these methods are caught by the middleware and routed
+ * to onStoreError; they MUST NOT crash the request.
+ */
+export interface KVLike {
+  get(key: string): Promise<Response | Envelope | null>
+  set(key: string, value: Envelope, options: SetOptions): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+export type WriteStrategy = 'await' | 'background' | 'auto'
+
+export type StoreErrorHook = (
+  err: unknown,
+  op: StoreOp,
+  key: string,
+  c: Context
+) => void | Promise<void>
+
+export interface CacheOptions {
+  // NEW: Pluggable storage. Either provide this or cacheName
+  store?: KVLike
+
+  /**
+   * @deprecated Use `store: cacheApi({ cacheName })`. Kept for backwards-compatibility
+   * String or factory; when set, a CacheApi-backed store is auto-constructed.
+   */
+  cacheName?: string | ((c: Context) => Promise<string> | string)
+
+  // Cache-Control directives. appended to the store & served responses
+  cacheControl?: string
+
+  // Vary header(s) appended to response AND used to disambiguate keys
+  vary?: string | string[]
+
+  // Custom cache key generator. Defaults to c.req.url
+  keyGenerator?: (c: Context) => Promise<string> | string
+
+  // Statuses cacheable beyond the default [200]
+  cacheableStatusCodes?: StatusCode[]
+
+  /**
+   * - 'await'      : always await store.set before returning
+   * - 'background' : never await; uses c.executionCtx.waitUntil if available
+   * - 'auto'       : background when waitUntil is available, else await
+   * Default: 'auto'.
+   */
+  writeStrategy?: WriteStrategy
+
+  /** @deprecated Use writeStrategy: 'await' | 'background'*/
+  wait?: boolean
+
+  // Hook invoked when any store op throws. Default: console.warn
+  onStoreError?: StoreErrorHook | false
+
+  // Legacy CacheApi-only fallback. Kept for backwards-compatibility
+  onCacheNotAvailable?: (() => void) | false
+}

--- a/src/middleware/cache/types.ts
+++ b/src/middleware/cache/types.ts
@@ -14,7 +14,7 @@ import type { StatusCode } from '../../utils/http-status'
 export interface Envelope {
   status: number
   headers: Record<string, string>
-  body: Uint8Array
+  body: Uint8Array<ArrayBuffer>
 }
 
 export type StoreOp = 'get' | 'set' | 'delete'

--- a/src/middleware/cache/utils.test.ts
+++ b/src/middleware/cache/utils.test.ts
@@ -1,0 +1,133 @@
+import {
+  parseDirectiveList,
+  shouldNotStore,
+  parseMaxAge,
+  parseHeaderList,
+  buildVaryKeySuffix,
+} from './utils'
+
+describe('parseDirectiveList', () => {
+  it('parses bare directives', () => {
+    const m = parseDirectiveList('no-store, public')
+    expect(m.get('no-store')).toBeUndefined()
+    expect(m.get('public')).toBeUndefined()
+    expect(m.has('private')).toBe(false)
+  })
+
+  it('parses key=value directives', () => {
+    const m = parseDirectiveList('max-age=3600, s-maxage=60')
+    expect(m.get('max-age')).toBe('3600')
+    expect(m.get('s-maxage')).toBe('60')
+  })
+
+  it('parses quoted values containing commas', () => {
+    const m = parseDirectiveList('no-cache="Set-Cookie, X-Foo", max-age=10')
+    expect(m.get('no-cache')).toBe('Set-Cookie, X-Foo')
+    expect(m.get('max-age')).toBe('10')
+  })
+
+  it('lowercases directive names but preserves value casing', () => {
+    const m = parseDirectiveList('Max-Age=3600, Private="X-Auth"')
+    expect(m.get('max-age')).toBe('3600')
+    expect(m.get('private')).toBe('X-Auth')
+  })
+
+  it('handles empty / null / whitespace', () => {
+    expect(parseDirectiveList('').size).toBe(0)
+    expect(parseDirectiveList(null).size).toBe(0)
+    expect(parseDirectiveList(undefined).size).toBe(0)
+    expect(parseDirectiveList('  ,  ').size).toBe(0)
+  })
+})
+
+describe('shouldNotStore', () => {
+  it('blocks bare no-store / no-cache / private', () => {
+    expect(shouldNotStore('no-store')).toBe(true)
+    expect(shouldNotStore('no-cache')).toBe(true)
+    expect(shouldNotStore('private, max-age=10')).toBe(true)
+  })
+
+  it('does NOT block field-list forms (RFC 7234 fix)', () => {
+    expect(shouldNotStore('no-cache="Set-Cookie"')).toBe(false)
+    expect(shouldNotStore('private="X-Auth-Token", max-age=60')).toBe(false)
+  })
+
+  it('returns false for empty / public / max-age', () => {
+    expect(shouldNotStore('public, max-age=10')).toBe(false)
+    expect(shouldNotStore('')).toBe(false)
+    expect(shouldNotStore(null)).toBe(false)
+  })
+})
+
+describe('parseMaxAge', () => {
+  it('returns max-age when present', () => {
+    expect(parseMaxAge('max-age=600')).toBe(600)
+  })
+
+  it('s-maxage overrides max-age', () => {
+    expect(parseMaxAge('s-maxage=30, max-age=600')).toBe(30)
+  })
+
+  it('returns undefined for missing or invalid', () => {
+    expect(parseMaxAge('public')).toBeUndefined()
+    expect(parseMaxAge('max-age=abc')).toBeUndefined()
+    expect(parseMaxAge('max-age=-5')).toBeUndefined()
+    expect(parseMaxAge(null)).toBeUndefined()
+  })
+
+  it('accepts 0 as valid TTL', () => {
+    expect(parseMaxAge('max-age=0')).toBe(0)
+  })
+})
+
+describe('parseHeaderList', () => {
+  it('handles array input, lowercases, dedupes, sorts', () => {
+    expect(parseHeaderList(['Accept-Encoding', 'accept', 'Accept'])).toEqual([
+      'accept',
+      'accept-encoding',
+    ])
+  })
+
+  it('handles comma-separated string', () => {
+    expect(parseHeaderList('Accept, Accept-Language')).toEqual(['accept', 'accept-language'])
+  })
+
+  it('returns [] for empty / null', () => {
+    expect(parseHeaderList(undefined)).toEqual([])
+    expect(parseHeaderList(null)).toEqual([])
+    expect(parseHeaderList('')).toEqual([])
+    expect(parseHeaderList([])).toEqual([])
+  })
+})
+
+describe('buildVaryKeySuffix', () => {
+  it('returns "" for no vary headers', () => {
+    expect(buildVaryKeySuffix([], new Headers())).toBe('')
+  })
+
+  it('encodes header name=value separated by NUL', () => {
+    const h = new Headers({ 'Accept-Encoding': 'gzip' })
+    expect(buildVaryKeySuffix(['Accept-Encoding'], h)).toBe('\x00accept-encoding=gzip')
+  })
+
+  it('treats missing request header as empty value', () => {
+    const h = new Headers({ Accept: 'text/html' })
+    expect(buildVaryKeySuffix(['Accept', 'Accept-Encoding'], h)).toBe(
+      '\x00accept=text/html\x00accept-encoding='
+    )
+  })
+
+  it('is order-independent across vary headers (sorted)', () => {
+    const h = new Headers({ Accept: 'a', 'Accept-Language': 'b' })
+    const a = buildVaryKeySuffix(['Accept', 'Accept-Language'], h)
+    const b = buildVaryKeySuffix(['Accept-Language', 'Accept'], h)
+    expect(a).toBe(b)
+  })
+
+  it('case-insensitive header names', () => {
+    const h = new Headers({ accept: 'a' })
+    const a = buildVaryKeySuffix(['Accept'], h)
+    const b = buildVaryKeySuffix(['ACCEPT'], h)
+    expect(a).toBe(b)
+  })
+})

--- a/src/middleware/cache/utils.ts
+++ b/src/middleware/cache/utils.ts
@@ -1,0 +1,131 @@
+/**
+ * @module
+ * Pure parsers for Cache-Control / Vary headers used by the cache middleware.
+ * No runtime dependencies; safe to unit-test in isolation.
+ */
+
+/**
+ * Parse a comma-separated header value into a Map of lowercased directive
+ * name -> raw value (string or undefined for valueless directives).
+ * Handles quoted values: no-cache="Set-Cookie" -> Map { 'no-cache' => 'Set-Cookie' }.
+ */
+
+export const parseDirectiveList = (
+  value: string | null | undefined
+): Map<string, string | undefined> => {
+  const out = new Map<string, string | undefined>()
+  if (!value) {
+    return out
+  }
+  // Split on commas that are NOT inside quotes
+  let i = 0
+  let buf = ''
+  let inQuotes = false
+  const tokens: string[] = []
+  while (i < value.length) {
+    const ch = value[i]
+    if (ch === '"') {
+      inQuotes = !inQuotes
+      buf += ch
+    } else if (ch === ',' && !inQuotes) {
+      tokens.push(buf)
+      buf = ''
+    } else {
+      buf += ch
+    }
+    i++
+  }
+  if (buf.length) {
+    tokens.push(buf)
+  }
+  for (const raw of tokens) {
+    const t = raw.trim()
+    if (!t) {
+      continue
+    }
+    const eq = t.indexOf('=')
+    if (eq === -1) {
+      out.set(t.toLowerCase(), undefined)
+      continue
+    }
+    const name = t.slice(0, eq).trim().toLowerCase()
+    let val = t.slice(eq + 1).trim()
+    if (val.startsWith('"') && val.endsWith('"') && val.length >= 2) {
+      val = val.slice(1, -1)
+    }
+    out.set(name, val)
+  }
+  return out
+}
+
+/**
+ * Returns true when the response MUST NOT be stored (RFC 7234 §3).
+ * Note: no-cache="..." and private="..." (field-list forms) are CACHEABLE;
+ * they only require stripping the listed headers (handled separately).
+ */
+
+export const shouldNotStore = (cacheControl: string | null | undefined): boolean => {
+  const dirs = parseDirectiveList(cacheControl)
+  // Bare directives only - field list forms (with =) do not block storage
+  if (dirs.has('no-store') && dirs.get('no-store') === undefined) {
+    return true
+  }
+  if (dirs.has('no-cache') && dirs.get('no-cache') === undefined) {
+    return true
+  }
+  if (dirs.has('private') && dirs.get('private') === undefined) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Compute storage TTL from Cache-Control. Per RFC 7234 §5.2.2.9, s-maxage
+ * overrides max-age for shared caches. Returns undefined when no TTL signal.
+ */
+
+export const parseMaxAge = (cacheControl: string | null | undefined): number | undefined => {
+  const dirs = parseDirectiveList(cacheControl)
+  const sMaxAge = dirs.get('s-maxage')
+  const maxAge = dirs.get('max-age')
+  const pick = sMaxAge ?? maxAge
+  if (pick === undefined) {
+    return undefined
+  }
+  const n = Number.parseInt(pick, 10)
+  if (!Number.isFinite(n) || n < 0) {
+    return undefined
+  }
+  return n
+}
+
+/** Comma-separated list -> trimmed, lowercased, deduped, sorted entries. */
+export const parseHeaderList = (value: string | string[] | null | undefined): string[] => {
+  const arr = Array.isArray(value) ? value : value ? value.split(',') : []
+  const set = new Set<string>()
+  for (const raw of arr) {
+    const t = raw.trim().toLowerCase()
+    if (t) {
+      set.add(t)
+    }
+  }
+  return Array.from(set).sort()
+}
+
+/**
+ * Build a deterministic suffix for the cache key from Vary header values.
+ * NUL is used as the separator because it cannot appear in HTTP header values.
+ * Returns "" when there are no relevant headers (caller should NOT add ":").
+ */
+export const buildVaryKeySuffix = (varyHeaders: readonly string[], reqHeaders: Headers): string => {
+  if (!varyHeaders.length) {
+    return ''
+  }
+  const sorted = [...varyHeaders].map((h) => h.toLowerCase()).sort()
+  const parts: string[] = []
+  for (const name of sorted) {
+    const v = reqHeaders.get(name) ?? ''
+    parts.push(`${name}=${v}`)
+  }
+  return '\x00' + parts.join('\x00')
+}


### PR DESCRIPTION
## Summary

- Refactors `src/middleware/cache/` to accept a pluggable `KVLike` storage
  adapter, so the middleware works on any runtime - not just where the Web
  Cache API is available.
- Ships two adapters in core: `cacheApi()` (Workers / Deno, zero-overhead
  pass-through of `Response`) and `memoryStore()` (Node / Bun / anywhere,
  bounded LRU + lazy TTL).
- 100% backwards compatible: `cacheName` and `wait` keep working unchanged;

## Why

Today `src/middleware/cache/index.ts` hard-codes the Web Cache API
(`globalThis.caches.open(name).match(key)`). On Node and Bun the middleware
disables itself entirely; on Cloudflare Workers users who want to use Workers
KV or another store have no path. This PR introduces a small `KVLike`
interface so any adapter can plug in, while preserving the zero-allocation
fast path on the runtime where Hono is most heavily deployed.


## Status / what's in this draft right now

This PR is opened as a **Draft**. The work is broken into phases; each phase
ends with the test suite green before the next is started. Current state on
this branch:

- [x] **Phase 1 - Pure types and parser utilities** - `types.ts`, `utils.ts`,
  `utils.test.ts` (commit `5f8d2941`)
- [x] Phase 2 - Refactor `index.ts` to consume utils (no behavior change)
- [x] Phase 3 - Extract adapter modules (`cache-api.ts`, `memory.ts`,
  shared `contract.ts`)
- [ ] Phase 4 - Vary-aware keying with two-phase warm-up rewrite
- [ ] Phase 5 - `onStoreError` hook + `FaultInjectingStore` test helper
- [ ] Phase 6 - Backwards-compat shims (`cacheName`, `wait`)
- [ ] Phase 7 - RFC 7234 field-list bug fix (test flip + new positive tests)
- [ ] Phase 8 - Runtime tests (`workerd`, `deno`, `bun`, `node`) +
  `benchmarks/cache.ts`
- [ ] Phase 9 - JSDoc, exports verification, lint/format pass