### PR TITLE
feat(bearer-auth): make bearerAuth generic for typed context in verifyToken

### DIFF
--- a/src/middleware/bearer-auth/index.test.ts
+++ b/src/middleware/bearer-auth/index.test.ts
@@ -1,4 +1,6 @@
+import { expectTypeOf } from 'vitest'
 import { Hono } from '../../hono'
+import type { Context, MiddlewareHandler } from '../../index'
 import { bearerAuth } from '.'
 
 describe('Bearer Auth by Middleware', () => {
@@ -980,5 +982,28 @@ describe('Bearer Auth with prefix containing regex metacharacters', () => {
     const res = await app.request(req)
     expect(res.status).toBe(400)
     expect(handlerExecuted).toBeFalsy()
+  })
+})
+
+describe('Bearer Auth types', () => {
+  interface TestEnv {
+    Bindings: { API_KEY: string }
+  }
+
+  it('returns MiddlewareHandler<E> with explicit generic', () => {
+    const middleware = bearerAuth<TestEnv>({
+      verifyToken: (token, ctx) => {
+        expectTypeOf(ctx.env.API_KEY).toEqualTypeOf<string>()
+        return token === ctx.env.API_KEY
+      },
+    })
+    expectTypeOf(middleware).toEqualTypeOf<MiddlewareHandler<TestEnv>>()
+  })
+
+  it('infers E from ctx annotation', () => {
+    const middleware = bearerAuth({
+      verifyToken: (token, ctx: Context<TestEnv>) => token === ctx.env.API_KEY,
+    })
+    expectTypeOf(middleware).toEqualTypeOf<MiddlewareHandler<TestEnv>>()
   })
 })

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -5,7 +5,7 @@
 
 import type { Context } from '../../context'
 import { HTTPException } from '../../http-exception'
-import type { MiddlewareHandler } from '../../types'
+import type { Env, MiddlewareHandler } from '../../types'
 import { timingSafeEqual } from '../../utils/buffer'
 import type { ContentfulStatusCode } from '../../utils/http-status'
 
@@ -19,7 +19,7 @@ type CustomizedErrorResponseOptions = {
   message?: string | object | MessageFunction
 }
 
-type BearerAuthOptions =
+type BearerAuthOptions<E extends Env = Env> =
   | {
       token: string | string[]
       realm?: string
@@ -46,7 +46,7 @@ type BearerAuthOptions =
       realm?: string
       prefix?: string
       headerName?: string
-      verifyToken: (token: string, c: Context) => boolean | Promise<boolean>
+      verifyToken: (token: string, c: Context<E>) => boolean | Promise<boolean>
       hashFunction?: Function
       /**
        * @deprecated Use noAuthenticationHeader.message instead
@@ -100,7 +100,9 @@ type BearerAuthOptions =
  * })
  * ```
  */
-export const bearerAuth = (options: BearerAuthOptions): MiddlewareHandler => {
+export const bearerAuth = <E extends Env = Env>(
+  options: BearerAuthOptions<E>
+): MiddlewareHandler<E> => {
   if (!('token' in options || 'verifyToken' in options)) {
     throw new Error('bearer auth middleware requires options for "token"')
   }

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -70,6 +70,7 @@ type BearerAuthOptions<E extends Env = Env> =
  *
  * @see {@link https://hono.dev/docs/middleware/builtin/bearer-auth}
  *
+ * @template E - The environment type.
  * @param {BearerAuthOptions} options - The options for the bearer authentication middleware.
  * @param {string | string[]} [options.token] - The string or array of strings to validate the incoming bearer token against.
  * @param {Function} [options.verifyToken] - The function to verify the token.
@@ -83,7 +84,7 @@ type BearerAuthOptions<E extends Env = Env> =
  * @param {string | object | MessageFunction} [options.invalidAuthenticationHeader.wwwAuthenticateHeader="Bearer error=\"invalid_request\""] - The response header value for the WWW-Authenticate header when authentication header is invalid.
  * @param {string | object | MessageFunction} [options.invalidToken.message="Unauthorized"] - The invalid token message.
  * @param {string | object | MessageFunction} [options.invalidToken.wwwAuthenticateHeader="Bearer error=\"invalid_token\""] - The response header value for the WWW-Authenticate header when token is invalid.
- * @returns {MiddlewareHandler} The middleware handler function.
+ * @returns {MiddlewareHandler<E>} The middleware handler function.
  * @throws {Error} If neither "token" nor "verifyToken" options are provided.
  * @throws {HTTPException} If authentication fails, with 401 status code for missing or invalid token, or 400 status code for invalid request.
  *


### PR DESCRIPTION
Adds a generic type parameter `E extends Env` to `bearerAuth` so that the `verifyToken` callback receives a typed `Context<E>` instead of a plain `Context`.

This allows callers to access strongly-typed bindings (e.g. `c.env.AUTH_URL`) without casting:

Before:
```ts
type AppEnv = { Bindings: { AUTH_URL: string } }

const app = new Hono<AppEnv>()

app.use('/api/*', bearerAuth({
  verifyToken: (token, c) => verifyWithAuthService(c.env?.AUTH_URL, token),
  //                                                      ^^^^^^^^^
  // Property 'AUTH_URL' does not exist on type 'object'. ts(2339)
}))
```


After:
```ts
type AppEnv = { Bindings: { AUTH_URL: string } }

const app = new Hono<AppEnv>()

app.use('/api/*', bearerAuth<AppEnv>({
  verifyToken: (token, c) => verifyWithAuthService(c.env.AUTH_URL, token),
}))
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
