### PR TITLE
fix(cookie): return the first cookie when there are multiple cookies with the same name

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -118,6 +118,26 @@ describe('Parse cookie', () => {
     expect(parse(cookieString)['session']).toBe(parse(cookieString, 'session')['session'])
   })
 
+  it('Should parse cookies whose names collide with Object.prototype properties', () => {
+    const cookieString = 'toString=foo; hasOwnProperty=bar; constructor=baz'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['toString']).toBe('foo')
+    expect(cookie['hasOwnProperty']).toBe('bar')
+    expect(cookie['constructor']).toBe('baz')
+  })
+
+  it('Should parse a cookie whose name collides with Object.prototype when parsed by name', () => {
+    const cookieString = 'toString=foo'
+    const cookie: Cookie = parse(cookieString, 'toString')
+    expect(cookie['toString']).toBe('foo')
+  })
+
+  it('Should keep first-wins behavior for cookies whose names collide with Object.prototype', () => {
+    const cookieString = 'toString=first; toString=last'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['toString']).toBe('first')
+  })
+
   it('Should parse signed cookies', async () => {
     const secret = 'secret ingredient'
     const cookieString =
@@ -211,6 +231,13 @@ describe('Parse cookie', () => {
       'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; yummy_cookie=strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
     const cookie: SignedCookie = await parseSigned(cookieString, secret)
     expect(cookie['yummy_cookie']).toBe('choco')
+  })
+
+  it('Should parse signed cookies whose names collide with Object.prototype properties', async () => {
+    const secret = 'secret ingredient'
+    const cookieString = 'toString=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret)
+    expect(cookie['toString']).toBe('choco')
   })
 })
 

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -101,6 +101,23 @@ describe('Parse cookie', () => {
     expect(cookie['\u00a0dummy-cookie']).toBeUndefined()
   })
 
+  it('Should return the first value for duplicate cookie names', () => {
+    const cookieString = 'a=first; a=last'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['a']).toBe('first')
+  })
+
+  it('Should return the first value for duplicate cookie names when parsed by name', () => {
+    const cookieString = 'a=first; a=last'
+    const cookie: Cookie = parse(cookieString, 'a')
+    expect(cookie['a']).toBe('first')
+  })
+
+  it('Should return consistent values between parse() and parse(name) for duplicates', () => {
+    const cookieString = 'session=legit; other=x; session=evil'
+    expect(parse(cookieString)['session']).toBe(parse(cookieString, 'session')['session'])
+  })
+
   it('Should parse signed cookies', async () => {
     const secret = 'secret ingredient'
     const cookieString =
@@ -186,6 +203,14 @@ describe('Parse cookie', () => {
       '\u00a0dummy-cookie=evil.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; dummy-cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D'
     const cookie: SignedCookie = await parseSigned(cookieString, secret, 'dummy-cookie')
     expect(cookie['dummy-cookie']).toBe('choco')
+  })
+
+  it('Should return the first signed cookie when there are duplicate names', async () => {
+    const secret = 'secret ingredient'
+    const cookieString =
+      'yummy_cookie=choco.UdFR2rBpS1GsHfGlUiYyMIdqxqwuEgplyQIgTJgpGWY%3D; yummy_cookie=strawberry.I9qAeGQOvWjCEJgRPmrw90JjYpnnX2C9zoOiGSxh1Ig%3D'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret)
+    expect(cookie['yummy_cookie']).toBe('choco')
   })
 })
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -105,7 +105,7 @@ export const parse = (cookie: string, name?: string): Cookie => {
     return {}
   }
   const pairs = cookie.split(';')
-  const parsedCookie: Cookie = {}
+  const parsedCookie: Cookie = Object.create(null)
   for (const pairStr of pairs) {
     const valueStartPos = pairStr.indexOf('=')
     if (valueStartPos === -1) {
@@ -142,7 +142,7 @@ export const parseSigned = async (
   secret: string | BufferSource,
   name?: string
 ): Promise<SignedCookie> => {
-  const parsedCookie: SignedCookie = {}
+  const parsedCookie: SignedCookie = Object.create(null)
   const secretKey = await getCryptoKey(secret)
 
   for (const [key, value] of Object.entries(parse(cookie, name))) {

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -113,7 +113,11 @@ export const parse = (cookie: string, name?: string): Cookie => {
     }
 
     const cookieName = trimCookieWhitespace(pairStr.substring(0, valueStartPos))
-    if ((name && name !== cookieName) || !validCookieNameRegEx.test(cookieName)) {
+    if (
+      (name && name !== cookieName) ||
+      !validCookieNameRegEx.test(cookieName) ||
+      cookieName in parsedCookie
+    ) {
       continue
     }
 


### PR DESCRIPTION
fixes #4916

- eee6fa1ec9dcbff25a97a186a6f6ff5abadbd505: Align both code paths to first-wins semantics.
- e8a6fcfabfe8464c7dc5bfd89acd3f467d624498 : Additionally, use `Object.create(null)` to avoid collisions with `Object.prototype` properties.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
