### PR TITLE
feat(compress): add contentTypeFilter option and `COMPRESSIBLE_CONTENT_TYPE_REGEX` re-export

### DIFF
--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -245,6 +245,50 @@ describe('Compress Middleware', () => {
     })
   })
 
+  describe('contentTypeFilter', () => {
+    describe('RegExp', () => {
+      const app = new Hono()
+      app.use('*', compress({ contentTypeFilter: /^application\/json/, threshold: 0 }))
+      app.get('/json', (c) => c.json({ data: 'a'.repeat(1024) }))
+      app.get('/text', (c) => c.text('a'.repeat(1024)))
+
+      it('should compress when Content-Type matches', async () => {
+        const res = await app.request('/json', {
+          headers: { 'Accept-Encoding': 'gzip' },
+        })
+        expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      })
+
+      it('should not compress when Content-Type does not match', async () => {
+        const res = await app.request('/text', {
+          headers: { 'Accept-Encoding': 'gzip' },
+        })
+        expect(res.headers.get('Content-Encoding')).toBeNull()
+      })
+    })
+
+    describe('function', () => {
+      const app = new Hono()
+      app.use('*', compress({ contentTypeFilter: (type) => type.includes('json'), threshold: 0 }))
+      app.get('/json', (c) => c.json({ data: 'a'.repeat(1024) }))
+      app.get('/text', (c) => c.text('a'.repeat(1024)))
+
+      it('should compress when Content-Type matches', async () => {
+        const res = await app.request('/json', {
+          headers: { 'Accept-Encoding': 'gzip' },
+        })
+        expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      })
+
+      it('should not compress when Content-Type does not match', async () => {
+        const res = await app.request('/text', {
+          headers: { 'Accept-Encoding': 'gzip' },
+        })
+        expect(res.headers.get('Content-Encoding')).toBeNull()
+      })
+    })
+  })
+
   describe('Edge Cases', () => {
     it('should not compress responses with Cache-Control: no-transform', async () => {
       await testCompression('/no-transform', 'gzip', null)

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -6,12 +6,17 @@
 import type { MiddlewareHandler } from '../../types'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
 
+export { COMPRESSIBLE_CONTENT_TYPE_REGEX }
+
 const ENCODING_TYPES = ['gzip', 'deflate'] as const
 const cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
+
+type ContentTypeFilter = RegExp | ((contentType: string) => boolean)
 
 interface CompressionOptions {
   encoding?: (typeof ENCODING_TYPES)[number]
   threshold?: number
+  contentTypeFilter?: ContentTypeFilter
 }
 
 /**
@@ -22,6 +27,7 @@ interface CompressionOptions {
  * @param {CompressionOptions} [options] - The options for the compress middleware.
  * @param {'gzip' | 'deflate'} [options.encoding] - The compression scheme to allow for response compression. Either 'gzip' or 'deflate'. If not defined, both are allowed and will be used based on the Accept-Encoding header. 'gzip' is prioritized if this option is not provided and the client provides both in the Accept-Encoding header.
  * @param {number} [options.threshold=1024] - The minimum size in bytes to compress. Defaults to 1024 bytes.
+ * @param {RegExp | Function} [options.contentTypeFilter=COMPRESSIBLE_CONTENT_TYPE_REGEX] - A RegExp or function to determine if the response Content-Type should be compressed.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -29,10 +35,28 @@ interface CompressionOptions {
  * const app = new Hono()
  *
  * app.use(compress())
+ *
+ * // Compress only JSON responses
+ * app.use(compress({ contentTypeFilter: /^application\/json/ }))
+ *
+ * // Compress based on custom Content-Type logic
+ * app.use(compress({ contentTypeFilter: (type) => COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type) || type === "application/x-myformat" }))
  * ```
  */
 export const compress = (options?: CompressionOptions): MiddlewareHandler => {
   const threshold = options?.threshold ?? 1024
+
+  const contentTypeFilter = options?.contentTypeFilter ?? COMPRESSIBLE_CONTENT_TYPE_REGEX
+  const shouldCompress =
+    typeof contentTypeFilter === 'function'
+      ? (res: Response) => {
+          const type = res.headers.get('Content-Type')
+          return type && contentTypeFilter(type)
+        }
+      : (res: Response) => {
+          const type = res.headers.get('Content-Type')
+          return type && contentTypeFilter.test(type)
+        }
 
   return async function compress(ctx, next) {
     await next()
@@ -70,11 +94,6 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
       ctx.res.headers.set('ETag', `W/${etag}`)
     }
   }
-}
-
-const shouldCompress = (res: Response) => {
-  const type = res.headers.get('Content-Type')
-  return type && COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type)
 }
 
 const shouldTransform = (res: Response) => {


### PR DESCRIPTION
close #4946 

* Added `contentTypeFilter` option to compress middleware that allows users to set custom conditions for which Content-Types are allowed to be compressed.
* Added re-export of `COMPRESSIBLE_CONTENT_TYPE_REGEX` in middleware/compress/index.ts so users can import it from "hono/compress" to use with contentTypeFilter option.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
