### PR TITLE
feat(compress): add shouldCompress option for custom content-type filtering

### DIFF
--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -216,6 +216,48 @@ describe('Compress Middleware', () => {
   })
 })
 
+describe('shouldCompress option', () => {
+  it('should compress custom content types when shouldCompress returns true', async () => {
+    const app = new Hono()
+    app.use(
+      '*',
+      compress({
+        shouldCompress: (res) => {
+          const type = res.headers.get('Content-Type') ?? ''
+          return type.startsWith('application/vnd.msgpack')
+        },
+      })
+    )
+    app.get('/msgpack', (c) => {
+      c.header('Content-Type', 'application/vnd.msgpack')
+      c.header('Content-Length', '1024')
+      return c.body(new Uint8Array(1024))
+    })
+
+    const req = new Request('http://localhost/msgpack', {
+      headers: { 'Accept-Encoding': 'gzip' },
+    })
+    const res = await app.request(req)
+    expect(res.headers.get('Content-Encoding')).toBe('gzip')
+  })
+
+  it('should not compress when shouldCompress returns false', async () => {
+    const app = new Hono()
+    app.use('*', compress({ shouldCompress: () => false }))
+    app.get('/large', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Length', '1024')
+      return c.text('a'.repeat(1024))
+    })
+
+    const req = new Request('http://localhost/large', {
+      headers: { 'Accept-Encoding': 'gzip' },
+    })
+    const res = await app.request(req)
+    expect(res.headers.get('Content-Encoding')).toBeNull()
+  })
+})
+
 async function decompressResponse(res: Response): Promise<string> {
   const decompressedStream = res.body!.pipeThrough(new DecompressionStream('gzip'))
   const decompressedResponse = new Response(decompressedStream)

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -12,6 +12,12 @@ const cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
 interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
   threshold?: number
+  /**
+   * A custom function to determine whether a response should be compressed.
+   * When provided, it replaces the default content-type check.
+   * Receives the response object; return `true` to compress, `false` to skip.
+   */
+  shouldCompress?: (res: Response) => boolean
 }
 
 /**
@@ -22,6 +28,7 @@ interface CompressionOptions {
  * @param {CompressionOptions} [options] - The options for the compress middleware.
  * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.
  * @param {number} [options.threshold=1024] - The minimum size in bytes to compress. Defaults to 1024 bytes.
+ * @param {Function} [options.shouldCompress] - A custom function to determine whether a response should be compressed. When provided, replaces the built-in content-type check. Return `true` to compress, `false` to skip.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -30,9 +37,21 @@ interface CompressionOptions {
  *
  * app.use(compress())
  * ```
+ *
+ * @example
+ * ```ts
+ * // Compress custom content types in addition to the defaults
+ * app.use(compress({
+ *   shouldCompress: (res) => {
+ *     const type = res.headers.get('Content-Type') ?? ''
+ *     return COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type) || type.startsWith('application/vnd.msgpack')
+ *   }
+ * }))
+ * ```
  */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   const threshold = options?.threshold ?? 1024
+  const compressCheck = options?.shouldCompress ?? defaultShouldCompress
 
   return async function compress(ctx, next) {
     await next()
@@ -45,7 +64,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
       ctx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
       ctx.req.method === 'HEAD' || // HEAD request
       (contentLength && Number(contentLength) < threshold) || // content-length below threshold
-      !shouldCompress(ctx.res) || // not compressible type
+      !compressCheck(ctx.res) || // not compressible type
       !shouldTransform(ctx.res) // cache-control: no-transform
     ) {
       return
@@ -66,9 +85,11 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   }
 }
 
-const shouldCompress = (res: Response) => {
+export { COMPRESSIBLE_CONTENT_TYPE_REGEX }
+
+const defaultShouldCompress = (res: Response) => {
   const type = res.headers.get('Content-Type')
-  return type && COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type)
+  return type ? COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type) : false
 }
 
 const shouldTransform = (res: Response) => {


### PR DESCRIPTION
Closes #4946.

Adds an optional `shouldCompress` function to `CompressionOptions` that lets callers override the built-in content-type check entirely. When provided it replaces the default `COMPRESSIBLE_CONTENT_TYPE_REGEX` test, so any content-type (e.g. `application/vnd.msgpack`, custom vendor types) can be included or excluded.

```ts
app.use(compress({
  shouldCompress: (res) => {
    const type = res.headers.get('Content-Type') ?? ''
    return COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type) || type.startsWith('application/vnd.msgpack')
  }
}))
```

`COMPRESSIBLE_CONTENT_TYPE_REGEX` is now re-exported from the middleware module so callers can compose it in their own predicate.

Two tests added: one verifying a custom type is compressed when `shouldCompress` returns `true`, one verifying nothing is compressed when it always returns `false`. All 21 tests pass.