### PR TITLE
fix(mime): specify charset parameter per MIME type instead of mechanical detection

### DIFF
--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -18,6 +18,16 @@ describe('mime', () => {
     expect(getMimeType('IMAGE.JPG')).toBe('image/jpeg')
   })
 
+  it('getMimeType returns charset parameter for text and XML-based formats', () => {
+    expect(getMimeType('icon.svg')).toBe('image/svg+xml; charset=utf-8')
+    expect(getMimeType('page.xhtml')).toBe('application/xhtml+xml; charset=utf-8')
+    expect(getMimeType('feed.xml')).toBe('application/xml; charset=utf-8')
+    expect(getMimeType('events.ics')).toBe('text/calendar; charset=utf-8')
+    expect(getMimeType('script.mjs')).toBe('text/javascript; charset=utf-8')
+    expect(getMimeType('style.css')).toBe('text/css; charset=utf-8')
+    expect(getMimeType('data.csv')).toBe('text/csv; charset=utf-8')
+  })
+
   it('getMimeType with custom mime', () => {
     expect(getMimeType('morning-routine.m3u8', mime)).toBe('application/vnd.apple.mpegurl')
     expect(getMimeType('morning-routine1.ts', mime)).toBe('video/mp2t')
@@ -39,5 +49,16 @@ describe('mime', () => {
     expect(getExtension('image/png')).toBe('png')
     expect(getExtension('application/zip')).toBe('zip')
     expect(getExtension('non/existent')).toBeUndefined()
+  })
+
+  it('getExtension matches MIME types regardless of charset/parameters', () => {
+    expect(getExtension('text/html; charset=utf-8')).toBe('htm')
+    expect(getExtension('text/plain; charset=utf-8')).toBe('txt')
+    expect(getExtension('image/svg+xml; charset=utf-8')).toBe('svg')
+    expect(getExtension('application/xml; charset=utf-8')).toBe('xml')
+    expect(getExtension('application/xhtml+xml; charset=utf-8')).toBe('xhtml')
+    expect(getExtension('text/css; charset=utf-16')).toBe('css')
+    expect(getExtension('image/svg+xml')).toBe('svg')
+    expect(getExtension('application/xml')).toBe('xml')
   })
 })

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -12,16 +12,14 @@ export const getMimeType = (
   if (!match) {
     return
   }
-  let mimeType = mimes[match[1].toLowerCase()]
-  if (mimeType && mimeType.startsWith('text')) {
-    mimeType += '; charset=utf-8'
-  }
-  return mimeType
+  return mimes[match[1].toLowerCase()]
 }
 
 export const getExtension = (mimeType: string): string | undefined => {
+  const baseType = mimeType.split(';', 1)[0].trim()
   for (const ext in baseMimes) {
-    if (baseMimes[ext] === mimeType) {
+    const stored = baseMimes[ext]
+    if (stored === mimeType || stored.split(';', 1)[0].trim() === baseType) {
       return ext
     }
   }
@@ -41,25 +39,25 @@ const _baseMimes = {
   av1: 'video/av1',
   bin: 'application/octet-stream',
   bmp: 'image/bmp',
-  css: 'text/css',
-  csv: 'text/csv',
+  css: 'text/css; charset=utf-8',
+  csv: 'text/csv; charset=utf-8',
   eot: 'application/vnd.ms-fontobject',
   epub: 'application/epub+zip',
   gif: 'image/gif',
   gz: 'application/gzip',
-  htm: 'text/html',
-  html: 'text/html',
+  htm: 'text/html; charset=utf-8',
+  html: 'text/html; charset=utf-8',
   ico: 'image/x-icon',
-  ics: 'text/calendar',
+  ics: 'text/calendar; charset=utf-8',
   jpeg: 'image/jpeg',
   jpg: 'image/jpeg',
-  js: 'text/javascript',
+  js: 'text/javascript; charset=utf-8',
   json: 'application/json',
   jsonld: 'application/ld+json',
   map: 'application/json',
   mid: 'audio/x-midi',
   midi: 'audio/x-midi',
-  mjs: 'text/javascript',
+  mjs: 'text/javascript; charset=utf-8',
   mp3: 'audio/mpeg',
   mp4: 'video/mp4',
   mpeg: 'video/mpeg',
@@ -71,12 +69,12 @@ const _baseMimes = {
   pdf: 'application/pdf',
   png: 'image/png',
   rtf: 'application/rtf',
-  svg: 'image/svg+xml',
+  svg: 'image/svg+xml; charset=utf-8',
   tif: 'image/tiff',
   tiff: 'image/tiff',
   ts: 'video/mp2t',
   ttf: 'font/ttf',
-  txt: 'text/plain',
+  txt: 'text/plain; charset=utf-8',
   wasm: 'application/wasm',
   webm: 'video/webm',
   weba: 'audio/webm',
@@ -84,8 +82,8 @@ const _baseMimes = {
   webp: 'image/webp',
   woff: 'font/woff',
   woff2: 'font/woff2',
-  xhtml: 'application/xhtml+xml',
-  xml: 'application/xml',
+  xhtml: 'application/xhtml+xml; charset=utf-8',
+  xml: 'application/xml; charset=utf-8',
   zip: 'application/zip',
   '3gp': 'video/3gpp',
   '3g2': 'video/3gpp2',


### PR DESCRIPTION
Closes #4510

## Summary

Move the `; charset=utf-8` suffix from a runtime check in `getMimeType` into the `_baseMimes` data table itself, and extend it to `image/svg+xml`, `application/xhtml+xml`, and `application/xml` as the issue requested.

## Why

Per #4510:
1. Other entries besides `text/*` benefit from a `charset` parameter (XML-based formats).
2. Per [IANA media types](https://www.iana.org/assignments/media-types/media-types.xhtml), `charset` is not universal across all `text/*` formats — keeping it as data lets us be precise per entry rather than running a generic `startsWith("text")` check.

The output of `getMimeType()` for previously-charseted text types is unchanged (still `text/<sub>; charset=utf-8`), so this is backward-compatible at the call site.

## Changes

`src/utils/mime.ts`
- `_baseMimes`: append `; charset=utf-8` to `css`, `csv`, `htm`, `html`, `ics`, `js`, `mjs`, `txt`, `svg`, `xhtml`, `xml`.
- `getMimeType`: drop the `if (mimeType.startsWith("text"))` block; data now carries the charset.
- `getExtension`: compare the base type (split on `;`) so callers can pass either `"text/html"` or `"text/html; charset=utf-8"` and still get the right extension. No behavior change for callers passing the raw type.

`src/utils/mime.test.ts`
- 2 new `it` blocks: charset values for the new XML-based formats and the additional text types; `getExtension` round-trip with and without parameters.

## Test plan

- [x] `npx vitest run src/utils/mime.test.ts` — 5/5 pass (3 existing + 2 new)
- [x] `npx vitest run src/middleware/compress src/middleware/jsx-renderer src/middleware/serve-static` — 56/56 pass (covers the consumers I could trace: `getMimeType` is used by `serve-static`, `BaseMime` is referenced by `context.ts`)
- [x] `npx tsc --noEmit` clean

The pre-existing `stream`/`streamSSE` `onAbort` and a few other failures on `main` are unrelated to this change (verified via `git stash` + re-run).