### PR TITLE
fix(aws-lambda): combine ALB multi-value headers per RFC 9110

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -365,6 +365,58 @@ describe('EventProcessor.createRequest', () => {
       expect(decodeURIComponent(xCity)).toBe('炎')
     })
   })
+
+  describe('ALBProcessor multi-value header handling', () => {
+    const baseALBEvent = {
+      httpMethod: 'GET',
+      path: '/my/path',
+      headers: undefined,
+      body: null,
+      isBase64Encoded: false,
+      queryStringParameters: {},
+      requestContext: {
+        elb: {
+          targetGroupArn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/g/abc',
+        },
+      },
+    }
+
+    it('Should join non-cookie multi-value headers with ", " (RFC 9110 §5.3)', () => {
+      const event = {
+        ...baseALBEvent,
+        multiValueHeaders: {
+          host: ['example.com'],
+          accept: ['text/html', 'application/json'],
+          'cache-control': ['no-cache', 'no-store'],
+        },
+      }
+
+      const processor = getProcessor(event)
+      const request = processor.createRequest(event)
+
+      // The previous implementation joined every multi-value header with "; ",
+      // which is only correct for Cookie. Real clients sending two Accept
+      // values would be interpreted as a single non-conformant value
+      // "text/html; application/json" instead of two distinct media ranges.
+      expect(request.headers.get('accept')).toBe('text/html, application/json')
+      expect(request.headers.get('cache-control')).toBe('no-cache, no-store')
+    })
+
+    it('Should still join Cookie multi-value with "; " (RFC 6265 §5.4)', () => {
+      const event = {
+        ...baseALBEvent,
+        multiValueHeaders: {
+          host: ['example.com'],
+          cookie: ['session=abc123', 'user=john'],
+        },
+      }
+
+      const processor = getProcessor(event)
+      const request = processor.createRequest(event)
+
+      expect(request.headers.get('cookie')).toBe('session=abc123; user=john')
+    })
+  })
 })
 
 describe('handle', () => {

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -511,9 +511,15 @@ export class ALBProcessor extends EventProcessor<ALBProxyEvent> {
     if (event.multiValueHeaders) {
       for (const [key, values] of Object.entries(event.multiValueHeaders)) {
         if (values && Array.isArray(values)) {
-          // https://www.rfc-editor.org/rfc/rfc9110.html#name-common-rules-for-defining-f
-          const sanitizedValue = sanitizeHeaderValue(values.join('; '))
-          headers.set(key, sanitizedValue)
+          if (key.toLowerCase() === 'cookie') {
+            // RFC 6265 §5.4: cookies in a Cookie request header are separated by '; '.
+            headers.set(key, sanitizeHeaderValue(values.join('; ')))
+          } else {
+            // RFC 9110 §5.3: multi-valued field lines combine with ', '.
+            for (const value of values) {
+              headers.append(key, sanitizeHeaderValue(value))
+            }
+          }
         }
       }
     } else {


### PR DESCRIPTION
## Problem

\`ALBProcessor.getHeaders\` (\`src/adapter/aws-lambda/handler.ts:511-518\`) joined every multi-valued header with \`'; '\`:

\`\`\`ts
if (event.multiValueHeaders) {
  for (const [key, values] of Object.entries(event.multiValueHeaders)) {
    if (values && Array.isArray(values)) {
      const sanitizedValue = sanitizeHeaderValue(values.join('; '))
      headers.set(key, sanitizedValue)
    }
  }
}
\`\`\`

[RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#name-field-order) requires \`, \` as the separator when combining field-line values; \`; \` is only correct for the \`Cookie\` request header (RFC 6265 §5.4) and a handful of structured headers using parameters.

A real client sending:

\`\`\`
Accept: text/html
Accept: application/json
\`\`\`

is delivered to ALB as \`multiValueHeaders: { accept: ['text/html', 'application/json'] }\` and reaches the Hono handler as the single value \`text/html; application/json\`. Content-negotiation libraries (and Hono's own \`c.req.header('accept')\` consumers) interpret that as one media range with a parameter, not two distinct ranges. The same flaw affects \`Cache-Control\`, \`Forwarded\`, \`If-None-Match\`, \`Accept-Language\`, \`Vary\`, \`Link\`, etc.

## Fix

Append each value individually so the WHATWG \`Headers\` combine them with \`, \` automatically. Special-case \`cookie\` (case-insensitive) to keep the \`; \` join, matching the existing test expectation and RFC 6265.

\`\`\`ts
if (key.toLowerCase() === 'cookie') {
  headers.set(key, sanitizeHeaderValue(values.join('; ')))
} else {
  for (const value of values) {
    headers.append(key, sanitizeHeaderValue(value))
  }
}
\`\`\`

## Test

Added two tests under \`EventProcessor.createRequest > ALBProcessor multi-value header handling\`:

1. **Non-cookie multi-value** — sends two \`Accept\` values plus two \`Cache-Control\` values via \`multiValueHeaders\`, asserts \`request.headers.get('accept')\` returns \`'text/html, application/json'\` and \`cache-control\` returns \`'no-cache, no-store'\`. Fails on \`main\` (returns \`'text/html; application/json'\`); passes with the fix.

2. **Cookie still uses \`; \`** — confirms the special case continues to behave correctly per RFC 6265.

- [x] Add tests
- [x] Run tests (\`bun run test\` — 31/31 passes)
- [x] \`bun run format:fix && bun run lint:fix\`
- [x] Add TSDoc/JSDoc — no API surface change