### PR TITLE
fix(lambda-edge): preserve multi-value request headers

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -122,6 +122,45 @@ describe('handle', () => {
     })
   })
 
+  it('Should preserve multi-value request headers from CloudFront', async () => {
+    // CloudFront delivers headers as { name: [{ key, value }, ...] }, allowing
+    // multiple values per header name. The previous implementation used
+    // headers.set() inside the inner loop, so only the last value reached
+    // the Hono Request — silently dropping repeated Accept, Cookie, etc.
+    const app = new Hono()
+    app.get('/test-path', (c) => {
+      return c.json({
+        accept: c.req.raw.headers.get('accept'),
+        // Headers.get() collapses repeated values with ", " per the WHATWG spec,
+        // so a passthrough of two Accept values appears here as "a/b, c/d".
+      })
+    })
+    const handler = handle(app)
+
+    const event: CloudFrontEdgeEvent = {
+      Records: [
+        {
+          cf: {
+            ...cloudFrontEdgeEvent.Records[0].cf,
+            request: {
+              ...cloudFrontEdgeEvent.Records[0].cf.request,
+              headers: {
+                host: [{ key: 'Host', value: 'hono.dev' }],
+                accept: [
+                  { key: 'Accept', value: 'text/html' },
+                  { key: 'Accept', value: 'application/json' },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    const res = await handler(event)
+    expect(res.body).toBe(JSON.stringify({ accept: 'text/html, application/json' }))
+  })
+
   it('Should support multiple cookies', async () => {
     const app = new Hono()
     app.get('/test-path', (c) => {

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -159,7 +159,7 @@ const createRequest = (event: CloudFrontEdgeEvent): Request => {
 
   const headers = new Headers()
   Object.entries(event.Records[0].cf.request.headers).forEach(([k, v]) => {
-    v.forEach((header) => headers.set(k, header.value))
+    v.forEach((header) => headers.append(k, header.value))
   })
 
   const requestBody = event.Records[0].cf.request.body


### PR DESCRIPTION
## Problem

CloudFront delivers request headers in the multi-value form documented at https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-viewer-request-headers:

\`\`\`js
headers: {
  accept: [
    { key: 'Accept', value: 'text/html' },
    { key: 'Accept', value: 'application/json' },
  ],
  // ...
}
\`\`\`

The inner loop in \`createRequest\` (\`src/adapter/lambda-edge/handler.ts:161-163\`) used \`headers.set(k, header.value)\`, so each iteration overwrote the previous value. Only the last value reached the Hono \`Request\` — every earlier value was silently dropped.

This affects any header that arrives with multiple values: \`Accept\`, \`Accept-Language\`, \`Cache-Control\`, \`Forwarded\`, \`If-None-Match\`, multi-cookie ingress, etc.

## Fix

Use \`headers.append\` so every value is preserved. Reading the header back via \`Request.headers.get(...)\` produces the WHATWG-spec joined form (\`a, b\`), matching what an origin would see when reading the raw CloudFront request.

## Test

Added a regression test that sends two \`Accept\` values and verifies both survive into the Hono handler. Fails on \`main\` (returns \`application/json\` only); passes with the fix (returns \`text/html, application/json\`).

- [x] Add tests
- [x] Run tests (\`bun run test\` — passes)
- [x] \`bun run format:fix && bun run lint:fix\`
- [x] Add TSDoc/JSDoc — no API surface change