### PR TITLE
feat(request): add `bytes()`

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -253,6 +253,7 @@ describe('Body methods with caching', () => {
     expect(await req.text()).toEqual(text)
     expect(await req.json()).toEqual(json)
     expect(await req.arrayBuffer()).toEqual(buffer)
+    expect(await req.bytes()).toEqual(new Uint8Array(buffer))
     expect(await req.blob()).toEqual(
       new Blob([text], {
         type: 'text/plain;charset=utf-8',
@@ -270,6 +271,7 @@ describe('Body methods with caching', () => {
     expect(await req.json()).toEqual(json)
     expect(await req.text()).toEqual(text)
     expect(await req.arrayBuffer()).toEqual(buffer)
+    expect(await req.bytes()).toEqual(new Uint8Array(buffer))
     expect(await req.blob()).toEqual(
       new Blob([text], {
         type: 'text/plain;charset=utf-8',
@@ -300,6 +302,28 @@ describe('Body methods with caching', () => {
     expect(await req.arrayBuffer()).toEqual(buffer)
     expect(await req.text()).toEqual(text)
     expect(await req.json()).toEqual(json)
+    expect(await req.bytes()).toEqual(new Uint8Array(buffer))
+    expect(await req.blob()).toEqual(
+      new Blob([text], {
+        type: '',
+      })
+    )
+  })
+
+  test('req.bytes()', async () => {
+    const bytes = new TextEncoder().encode('{"foo":"bar"}')
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: bytes,
+      })
+    )
+    const result = await req.bytes()
+    expect(result).toBeInstanceOf(Uint8Array)
+    expect(result).toEqual(bytes)
+    expect(await req.text()).toEqual(text)
+    expect(await req.json()).toEqual(json)
+    expect(await req.arrayBuffer()).toEqual(buffer)
     expect(await req.blob()).toEqual(
       new Blob([text], {
         type: '',
@@ -321,6 +345,7 @@ describe('Body methods with caching', () => {
     expect(await req.text()).toEqual(text)
     expect(await req.json()).toEqual(json)
     expect(await req.arrayBuffer()).toEqual(buffer)
+    expect(await req.bytes()).toEqual(new Uint8Array(buffer))
   })
 
   test('req.formData()', async () => {
@@ -335,6 +360,7 @@ describe('Body methods with caching', () => {
     expect((await req.formData()).get('foo')).toBe('bar')
     expect(async () => await req.text()).not.toThrow()
     expect(async () => await req.arrayBuffer()).not.toThrow()
+    expect(async () => await req.bytes()).not.toThrow()
     expect(async () => await req.blob()).not.toThrow()
   })
 
@@ -351,6 +377,7 @@ describe('Body methods with caching', () => {
       expect((await req.parseBody())['foo']).toBe('bar')
       expect(async () => await req.text()).not.toThrow()
       expect(async () => await req.arrayBuffer()).not.toThrow()
+      expect(async () => await req.bytes()).not.toThrow()
       expect(async () => await req.blob()).not.toThrow()
     })
 
@@ -380,6 +407,12 @@ describe('Body methods with caching', () => {
         const req = createReq()
         await req.parseBody()
         expect(await req.arrayBuffer()).toBeInstanceOf(ArrayBuffer)
+      })
+
+      it('bytes()', async () => {
+        const req = createReq()
+        await req.parseBody()
+        expect(await req.bytes()).toBeInstanceOf(Uint8Array)
       })
 
       it('blob()', async () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -287,6 +287,22 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   /**
+   * `.bytes()` parses the request body as a `Uint8Array`.
+   *
+   * @see {@link https://hono.dev/docs/api/request#bytes}
+   *
+   * @example
+   * ```ts
+   * app.post('/entry', async (c) => {
+   *   const body = await c.req.bytes()
+   * })
+   * ```
+   */
+  bytes(): Promise<Uint8Array> {
+    return this.#cachedBody('arrayBuffer').then((buffer: ArrayBuffer) => new Uint8Array(buffer))
+  }
+
+  /**
    * Parses the request body as a `Blob`.
    * @example
    * ```ts


### PR DESCRIPTION
Resolves #4920

I realized `bytes()` is not implemented in the HonoRequest, as seen in https://github.com/honojs/hono/issues/4920. Implemented it in this PR.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
