### PR TITLE
fix(types): propagate middleware response types to app.on overloads

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -3498,6 +3498,282 @@ describe('RPC supports Middleware responses', () => {
       type verify = Expect<Equal<Expected, Actual>>
     })
   })
+
+  describe('Merge responses from app.on handlers, single method', () => {
+    test('merge responses from 1 middleware', async () => {
+      const middleware = createMiddleware(async (c) => c.json({ '400': true }, 400))
+
+      const app = new Hono().on('GET', '/test', middleware, (c) => c.json({ '200': true }, 200))
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+    })
+
+    test('merge responses from 2 middlewares', async () => {
+      const middleware1 = createMiddleware(async (c) => c.json({ '400': true }, 400))
+      const middleware2 = createMiddleware(async (c) => c.json({ '401': true }, 401))
+
+      const app = new Hono().on('GET', '/test', middleware1, middleware2, (c) =>
+        c.json({ '200': true }, 200)
+      )
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+      if (res.status === 401) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+      }
+    })
+
+    test('merge responses from 5 middlewares', async () => {
+      const middleware1 = createMiddleware(async (c) => c.json({ '400': true }, 400))
+      const middleware2 = createMiddleware(async (c) => c.json({ '401': true }, 401))
+      const middleware3 = createMiddleware(async (c) => c.json({ '403': true }, 403))
+      const middleware4 = createMiddleware(async (c) => c.json({ '404': true }, 404))
+      const middleware5 = createMiddleware(async (c) => c.json({ '300': true }, 300))
+
+      const app = new Hono().on(
+        'GET',
+        '/test',
+        middleware1,
+        middleware2,
+        middleware3,
+        middleware4,
+        middleware5,
+        (c) => c.json({ '200': true }, 200)
+      )
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+      if (res.status === 401) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+      }
+      if (res.status === 403) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>()
+      }
+      if (res.status === 404) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 404: true }>()
+      }
+      if (res.status === 300) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
+      }
+    })
+
+    test('merge responses from 9 middlewares', async () => {
+      const middleware1 = createMiddleware(async (c) => c.json({ '400': true }, 400))
+      const middleware2 = createMiddleware(async (c) => c.json({ '401': true }, 401))
+      const middleware3 = createMiddleware(async (c) => c.json({ '403': true }, 403))
+      const middleware4 = createMiddleware(async (c) => c.json({ '404': true }, 404))
+      const middleware5 = createMiddleware(async (c) => c.json({ '300': true }, 300))
+      const middleware6 = createMiddleware(async (c) => c.json({ '201': true }, 201))
+      const middleware7 = createMiddleware(async (c) => c.json({ '202': true }, 202))
+      const middleware8 = createMiddleware(async (c) => c.json({ '203': true }, 203))
+      const middleware9 = createMiddleware(async (c) => c.json({ '301': true }, 301))
+
+      const app = new Hono().on(
+        'GET',
+        '/test',
+        middleware1,
+        middleware2,
+        middleware3,
+        middleware4,
+        middleware5,
+        middleware6,
+        middleware7,
+        middleware8,
+        middleware9,
+        (c) => c.json({ '200': true }, 200)
+      )
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+      if (res.status === 401) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+      }
+      if (res.status === 403) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>()
+      }
+      if (res.status === 404) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 404: true }>()
+      }
+      if (res.status === 300) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
+      }
+      if (res.status === 201) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
+      }
+      if (res.status === 202) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
+      }
+      if (res.status === 203) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>()
+      }
+      if (res.status === 301) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 301: true }>()
+      }
+    })
+  })
+
+  describe('Merge responses from app.on handlers, method[]', () => {
+    test('merge responses from 1 middleware', async () => {
+      const middleware = createMiddleware(async (c) => c.json({ '400': true }, 400))
+
+      const app = new Hono().on(['GET'], '/test', middleware, (c) => c.json({ '200': true }, 200))
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+    })
+
+    test('merge responses from 2 middlewares', async () => {
+      const middleware1 = createMiddleware(async (c) => c.json({ '400': true }, 400))
+      const middleware2 = createMiddleware(async (c) => c.json({ '401': true }, 401))
+
+      const app = new Hono().on(['GET'], '/test', middleware1, middleware2, (c) =>
+        c.json({ '200': true }, 200)
+      )
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+      if (res.status === 401) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+      }
+    })
+
+    test('merge responses from 5 middlewares', async () => {
+      const middleware1 = createMiddleware(async (c) => c.json({ '400': true }, 400))
+      const middleware2 = createMiddleware(async (c) => c.json({ '401': true }, 401))
+      const middleware3 = createMiddleware(async (c) => c.json({ '403': true }, 403))
+      const middleware4 = createMiddleware(async (c) => c.json({ '404': true }, 404))
+      const middleware5 = createMiddleware(async (c) => c.json({ '300': true }, 300))
+
+      const app = new Hono().on(
+        ['GET'],
+        '/test',
+        middleware1,
+        middleware2,
+        middleware3,
+        middleware4,
+        middleware5,
+        (c) => c.json({ '200': true }, 200)
+      )
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+      if (res.status === 401) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+      }
+      if (res.status === 403) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>()
+      }
+      if (res.status === 404) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 404: true }>()
+      }
+      if (res.status === 300) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
+      }
+    })
+
+    test('merge responses from 9 middlewares', async () => {
+      const middleware1 = createMiddleware(async (c) => c.json({ '400': true }, 400))
+      const middleware2 = createMiddleware(async (c) => c.json({ '401': true }, 401))
+      const middleware3 = createMiddleware(async (c) => c.json({ '403': true }, 403))
+      const middleware4 = createMiddleware(async (c) => c.json({ '404': true }, 404))
+      const middleware5 = createMiddleware(async (c) => c.json({ '300': true }, 300))
+      const middleware6 = createMiddleware(async (c) => c.json({ '201': true }, 201))
+      const middleware7 = createMiddleware(async (c) => c.json({ '202': true }, 202))
+      const middleware8 = createMiddleware(async (c) => c.json({ '203': true }, 203))
+      const middleware9 = createMiddleware(async (c) => c.json({ '301': true }, 301))
+
+      const app = new Hono().on(
+        ['GET'],
+        '/test',
+        middleware1,
+        middleware2,
+        middleware3,
+        middleware4,
+        middleware5,
+        middleware6,
+        middleware7,
+        middleware8,
+        middleware9,
+        (c) => c.json({ '200': true }, 200)
+      )
+      const client = hc<typeof app>('http://localhost', { fetch: app.request })
+      const res = await client.test.$get()
+
+      if (res.status === 200) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 200: true }>()
+      }
+      if (res.status === 400) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 400: true }>()
+      }
+      if (res.status === 401) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 401: true }>()
+      }
+      if (res.status === 403) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 403: true }>()
+      }
+      if (res.status === 404) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 404: true }>()
+      }
+      if (res.status === 300) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 300: true }>()
+      }
+      if (res.status === 201) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 201: true }>()
+      }
+      if (res.status === 202) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 202: true }>()
+      }
+      if (res.status === 203) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 203: true }>()
+      }
+      if (res.status === 301) {
+        expectTypeOf(await res.json()).toEqualTypeOf<{ 301: true }>()
+      }
+    })
+  })
 })
 
 describe('Handlers returning Promise<void>', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1488,13 +1488,16 @@ export interface OnHandlerInterface<
     I2 extends Input = I,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
   >(
     method: M,
     path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+    ...handlers: [H<E2, MergedPath, I> & M1, H<E3, MergedPath, I2, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponse<R>>,
+    S &
+      ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponse<R> | MergeMiddlewareResponse<M1>>,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1511,13 +1514,22 @@ export interface OnHandlerInterface<
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
   >(
     method: M,
     path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+    ...handlers: [H<E2, MergedPath, I> & M1, H<E3, MergedPath, I2> & M2, H<E4, MergedPath, I3, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I3,
+        MergeTypedResponse<R> | MergeMiddlewareResponse<M1> | MergeMiddlewareResponse<M2>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1536,18 +1548,31 @@ export interface OnHandlerInterface<
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
       H<E5, MergedPath, I4, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I4,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1568,19 +1593,34 @@ export interface OnHandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
       H<E6, MergedPath, I5, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I5,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1603,20 +1643,37 @@ export interface OnHandlerInterface<
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
       H<E7, MergedPath, I6, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I6,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1641,21 +1698,40 @@ export interface OnHandlerInterface<
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
       H<E8, MergedPath, I7, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I7,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1682,22 +1758,43 @@ export interface OnHandlerInterface<
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
+    M7 extends H<E8, MergedPath, I7> = H<E8, MergedPath, I7>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
       H<E9, MergedPath, I8, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I8,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+        | MergeMiddlewareResponse<M7>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1726,23 +1823,46 @@ export interface OnHandlerInterface<
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
+    M7 extends H<E8, MergedPath, I7> = H<E8, MergedPath, I7>,
+    M8 extends H<E9, MergedPath, I8> = H<E9, MergedPath, I8>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
+      H<E9, MergedPath, I8> & M8,
       H<E10, MergedPath, I9, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I9,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+        | MergeMiddlewareResponse<M7>
+        | MergeMiddlewareResponse<M8>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1773,24 +1893,49 @@ export interface OnHandlerInterface<
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
     E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
+    M7 extends H<E8, MergedPath, I7> = H<E8, MergedPath, I7>,
+    M8 extends H<E9, MergedPath, I8> = H<E9, MergedPath, I8>,
+    M9 extends H<E10, MergedPath, I9> = H<E10, MergedPath, I9>,
   >(
     method: M,
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
-      H<E10, MergedPath, I9>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
+      H<E9, MergedPath, I8> & M8,
+      H<E10, MergedPath, I9> & M9,
       H<E11, MergedPath, I10, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I10,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+        | MergeMiddlewareResponse<M7>
+        | MergeMiddlewareResponse<M8>
+        | MergeMiddlewareResponse<M9>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1841,13 +1986,16 @@ export interface OnHandlerInterface<
     I2 extends Input = I,
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
   >(
     methods: M[],
     path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2, R>]
+    ...handlers: [H<E2, MergedPath, I> & M1, H<E3, MergedPath, I2, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponse<R>>,
+    S &
+      ToSchema<M, MergePath<BasePath, P>, I2, MergeTypedResponse<R> | MergeMiddlewareResponse<M1>>,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1864,13 +2012,22 @@ export interface OnHandlerInterface<
     E2 extends Env = E,
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
   >(
     methods: M[],
     path: P,
-    ...handlers: [H<E2, MergedPath, I>, H<E3, MergedPath, I2>, H<E4, MergedPath, I3, R>]
+    ...handlers: [H<E2, MergedPath, I> & M1, H<E3, MergedPath, I2> & M2, H<E4, MergedPath, I3, R>]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I3, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I3,
+        MergeTypedResponse<R> | MergeMiddlewareResponse<M1> | MergeMiddlewareResponse<M2>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1889,18 +2046,31 @@ export interface OnHandlerInterface<
     E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
       H<E5, MergedPath, I4, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I4, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I4,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1921,19 +2091,34 @@ export interface OnHandlerInterface<
     E4 extends Env = IntersectNonAnyTypes<[E, E2, E3]>,
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
       H<E6, MergedPath, I5, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I5, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I5,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1956,20 +2141,37 @@ export interface OnHandlerInterface<
     E5 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4]>,
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
       H<E7, MergedPath, I6, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I6, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I6,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -1994,21 +2196,40 @@ export interface OnHandlerInterface<
     E6 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5]>,
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
       H<E8, MergedPath, I7, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I7, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I7,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -2035,22 +2256,43 @@ export interface OnHandlerInterface<
     E7 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6]>,
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
+    M7 extends H<E8, MergedPath, I7> = H<E8, MergedPath, I7>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
       H<E9, MergedPath, I8, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I8, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I8,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+        | MergeMiddlewareResponse<M7>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -2079,23 +2321,46 @@ export interface OnHandlerInterface<
     E8 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7]>,
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
+    M7 extends H<E8, MergedPath, I7> = H<E8, MergedPath, I7>,
+    M8 extends H<E9, MergedPath, I8> = H<E9, MergedPath, I8>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
+      H<E9, MergedPath, I8> & M8,
       H<E10, MergedPath, I9, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I9, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I9,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+        | MergeMiddlewareResponse<M7>
+        | MergeMiddlewareResponse<M8>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >
@@ -2126,24 +2391,49 @@ export interface OnHandlerInterface<
     E9 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8]>,
     E10 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9]>,
     E11 extends Env = IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10]>,
+    // Middleware
+    M1 extends H<E2, MergedPath, I> = H<E2, MergedPath, I>,
+    M2 extends H<E3, MergedPath, I2> = H<E3, MergedPath, I2>,
+    M3 extends H<E4, MergedPath, I3> = H<E4, MergedPath, I3>,
+    M4 extends H<E5, MergedPath, I4> = H<E5, MergedPath, I4>,
+    M5 extends H<E6, MergedPath, I5> = H<E6, MergedPath, I5>,
+    M6 extends H<E7, MergedPath, I6> = H<E7, MergedPath, I6>,
+    M7 extends H<E8, MergedPath, I7> = H<E8, MergedPath, I7>,
+    M8 extends H<E9, MergedPath, I8> = H<E9, MergedPath, I8>,
+    M9 extends H<E10, MergedPath, I9> = H<E10, MergedPath, I9>,
   >(
     methods: M[],
     path: P,
     ...handlers: [
-      H<E2, MergedPath, I>,
-      H<E3, MergedPath, I2>,
-      H<E4, MergedPath, I3>,
-      H<E5, MergedPath, I4>,
-      H<E6, MergedPath, I5>,
-      H<E7, MergedPath, I6>,
-      H<E8, MergedPath, I7>,
-      H<E9, MergedPath, I8>,
-      H<E10, MergedPath, I9>,
+      H<E2, MergedPath, I> & M1,
+      H<E3, MergedPath, I2> & M2,
+      H<E4, MergedPath, I3> & M3,
+      H<E5, MergedPath, I4> & M4,
+      H<E6, MergedPath, I5> & M5,
+      H<E7, MergedPath, I6> & M6,
+      H<E8, MergedPath, I7> & M7,
+      H<E9, MergedPath, I8> & M8,
+      H<E10, MergedPath, I9> & M9,
       H<E11, MergedPath, I10, R>,
     ]
   ): HonoBase<
     IntersectNonAnyTypes<[E, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11]>,
-    S & ToSchema<M, MergePath<BasePath, P>, I10, MergeTypedResponse<R>>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, P>,
+        I10,
+        | MergeTypedResponse<R>
+        | MergeMiddlewareResponse<M1>
+        | MergeMiddlewareResponse<M2>
+        | MergeMiddlewareResponse<M3>
+        | MergeMiddlewareResponse<M4>
+        | MergeMiddlewareResponse<M5>
+        | MergeMiddlewareResponse<M6>
+        | MergeMiddlewareResponse<M7>
+        | MergeMiddlewareResponse<M8>
+        | MergeMiddlewareResponse<M9>
+      >,
     BasePath,
     MergePath<BasePath, P>
   >


### PR DESCRIPTION
## Summary

PR #4393 introduced `MergeMiddlewareResponse<M_k>` to capture middleware responses (e.g. `c.json({
error }, 401)` returned from a preceding handler) into the inferred RPC schema. The change was applied
to `HandlerInterface` (`app.get/post/...`) but **`OnHandlerInterface` was not updated**, so the same
route declared with `app.on(method, path, ...)` or `app.on(method[], path, ...)` silently dropped
middleware responses from the schema.

This is the same shape of asymmetry that #3852 and #4865 already fixed for narrower cases (`R` discard)
 — `OnHandlerInterface` keeps drifting away from `HandlerInterface` whenever the handler-side overloads
 gain new type parameters.

## Affected overloads

18 overloads in total:

- `app.on(method, path, handler x2..x10)` — 9 overloads
- `app.on(method[], path, handler x2..x10)` — 9 overloads

The single-handler variants (`x1`) and the rest-array fallback overloads are unaffected because they
have no preceding middleware position to capture.

## Reproduction

```ts
import { Hono } from 'hono'
import { hc } from 'hono/client'
import { createMiddleware } from 'hono/factory'

const auth = createMiddleware(async (c, next) => {
  if (!authorized) return c.json({ error: 'unauthorized' }, 401)
  await next()
})

// Works correctly (already covered by #4393)
const a = new Hono().get('/secret', auth, (c) => c.json({ ok: true }, 200))

// Bug: `output` collapses to `{ ok: true }` only, dropping the 401 response
const b = new Hono().on('GET', '/secret', auth, (c) => c.json({ ok: true }, 200))

const client = hc<typeof b>('/')
const res = await client.secret.$get()
if (res.status === 401) {
  // Before this PR: TypeScript narrows to `never`, so this branch is unreachable
  // After this PR:  `res.json()` resolves to `{ error: string }`
  const err = await res.json()
}
```

Switching `app.on('GET', ...)` ↔ `app.get(...)` flips the inference even though the routes are
semantically identical. The same gap exists for the `method[]` form.

## Fix

For each of the 18 affected overloads, add `M1..M(n-1)` middleware type parameters mirroring
`HandlerInterface`, intersect them into the handler tuple positions before the final response handler,
and union `MergeMiddlewareResponse<M_k>` into the schema's response type.

The same shape is applied for handler counts 3..10 (with `M1..M(n-1)`) and for the `methods: M[]`
overloads.

## Test plan

Added regression tests under the existing `describe('RPC supports Middleware responses', ...)` block in
 `src/types.test.ts`, mirroring the corresponding `app.get` tests. Coverage:

- `app.on('GET', '/test', ...)` with 1, 2, 5, and 9 middlewares before the response handler
- `app.on(['GET'], '/test', ...)` with 1, 2, 5, and 9 middlewares before the response handler

Each test asserts that every middleware status code (`400`, `401`, `403`, ...) is reachable in the
inferred RPC client and that `res.json()` is narrowed correctly per status. These tests fail on `main`
(status union collapses to just `200`, so every middleware-status branch becomes `never`) and pass
after this fix.

- [x] `bun run format:fix && bun run lint:fix`
- [x] `bun run test` (full type check + vitest, 3400 passed)
- [x] Added regression tests for both single-method and `method[]` variants

## Related history

- **#4393** (2025-10-15) — feat(types): passing middleware types
  Introduced `MergeMiddlewareResponse<M_k>` for `HandlerInterface` only.
- **#3852** (2025-01-25) — fix(types): missing response type on `OnHandlerInterface`
  Earlier `R` discard fix for `OnHandlerInterface` (different from this one).
- **#4865** (2026-04-08) — fix(types): infer response type from last handler in app.on 9-/10-handler
overloads
  Closer cousin: same kind of `OnHandlerInterface` drift, narrower scope.

This PR completes the alignment so that `OnHandlerInterface` mirrors `HandlerInterface` for both `R`
and `M_k` propagation. May also alleviate the open feedback in #3746.