### PR TITLE
fix(serveStatic): make options parameter optional in all adapters

### DIFF
--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -6,7 +6,7 @@ import type { ServeStaticOptions } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -19,7 +19,7 @@ export type ServeStaticOptions<E extends Env = Env> = BaseServeStaticOptions<E> 
  * application with the `npm create hono@latest` command.
  */
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {

--- a/src/adapter/cloudflare-workers/serve-static.ts
+++ b/src/adapter/cloudflare-workers/serve-static.ts
@@ -6,7 +6,7 @@ import { getContentFromKVAsset } from './utils'
 export type ServeStaticOptions<E extends Env = Env> = BaseServeStaticOptions<E> & {
   // namespace is KVNamespace
   namespace?: unknown
-  manifest: object | string
+  manifest?: object | string
 }
 
 /**

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -6,7 +6,7 @@ import type { Env, MiddlewareHandler } from '../../types'
 const { open, lstatSync, errors } = Deno
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {


### PR DESCRIPTION
## Description

All properties in `ServeStaticOptions` are already optional, but the `serveStatic()` function in the Deno, Bun, and Cloudflare Workers adapters requires an explicit `{}` argument.

This change makes the `options` parameter optional with a default of `{}`, allowing:

```ts
serveStatic() // instead of serveStatic({})
```

Applied to all three adapters: Deno, Bun, and Cloudflare Workers.

Fixes #4911