### PR TITLE
fix(serve-static): normalize all backslashes in file paths, not just the first

### DIFF
--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -43,6 +43,17 @@ describe('getFilePathWithoutDefaultDocument', () => {
     expect(
       getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./..foo../bar.txt') })
     ).toBe('..foo../bar.txt')
+
+    // Multiple path segments: every backslash must be normalized, not just the first
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: slashToBackslash('foo/bar/baz.txt') })
+    ).toBe('foo/bar/baz.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({
+        filename: slashToBackslash('foo/bar/baz.txt'),
+        root: 'assets',
+      })
+    ).toBe('assets/foo/bar/baz.txt')
   })
 })
 

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -43,7 +43,7 @@ export const getFilePathWithoutDefaultDocument = (
   filename = filename.replace(/^\.?[\/\\]/, '')
 
   // foo\bar.txt => foo/bar.txt
-  filename = filename.replace(/\\/, '/')
+  filename = filename.replace(/\\/g, '/')
 
   // assets/ => assets
   root = root.replace(/\/$/, '')


### PR DESCRIPTION
## What

`getFilePathWithoutDefaultDocument` in `src/utils/filepath.ts` normalizes backslash path separators to forward slashes so a requested path resolves consistently regardless of separator style. The replacement uses a **non-global** regex:

```ts
// foo\bar.txt => foo/bar.txt
filename = filename.replace(/\\/, '/')
```

Without the `g` flag, only the **first** backslash is converted, so a path with more than one segment is left with mixed separators:

| input | current | expected |
|---|---|---|
| `foo\bar\baz.txt` | `foo/bar\baz.txt` | `foo/bar/baz.txt` |

The remaining `\` then resolves to the wrong file (or a 404) on back-ends that don't treat `\` as a path separator. The adjacent comment (`foo\bar.txt => foo/bar.txt`) shows the intent was to normalize all of them.

## Fix

Add the `g` flag:

```ts
filename = filename.replace(/\\/g, '/')
```

Behaviour is unchanged for any path with zero or one backslash, so all existing tests pass. I also added a regression test covering a multi-segment path (with and without `root`), which returns the broken `foo/bar\baz.txt` before this change.

## Why it was easy to miss

Every existing `slashToBackslash(...)` test case contains only a single backslash after the leading-separator strip, so the suite stayed green and the missing flag was invisible on a skim.

## Checks

- `vitest run src/utils/filepath.test.ts` — green (incl. new regression test)
- `tsc --noEmit` — clean
- `eslint` + `prettier` — clean
- Blast radius: one character + one test; no public API change.
