### PR TITLE
fix(body-limit): cancel the request reader when the body exceeds the limit

### DIFF
--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -91,6 +91,7 @@ describe('Body Limit Middleware', () => {
         const stream = new ReadableStream()
         vi.spyOn(stream, 'getReader').mockReturnValue({
           read: readSpy,
+          cancel: vi.fn().mockResolvedValue(undefined),
         } as unknown as ReadableStreamDefaultReader)
         const res = await app.request('/body-limit-15byte', buildRequestInit({ body: stream }))
 
@@ -166,6 +167,32 @@ describe('Body Limit Middleware', () => {
 
       // Should reject based on actual chunked content size, not Content-Length
       expect(res.status).toBe(413)
+    })
+
+    it('should cancel the underlying reader when the chunked body exceeds the limit', async () => {
+      let cancelled = false
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('12345'))
+          controller.enqueue(new TextEncoder().encode('67890ABCDE')) // size now 15 > maxSize 10
+          // deliberately left open — a real oversized upload keeps streaming
+        },
+        cancel() {
+          cancelled = true
+        },
+      })
+
+      const res = await app.request('/test', {
+        method: 'POST',
+        headers: { 'Transfer-Encoding': 'chunked' },
+        body: stream,
+        duplex: 'half',
+      } as RequestInit)
+
+      expect(res.status).toBe(413)
+      // Without cancelling, the reader keeps the stream locked and the source is never
+      // told to stop sending the (rejected) body.
+      expect(cancelled).toBe(true)
     })
 
     it('should handle only Content-Length header correctly', async () => {

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -88,6 +88,9 @@ export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
       }
       size += value.length
       if (size > maxSize) {
+        // Release the reader lock and signal the source to stop sending the
+        // (now-rejected) body, instead of abandoning a locked, half-read stream.
+        await rawReader.cancel()
         return onError(c)
       }
       chunks.push(value)


### PR DESCRIPTION
## What

On the chunked / `Transfer-Encoding` path, the body-limit middleware reads the request body through a reader:

```ts
const rawReader = c.req.raw.body.getReader()
for (;;) {
  const { done, value } = await rawReader.read()
  if (done) break
  size += value.length
  if (size > maxSize) {
    return onError(c)   // reader still locked; source never told to stop
  }
  chunks.push(value)
}
```

When the body exceeds `maxSize`, it returns `onError(c)` without releasing the reader. The stream is left locked and half-read, and the underlying source is never signalled to stop sending the body it has already decided to reject — wasteful precisely in the abuse scenario this middleware exists to defend against.

## Fix

Call `await rawReader.cancel()` before returning the error. `cancel()` releases the lock **and** runs the stream's cancel algorithm, telling the source to stop.

## Test

Adds a regression test asserting the underlying stream's `cancel` is invoked when a chunked body exceeds the limit (still returns 413).

The pre-existing mocked-reader test (`should return 413 response`) mocked `getReader()` with an object that had only `read` — it masked this path. Updated to include `cancel`, since a real `ReadableStreamDefaultReader` always has it.

`src/middleware/body-limit/index.test.ts`: 13 passed. `tsc --noEmit` clean.