### PR TITLE
Handle multi-value query parameters for AWS Lambda v2 events

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -303,6 +303,29 @@ describe('EventProcessor.createRequest', () => {
     })
   })
 
+  it('Should return multi-value query params for version 2.0 API Gateway event when rawQueryString is unavailable', () => {
+    const event: LambdaEvent = {
+      ...baseV2Event,
+      rawQueryString: '',
+      multiValueQueryStringParameters: {
+        parameter1: ['value1', 'value2'],
+        parameter2: ['value'],
+      },
+      queryStringParameters: {
+        parameter1: 'value2',
+        parameter2: 'value',
+      },
+      body: 'Hello from Lambda',
+    }
+
+    const processor = getProcessor(event)
+    const request = processor.createRequest(event)
+
+    expect(request.url).toEqual(
+      'https://id.execute-api.us-east-1.amazonaws.com/my/path?parameter1=value1&parameter1=value2&parameter2=value'
+    )
+  })
+
   it('Should return valid Request object from version 2.0 Lattice event', async () => {
     const event: LatticeProxyEventV2 = {
       version: '2.0',

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -52,6 +52,9 @@ export interface APIGatewayProxyEventV2 {
   queryStringParameters?: {
     [name: string]: string | undefined
   }
+  multiValueQueryStringParameters?: {
+    [parameterKey: string]: string[]
+  }
   pathParameters?: {
     [name: string]: string | undefined
   }
@@ -407,7 +410,21 @@ export class EventV2Processor extends EventProcessor<APIGatewayProxyEventV2> {
   }
 
   protected getQueryString(event: APIGatewayProxyEventV2): string {
-    return event.rawQueryString
+    if (event.multiValueQueryStringParameters) {
+      return Object.entries(event.multiValueQueryStringParameters || {})
+        .filter(([, value]) => value)
+        .map(([key, values]) => values.map((value) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join('&'))
+        .join('&')
+    }
+
+    if (event.rawQueryString) {
+      return event.rawQueryString
+    }
+
+    return Object.entries(event.queryStringParameters || {})
+      .filter(([, value]) => value)
+      .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value || '')}`)
+      .join('&')
   }
 
   protected getCookies(event: APIGatewayProxyEventV2, headers: Headers): void {


### PR DESCRIPTION
## Summary
- Preserve duplicate query values for AWS Lambda API Gateway v2 events when `multiValueQueryStringParameters` is present.
- Add a lambda adapter regression test for multi-value query reconstruction.

## Validation
- `npx tsc --noEmit`
- `npm run lint -- src/adapter/aws-lambda/handler.ts src/adapter/aws-lambda/handler.test.ts`
- `npm run test:lambda`