### PR TITLE
fix: allow adapter serveStatic without options

### DIFF
--- a/src/adapter/bun/serve-static.test.ts
+++ b/src/adapter/bun/serve-static.test.ts
@@ -1,0 +1,50 @@
+import { Hono } from '../..'
+import { serveStatic } from './serve-static'
+
+globalThis.Bun = {} as typeof Bun
+
+describe('serveStatic()', () => {
+  const fileMock = vi.fn((path: string) => {
+    if (path.endsWith('missing.txt')) {
+      return Object.assign('', {
+        exists: async () => false,
+      }) as unknown as ReturnType<typeof Bun.file>
+    }
+
+    return Object.assign(`Hello in ${path}`, {
+      exists: async () => true,
+    }) as unknown as ReturnType<typeof Bun.file>
+  })
+
+  beforeEach(() => {
+    fileMock.mockClear()
+    Bun = {
+      file: fileMock,
+    } as typeof Bun
+  })
+
+  it('Should serve file without options', async () => {
+    const app = new Hono()
+    app.use('/static/*', serveStatic())
+
+    const res = await app.request('/static/hello.html')
+    const text = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(text).toContain('Hello in')
+    expect(text).toContain('hello.html')
+  })
+
+  it('Should continue to next when file is missing', async () => {
+    const app = new Hono()
+    app.use('/static/*', serveStatic())
+    app.get('/static/*', (c) => {
+      return c.text('fallback')
+    })
+
+    const res = await app.request('/static/missing.txt')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('fallback')
+  })
+})

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -6,7 +6,7 @@ import type { ServeStaticOptions } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {

--- a/src/adapter/deno/serve-static.test.ts
+++ b/src/adapter/deno/serve-static.test.ts
@@ -1,0 +1,60 @@
+import { Hono } from '../..'
+import type { MiddlewareHandler } from '../../types'
+globalThis.Deno = {} as typeof Deno
+
+describe('serveStatic()', () => {
+  let serveStatic: (options?: Record<string, unknown>) => MiddlewareHandler
+  const NotFound = class NotFound extends Error {}
+
+  const openMock = vi.fn(async (path: string) => {
+    if (path.endsWith('missing.txt')) {
+      throw new NotFound()
+    }
+    return {
+      readable: new Blob([`Hello in ${path}`]).stream(),
+    }
+  })
+
+  const lstatMock = vi.fn(() => ({
+    isDirectory: false,
+  }))
+
+  beforeEach(async () => {
+    openMock.mockClear()
+    lstatMock.mockClear()
+    Deno = {
+      open: openMock,
+      lstatSync: lstatMock,
+      errors: {
+        NotFound,
+      },
+    } as typeof Deno
+
+    ;({ serveStatic } = await import('./serve-static'))
+  })
+
+  it('Should serve file without options', async () => {
+    const app = new Hono()
+    app.use('/static/*', serveStatic())
+
+    const res = await app.request('/static/hello.html')
+    const text = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(text).toContain('Hello in')
+    expect(text).toContain('hello.html')
+  })
+
+  it('Should continue to next when file is missing', async () => {
+    const app = new Hono()
+    app.use('/static/*', serveStatic())
+    app.get('/static/*', (c) => {
+      return c.text('fallback')
+    })
+
+    const res = await app.request('/static/missing.txt')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('fallback')
+  })
+})

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -6,7 +6,7 @@ import type { Env, MiddlewareHandler } from '../../types'
 const { open, lstatSync, errors } = Deno
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {


### PR DESCRIPTION
## Summary

The Bun and Deno adapter `serveStatic` helpers required an options object even when the caller wanted default behavior, so TypeScript rejected `serveStatic()` and forced users to write `serveStatic({})`.

This defaults the adapter options to `{}` and adds coverage for serving files and falling through on missing files without passing an options object.

Fixes #4911.

## Validation

- `.\node_modules\.bin\vitest.cmd run src/adapter/deno/serve-static.test.ts src/adapter/bun/serve-static.test.ts src/adapter/cloudflare-workers/serve-static.test.ts`
- `.\node_modules\.bin\tsc.cmd --noEmit`
- `.\node_modules\.bin\eslint.cmd src/adapter/deno/serve-static.ts src/adapter/bun/serve-static.ts src/adapter/deno/serve-static.test.ts src/adapter/bun/serve-static.test.ts`