### PR TITLE
feat: websocket proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -409,6 +409,11 @@
       "types": "./dist/types/helper/proxy/index.d.ts",
       "import": "./dist/helper/proxy/index.js",
       "require": "./dist/cjs/helper/proxy/index.js"
+    },
+    "./websocket-proxy": {
+      "types": "./dist/types/helper/websocket-proxy/index.d.ts",
+      "import": "./dist/helper/websocket-proxy/index.js",
+      "require": "./dist/cjs/helper/websocket-proxy/index.js"
     }
   },
   "typesVersions": {
@@ -625,6 +630,9 @@
       ],
       "proxy": [
         "./dist/types/helper/proxy"
+      ],
+      "websocket-proxy": [
+        "./dist/types/helper/websocket-proxy"
       ]
     }
   },

--- a/src/helper/proxy-websocket/index.test.ts
+++ b/src/helper/proxy-websocket/index.test.ts
@@ -1,0 +1,146 @@
+import type { WSContext } from '../websocket'
+import { proxyWebsocket } from '.'
+
+class MockWebSocket extends EventTarget {
+  url: string
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    super()
+    this.url = url
+  }
+}
+
+describe('Proxy Websocket', () => {
+  describe('proxyWebsocket', () => {
+    let webSocketMock: ReturnType<typeof vi.fn>
+    let upstreamSocket: MockWebSocket
+
+    beforeEach(() => {
+      webSocketMock = vi.fn((url: string) => {
+        upstreamSocket = new MockWebSocket(url)
+        return upstreamSocket
+      })
+      vi.stubGlobal('WebSocket', webSocketMock)
+    })
+
+    afterEach(() => {
+      vi.clearAllMocks()
+      vi.unstubAllGlobals()
+    })
+
+    it('creates an upstream websocket', async () => {
+      const events = await proxyWebsocket('ws://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+
+      expect(webSocketMock).toHaveBeenCalledWith('ws://example.com/')
+    })
+
+    it('creates an upstream websocket on path', async () => {
+      const events = await proxyWebsocket('ws://example.com/test')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+
+      expect(webSocketMock).toHaveBeenCalledWith('ws://example.com/test')
+    })
+
+    it('creates an upstream websocket using the translated HTTP websocket URL', async () => {
+      const events = await proxyWebsocket('http://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+
+      expect(webSocketMock).toHaveBeenCalledWith('ws://example.com/')
+    })
+
+    it('creates an upstream websocket using the translated HTTPS websocket URL', async () => {
+      const events = await proxyWebsocket('https://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+
+      expect(webSocketMock).toHaveBeenCalledWith('wss://example.com/')
+    })
+
+    it('forwards upstream messages to the downstream context', async () => {
+      const events = await proxyWebsocket('ws://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+      upstreamSocket.dispatchEvent(new MessageEvent('message', { data: 'hello from upstream' }))
+
+      expect(context.send).toHaveBeenCalledWith('hello from upstream')
+    })
+
+    it('forwards downstream messages to the upstream websocket', async () => {
+      const events = await proxyWebsocket('ws://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+      events.onMessage?.(new MessageEvent('message', { data: 'hello from client' }), context)
+
+      expect(upstreamSocket.send).toHaveBeenCalledWith('hello from client')
+    })
+
+    it('closes the downstream context when the upstream websocket closes', async () => {
+      const events = await proxyWebsocket('ws://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+      upstreamSocket.dispatchEvent(new CloseEvent('close'))
+
+      expect(context.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('closes the downstream context when the upstream websocket error', async () => {
+      const events = await proxyWebsocket('ws://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+      upstreamSocket.dispatchEvent(new Event('error'))
+
+      expect(context.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('closes the upstream websocket when the downstream context closes', async () => {
+      const events = await proxyWebsocket('ws://example.com/')
+      const context = {
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WSContext
+
+      events.onOpen?.(new Event('open'), context)
+      events.onClose?.(new CloseEvent('close'), context)
+
+      expect(upstreamSocket.close).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/helper/proxy-websocket/index.ts
+++ b/src/helper/proxy-websocket/index.ts
@@ -1,0 +1,60 @@
+/**
+ * @module
+ * WebSocket Proxy Helper for Hono.
+ */
+
+import { hc } from '../../client'
+import type { WSEvents } from '../websocket'
+
+interface ProxyWebsocketFetch {
+  (input: string | URL | Request): Promise<WSEvents>
+}
+
+/**
+ * A helper for proxying WebSockets.
+ *
+ * @example
+ * ```ts
+ * app.get(
+ *   '/ws',
+ *   upgradeWebSocket(() => {
+ *     return proxyWebsocket('ws://example.com/')
+ *   })
+ * )
+ * ```
+ */
+export const proxyWebsocket: ProxyWebsocketFetch = async (input) => {
+  const request = new Request(input)
+  const url = new URL(request.url)
+  let upstream: WebSocket
+
+  return {
+    async onOpen(_event, context) {
+      const client = hc(url.origin)
+      upstream = client[url.pathname].$ws(0)
+
+      upstream.addEventListener('message', (event) => {
+        if (context.readyState === WebSocket.OPEN) {
+          context.send(event.data.toString())
+        }
+      })
+
+      upstream.addEventListener('close', () => {
+        context.close()
+      })
+
+      upstream.addEventListener('error', (err) => {
+        console.error('Upstream WebSocket error:', err)
+        context.close()
+      })
+    },
+    onMessage(event, _context) {
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(event.data.toString())
+      }
+    },
+    onClose() {
+      upstream?.close()
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Added a websocket proxy helper. A feature that I and assumably many others liked from node-http-proxy.

Related https://github.com/orgs/honojs/discussions/4086 & https://github.com/orgs/honojs/discussions/3588

### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [X] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
