### PR TITLE
fix(concurrent): release pool slot when a task rejects

### DIFF
--- a/src/utils/concurrent.test.ts
+++ b/src/utils/concurrent.test.ts
@@ -37,6 +37,23 @@ describe('concurrent execution', () => {
     expect(results).toEqual(expectedResults)
   })
 
+  test('releases the slot when a task rejects (no permanent leak)', async () => {
+    const pool = createPool({ concurrency: 1 })
+
+    // A rejected task must still free its pool slot.
+    await expect(pool.run(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom')
+
+    // Before the fix the slot was never released, so this second task queued forever.
+    // Race against a timeout so the failure is a clean assertion, not a hung suite.
+    const result = await Promise.race([
+      pool.run(() => Promise.resolve('ok')),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('pool slot leaked — task never ran')), 1000)
+      ),
+    ])
+    expect(result).toBe('ok')
+  })
+
   describe('with interval', () => {
     test.each`
       concurrency | interval

--- a/src/utils/concurrent.ts
+++ b/src/utils/concurrent.ts
@@ -38,17 +38,23 @@ export const createPool = ({
     }
     const marker = {}
     pool.add(marker)
-    const result = await fn()
-    if (interval) {
-      setTimeout(() => pool.delete(marker), interval)
-    } else {
-      pool.delete(marker)
-    }
-    if (resolve) {
-      resolve(result)
-      return promise as Promise<T>
-    } else {
-      return result
+    try {
+      const result = await fn()
+      if (resolve) {
+        resolve(result)
+        return promise as Promise<T>
+      } else {
+        return result
+      }
+    } finally {
+      // Release the slot even when `fn` throws. Without this, a rejected task
+      // leaks its marker permanently; once `concurrency` tasks have thrown the
+      // pool is full forever and every later task queues via setTimeout endlessly.
+      if (interval) {
+        setTimeout(() => pool.delete(marker), interval)
+      } else {
+        pool.delete(marker)
+      }
     }
   }
   return { run }


### PR DESCRIPTION
## What

`createPool().run()` adds a marker to the internal `pool` set before awaiting the task, but only removes it on the success path:

```ts
const marker = {}
pool.add(marker)
const result = await fn()      // if this rejects, we never reach the delete below
if (interval) {
  setTimeout(() => pool.delete(marker), interval)
} else {
  pool.delete(marker)
}
```

When `fn()` rejects, the marker is never deleted, so the slot leaks permanently. Once `concurrency` tasks have thrown, `pool.size >= concurrency` stays true forever and every subsequent task re-queues via `setTimeout` indefinitely — a livelock. The pool stops doing any work.

This affects SSG (`fetchRoutesContent` runs page fetches through the pool): a few failing routes can permanently wedge the rest.

## Fix

Wrap the task body in `try/finally` so the slot is released on both the success and rejection paths. The interval-delayed release behaviour is preserved unchanged.

## Test

Adds a regression test: with `concurrency: 1`, a rejected task must not prevent a following task from running. It fails before the change (the second task never runs) and passes after.

`src/utils/concurrent.test.ts`: 7 passed, 100% coverage. `tsc --noEmit` clean. SSG suite: 59 passed.