### PR TITLE
fix: improve error message when next() is called multiple times

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -31,7 +31,10 @@ export const compose = <E extends Env = Env>(
      */
     async function dispatch(i: number): Promise<Context> {
       if (i <= index) {
-        throw new Error('next() called multiple times')
+        throw new Error(
+          `next() called multiple times in middleware at index ${index}. ` +
+          'Each middleware should call next() exactly once, or not at all.'
+        )
       }
       index = i
 


### PR DESCRIPTION
## What this PR does

Improves the error message thrown when a middleware calls `next()` more than once.

## Before

```
Error: next() called multiple times
```

## After

```
Error: next() called multiple times in middleware at index 2. Each middleware should call next() exactly once, or not at all.
```

## Why this helps

When debugging middleware chain issues, the original error message gives no indication of:

1. Which middleware caused the problem
2. What the correct behavior should be

The improved message includes the middleware index (making it easy to find the offending handler) and a brief explanation of the expected contract. This turns a confusing runtime error into an actionable debugging cue.

## Changes

- `src/compose.ts`: Updated the error message in the `dispatch` function to include the middleware index and guidance.