### PR TITLE
fix: return undefined for missing executionCtx

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -375,9 +375,9 @@ describe('event and executionCtx', () => {
     expect(waitUntil).toHaveBeenCalled()
   })
 
-  it('Should throw an error if accessing c.executionCtx', () => {
+  it('Should return undefined if executionCtx is not set', () => {
     const c = new Context(req)
-    expect(() => c.executionCtx).toThrowError()
+    expect(c.executionCtx).toBeUndefined()
   })
 })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -385,15 +385,12 @@ export class Context<
   /**
    * @see {@link https://hono.dev/docs/api/context#executionctx}
    * The ExecutionContext associated with the current request.
-   *
-   * @throws Will throw an error if the context does not have an ExecutionContext.
    */
-  get executionCtx(): ExecutionContext {
+  get executionCtx(): ExecutionContext | undefined {
     if (this.#executionCtx) {
       return this.#executionCtx as ExecutionContext
-    } else {
-      throw Error('This context has no ExecutionContext')
     }
+    return undefined
   }
 
   /**

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -171,7 +171,7 @@ export const cache = (options: {
     if (options.wait) {
       await cache.put(key, res)
     } else {
-      c.executionCtx.waitUntil(cache.put(key, res))
+      c.executionCtx!.waitUntil(cache.put(key, res))
     }
   }
 }


### PR DESCRIPTION
## Summary

Accessing `c.executionCtx` outside runtimes that provide an `ExecutionContext` currently throws, so code cannot safely branch with `if (c.executionCtx)` before deciding whether to call `waitUntil`.

This changes the getter to return `undefined` when no execution context is available and updates the cache middleware call site to keep its existing Workers-only assumption explicit.

Fixes #2649.

## Validation

- `.\node_modules\.bin\vitest.cmd run --config .\vitest.config.ts --project main src/context.test.ts src/middleware/cache/index.test.ts`
- `.\node_modules\.bin\tsc.cmd --noEmit`
- `.\node_modules\.bin\eslint.cmd src/context.ts src/context.test.ts src/middleware/cache/index.ts`