### PR TITLE
fix(vercel): add void to handle() return type for Next.js 15 compatibility

### DIFF
--- a/src/adapter/vercel/handler.ts
+++ b/src/adapter/vercel/handler.ts
@@ -3,6 +3,6 @@ import type { Hono } from '../../hono'
 
 export const handle =
   (app: Hono<any, any, any>) =>
-  (req: Request): Response | Promise<Response> => {
+  (req: Request): Response | Promise<Response> | void => {
     return app.fetch(req)
   }


### PR DESCRIPTION
Fixes #4877

Why
handle() from hono/vercel is typed as returning (req: Request) => Response | Promise<Response>. Next.js 15 App Router route handlers expect a return type that includes void (Response | void | Promise<Response | void>). This causes tsc --noEmit to fail.

Changes
Added | void to the return type of the inner function returned by handle().

Updated component: src/adapter/vercel/handler.ts

Testing
No runtime behavior change. The | void union merely satisfies the stricter type constraint imposed by Next.js 15.

Surface area
- Adapter / Vercel
- Bug fix
- TypeScript only