### PR TITLE
fix: throw for non-serializable c.json values

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,16 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() should throw for undefined', () => {
+    expect(() => c.json(undefined)).toThrow(new TypeError('Value is not JSON serializable.'))
+  })
+
+  it('c.json() should stringify null', async () => {
+    const res = c.json(null)
+    expect(res.headers.get('Content-Type')).toMatch('application/json')
+    expect(await res.text()).toBe('null')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -290,6 +290,16 @@ const createResponseInstance = (
   init?: globalThis.ResponseInit
 ): Response => new Response(body, init)
 
+const serializeJSON = (value: unknown): string => {
+  const body = JSON.stringify(value)
+
+  if (body === undefined) {
+    throw new TypeError('Value is not JSON serializable.')
+  }
+
+  return body
+}
+
 export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
@@ -714,7 +724,7 @@ export class Context<
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
     return this.#newResponse(
-      JSON.stringify(object),
+      serializeJSON(object),
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## Summary

`c.json()` previously passed the result of `JSON.stringify()` directly into the response body. For values like `undefined`, functions, and symbols, `JSON.stringify()` returns `undefined`, which produced an empty response body instead of surfacing that the value is not JSON serializable.

This adds a small serialization guard so `c.json(undefined)` throws a `TypeError`, while valid JSON values such as `null` continue to serialize as expected.

Fixes #2343.

## Validation

- `.\node_modules\.bin\vitest.cmd run --config .\vitest.config.ts --project main src/context.test.ts`
- `.\node_modules\.bin\eslint.cmd src/context.ts src/context.test.ts`