### PR TITLE
fix(compress): respect Accept-Encoding when encoding option is set

### DIFF
--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -266,6 +266,41 @@ describe('Compress Middleware', () => {
       expect(decompressed).toBe('Custom NotFound')
     })
   })
+
+  describe('Encoding Option', () => {
+    const buildApp = (encoding: 'gzip' | 'deflate') => {
+      const app = new Hono()
+      app.use('*', compress({ encoding }))
+      app.get('/large', (c) => {
+        c.header('Content-Type', 'text/plain')
+        c.header('Content-Length', '1024')
+        return c.text('a'.repeat(1024))
+      })
+      return app
+    }
+
+    it('should compress when configured encoding is accepted by the client', async () => {
+      const app = buildApp('gzip')
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+    })
+
+    it('should not compress when configured encoding is not in Accept-Encoding', async () => {
+      const app = buildApp('gzip')
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'deflate' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+    })
+
+    it('should not compress when Accept-Encoding header is absent', async () => {
+      const app = buildApp('gzip')
+      const res = await app.request('/large')
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+    })
+  })
 })
 
 async function decompressResponse(res: Response): Promise<string> {

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -301,6 +301,86 @@ describe('Compress Middleware', () => {
       expect(res.headers.get('Content-Encoding')).toBeNull()
     })
   })
+
+  describe('Accept-Encoding parsing', () => {
+    const buildAppDefault = () => {
+      const app = new Hono()
+      app.use('*', compress())
+      app.get('/large', (c) => {
+        c.header('Content-Type', 'text/plain')
+        c.header('Content-Length', '1024')
+        return c.text('a'.repeat(1024))
+      })
+      return app
+    }
+
+    const buildAppWithEncoding = (encoding: 'gzip' | 'deflate') => {
+      const app = new Hono()
+      app.use('*', compress({ encoding }))
+      app.get('/large', (c) => {
+        c.header('Content-Type', 'text/plain')
+        c.header('Content-Length', '1024')
+        return c.text('a'.repeat(1024))
+      })
+      return app
+    }
+
+    it('should not compress when configured encoding has q=0', async () => {
+      const app = buildAppWithEncoding('gzip')
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'gzip;q=0' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+    })
+
+    it('should fall back to another encoding when the preferred one has q=0', async () => {
+      const app = buildAppDefault()
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'gzip;q=0, deflate' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('deflate')
+    })
+
+    it('should compress when Accept-Encoding is the wildcard *', async () => {
+      const app = buildAppWithEncoding('gzip')
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': '*' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+    })
+
+    it('should compress when Accept-Encoding token differs only in case', async () => {
+      const app = buildAppWithEncoding('gzip')
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'GZIP' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+    })
+
+    it('should not treat x-gzip as gzip', async () => {
+      const app = buildAppWithEncoding('gzip')
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'x-gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+    })
+
+    it('should pick the encoding with the highest q value', async () => {
+      const app = buildAppDefault()
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'gzip;q=0.5, deflate;q=0.9' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('deflate')
+    })
+
+    it('should prefer gzip over deflate when q values are equal', async () => {
+      const app = buildAppDefault()
+      const res = await app.request('/large', {
+        headers: { 'Accept-Encoding': 'gzip;q=0.5, deflate;q=0.5' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+    })
+  })
 })
 
 async function decompressResponse(res: Response): Promise<string> {

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -29,7 +29,9 @@ const selectEncoding = (
   for (const enc of candidates) {
     const explicit = accepts.find((a) => a.type.toLowerCase() === enc)
     const q = explicit ? explicit.q : (wildcardQ ?? 0)
-    if (q > 0 && (!best || q > best.q)) {
+    if (q === 1) {
+      return enc
+    } else if (q > 0 && (!best || q > best.q)) {
       best = { encoding: enc, q }
     }
   }

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -52,8 +52,11 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     }
 
     const accepted = ctx.req.header('Accept-Encoding')
-    const encoding =
-      options?.encoding ?? ENCODING_TYPES.find((encoding) => accepted?.includes(encoding))
+    const encoding = options?.encoding
+      ? accepted?.includes(options.encoding)
+        ? options.encoding
+        : undefined
+      : ENCODING_TYPES.find((encoding) => accepted?.includes(encoding))
     if (!encoding || !ctx.res.body) {
       return
     }

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -4,14 +4,36 @@
  */
 
 import type { MiddlewareHandler } from '../../types'
+import { parseAccept } from '../../utils/accept'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
 
 const ENCODING_TYPES = ['gzip', 'deflate'] as const
+type Encoding = (typeof ENCODING_TYPES)[number]
 const cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
 
 interface CompressionOptions {
-  encoding?: (typeof ENCODING_TYPES)[number]
+  encoding?: Encoding
   threshold?: number
+}
+
+const selectEncoding = (
+  header: string | undefined,
+  candidates: readonly Encoding[]
+): Encoding | undefined => {
+  if (header === undefined) {
+    return undefined
+  }
+  const accepts = parseAccept(header)
+  const wildcardQ = accepts.find((a) => a.type === '*')?.q
+  let best: { encoding: Encoding; q: number } | undefined
+  for (const enc of candidates) {
+    const explicit = accepts.find((a) => a.type.toLowerCase() === enc)
+    const q = explicit ? explicit.q : (wildcardQ ?? 0)
+    if (q > 0 && (!best || q > best.q)) {
+      best = { encoding: enc, q }
+    }
+  }
+  return best?.encoding
 }
 
 /**
@@ -33,6 +55,7 @@ interface CompressionOptions {
  */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   const threshold = options?.threshold ?? 1024
+  const candidates: readonly Encoding[] = options?.encoding ? [options.encoding] : ENCODING_TYPES
 
   return async function compress(ctx, next) {
     await next()
@@ -52,11 +75,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     }
 
     const accepted = ctx.req.header('Accept-Encoding')
-    const encoding = options?.encoding
-      ? accepted?.includes(options.encoding)
-        ? options.encoding
-        : undefined
-      : ENCODING_TYPES.find((encoding) => accepted?.includes(encoding))
+    const encoding = selectEncoding(accepted, candidates)
     if (!encoding || !ctx.res.body) {
       return
     }


### PR DESCRIPTION
When the `encoding` option is provided to the compress middleware, the response is currently compressed regardless of what the client advertised in its `Accept-Encoding` header. This can produce responses the client cannot decode.

For example, with `compress({ encoding: 'gzip' })`:

- A request with `Accept-Encoding: deflate` still receives a gzip-encoded body.
- A request with no `Accept-Encoding` header still receives a gzip-encoded body.

The fallback path (when `encoding` is not set) already honors `Accept-Encoding` via `ENCODING_TYPES.find((encoding) => accepted?.includes(encoding))`. The configured-encoding path skipped that check.

This change checks the `Accept-Encoding` header in both paths. When the configured encoding is not present in the client's accepted encodings, the response is left uncompressed, matching the documented behavior of the default path.

Added three regression tests under a new "Encoding Option" describe block covering the accepted, not-accepted, and absent-header cases.