### PR TITLE
fix(utils/ipaddr): do not compress a single 0 group to `::`

### DIFF
--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -125,6 +125,10 @@ describe('convertIPv6ToString', () => {
     ${'1234:5678:9abc:def0:1234:5678:9abc:def0'} | ${'1234:5678:9abc:def0:1234:5678:9abc:def0'}
     ${'::ffff:127.0.0.1'}                        | ${'::ffff:127.0.0.1'}
     ${'fe80::1%eth0'}                            | ${'fe80::1'}
+    ${'1:0:2:3:4:5:6:7'}                         | ${'1:0:2:3:4:5:6:7'}
+    ${'0:1:2:3:4:5:6:7'}                         | ${'0:1:2:3:4:5:6:7'}
+    ${'1:2:3:4:5:6:7:0'}                         | ${'1:2:3:4:5:6:7:0'}
+    ${'1:0:0:2:3:4:5:6'}                         | ${'1::2:3:4:5:6'}
   `('convertIPv6ToString($input) === $expected', ({ input, expected }) => {
     expect(convertIPv6BinaryToString(convertIPv6ToBinary(input))).toBe(expected)
   })

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -355,7 +355,8 @@ export const convertIPv6BinaryToString = (ipV6: bigint): string => {
       maxZeroEnd = 8
     }
   }
-  if (maxZeroStart !== -1) {
+  // RFC 5952 4.2.2: compress only zero runs of at least two 16-bit fields.
+  if (maxZeroStart !== -1 && maxZeroEnd - maxZeroStart > 1) {
     sections.splice(maxZeroStart, maxZeroEnd - maxZeroStart, ':')
   }
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
