### PR TITLE
fix(router): handle ** wildcard in TrieRouter

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -774,6 +774,31 @@ export const runTest = ({
       })
     })
 
+    describe('Double wildcard **', () => {
+      beforeEach(() => {
+        router.add('ALL', '/auth/**', 'auth')
+        router.add('GET', '/other', 'other')
+      })
+
+      it('GET /auth/test - should match **', () => {
+        const res = match('GET', '/auth/test')
+        expect(res.length).toBeGreaterThanOrEqual(1)
+        expect(res[0].handler).toEqual('auth')
+      })
+
+      it('GET /auth/deep/path - should match **', () => {
+        const res = match('GET', '/auth/deep/path')
+        expect(res.length).toBeGreaterThanOrEqual(1)
+        expect(res[0].handler).toEqual('auth')
+      })
+
+      it('GET /other - non-wildcard route still works', () => {
+        const res = match('GET', '/other')
+        expect(res.length).toBeGreaterThanOrEqual(1)
+        expect(res[0].handler).toEqual('other')
+      })
+    })
+
     describe('Capture Group', () => {
       describe('Simple capturing group', () => {
         beforeEach(() => {

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -54,7 +54,7 @@ export class Node<T> {
       const p: string = parts[i]
       const nextP = parts[i + 1]
       const pattern = getPattern(p, nextP)
-      const key = Array.isArray(pattern) ? pattern[0] : p
+      const key = pattern === '*' ? '*' : Array.isArray(pattern) ? pattern[0] : p
 
       if (key in curNode.#children) {
         curNode = curNode.#children[key]

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -89,6 +89,16 @@ describe('url', () => {
       const res = getPattern('*', 'next')
       expect(res).toBe('*')
     })
+
+    it('double wildcard', () => {
+      const res = getPattern('**')
+      expect(res).toBe('*')
+    })
+
+    it('double wildcard with next', () => {
+      const res = getPattern('**', 'next')
+      expect(res).toBe('*')
+    })
   })
 
   describe('getPath', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -53,7 +53,7 @@ export const getPattern = (label: string, next?: string): Pattern | null => {
   // :id{[0-9]+}  => ([0-9]+)
   // :id          => (.+)
 
-  if (label === '*') {
+  if (label === '*' || label === '**') {
     return '*'
   }
 


### PR DESCRIPTION
Fixes #4975

## Summary

`TrieRouter` didn't recognize `**` as a wildcard pattern, causing routes like `/auth/**` to silently return 404 when `SmartRouter` fell back from `RegExpRouter` to `TrieRouter`.

## Root Cause

Two issues in the trie insertion path:

1. **`getPattern('**')` returned `null`** — only `'*'` was recognized (`src/utils/url.ts:56`)
2. **Child node key used raw part `'**'`** — `node.insert()` stored the child under key `'**'` instead of `'*'`, so the search logic (which looks up `children['*']`) never found it (`src/router/trie-router/node.ts:57`)

## Fix

- `getPattern()`: treat `'**'` the same as `'*'` (both return the `'*'` pattern)
- `node.insert()`: when pattern is `'*'`, use `'*'` as the child key instead of the raw path part

## When does this matter?

Most apps never hit this because `SmartRouter` uses `RegExpRouter` by default, which handles `**` correctly. The bug surfaces when `RegExpRouter` can't handle the route set (e.g., overlapping parameterized segments like `/:name/:version` and `/:name/versions`) and `SmartRouter` falls back to `TrieRouter`.

## Tests

- Added `getPattern('**')` unit tests in `src/utils/url.test.ts`
- Added `**` wildcard integration tests in `src/router/common.case.test.ts` (runs against all router implementations)
- All 573 existing router tests pass