### PR TITLE
fix(aws-lambda): build URL query string from Lattice queryStringParameters

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -306,8 +306,9 @@ describe('EventProcessor.createRequest', () => {
   it('Should return valid Request object from version 2.0 Lattice event', async () => {
     const event: LatticeProxyEventV2 = {
       version: '2.0',
-      // query string parameters from the path take precedence over the explicit notation below
-      path: '/my/path?parameter1=value1&parameter1=value2&parameter2=value',
+      // Per AWS docs, Lattice delivers `path` and `queryStringParameters` as
+      // separate fields — `path` does not contain a query string.
+      path: '/my/path',
       method: 'POST',
       headers: {
         cookie: ['cookie1=value1; cookie2=value2'],
@@ -414,5 +415,80 @@ describe('handle', () => {
     const result = await handler(event)
     expect(result.statusCode).toBe(400)
     expect(result.body).toBe('Invalid request')
+  })
+})
+
+describe('LatticeV2Processor query string handling', () => {
+  const baseLatticeEvent: LatticeProxyEventV2 = {
+    version: '2.0',
+    path: '/items',
+    method: 'GET',
+    headers: { host: ['my-service.us-east-1.on.aws'] },
+    queryStringParameters: {},
+    body: null,
+    isBase64Encoded: false,
+    requestContext: {
+      serviceNetworkArn: 'arn:aws:vpc-lattice:us-east-1:123456789012:servicenetwork/sn-abc',
+      serviceArn: 'arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-abc',
+      targetGroupArn: 'arn:aws:vpc-lattice:us-east-1:123456789012:targetgroup/tg-abc',
+      region: 'us-east-1',
+      timeEpoch: '1583348638390123',
+      identity: {},
+    },
+  }
+
+  it('Should expose Lattice queryStringParameters via c.req.query()', async () => {
+    const app = new Hono()
+    app.get('/items', (c) =>
+      c.json({
+        q: c.req.query('q'),
+        page: c.req.query('page'),
+      })
+    )
+    const handler = handle(app)
+
+    const event: LatticeProxyEventV2 = {
+      ...baseLatticeEvent,
+      queryStringParameters: {
+        q: ['hello'],
+        page: ['2'],
+      },
+    }
+
+    const result = await handler(event)
+    expect(result.statusCode).toBe(200)
+    expect(JSON.parse(result.body)).toEqual({ q: 'hello', page: '2' })
+  })
+
+  it('Should preserve repeated values in Lattice queryStringParameters', async () => {
+    const app = new Hono()
+    app.get('/items', (c) => c.json({ tags: c.req.queries('tag') }))
+    const handler = handle(app)
+
+    const event: LatticeProxyEventV2 = {
+      ...baseLatticeEvent,
+      queryStringParameters: {
+        tag: ['red', 'blue'],
+      },
+    }
+
+    const result = await handler(event)
+    expect(JSON.parse(result.body)).toEqual({ tags: ['red', 'blue'] })
+  })
+
+  it('Should percent-encode special characters in Lattice query parameters', async () => {
+    const app = new Hono()
+    app.get('/items', (c) => c.json({ name: c.req.query('name') }))
+    const handler = handle(app)
+
+    const event: LatticeProxyEventV2 = {
+      ...baseLatticeEvent,
+      queryStringParameters: {
+        name: ['John Doe'],
+      },
+    }
+
+    const result = await handler(event)
+    expect(JSON.parse(result.body)).toEqual({ name: 'John Doe' })
   })
 })

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -594,8 +594,15 @@ export class LatticeV2Processor extends EventProcessor<LatticeProxyEventV2> {
     return event.method
   }
 
-  protected getQueryString(): string {
-    return ''
+  protected getQueryString(event: LatticeProxyEventV2): string {
+    // VPC Lattice delivers query parameters as { name: [value, ...] } with
+    // already-decoded values. Re-encode them so the resulting URL is well-formed.
+    return Object.entries(event.queryStringParameters || {})
+      .filter(([, values]) => values && values.length > 0)
+      .map(([key, values]) =>
+        values!.map((value) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join('&')
+      )
+      .join('&')
   }
 
   protected getHeaders(event: LatticeProxyEventV2): Headers {


### PR DESCRIPTION
## Problem

\`LatticeV2Processor.getQueryString()\` (\`src/adapter/aws-lambda/handler.ts:597-599\`) returned the empty string unconditionally:

\`\`\`ts
protected getQueryString(): string {
  return ''
}
\`\`\`

But \`LatticeProxyEventV2.queryStringParameters\` is typed \`Record<string, string[] | undefined>\` (handler.ts:34) and the [AWS Lattice event-shape docs](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html) describe it as the canonical source for query parameters. The result: every Hono route running on a Lattice target saw \`c.req.query(...)\` and \`c.req.queries(...)\` return \`undefined\` / empty even when the client sent query parameters.

## Fix

Build the query string from \`event.queryStringParameters\`, mirroring how V1 handles \`multiValueQueryStringParameters\` — encode keys and values via \`encodeURIComponent\`, support repeated values per key, skip entries without values:

\`\`\`ts
protected getQueryString(event: LatticeProxyEventV2): string {
  return Object.entries(event.queryStringParameters || {})
    .filter(([, values]) => values && values.length > 0)
    .map(([key, values]) =>
      values!
        .map((value) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(value)}\`)
        .join('&')
    )
    .join('&')
}
\`\`\`

## Test

Three new behavioral tests in \`LatticeV2Processor query string handling\`:

1. **Single value** — verifies \`c.req.query('q')\` returns the Lattice-supplied value.
2. **Repeated values** — sends \`tag=red&tag=blue\`, asserts \`c.req.queries('tag')\` returns \`['red', 'blue']\`.
3. **Special characters** — sends \`John Doe\` and asserts the percent-encoded URL round-trips back to the original via \`c.req.query('name')\`.

All three fail on \`main\` (return \`undefined\`/\`[]\` because \`getQueryString\` returns \`''\`); all pass with the fix.

The existing \"valid Request object from version 2.0 Lattice event\" test embedded the query string inside \`path\` (\`/my/path?...\`) as a workaround for the empty-string return. Per the AWS docs \`path\` and \`queryStringParameters\` are disjoint fields, so that test is now updated to use a plain path and the URL is assembled from \`queryStringParameters\` instead — verifying the same end-to-end shape via the canonical field.

- [x] Add tests
- [x] Run tests (\`bun run test\` — 32/32 passes)
- [x] \`bun run format:fix && bun run lint:fix\`
- [x] Add TSDoc/JSDoc — no API surface change