### PR TITLE
Fix AWS Lambda websocket event method fallback

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -264,6 +264,20 @@ describe('EventProcessor.createRequest', () => {
     })
   })
 
+  it('Should default method to POST when httpMethod is missing on version 1.0 events', async () => {
+    const event: LambdaEvent = {
+      ...baseV1Event,
+      httpMethod: undefined as unknown as string,
+      body: '{"message":"hello"}',
+    }
+
+    const processor = getProcessor(event)
+    const request = processor.createRequest(event)
+
+    expect(request.method).toEqual('POST')
+    expect(await request.text()).toEqual('{"message":"hello"}')
+  })
+
   it('Should return valid Request object from version 2.0 API Gateway event', () => {
     const event: LambdaEvent = {
       ...baseV2Event,

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -442,7 +442,7 @@ export class EventV1Processor extends EventProcessor<APIGatewayProxyEvent> {
   }
 
   protected getMethod(event: APIGatewayProxyEvent): string {
-    return event.httpMethod
+    return event.httpMethod || 'POST'
   }
 
   protected getQueryString(event: APIGatewayProxyEvent): string {


### PR DESCRIPTION
## Summary
- Handle missing `httpMethod` in `EventV1Processor` by defaulting to `POST`.
- Add a regression test for websocket-shaped API Gateway v1 events without `httpMethod`.

## Validation
- `npx tsc --noEmit`
- `npm run lint src/adapter/aws-lambda/handler.ts src/adapter/aws-lambda/handler.test.ts`
- `npm run test:lambda`