### PR TITLE
fix(etag): make stream digests independent of chunk boundaries

### DIFF
--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -1,5 +1,5 @@
 const mergeBuffers = (
-  buffer1: ArrayBuffer | undefined,
+  buffer1: Uint8Array<ArrayBuffer> | undefined,
   buffer2: Uint8Array<ArrayBuffer>
 ): Uint8Array<ArrayBuffer> => {
   if (!buffer1) {
@@ -8,7 +8,7 @@ const mergeBuffers = (
   const merged = new Uint8Array<ArrayBuffer>(
     new ArrayBuffer(buffer1.byteLength + buffer2.byteLength)
   )
-  merged.set(new Uint8Array(buffer1), 0)
+  merged.set(buffer1, 0)
   merged.set(buffer2, buffer1.byteLength)
   return merged
 }
@@ -21,7 +21,7 @@ export const generateDigest = async (
     return null
   }
 
-  let result: ArrayBuffer | undefined = undefined
+  let body: Uint8Array<ArrayBuffer> | undefined = undefined
 
   const reader = stream.getReader()
   for (;;) {
@@ -30,12 +30,14 @@ export const generateDigest = async (
       break
     }
 
-    result = await generator(mergeBuffers(result, value))
+    body = mergeBuffers(body, value)
   }
 
-  if (!result) {
+  if (!body) {
     return null
   }
+
+  const result = await generator(body)
 
   return Array.prototype.map
     .call(new Uint8Array(result), (x) => x.toString(16).padStart(2, '0'))

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -130,6 +130,35 @@ describe('Etag Middleware', () => {
     expect(res.headers.get('ETag')).not.toBe(hash)
   })
 
+  it('Should return the same etag for the same stream bytes split into different chunks', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+
+    const streamFrom = (chunks: number[][]) =>
+      new ReadableStream<Uint8Array<ArrayBuffer>>({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(new Uint8Array(chunk))
+          }
+          controller.close()
+        },
+      })
+
+    app.get('/etag/rs-chunked-one', (c) => {
+      return c.body(streamFrom([[1], [2, 3], [4]]))
+    })
+    app.get('/etag/rs-chunked-two', (c) => {
+      return c.body(streamFrom([[1, 2], [3], [4]]))
+    })
+
+    let res = await app.request('http://localhost/etag/rs-chunked-one')
+    const hash = res.headers.get('ETag')
+    expect(hash).not.toBeFalsy()
+
+    res = await app.request('http://localhost/etag/rs-chunked-two')
+    expect(res.headers.get('ETag')).toBe(hash)
+  })
+
   it('Should not return etag header when the stream is empty', async () => {
     const app = new Hono()
     app.use('/etag/*', etag())


### PR DESCRIPTION
## Summary

- Accumulate the original response stream bytes before generating an ETag digest.
- Avoid feeding the previous digest into the next chunk, which made the final ETag depend on stream chunk boundaries.
- Add a regression test proving identical stream bytes produce the same ETag when split differently.

Fixes #4071.

## Validation

- `npx vitest --run src/middleware/etag/index.test.ts`
- `npx prettier --check src/middleware/etag/digest.ts src/middleware/etag/index.test.ts`
- `npx eslint src/middleware/etag/digest.ts src/middleware/etag/index.test.ts`
- `npx tsc --noEmit`
- `git diff --check`