### PR TITLE
fix(cors): make  option optional in CORSOptions type

### DIFF
--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -7,7 +7,7 @@ import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 
 type CORSOptions = {
-  origin:
+  origin?:
     | string
     | string[]
     | ((


### PR DESCRIPTION
## Summary

- Fixes #4904: The `origin` field in `CORSOptions` was required, but `cors()` already handles the case when no options are provided by defaulting to `'*'`
- The documentation also shows `origin` as optional with a default value
- This change makes `origin` optional in the type definition to match the runtime behavior and documentation

## Changes

Changed `CORSOptions.origin` from required to optional by adding `?`:

```typescript
// Before
type CORSOptions = {
  origin: string | string[] | ((...) => ...)
  // ...
}

// After
type CORSOptions = {
  origin?: string | string[] | ((...) => ...)
  // ...
}
```

## Test plan

- [x] All 19 existing CORS middleware tests pass
- [x] `cors()` without arguments still works (already tested in existing tests)
- [x] `cors({ allowMethods: [...] })` without `origin` should now be valid TypeScript