### PR TITLE
fix(deno): echo negotiated WebSocket subprotocol in upgrade response

### DIFF
--- a/src/adapter/deno/websocket.test.ts
+++ b/src/adapter/deno/websocket.test.ts
@@ -76,6 +76,51 @@ describe('WebSockets', () => {
       )
     expect(await messagePromise).toBe(data)
   })
+  it('Should pass the first Sec-WebSocket-Protocol value as the protocol option', async () => {
+    app.get(
+      '/ws',
+      upgradeWebSocket(() => ({}))
+    )
+    const socket = new EventTarget() as WebSocket
+    let passedOptions: Deno.UpgradeWebSocketOptions | undefined
+    Deno.upgradeWebSocket = (_req, options) => {
+      passedOptions = options
+      return {
+        response: new Response(),
+        socket,
+      }
+    }
+    await app.request('/ws', {
+      headers: {
+        upgrade: 'websocket',
+        'sec-websocket-protocol': 'rivet, rivet_target.actor, rivet_actor.19c4f9038947cdcb',
+      },
+    })
+    expect(passedOptions?.protocol).toBe('rivet')
+  })
+
+  it('Should not set the protocol option when Sec-WebSocket-Protocol is absent', async () => {
+    app.get(
+      '/ws',
+      upgradeWebSocket(() => ({}))
+    )
+    const socket = new EventTarget() as WebSocket
+    let passedOptions: Deno.UpgradeWebSocketOptions | undefined
+    Deno.upgradeWebSocket = (_req, options) => {
+      passedOptions = options
+      return {
+        response: new Response(),
+        socket,
+      }
+    }
+    await app.request('/ws', {
+      headers: {
+        upgrade: 'websocket',
+      },
+    })
+    expect(passedOptions?.protocol).toBeUndefined()
+  })
+
   it('Should call next() when header does not have upgrade', async () => {
     const next = vi.fn()
     await upgradeWebSocket(() => ({}))(

--- a/src/adapter/deno/websocket.test.ts
+++ b/src/adapter/deno/websocket.test.ts
@@ -76,6 +76,7 @@ describe('WebSockets', () => {
       )
     expect(await messagePromise).toBe(data)
   })
+
   it('Should pass the first Sec-WebSocket-Protocol value as the protocol option', async () => {
     app.get(
       '/ws',
@@ -119,6 +120,29 @@ describe('WebSockets', () => {
       },
     })
     expect(passedOptions?.protocol).toBeUndefined()
+  })
+
+  it('Should let an explicit protocol option take precedence over the request header', async () => {
+    app.get(
+      '/ws',
+      upgradeWebSocket(() => ({}), { protocol: 'user-chosen' })
+    )
+    const socket = new EventTarget() as WebSocket
+    let passedOptions: Deno.UpgradeWebSocketOptions | undefined
+    Deno.upgradeWebSocket = (_req, options) => {
+      passedOptions = options
+      return {
+        response: new Response(),
+        socket,
+      }
+    }
+    await app.request('/ws', {
+      headers: {
+        upgrade: 'websocket',
+        'sec-websocket-protocol': 'header-value',
+      },
+    })
+    expect(passedOptions?.protocol).toBe('user-chosen')
   })
 
   it('Should call next() when header does not have upgrade', async () => {

--- a/src/adapter/deno/websocket.ts
+++ b/src/adapter/deno/websocket.ts
@@ -7,7 +7,15 @@ export const upgradeWebSocket: UpgradeWebSocket<WebSocket, Deno.UpgradeWebSocket
       return
     }
 
-    const { response, socket } = Deno.upgradeWebSocket(c.req.raw, options ?? {})
+    // Echo the negotiated subprotocol back to the client. Browsers (e.g. Chrome)
+    // reject the connection when a subprotocol was requested but the response is
+    // missing the `Sec-WebSocket-Protocol` header.
+    const subprotocol = c.req.header('sec-websocket-protocol')?.split(',')[0]?.trim()
+
+    const { response, socket } = Deno.upgradeWebSocket(c.req.raw, {
+      ...(subprotocol ? { protocol: subprotocol } : {}),
+      ...options,
+    })
 
     const wsContext: WSContext<WebSocket> = new WSContext({
       close: (code, reason) => socket.close(code, reason),


### PR DESCRIPTION
## What

The Deno adapter's `upgradeWebSocket` does not set the `Sec-WebSocket-Protocol` header on the upgrade response. When a client opens a socket with a subprotocol (e.g. `new WebSocket(url, ["foobar"])`), Chrome rejects the connection because the negotiated subprotocol is missing from the 101 response. Firefox is more lenient, which is why this looked Chrome-specific.

## How

`Deno.upgradeWebSocket` only emits the `Sec-WebSocket-Protocol` response header when given a `protocol` option. This reads the first value from the request's `Sec-WebSocket-Protocol` header and passes it through as `protocol`. An explicitly provided `protocol` option still takes precedence, so existing behavior is preserved.

## Tests

Added unit tests that mock the `Deno.upgradeWebSocket` global and assert the `protocol` option is derived from the request header (and left unset when no subprotocol is requested). `tsc --noEmit`, eslint, and prettier all pass.

Closes #4439