### PR TITLE
fix(lambda-edge): classify ZIP-based document subtypes as binary

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -17,7 +17,29 @@ describe('isContentTypeBinary', () => {
     expect(isContentTypeBinary('text/javascript')).toBe(false)
     expect(isContentTypeBinary('application/json')).toBe(false)
     expect(isContentTypeBinary('application/ld+json')).toBe(false)
-    expect(isContentTypeBinary('application/json')).toBe(false)
+    expect(isContentTypeBinary('application/atom+xml')).toBe(false)
+  })
+
+  it('Should classify ZIP-based document subtypes as binary', () => {
+    // OOXML formats (.docx/.xlsx/.pptx) are ZIP archives; the previous regex
+    // matched the substring "xml" inside "openxmlformats" and incorrectly
+    // returned non-binary, causing CloudFront to receive corrupted bodies.
+    expect(
+      isContentTypeBinary('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+    ).toBe(true)
+    expect(
+      isContentTypeBinary('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    ).toBe(true)
+    expect(
+      isContentTypeBinary(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+      )
+    ).toBe(true)
+    expect(isContentTypeBinary('application/epub+zip')).toBe(true)
+    expect(isContentTypeBinary('application/vnd.oasis.opendocument.text')).toBe(true)
+    expect(isContentTypeBinary('application/msword')).toBe(true)
+    expect(isContentTypeBinary('application/octet-stream')).toBe(true)
+    expect(isContentTypeBinary('application/pdf')).toBe(true)
   })
 })
 

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -190,7 +190,7 @@ export const createBody = (
 }
 
 export const isContentTypeBinary = (contentType: string): boolean => {
-  return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
+  return !/^text\/(?:plain|html|css|javascript|csv)|(?:\/|\+)(?:json|xml)\s*(?:;|$)/.test(
     contentType
   )
 }


### PR DESCRIPTION
## Problem

`isContentTypeBinary` in `src/adapter/lambda-edge/handler.ts` used the regex `application/(.*json|.*xml).*`, which matches any subtype that contains the substring `json` or `xml` anywhere — including ZIP archives whose subtypes happen to embed those letters:

| Content-Type | Actual format | Currently classified |
| --- | --- | --- |
| `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (.docx) | ZIP | non-binary ❌ |
| `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (.xlsx) | ZIP | non-binary ❌ |
| `application/vnd.openxmlformats-officedocument.presentationml.presentation` (.pptx) | ZIP | non-binary ❌ |
| `application/epub+zip` (.epub) | ZIP | non-binary ❌ |
| `application/vnd.oasis.opendocument.text` (.odt) | ZIP | non-binary ❌ |

When `isContentTypeBinary` returns `false`, the response body is returned to CloudFront un-base64-encoded, so any user serving these document types from a Lambda@Edge handler delivers a corrupted file.

## Fix

Replace the regex with the boundary-aware pattern already used by the aws-lambda adapter (`src/adapter/aws-lambda/handler.ts:675`):

```
^text\/(?:plain|html|css|javascript|csv)|(?:\/|\+)(?:json|xml)\s*(?:;|$)
```

This accepts:
- `text/(plain|html|css|javascript|csv)` at the start
- `/json`, `/xml`, `+json`, `+xml` followed by `;` or end-of-string

So `application/atom+xml`, `application/ld+json`, and `image/svg+xml` continue to be treated as text, while OOXML/EPUB/ODT subtypes are correctly classified as binary.

## Test

Added a regression test covering the OOXML triple, `application/epub+zip`, and `application/vnd.oasis.opendocument.text` alongside the existing assertions. The new test fails on `main` and passes with the regex fix.

- [x] Add tests
- [x] Run tests (`bun run test` — passes)
- [x] `bun run format:fix && bun run lint:fix`
- [x] Add TSDoc/JSDoc — no API surface change