### PR TITLE
Throw for non-serializable JSON responses

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,10 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws when the value is not JSON serializable', () => {
+    expect(() => c.json(undefined as never)).toThrow(TypeError)
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable.')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## Summary
- detect when `JSON.stringify()` cannot serialize a `c.json()` value
- throw a `TypeError` instead of creating a response with an undefined body
- add regression coverage for `c.json(undefined)`

## Verification
- `bun test src/context.test.ts --test-name-pattern "not JSON serializable"` (failed before implementation)
- `bun test src/context.test.ts --test-name-pattern "not JSON serializable"`
- `node node_modules/vitest/vitest.mjs run src/context.test.ts -t "not JSON serializable" --coverage.enabled=false`
- `node node_modules/vitest/vitest.mjs run src/context.test.ts --coverage.enabled=false`
- `bunx tsc --noEmit --pretty false`
- `bunx prettier --check src/context.ts src/context.test.ts`
- `bunx eslint src/context.ts src/context.test.ts`
- `git diff --check`

Fixes #2343.

AI-assisted: yes. I reviewed and tested the change locally.