### PR TITLE
fix: allow middleware to catch downstream errors when onError is regi…

### DIFF
--- a/src/compose.test.ts
+++ b/src/compose.test.ts
@@ -748,4 +748,33 @@ describe('Compose', function () {
     expect(ctx.get('middleware')).toEqual(1)
     expect(ctx.get('next')).toEqual(1)
   })
+
+})
+describe('compose with rethrow option', () => {
+  it('should rethrow error to middleware when next({ rethrow: true }) is called', async () => {
+    const middleware: MiddlewareTuple[] = []
+    let middlewareCaughtError = false
+
+    const mHandler = async (_c: Context, next: Next) => {
+      try {
+        await next({ rethrow: true })
+      } catch {
+        middlewareCaughtError = true
+      }
+    }
+
+    const handler = () => {
+      throw new Error('downstream error')
+    }
+
+    const onError = (_err: Error, c: Context) => c.text('onError', 500)
+
+    middleware.push(buildMiddlewareTuple(mHandler))
+    middleware.push(buildMiddlewareTuple(handler))
+
+    const composed = compose(middleware, onError)
+    await composed(new Context(new Request('http://localhost/')))
+
+    expect(middlewareCaughtError).toBe(true)
+  })
 })

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -29,7 +29,7 @@ export const compose = <E extends Env = Env>(
      *
      * @returns {Promise<Context>} - A promise that resolves to the context.
      */
-    async function dispatch(i: number): Promise<Context> {
+    async function dispatch(i: number, rethrow: boolean = false): Promise<Context> {
       if (i <= index) {
         throw new Error('next() called multiple times')
       }
@@ -48,9 +48,9 @@ export const compose = <E extends Env = Env>(
 
       if (handler) {
         try {
-          res = await handler(context, () => dispatch(i + 1))
+          res = await handler(context, (options?: {rethrow?: boolean}) => dispatch(i + 1, options?.rethrow))
         } catch (err) {
-          if (err instanceof Error && onError) {
+          if (err instanceof Error && onError && !rethrow) {
             context.error = err
             res = await onError(err, context)
             isError = true


### PR DESCRIPTION
Closes #4895

**Problem**
When `app.onError` is registered, middleware wrapping `await next()` in a 
try/catch never sees downstream errors. `compose.ts` catches them inside 
`dispatch` and routes them to `onError` before the error can bubble up.

**Fix**
Add an optional `{ rethrow?: boolean }` argument to `next`. When 
`rethrow: true` is passed, the catch block skips `onError` and rethrows 
the error, allowing the calling middleware's try/catch to handle it.

Default behavior is unchanged — fully backward compatible.

**Usage**
app.use(async (c, next) => {
  try {
    await next({ rethrow: true })
  } catch (err) {
    return c.text('fallback', 500)
  }
})


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
