### PR TITLE
fix(jsx): widen jsx and jsxFn children to Child[]

### DIFF
--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource ./ */
 
-import type { JSXNode } from './base'
+import type { Child, JSXNode } from './base'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { cloneElement, jsx, Fragment } from './base'
 
@@ -42,5 +42,16 @@ describe('createElement', () => {
     expect(element.tag).toBe('svg')
     expect(element.type).toBe('svg')
     expect(element.ref).toBe(ref)
+  })
+
+  it('should accept a Child-typed value as children (regression: jsx/jsxFn signature)', () => {
+    // The jsx/jsxFn factories must accept the same children types that the
+    // JSXNode constructor and the Child type itself allow. Before the
+    // signature was widened, passing a Child-typed value to jsx() raised
+    // TS2345 even though the underlying node accepted it at runtime.
+    const child: Child = 'hello'
+    const element = jsx('div', null, child) as unknown as JSXNode
+    expect(element.tag).toBe('div')
+    expect(element.toString()).toBe('<div>hello</div>')
   })
 })

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -302,11 +302,7 @@ export class JSXFragmentNode extends JSXNode {
   }
 }
 
-export const jsx = (
-  tag: string | Function,
-  props: Props | null,
-  ...children: (string | number | HtmlEscapedString)[]
-): JSXNode => {
+export const jsx = (tag: string | Function, props: Props | null, ...children: Child[]): JSXNode => {
   props ??= {}
   if (children.length) {
     props.children = children.length === 1 ? children[0] : children
@@ -321,11 +317,7 @@ export const jsx = (
 }
 
 let initDomRenderer = false
-export const jsxFn = (
-  tag: string | Function,
-  props: Props,
-  children: (string | number | HtmlEscapedString)[]
-): JSXNode => {
+export const jsxFn = (tag: string | Function, props: Props, children: Child[]): JSXNode => {
   if (!initDomRenderer) {
     for (const k in domRenderers) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #4943.

`jsx`, `jsxFn`, and the `createElement` alias accept a narrower `(string | number | HtmlEscapedString)[]` for children, while the `JSXNode` constructor, `cloneElement`, and the `Child` type itself accept `Child[]`. The mismatch forces consumer libraries that pass a `Child`-typed value through `createElement` to cast, or to import the wider `createElement` from `hono/jsx/dom` — which then breaks SSR because the DOM variant produces plain VNodes that `renderToString` can't consume.

This widens `jsx` and `jsxFn` to `Child[]`, matching the rest of the surface.

## Safety

- `HtmlEscapedString` is declared as `string & HtmlEscaped`, so existing callers passing strings or `HtmlEscapedString` remain assignable to `Child`.
- The `JSXNode` constructor already accepts `Child[]` and is what `jsxFn` ultimately calls, so no runtime change is needed.
- Default behaviour for existing consumers is unchanged — this is a strict widening.

## Test plan

- Adds a regression test in `src/jsx/base.test.tsx` that constructs a value typed as `Child` and passes it to `jsx`. Before the widening this call failed with TS2345; after, it type-checks and renders correctly.
- `bunx tsc --noEmit` — clean.
- `bunx vitest run --no-coverage src/jsx/` — 1869 passed / 9 skipped, including the new case.
- `bun run lint` — 0 errors (38 pre-existing warnings unrelated to this diff).