### PR TITLE
fix(filepath): normalize all backslashes, not just the first

### DIFF
--- a/src/utils/filepath.test.ts
+++ b/src/utils/filepath.test.ts
@@ -44,6 +44,16 @@ describe('getFilePathWithoutDefaultDocument', () => {
       getFilePathWithoutDefaultDocument({ filename: slashToBackslash('./..foo../bar.txt') })
     ).toBe('..foo../bar.txt')
   })
+
+  it('Should normalize every backslash to a slash, not only the first one', async () => {
+    expect(getFilePathWithoutDefaultDocument({ filename: 'foo\\bar\\baz.txt' })).toBe(
+      'foo/bar/baz.txt'
+    )
+    expect(getFilePathWithoutDefaultDocument({ filename: 'a\\b\\c\\d.txt' })).toBe('a/b/c/d.txt')
+    expect(
+      getFilePathWithoutDefaultDocument({ filename: 'dir\\sub\\file.txt', root: 'root' })
+    ).toBe('root/dir/sub/file.txt')
+  })
 })
 
 describe('getFilePath', () => {

--- a/src/utils/filepath.ts
+++ b/src/utils/filepath.ts
@@ -43,7 +43,7 @@ export const getFilePathWithoutDefaultDocument = (
   filename = filename.replace(/^\.?[\/\\]/, '')
 
   // foo\bar.txt => foo/bar.txt
-  filename = filename.replace(/\\/, '/')
+  filename = filename.replace(/\\/g, '/')
 
   // assets/ => assets
   root = root.replace(/\/$/, '')


### PR DESCRIPTION
## What
`getFilePathWithoutDefaultDocument` now converts **every** backslash in the path to a forward slash, not only the first one.

## Why
The function used `filename.replace(/\/, '/')` — a non-global regex, so only the first `\` is replaced. Multi-segment Windows-style paths are left partially normalized: `a\b\c\d.txt` → `a/b\c\d.txt` (expected `a/b/c/d.txt`). The function's own doc comment (`foo\bar.txt => foo/bar.txt`) shows full normalization was intended, and the util is exported and consumed by serve-static across adapters.

This is the same *class* of defect as the already-merged #4962 (a missing `/g`), but in a **separate function** — `#4962` fixed a regex inside serve-static; this is a distinct regex in the filepath util.

## Safety
Not a traversal-bypass: the `..` rejection check already matches both `/` and `\` separators, so security behaviour is unchanged. This is purely a path-normalization correctness fix; behaviour is identical for paths that contain at most one backslash.

## Testing
Added "Should normalize every backslash to a slash, not only the first one" to `src/utils/filepath.test.ts`: fails before (`expected 'foo/bar\baz.txt' to be 'foo/bar/baz.txt'`), passes after the minimal `/\/` → `/\/g` change. Full filepath + serve-static suites green; `tsc --noEmit` clean.

## Impact
Correct, complete backslash normalization for multi-segment paths on Windows-style inputs.