### PR TITLE
fix(utils/mime): extend charset to xml-based mime types

### DIFF
--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -16,6 +16,9 @@ describe('mime', () => {
     expect(getMimeType('goodmorninghellogif')).toBeUndefined()
     expect(getMimeType('indexjs.abcd')).toBeUndefined()
     expect(getMimeType('IMAGE.JPG')).toBe('image/jpeg')
+    expect(getMimeType('logo.svg')).toBe('image/svg+xml; charset=utf-8')
+    expect(getMimeType('page.xhtml')).toBe('application/xhtml+xml; charset=utf-8')
+    expect(getMimeType('feed.xml')).toBe('application/xml; charset=utf-8')
   })
 
   it('getMimeType with custom mime', () => {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -13,7 +13,8 @@ export const getMimeType = (
     return
   }
   let mimeType = mimes[match[1].toLowerCase()]
-  if (mimeType && mimeType.startsWith('text')) {
+  // text/: RFC 2046; +xml suffix: RFC 6839; application/xml: RFC 7303 §8.5
+  if (mimeType && (mimeType.startsWith('text/') || mimeType.endsWith('+xml') || mimeType === 'application/xml')) {
     mimeType += '; charset=utf-8'
   }
   return mimeType

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -14,7 +14,10 @@ export const getMimeType = (
   }
   let mimeType = mimes[match[1].toLowerCase()]
   // text/: RFC 2046; +xml suffix: RFC 6839; application/xml: RFC 7303 §8.5
-  if (mimeType && (mimeType.startsWith('text/') || mimeType.endsWith('+xml') || mimeType === 'application/xml')) {
+  if (
+    mimeType &&
+    (mimeType.startsWith('text/') || mimeType.endsWith('+xml') || mimeType === 'application/xml')
+  ) {
     mimeType += '; charset=utf-8'
   }
   return mimeType


### PR DESCRIPTION
The getMimeType() function was using startsWith('text') to decide when to append ; charset=utf-8 to a MIME type, that heuristic misses types like image/svg+xml, application/xhtml+xml and application/xml, which are all textual formats where charset matters for correct decoding.

This replaces the prefix check with a condition that covers three cases:
  text/ prefix, per RFC 2046
  +xml structured syntax suffix, per RFC 6839
  application/xml explicitly, per RFC 7303 §8.5

The change is a single-line diff in mime.ts, with three new assertions in
mime.test.ts covering the previously untested types.

Fixes #4510