### PR TITLE
fix(deno): infer WebSocket subprotocol from request header

### DIFF
--- a/src/adapter/deno/websocket.test.ts
+++ b/src/adapter/deno/websocket.test.ts
@@ -76,6 +76,62 @@ describe('WebSockets', () => {
       )
     expect(await messagePromise).toBe(data)
   })
+
+  it('Should pass first requested protocol to Deno.upgradeWebSocket', async () => {
+    app.get(
+      '/ws',
+      upgradeWebSocket(() => ({}))
+    )
+    const socket = new EventTarget() as WebSocket
+    let upgradeOptions: Deno.UpgradeWebSocketOptions | undefined
+    Deno.upgradeWebSocket = (_request, options) => {
+      upgradeOptions = options
+      return {
+        response: new Response(),
+        socket,
+      }
+    }
+
+    await app.request('/ws', {
+      headers: {
+        upgrade: 'websocket',
+        'sec-websocket-protocol': 'chat, superchat',
+      },
+    })
+
+    expect(upgradeOptions).toEqual({
+      protocol: 'chat',
+    })
+  })
+
+  it('Should not override protocol provided in options', async () => {
+    app.get(
+      '/ws',
+      upgradeWebSocket(() => ({}), { protocol: 'superchat', idleTimeout: 5000 })
+    )
+    const socket = new EventTarget() as WebSocket
+    let upgradeOptions: Deno.UpgradeWebSocketOptions | undefined
+    Deno.upgradeWebSocket = (_request, options) => {
+      upgradeOptions = options
+      return {
+        response: new Response(),
+        socket,
+      }
+    }
+
+    await app.request('/ws', {
+      headers: {
+        upgrade: 'websocket',
+        'sec-websocket-protocol': 'chat',
+      },
+    })
+
+    expect(upgradeOptions).toEqual({
+      idleTimeout: 5000,
+      protocol: 'superchat',
+    })
+  })
+
   it('Should call next() when header does not have upgrade', async () => {
     const next = vi.fn()
     await upgradeWebSocket(() => ({}))(

--- a/src/adapter/deno/websocket.ts
+++ b/src/adapter/deno/websocket.ts
@@ -1,5 +1,11 @@
+import type { Context } from '../../context'
 import type { UpgradeWebSocket, WSReadyState } from '../../helper/websocket'
 import { WSContext, defineWebSocketHelper } from '../../helper/websocket'
+
+const getProtocol = (c: Context): string | undefined => {
+  const protocol = c.req.header('Sec-WebSocket-Protocol')?.split(',')[0]?.trim()
+  return protocol || undefined
+}
 
 export const upgradeWebSocket: UpgradeWebSocket<WebSocket, Deno.UpgradeWebSocketOptions> =
   defineWebSocketHelper(async (c, events, options) => {
@@ -7,7 +13,9 @@ export const upgradeWebSocket: UpgradeWebSocket<WebSocket, Deno.UpgradeWebSocket
       return
     }
 
-    const { response, socket } = Deno.upgradeWebSocket(c.req.raw, options ?? {})
+    const protocol = options?.protocol ?? getProtocol(c)
+    const upgradeOptions = protocol === undefined ? (options ?? {}) : { ...options, protocol }
+    const { response, socket } = Deno.upgradeWebSocket(c.req.raw, upgradeOptions)
 
     const wsContext: WSContext<WebSocket> = new WSContext({
       close: (code, reason) => socket.close(code, reason),


### PR DESCRIPTION
## Summary

- Derive the Deno `upgradeWebSocket` protocol option from the first `Sec-WebSocket-Protocol` request value when no explicit protocol option is provided.
- Preserve caller-provided `options.protocol` so applications can still select a specific subprotocol.
- Add Deno adapter regression tests for inferred and explicit protocol behavior.

Fixes #4439.

## Validation

- `npx vitest --run src/adapter/deno/websocket.test.ts`
- `npx prettier --check src/adapter/deno/websocket.ts src/adapter/deno/websocket.test.ts`
- `npx eslint src/adapter/deno/websocket.ts src/adapter/deno/websocket.test.ts`
- `npx tsc --noEmit`
- `git diff --check`