### PR TITLE
fix(stream): upgrade `@hono/node-server` to v2 and fix abort handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18.18.2', '20.x', '22.x']
+        node: ['20.x', '22.x', '24.x']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "hono",
       "devDependencies": {
         "@hono/eslint-config": "^2.1.0",
-        "@hono/node-server": "^1.13.5",
+        "@hono/node-server": "^2.0.2",
         "@types/glob": "^9.0.0",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^24.3.0",
@@ -179,7 +179,7 @@
 
     "@hono/eslint-config": ["@hono/eslint-config@2.1.0", "", { "dependencies": { "@eslint/js": "^9.39.3", "eslint-config-prettier": "^10.1.8", "eslint-import-resolver-typescript": "^4.4.4", "eslint-plugin-import-x": "^4.16.1", "eslint-plugin-n": "^17.24.0", "typescript-eslint": "^8.56.1" }, "peerDependencies": { "eslint": "^9.0.0", "typescript": "^5.0.0" } }, "sha512-uNR7As09OPTFLj5f6JwMd5DgTkEhMMlN8kqSlHmPYDU0p3voyaDghNahckydnAdhxIyRHrZhtLkuJDmZ5aeiqg=="],
 
-    "@hono/node-server": ["@hono/node-server@1.13.5", "", { "peerDependencies": { "hono": "^4" } }, "sha512-lSo+CFlLqAFB4fX7ePqI9nauEn64wOfJHAfc9duYFTvAG3o416pC0nTGeNjuLHchLedH+XyWda5v79CVx1PIjg=="],
+    "@hono/node-server": ["@hono/node-server@2.0.2", "", { "peerDependencies": { "hono": "^4" } }, "sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -879,7 +879,7 @@
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
-    "hono": ["hono@4.6.3", "", {}, "sha512-0LeEuBNFeSHGqZ9sNVVgZjB1V5fmhkBSB0hZrpqStSMLOWgfLy0dHOvrjbJh0H2khsjet6rbHfWTHY0kpYThKQ=="],
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
 
     "hosted-git-info": ["hosted-git-info@8.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-sYKnA7eGln5ov8T8gnYlkSOxFJvywzEx9BueN6xo/GKO8PGiI6uK6xx+DIGe45T3bdVjLAQDQW1aicT8z8JwQg=="],
 

--- a/package.json
+++ b/package.json
@@ -657,7 +657,7 @@
   ],
   "devDependencies": {
     "@hono/eslint-config": "^2.1.0",
-    "@hono/node-server": "^1.13.5",
+    "@hono/node-server": "^2.0.2",
     "@types/glob": "^9.0.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^24.3.0",

--- a/runtime-tests/node/index.test.ts
+++ b/runtime-tests/node/index.test.ts
@@ -133,14 +133,12 @@ describe('stream', () => {
 
   it('Should call onAbort', async () => {
     const controller = new AbortController()
-    const res = expect(agent.get('/stream', { signal: controller.signal })).rejects.toThrow(
-      'This operation was aborted'
-    )
+    const req = agent.get('/stream', { signal: controller.signal })
 
     expect(aborted).toBe(false)
     await new Promise((resolve) => setTimeout(resolve, 10))
     controller.abort()
-    await res
+    await req.catch(() => {})
     while (!aborted) {
       await new Promise((resolve) => setTimeout(resolve))
     }
@@ -188,14 +186,12 @@ describe('streamSSE', () => {
 
   it('Should call onAbort', async () => {
     const controller = new AbortController()
-    const res = expect(agent.get('/stream', { signal: controller.signal })).rejects.toThrow(
-      'This operation was aborted'
-    )
+    const req = agent.get('/stream', { signal: controller.signal })
 
     expect(aborted).toBe(false)
     await new Promise((resolve) => setTimeout(resolve, 10))
     controller.abort()
-    await res
+    await req.catch(() => {})
     while (!aborted) {
       await new Promise((resolve) => setTimeout(resolve))
     }

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -38,7 +38,9 @@ export class StreamingApi {
         done ? controller.close() : controller.enqueue(value)
       },
       cancel: () => {
-        this.abort()
+        if (!this.closed) {
+          this.abort()
+        }
       },
     })
   }
@@ -65,12 +67,12 @@ export class StreamingApi {
   }
 
   async close() {
+    this.closed = true
     try {
       await this.writer.close()
     } catch {
       // Do nothing. If you want to handle errors, create a stream by yourself.
     }
-    this.closed = true
   }
 
   async pipe(body: ReadableStream) {


### PR DESCRIPTION
This PR has several changes.

Initially, I tried to update `@hono/node-server` v1 to v2 in the devDependencies. After that, the test for Node.js (`bun run test:node`) failed. I investigated it, found the stream utility has a bug, and the test should be fixed.

Plus, I updated the CI, removed the `18.x`, and added `24.x` for Node.js.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
