### PR TITLE
docs: add JSDoc to request/constants module

### DIFF
--- a/src/request/constants.ts
+++ b/src/request/constants.ts
@@ -1,1 +1,11 @@
+/**
+ * @module
+ * Internal constants used by the request module.
+ */
+
+/**
+ * Symbol used as a key to store and retrieve the route match result
+ * on a HonoRequest instance. This avoids string key collisions and
+ * keeps the match result as an internal implementation detail.
+ */
 export const GET_MATCH_RESULT: unique symbol = Symbol()


### PR DESCRIPTION
## What this PR does

Adds JSDoc documentation to `src/request/constants.ts`.

## Changes

- Added `@module` JSDoc comment to the file
- Added JSDoc for the `GET_MATCH_RESULT` symbol explaining it is used as an internal key for storing route match results on HonoRequest instances

## Why this helps

The module exports a single Symbol with no documentation. Understanding what `GET_MATCH_RESULT` is for requires reading the request module internals. A quick JSDoc comment makes this self-documenting.