### PR TITLE
fix(bearer-auth): mention verifyToken in missing-options error message

### DIFF
--- a/src/middleware/bearer-auth/index.test.ts
+++ b/src/middleware/bearer-auth/index.test.ts
@@ -1007,3 +1007,12 @@ describe('Bearer Auth types', () => {
     expectTypeOf(middleware).toEqualTypeOf<MiddlewareHandler<TestEnv>>()
   })
 })
+
+describe('Bearer Auth options validation', () => {
+  it('Should throw an error mentioning both "token" and "verifyToken" when neither is provided', () => {
+    expect(() => {
+      // @ts-expect-error testing runtime guard with no valid options
+      bearerAuth({})
+    }).toThrow('bearer auth middleware requires options for "token" or "verifyToken"')
+  })
+})

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -105,7 +105,7 @@ export const bearerAuth = <E extends Env = Env>(
   options: BearerAuthOptions<E>
 ): MiddlewareHandler<E> => {
   if (!('token' in options || 'verifyToken' in options)) {
-    throw new Error('bearer auth middleware requires options for "token"')
+    throw new Error('bearer auth middleware requires options for "token" or "verifyToken"')
   }
   if (!options.realm) {
     options.realm = ''


### PR DESCRIPTION
The `bearerAuth` middleware accepts **either** a `token` **or** a `verifyToken` option, and throws when neither is provided. However, the error message only mentions `"token"`:

```ts
throw new Error('bearer auth middleware requires options for "token"')
```

This is misleading for users who intend to use `verifyToken` — the guard fires precisely when *neither* option is present, so the message should mention both. This also makes the message consistent with the sibling auth middlewares, which already list every accepted option:

- `basic-auth`: `'basic auth middleware requires options for "username and password" or "verifyUser"'`
- `jwk`: `'JWK auth middleware requires options for either "keys" or "jwks_uri" or both'`

This PR updates the message to:

```ts
throw new Error('bearer auth middleware requires options for "token" or "verifyToken"')
```

and adds a test that asserts the new message (it fails against the previous message and passes with this change).

## Author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] Double-check your code matches Hono's [coding style](https://github.com/honojs/hono/blob/main/CONTRIBUTING.md#coding-style)
