### PR TITLE
fix(jsx): widen children type in jsx/jsxFn to Child[]

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -294,7 +294,7 @@ export class JSXFragmentNode extends JSXNode {
 export const jsx = (
   tag: string | Function,
   props: Props | null,
-  ...children: (string | number | HtmlEscapedString)[]
+  ...children: Child[]
 ): JSXNode => {
   props ??= {}
   if (children.length) {
@@ -313,7 +313,7 @@ let initDomRenderer = false
 export const jsxFn = (
   tag: string | Function,
   props: Props,
-  children: (string | number | HtmlEscapedString)[]
+  children: Child[]
 ): JSXNode => {
   if (!initDomRenderer) {
     for (const k in domRenderers) {

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -291,11 +291,7 @@ export class JSXFragmentNode extends JSXNode {
   }
 }
 
-export const jsx = (
-  tag: string | Function,
-  props: Props | null,
-  ...children: Child[]
-): JSXNode => {
+export const jsx = (tag: string | Function, props: Props | null, ...children: Child[]): JSXNode => {
   props ??= {}
   if (children.length) {
     props.children = children.length === 1 ? children[0] : children
@@ -310,11 +306,7 @@ export const jsx = (
 }
 
 let initDomRenderer = false
-export const jsxFn = (
-  tag: string | Function,
-  props: Props,
-  children: Child[]
-): JSXNode => {
+export const jsxFn = (tag: string | Function, props: Props, children: Child[]): JSXNode => {
   if (!initDomRenderer) {
     for (const k in domRenderers) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #4943

`jsx` and `jsxFn` accepted `(string | number | HtmlEscapedString)[]` for children, which is narrower than the `Child` type, `JSXNode`'s constructor signature, and `cloneElement`. This caused TS2345 errors when passing a `Child`-typed value to `createElement`.

Widened both to `Child[]` to match the constructor and `cloneElement`.