### PR TITLE
feat(cache): key cache entries by configured vary headers

### DIFF
--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -379,6 +379,24 @@ describe('Cache Middleware', () => {
 })
 
 describe('Cache Skipping Logic', () => {
+  const stubStoreBackedCache = () => {
+    const store = new Map<string | Request, Response>()
+    const mockCache = {
+      match: vi.fn((key: string | Request) => Promise.resolve(store.get(key)?.clone())),
+      put: vi.fn((key: string | Request, response: Response) => {
+        store.set(key, response.clone())
+        return Promise.resolve()
+      }),
+      keys: vi.fn(() => Promise.resolve(Array.from(store.keys()))),
+    }
+
+    vi.stubGlobal('caches', {
+      open: vi.fn().mockResolvedValue(mockCache),
+    })
+
+    return { mockCache }
+  }
+
   let putSpy: ReturnType<typeof vi.fn>
   let matchSpy: ReturnType<typeof vi.fn>
 
@@ -477,7 +495,8 @@ describe('Cache Skipping Logic', () => {
     }
   )
 
-  it('Should set configured Vary header but not cache the response', async () => {
+  it('Should set configured Vary header and cache by the configured request header value', async () => {
+    const { mockCache } = stubStoreBackedCache()
     const app = new Hono()
     let count = 0
     app.use('*', cache({ cacheName: 'skip-test', wait: true, vary: 'Accept' }))
@@ -490,7 +509,170 @@ describe('Cache Skipping Logic', () => {
     await app.request('/')
     const res = await app.request('/')
     expect(res.headers.get('Vary')).toBe('accept')
-    expect(res.headers.get('X-Count')).toBe('2')
+    expect(res.headers.get('X-Count')).toBe('1')
+    expect(mockCache.put).toHaveBeenCalledOnce()
+  })
+
+  it('Should store separate variants for different Accept-Language request values', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let count = 0
+    app.use('*', cache({ cacheName: 'vary-language-test', wait: true, vary: 'Accept-Language' }))
+    app.get('/', (c) => {
+      count++
+      c.header('X-Count', `${count}`)
+      return c.text(c.req.header('Accept-Language') ?? 'missing')
+    })
+
+    await app.request('/', {
+      headers: {
+        'Accept-Language': 'en',
+      },
+    })
+    const en = await app.request('/', {
+      headers: {
+        'Accept-Language': 'en',
+      },
+    })
+    await app.request('/', {
+      headers: {
+        'Accept-Language': 'ja',
+      },
+    })
+    const ja = await app.request('/', {
+      headers: {
+        'Accept-Language': 'ja',
+      },
+    })
+
+    expect(await en.text()).toBe('en')
+    expect(en.headers.get('X-Count')).toBe('1')
+    expect(await ja.text()).toBe('ja')
+    expect(ja.headers.get('X-Count')).toBe('2')
+    expect(mockCache.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('Should keep missing and present Vary request header values in separate variants', async () => {
+    stubStoreBackedCache()
+    const app = new Hono()
+    let count = 0
+    app.use('*', cache({ cacheName: 'vary-missing-test', wait: true, vary: 'Accept-Language' }))
+    app.get('/', (c) => {
+      count++
+      c.header('X-Count', `${count}`)
+      return c.text(c.req.header('Accept-Language') ?? 'missing')
+    })
+
+    await app.request('/')
+    await app.request('/', {
+      headers: {
+        'Accept-Language': 'en',
+      },
+    })
+    const missing = await app.request('/')
+    const present = await app.request('/', {
+      headers: {
+        'Accept-Language': 'en',
+      },
+    })
+
+    expect(await missing.text()).toBe('missing')
+    expect(missing.headers.get('X-Count')).toBe('1')
+    expect(await present.text()).toBe('en')
+    expect(present.headers.get('X-Count')).toBe('2')
+  })
+
+  it('Should store separate variants using multiple configured request headers', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let count = 0
+    app.use(
+      '*',
+      cache({ cacheName: 'vary-multiple-test', wait: true, vary: ['Accept', 'Accept-Encoding'] })
+    )
+    app.get('/', (c) => {
+      count++
+      c.header('X-Count', `${count}`)
+      return c.text(`${c.req.header('Accept')}:${c.req.header('Accept-Encoding')}`)
+    })
+
+    await app.request('/', {
+      headers: {
+        Accept: 'text/plain',
+        'Accept-Encoding': 'gzip',
+      },
+    })
+    const same = await app.request('/', {
+      headers: {
+        Accept: 'text/plain',
+        'Accept-Encoding': 'gzip',
+      },
+    })
+    await app.request('/', {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Encoding': 'gzip',
+      },
+    })
+    const differentAccept = await app.request('/', {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Encoding': 'gzip',
+      },
+    })
+    await app.request('/', {
+      headers: {
+        Accept: 'text/plain',
+        'Accept-Encoding': 'br',
+      },
+    })
+    const differentEncoding = await app.request('/', {
+      headers: {
+        Accept: 'text/plain',
+        'Accept-Encoding': 'br',
+      },
+    })
+
+    expect(same.headers.get('X-Count')).toBe('1')
+    expect(differentAccept.headers.get('X-Count')).toBe('2')
+    expect(differentEncoding.headers.get('X-Count')).toBe('3')
+    expect(mockCache.put).toHaveBeenCalledTimes(3)
+  })
+
+  it('Should store when the handler Vary header is covered by configured Vary headers', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    app.use('*', cache({ cacheName: 'vary-covered-test', wait: true, vary: 'Accept-Language' }))
+    app.get('/', (c) => {
+      c.header('Vary', 'Accept-Language')
+      return c.text('response')
+    })
+
+    await app.request('/')
+    expect(mockCache.put).toHaveBeenCalledOnce()
+  })
+
+  it('Should not store when the handler adds Vary headers not covered by configured Vary headers', async () => {
+    const app = new Hono()
+    app.use('*', cache({ cacheName: 'skip-test', wait: true, vary: 'Accept-Language' }))
+    app.get('/', (c) => {
+      c.header('Vary', 'Accept-Language, Cookie')
+      return c.text('response')
+    })
+
+    await app.request('/')
+    expect(putSpy).not.toHaveBeenCalled()
+  })
+
+  it('Should not store Vary: * responses even when Vary headers are configured', async () => {
+    const app = new Hono()
+    app.use('*', cache({ cacheName: 'skip-test', wait: true, vary: 'Accept-Language' }))
+    app.get('/', (c) => {
+      c.header('Vary', '*')
+      return c.text('response')
+    })
+
+    await app.request('/')
     expect(putSpy).not.toHaveBeenCalled()
   })
 

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -12,25 +12,27 @@ import type { StatusCode } from '../../utils/http-status'
  */
 const defaultCacheableStatusCodes: ReadonlyArray<StatusCode> = [200]
 
-const shouldSkipCache = (res: Response) => {
-  if (res.headers.has('Vary')) {
-    return true
-  }
+const shouldSkipCacheControl = (cacheControl: string | null): boolean =>
+  !!cacheControl && /(?:^|,\s*)(?:private|no-(?:store|cache))(?:\s*(?:=|,|$))/i.test(cacheControl)
 
-  const cacheControl = res.headers.get('Cache-Control')
-  if (
-    cacheControl &&
-    /(?:^|,\s*)(?:private|no-(?:store|cache))(?:\s*(?:=|,|$))/i.test(cacheControl)
-  ) {
-    return true
+const parseVaryDirectives = (vary: string | string[] | null | undefined): string[] => {
+  if (vary == null) {
+    return []
   }
-
-  if (res.headers.has('Set-Cookie')) {
-    return true
-  }
-
-  return false
+  return (Array.isArray(vary) ? vary : vary.split(','))
+    .map((directive) => directive.trim().toLowerCase())
+    .filter(Boolean)
 }
+
+const shouldSkipCache = (
+  res: Response,
+  optionsVaryDirectives: Set<string> | undefined,
+  responseVary: string[]
+): boolean =>
+  (responseVary.length &&
+    (!optionsVaryDirectives || responseVary.some((name) => !optionsVaryDirectives.has(name)))) ||
+  shouldSkipCacheControl(res.headers.get('Cache-Control')) ||
+  res.headers.has('Set-Cookie')
 
 /**
  * Cache Middleware for Hono.
@@ -41,7 +43,7 @@ const shouldSkipCache = (res: Response) => {
  * @param {string | Function} options.cacheName - The name of the cache. Can be used to store multiple caches with different identifiers.
  * @param {boolean} [options.wait=false] - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. Required to be true for the Deno environment.
  * @param {string} [options.cacheControl] - A string of directives for the `Cache-Control` header.
- * @param {string | string[]} [options.vary] - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
+ * @param {string | string[]} [options.vary] - Adds the configured request headers to the cache key variants and sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
  * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
  * @param {number[]} [options.cacheableStatusCodes=[200]] - An array of status codes that can be cached.
  * @param {Function | false} [options.onCacheNotAvailable] - A callback invoked when `globalThis.caches` is not available. By default, a message is logged to the console. Set to `false` to suppress the log, or provide a custom function.
@@ -86,12 +88,11 @@ export const cache = (options: {
   const cacheControlDirectives = options.cacheControl
     ?.split(',')
     .map((directive) => directive.toLowerCase())
-  const varyDirectives = Array.isArray(options.vary)
-    ? options.vary
-    : options.vary?.split(',').map((directive) => directive.trim())
+  const optionsVaryList = parseVaryDirectives(options.vary)
+  const varyDirectives = optionsVaryList.length ? new Set(optionsVaryList) : undefined
   // RFC 7231 Section 7.1.4 specifies that "*" is not allowed in Vary header.
   // See: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
-  if (options.vary?.includes('*')) {
+  if (varyDirectives?.has('*')) {
     throw new Error(
       'Middleware vary configuration cannot include "*", as it disallows effective caching.'
     )
@@ -101,7 +102,7 @@ export const cache = (options: {
     options.cacheableStatusCodes ?? defaultCacheableStatusCodes
   )
 
-  const addHeader = (c: Context) => {
+  const addHeader = (c: Context, responseVary: string[]) => {
     if (cacheControlDirectives) {
       const existingDirectives =
         c.res.headers
@@ -118,22 +119,18 @@ export const cache = (options: {
     }
 
     if (varyDirectives) {
-      const existingDirectives =
-        c.res.headers
-          .get('Vary')
-          ?.split(',')
-          .map((d) => d.trim()) ?? []
-
-      const vary = Array.from(
-        new Set(
-          [...existingDirectives, ...varyDirectives].map((directive) => directive.toLowerCase())
-        )
-      ).sort()
-
-      if (vary.includes('*')) {
-        c.header('Vary', '*')
+      if (responseVary.length === 0) {
+        c.header('Vary', Array.from(varyDirectives).join(', '))
       } else {
-        c.header('Vary', vary.join(', '))
+        const merged = new Set(varyDirectives)
+        for (const directive of responseVary) {
+          merged.add(directive)
+        }
+        if (merged.has('*')) {
+          c.header('Vary', '*')
+        } else {
+          c.header('Vary', Array.from(merged).join(', '))
+        }
       }
     }
   }
@@ -148,6 +145,12 @@ export const cache = (options: {
     if (options.keyGenerator) {
       key = await options.keyGenerator(c)
     }
+    if (varyDirectives) {
+      for (const directive of varyDirectives) {
+        const value = c.req.raw.headers.get(directive) ?? ''
+        key += `::${directive}=${encodeURIComponent(value)}`
+      }
+    }
 
     const cacheName =
       typeof options.cacheName === 'function' ? await options.cacheName(c) : options.cacheName
@@ -161,9 +164,10 @@ export const cache = (options: {
     if (!cacheableStatusCodes.has(c.res.status)) {
       return
     }
-    addHeader(c)
+    const responseVary = parseVaryDirectives(c.res.headers.get('Vary'))
+    addHeader(c, responseVary)
 
-    if (shouldSkipCache(c.res)) {
+    if (shouldSkipCache(c.res, varyDirectives, responseVary)) {
       return
     }
 


### PR DESCRIPTION
### Summary

- Improves cache efficiency when the `Vary` header is in use.
- Until now, `options.vary` only affected the response headers. With this PR, it also contributes to the cache key.
- This is also a follow-up to the v4.12.18 vulnerability fix (568c2ecc), which made `Vary`-bearing responses uncacheable. The change preserves that fix while letting users opt back into caching where it's safe.

### Behavior changes

The behavior changes when `options.vary` is configured:

| Situation | Before | After this PR |
| --- | --- | --- |
| `options.vary` set / response has no `Vary` | All requests share a single cache entry (requests that should return distinct responses can collide) | Stored as separate variants keyed by the configured request header values |
| `options.vary` set / response `Vary` is a subset of `options.vary` | Cache skipped (since v4.12.18) | Stored as separate variants keyed by the configured request header values |
| Response `Vary` includes a header outside `options.vary` | Cache skipped | Cache skipped (unchanged) |
| Response `Vary: *` | Cache skipped | Cache skipped (unchanged) |

Because of this behavior change, requests that were previously (unintentionally) sharing the same entry under `options.vary` are now split per header value, which can lower the hit rate. That said, this aligns with the intended semantics of `Vary` and should be a desirable change in virtually every deployment. On the flip side, paths that produced `Vary`-bearing responses — which were not cached at all after v4.12.18 — become cacheable again as long as their `Vary` is covered by `options.vary`, which raises the hit rate there.

### Design note: interaction with `options.keyGenerator`

Users who already supply `options.keyGenerator` may already be folding the same request headers into the key themselves. With this change, those headers will be appended to the key a second time.

I considered skipping the `options.vary`-based key extension when `options.keyGenerator` is provided, but decided against it:

- If a user wrote their code assuming "configuring `options.vary` extends the cache key", silently skipping that extension would violate their assumption.
- A double append is a safe failure mode: it can only over-split variants — it cannot return the wrong response.

So when both are configured, `options.vary` still contributes to the cache key unconditionally.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code