### PR TITLE
fix(aws-lambda): add missing lambda authorizer context type

### DIFF
--- a/src/adapter/aws-lambda/types.ts
+++ b/src/adapter/aws-lambda/types.ts
@@ -114,6 +114,7 @@ interface Authorizer {
     userArn: string
     userId: string
   }
+  lambda?: Record<string, unknown>
 }
 
 export interface ApiGatewayRequestContextV2 {


### PR DESCRIPTION
## Summary

- Add `lambda?: Record<string, unknown>` to the `Authorizer` interface in `src/adapter/aws-lambda/types.ts`
- This allows TypeScript users to access `requestContext.authorizer.lambda` when using custom Lambda authorizers with AWS HTTP API Gateway v2

## Background

The `Authorizer` interface used by `ApiGatewayRequestContextV2` only had the `iam` field for IAM-based authorization. Custom Lambda authorizers return their context under `requestContext.authorizer.lambda`, but this field was missing from the type definition, causing TypeScript errors.

Fixes #3281

## Test plan

- [x] Existing tests continue to pass
- [x] Type change is backward compatible (adds an optional field)