### PR TITLE
Make executionCtx getter return undefined when absent

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -375,9 +375,9 @@ describe('event and executionCtx', () => {
     expect(waitUntil).toHaveBeenCalled()
   })
 
-  it('Should throw an error if accessing c.executionCtx', () => {
+  it('Should return undefined if accessing c.executionCtx without value', () => {
     const c = new Context(req)
-    expect(() => c.executionCtx).toThrowError()
+    expect(c.executionCtx).toBeUndefined()
   })
 })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -386,14 +386,10 @@ export class Context<
    * @see {@link https://hono.dev/docs/api/context#executionctx}
    * The ExecutionContext associated with the current request.
    *
-   * @throws Will throw an error if the context does not have an ExecutionContext.
+   * Returns `undefined` if the context does not have an ExecutionContext.
    */
-  get executionCtx(): ExecutionContext {
-    if (this.#executionCtx) {
-      return this.#executionCtx as ExecutionContext
-    } else {
-      throw Error('This context has no ExecutionContext')
-    }
+  get executionCtx(): ExecutionContext | undefined {
+    return this.#executionCtx as ExecutionContext | undefined
   }
 
   /**


### PR DESCRIPTION
## Summary
- Make `Context.executionCtx` return `undefined` when no execution context is available.
- Update context tests to assert guard-friendly behavior without throwing.

## Validation
- `npx tsc --noEmit`
- `npm run lint -- src/context.ts src/context.test.ts`
- `npx vitest --run src/context.test.ts`