### PR TITLE
Throw for unserializable JSON responses

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,13 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws when the value is not JSON serializable', () => {
+    expect(() => c.json(undefined)).toThrow(TypeError)
+    expect(() => c.json(undefined)).toThrow('Value is not JSON serializable.')
+    expect(() => c.json(Symbol('hono'))).toThrow('Value is not JSON serializable.')
+    expect(() => c.json(() => 'hono')).toThrow('Value is not JSON serializable.')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,13 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable.')
+    }
+
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
Fixes #2343

### Summary

- throw a TypeError when `c.json()` receives a top-level value that `JSON.stringify()` cannot serialize
- keep normal JSON response creation unchanged after serialization succeeds
- add coverage for `undefined`, symbol, and function values

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Tests

- `bunx vitest --run src/context.test.ts -t "c.json"`
- `bunx vitest --run src/context.test.ts`
- `bunx tsc --noEmit`
- `bun run format`
- `bun run lint`
- `bun run editorconfig-checker -format github-actions`
- `git diff --check`
