### PR TITLE
fix(jsx): widen jsx and jsxFn children to Child[]

### DIFF
--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource ./ */
 
-import type { JSXNode } from './base'
+import type { Child, JSXNode } from './base'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { cloneElement, jsx, Fragment } from './base'
 
@@ -42,5 +42,11 @@ describe('createElement', () => {
     expect(element.tag).toBe('svg')
     expect(element.type).toBe('svg')
     expect(element.ref).toBe(ref)
+  })
+
+  it('should accept a Child-typed value as a child', () => {
+    const child: Child = <span>inner</span>
+    const element = jsx('div', null, child) as unknown as JSXNode
+    expect(element.toString()).toBe('<div><span>inner</span></div>')
   })
 })

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -302,11 +302,7 @@ export class JSXFragmentNode extends JSXNode {
   }
 }
 
-export const jsx = (
-  tag: string | Function,
-  props: Props | null,
-  ...children: (string | number | HtmlEscapedString)[]
-): JSXNode => {
+export const jsx = (tag: string | Function, props: Props | null, ...children: Child[]): JSXNode => {
   props ??= {}
   if (children.length) {
     props.children = children.length === 1 ? children[0] : children
@@ -321,11 +317,7 @@ export const jsx = (
 }
 
 let initDomRenderer = false
-export const jsxFn = (
-  tag: string | Function,
-  props: Props,
-  children: (string | number | HtmlEscapedString)[]
-): JSXNode => {
+export const jsxFn = (tag: string | Function, props: Props, children: Child[]): JSXNode => {
   if (!initDomRenderer) {
     for (const k in domRenderers) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closes #4943.

`jsx`, `jsxFn`, and the `createElement` alias accepted a narrower
`(string | number | HtmlEscapedString)[]` for children, while the
`JSXNode` constructor and the `Child` type itself accept `Child[]`.
This forces callers that hold a `Child`-typed value (downstream
libraries, custom renderers) to either cast or import the wider
`createElement` from `hono/jsx/dom` — which then breaks SSR because
the DOM variant produces plain VNodes that `renderToString` can't
consume.

This widens `jsx` and `jsxFn` to `Child[]`, matching the rest of the
JSX surface.

### Safety

- `HtmlEscapedString` is `string & HtmlEscaped`, so existing callers
  passing strings or `HtmlEscapedString` remain assignable to `Child`.
- The `JSXNode` constructor already accepts `Child[]` and is what
  `jsxFn` ultimately calls, so no runtime change is needed.
- Strict widening — existing consumers see no behaviour change.

### Tests

- Added a regression test in \`src/jsx/base.test.tsx\` that passes a
  \`Child\`-typed value through \`jsx\`. Without the widening it fails
  with TS2345.
- \`bunx tsc --noEmit\` — clean.
- \`bunx vitest run --no-coverage src/jsx/\` — 1869 passed / 9 skipped.

### Checklist

- [x] Add tests
- [x] Run tests
- [x] \`bun run format:fix && bun run lint:fix\`