### PR TITLE
fix(adapter): make `options` optional in deno/bun `serveStatic` (closes #4911)

### DIFF
--- a/runtime-tests/bun/index.test.tsx
+++ b/runtime-tests/bun/index.test.tsx
@@ -174,6 +174,18 @@ describe('Serve Static Middleware', () => {
     expect(await res.text()).toMatch(/^Bun!(\r?\n)?$/)
     expect(onNotFound).not.toHaveBeenCalled()
   })
+
+  it('Should accept no arguments (#4911)', async () => {
+    const app = new Hono()
+    app.get('/no-options/*', serveStatic())
+    app.get('*', (c) => c.text('fallback'))
+
+    const res = await app.request('http://localhost/no-options/missing-file')
+    // Default root is the current working directory; the file does not exist,
+    // so the middleware should fall through to the next handler.
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('fallback')
+  })
 })
 
 // Bun support WebCrypto since v0.2.2

--- a/runtime-tests/deno/middleware.test.tsx
+++ b/runtime-tests/deno/middleware.test.tsx
@@ -157,6 +157,18 @@ Deno.test('Serve Static middleware', async () => {
   assertEquals(await res.text(), '404 Not Found')
 })
 
+Deno.test('Serve Static middleware - no options (#4911)', async () => {
+  const app = new Hono()
+  app.get('/no-options/*', serveStatic())
+  app.get('*', (c) => c.text('fallback'))
+
+  // Default root is the current working directory; the file does not exist,
+  // so the middleware should fall through to the next handler.
+  const res = await app.request('http://localhost/no-options/missing-file')
+  assertEquals(res.status, 200)
+  assertEquals(await res.text(), 'fallback')
+})
+
 Deno.test('JWT Authentication middleware', async () => {
   const app = new Hono<{ Variables: { 'x-foo': string } }>()
   app.use('/*', async (c, next) => {

--- a/src/adapter/bun/serve-static.ts
+++ b/src/adapter/bun/serve-static.ts
@@ -6,7 +6,7 @@ import type { ServeStaticOptions } from '../../middleware/serve-static'
 import type { Env, MiddlewareHandler } from '../../types'
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {

--- a/src/adapter/deno/serve-static.ts
+++ b/src/adapter/deno/serve-static.ts
@@ -6,7 +6,7 @@ import type { Env, MiddlewareHandler } from '../../types'
 const { open, lstatSync, errors } = Deno
 
 export const serveStatic = <E extends Env = Env>(
-  options: ServeStaticOptions<E>
+  options: ServeStaticOptions<E> = {}
 ): MiddlewareHandler => {
   return async function serveStatic(c, next) {
     const getContent = async (path: string) => {


### PR DESCRIPTION
Closes #4911.

## Problem

The Deno and Bun `serveStatic` adapters require an `options` argument even though every field on the base `ServeStaticOptions<E>` type (\`root\`, \`path\`, \`precompressed\`, \`mimes\`, \`rewriteRequestPath\`, \`onFound\`, \`onNotFound\`) is itself optional. To compile, callers have to write an empty-object stub:

\`\`\`ts
import { Hono } from '@hono/hono'
import { serveStatic } from '@hono/hono/deno'

const app = new Hono()
app.use('/static/*', serveStatic({}))   // {} only to please TypeScript
Deno.serve(app.fetch)
\`\`\`

The reporter (and the docs at hono.dev) would naturally write \`serveStatic()\`.

## Fix

Default \`options\` to \`{}\` in both adapters:

- \`src/adapter/deno/serve-static.ts\`
- \`src/adapter/bun/serve-static.ts\`

Now the empty-call form works and matches the base middleware's "all fields are optional" contract:

\`\`\`ts
app.use('/static/*', serveStatic())   // defaults: root = './'
\`\`\`

## What's intentionally not changed

- **\`src/adapter/cloudflare-workers/serve-static.ts\`** — that adapter extends \`ServeStaticOptions\` with a required \`manifest: object | string\` field, so the parameter can't be defaulted without breaking the existing required-field contract. The adapter is also marked \`@deprecated\` in favor of Cloudflare Static Assets, so churn here would be pure cost.

## Tests

Adds one runtime test per adapter (\`runtime-tests/bun/index.test.tsx\` and \`runtime-tests/deno/middleware.test.tsx\`) that mounts \`serveStatic()\` with no arguments and verifies the middleware falls through to a subsequent handler when the request path doesn't resolve to a real file. This pins both the new TypeScript signature and the runtime behavior with the default empty options object.

Verified locally:

- \`bun run lint\` — clean (0 errors; the 38 pre-existing \`no-explicit-any\` warnings are unrelated)
- \`bun run test\` — 4423 pass / 33 skipped / 0 fail across 144 test files
- \`bun run test:bun\` — 27/27 pass
- \`deno test … runtime-tests/deno/middleware.test.tsx\` — 5/5 pass, including the new \`Serve Static middleware - no options (#4911)\` test

(The full \`bun test:deno\` script also runs the \`deno-jsx\` suite which currently has TypeScript JSX-typing errors on \`main\`, unrelated to this change.)

## Disclosure

Drafted with assistance from Claude (Anthropic). I read the diff, ran the full test suite, and verified the no-args call shape on both runtimes before opening.