### PR TITLE
refactor: prefer startsWith over str[0] === 'c' in helper/util files

### DIFF
--- a/src/helper/css/index.ts
+++ b/src/helper/css/index.ts
@@ -98,7 +98,7 @@ export const createCssContext = ({
         added[className] = true
         stylesStr += className.startsWith(PSEUDO_GLOBAL_SELECTOR)
           ? toAdd[className]
-          : `${className[0] === '@' ? '' : '.'}${className}{${toAdd[className]}}`
+          : `${className.startsWith('@') ? '' : '.'}${className}{${toAdd[className]}}`
       })
       contextMap.set(context, [{}, added])
 

--- a/src/helper/ssg/utils.ts
+++ b/src/helper/ssg/utils.ts
@@ -51,7 +51,7 @@ export const joinPaths = (...paths: string[]): string => {
   paths = paths.map(normalizePath)
   const resultPaths: string[] = []
   handleSegments(paths.join('/').split('/'), resultPaths)
-  return (paths[0][0] === '/' ? '/' : '') + resultPaths.join('/')
+  return (paths[0].startsWith('/') ? '/' : '') + resultPaths.join('/')
 }
 
 interface FilterStaticGenerateRouteData {

--- a/src/jsx/dom/css.ts
+++ b/src/jsx/dom/css.ts
@@ -105,7 +105,7 @@ export const createCssJsxDomObjects: CreateCssJsxDomObjectsType = ({ id }) => {
       addedStyles.add(className)
       ;(className.startsWith(PSEUDO_GLOBAL_SELECTOR)
         ? splitRule(styleString)
-        : [`${className[0] === '@' ? '' : '.'}${className}{${styleString}}`]
+        : [`${className.startsWith('@') ? '' : '.'}${className}{${styleString}}`]
       ).forEach((rule) => {
         sheet.insertRule(rule, sheet.cssRules.length)
       })

--- a/src/jsx/utils.ts
+++ b/src/jsx/utils.ts
@@ -172,7 +172,7 @@ export const styleObjectForEach = (
 ): void => {
   for (const [k, v] of Object.entries(style)) {
     const key =
-      k[0] === '-' || !/[A-Z]/.test(k)
+      k.startsWith('-') || !/[A-Z]/.test(k)
         ? k // a CSS variable or a lowercase only property
         : k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`) // a camelCase property. convert to kebab-case
     if (!isValidStylePropertyName(key)) {

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -52,7 +52,7 @@ export const getFilePathWithoutDefaultDocument = (
   let path = root ? root + '/' + filename : filename
   path = path.replace(/^\.?\//, '')
 
-  if (root[0] !== '/' && path[0] === '/') {
+  if (!root.startsWith('/') && path.startsWith('/')) {
     return
   }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -63,7 +63,7 @@ export const getPattern = (label: string, next?: string): Pattern | null => {
     if (!patternCache[cacheKey]) {
       if (match[2]) {
         patternCache[cacheKey] =
-          next && next[0] !== ':' && next[0] !== '*'
+          next && !next.startsWith(':') && !next.startsWith('*')
             ? [cacheKey, match[1], new RegExp(`^${match[2]}(?=/${next})`)]
             : [label, match[1], new RegExp(`^${match[2]}$`)]
       } else {
@@ -163,8 +163,8 @@ export const mergePath: (...paths: string[]) => string = (
   if (rest.length) {
     sub = mergePath(sub as string, ...rest)
   }
-  return `${base?.[0] === '/' ? '' : '/'}${base}${
-    sub === '/' ? '' : `${base?.at(-1) === '/' ? '' : '/'}${sub?.[0] === '/' ? sub.slice(1) : sub}`
+  return `${base?.startsWith('/') ? '' : '/'}${base}${
+    sub === '/' ? '' : `${base?.at(-1) === '/' ? '' : '/'}${sub?.startsWith('/') ? sub.slice(1) : sub}`
   }`
 }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -164,7 +164,9 @@ export const mergePath: (...paths: string[]) => string = (
     sub = mergePath(sub as string, ...rest)
   }
   return `${base?.startsWith('/') ? '' : '/'}${base}${
-    sub === '/' ? '' : `${base?.at(-1) === '/' ? '' : '/'}${sub?.startsWith('/') ? sub.slice(1) : sub}`
+    sub === '/'
+      ? ''
+      : `${base?.at(-1) === '/' ? '' : '/'}${sub?.startsWith('/') ? sub.slice(1) : sub}`
   }`
 }
 


### PR DESCRIPTION
## Summary

Replaces `str[0] === 'c'` / `str[0] !== 'c'` character-index comparisons with `str.startsWith('c')` in helper and utility files. This is the pattern flagged by ESLint's `prefer-string-starts-ends-with` rule (currently disabled in `eslint.config.mjs`).

## Changes

| File | Before | After |
|------|--------|-------|
| `src/helper/css/index.ts` | `className[0] === '@'` | `className.startsWith('@')` |
| `src/jsx/dom/css.ts` | `className[0] === '@'` | `className.startsWith('@')` |
| `src/utils/filepath.ts` | `root[0] !== '/'`, `path[0] === '/'` | `root.startsWith('/')`, `path.startsWith('/')` |
| `src/helper/ssg/utils.ts` | `paths[0][0] === '/'` | `paths[0].startsWith('/')` |
| `src/jsx/utils.ts` | `k[0] === '-'` | `k.startsWith('-')` |
| `src/utils/url.ts` | 4 index comparisons in `getPattern`/`mergePath` | `startsWith` equivalents |

All 6 files are utility/helper code — not request-dispatch hot paths. `tsc --noEmit` passes cleanly.

**Excluded intentionally:** `src/router/trie-router/node.ts` (per-request path offset — `str[0] === '/'` is marginally faster in V8 for that hot loop); `src/middleware/secure-headers/secure-headers.ts` (inside a `length === 1 &&` guard where partial rewrite would create mixed style in the same expression).

## Motivation

`str.startsWith('c')` expresses intent more clearly than `str[0] === 'c'` and avoids the silent `undefined` return on empty strings. The index approach silently returns `undefined` (falsy, so usually harmless) when the string is empty; `startsWith` returns `false`. For the cases here — CSS class names, file paths, URL segments — that difference matters for robustness.