### PR TITLE
fix(ssg): add `atom+xml` and `rss+xml` to `defaultExtensionMap`

### DIFF
--- a/src/helper/ssg/ssg.test.tsx
+++ b/src/helper/ssg/ssg.test.tsx
@@ -541,6 +541,18 @@ describe('saveContentToFile function', () => {
       mimeType: htmlMimeType,
     }
 
+    const atomData = {
+      routePath: '/atom',
+      content: yamlContent,
+      mimeType: 'application/atom+xml',
+    }
+
+    const rssData = {
+      routePath: '/rss',
+      content: yamlContent,
+      mimeType: 'application/rss+xml',
+    }
+
     const fsMock: FileSystemModule = {
       writeFile: vi.fn(() => Promise.resolve()),
       mkdir: vi.fn(() => Promise.resolve()),
@@ -557,11 +569,15 @@ describe('saveContentToFile function', () => {
       ...defaultExtensionMap,
       ...extensionMap,
     })
+    await saveContentToFile(Promise.resolve(atomData), fsMock, './static')
+    await saveContentToFile(Promise.resolve(rssData), fsMock, './static')
 
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/yaml.yml', yamlContent)
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/yaml2.xyml', yamlContent)
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/html.htm', yamlContent) // extensionMap
     expect(fsMock.writeFile).toHaveBeenCalledWith('static/html.html', yamlContent) // default + extensionMap
+    expect(fsMock.writeFile).toHaveBeenCalledWith('static/atom.xml', yamlContent)
+    expect(fsMock.writeFile).toHaveBeenCalledWith('static/rss.xml', yamlContent)
   })
 
   it('should reject writing files outside outDir via path traversal', async () => {

--- a/src/helper/ssg/ssg.ts
+++ b/src/helper/ssg/ssg.ts
@@ -91,6 +91,8 @@ export const defaultExtensionMap: Record<string, string> = {
   'text/html': 'html',
   'text/xml': 'xml',
   'application/xml': 'xml',
+  'application/atom+xml': 'xml',
+  'application/rss+xml': 'xml',
   'application/yaml': 'yaml',
 }
 


### PR DESCRIPTION
I came across this issue while creating a custom Atom feed for my SSG website.
This adds `application/atom+xml` and `application/rss+xml` to `defaultExtensionMap`.

- `toSSG` supports a custom `extensionMap`, but `@hono/vite-ssg` does not expose it, so `application/atom+xml` routes like `atom.xml` fall back to `atom.xml.html`.
- Exposing `extensionMap` from `@hono/vite-ssg` would work around this, but Atom and RSS are common XML feed formats for SSG sites and should be handled correctly by default.
- `@hono/ssg-plugins-essential` writes its own `rss.xml`, but it should remain optional. Custom route-based Atom/RSS feeds still need correct default extension mapping.

This keeps the default mapping scoped to the two most common feed media types, without trying to cover every XML-based media type.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
