### PR TITLE
chore: remove @types/glob

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "devDependencies": {
         "@hono/eslint-config": "^2.1.0",
         "@hono/node-server": "^2.0.2",
-        "@types/glob": "^9.0.0",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^24.3.0",
         "@types/ws": "^8.18.1",
@@ -466,8 +465,6 @@
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
-
-    "@types/glob": ["@types/glob@9.0.0", "", { "dependencies": { "glob": "*" } }, "sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA=="],
 
     "@types/jsdom": ["@types/jsdom@21.1.7", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA=="],
 

--- a/package.json
+++ b/package.json
@@ -658,7 +658,6 @@
   "devDependencies": {
     "@hono/eslint-config": "^2.1.0",
     "@hono/node-server": "^2.0.2",
-    "@types/glob": "^9.0.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^24.3.0",
     "@types/ws": "^8.18.1",


### PR DESCRIPTION
`@types/glob` dependency was deprecated because `glob` types where introduced to Glob from v10 ([source](https://www.npmjs.com/package/@types/glob)).
Current repository uses glob v11 (types already included), so `@types/glob` dependency can be removed.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code