### PR TITLE
docs: fix grammar in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Note:
 This project is started by Yusuke Wada ([@yusukebe](https://github.com/yusukebe)) for the hobby proposal.
 It was just for fun. For now, this stance has not been changed basically.
 I want to write the code as I like.
-So, if you propose great ideas, but I do not appropriate them, the idea may not be accepted.
+So, if you propose great ideas, but I do not adopt them, the idea may not be accepted.
 
 Although, don't worry!
 Hono is tested well, polished by the contributors, and used by many developers. And I'll try my best to make Hono cool and hot, beautiful, and ultrafast.


### PR DESCRIPTION
## What this PR does

Fixes a grammar error in `docs/CONTRIBUTING.md` on line 16.

## The fix

Changed 'I do not appropriate them' to 'I do not adopt them'.

The word 'appropriate' means to take possession of something (or suitable/proper as an adjective). The intended meaning here is 'adopt', which means to accept or take up an idea or suggestion.

## Why this matters

Clear documentation helps new contributors understand the project's contribution philosophy without confusion.