### PR TITLE
fix(cors): make origin optional in CORSOptions

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -418,4 +418,22 @@ describe('CORS by Middleware', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('null')
     expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
   })
+
+  it('Options without origin fall back to wildcard default', async () => {
+    const subApp = new Hono()
+    subApp.use('/api/*', cors({ allowMethods: ['GET', 'POST'] }))
+    subApp.get('/api/abc', (c) => c.json({ ok: true }))
+
+    const res = await subApp.request('http://localhost/api/abc')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+
+    const preflight = await subApp.request(
+      new Request('http://localhost/api/abc', { method: 'OPTIONS' })
+    )
+    expect(preflight.headers.get('Access-Control-Allow-Methods')?.split(/\s*,\s*/)).toEqual([
+      'GET',
+      'POST',
+    ])
+  })
 })

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -7,7 +7,7 @@ import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
 type CORSOptions = {
-  origin:
+  origin?:
     | string
     | string[]
     | ((

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -61,16 +61,13 @@ type CORSOptions = {
  * ```
  */
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
-  const defaults: CORSOptions = {
+  const opts = {
     origin: '*',
     allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
     allowHeaders: [],
     exposeHeaders: [],
-  }
-  const opts = {
-    ...defaults,
     ...options,
-  }
+  } satisfies CORSOptions
 
   const findAllowOrigin = ((optsOrigin) => {
     if (typeof optsOrigin === 'string') {


### PR DESCRIPTION
The CORS middleware sets `origin: '*'` when not provided, and the JSDoc already documents `[options.origin='*']`. But `CORSOptions.origin` was required, so this failed to typecheck even though the runtime works:

```ts
cors({ allowMethods: ['GET', 'POST'] })
//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
// Property 'origin' is missing in type ...
```

Make `origin` optional so the type matches the documented runtime default. No runtime change.

Test verifies that omitting `origin` still produces `Access-Control-Allow-Origin: *` and that an explicit `allowMethods` is honored.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code (existing JSDoc already says `[options.origin='*']`)

Closes #4904