### PR TITLE
fix(utils/stream): re-acquire writer lock when pipe() throws

### DIFF
--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -57,6 +57,44 @@ describe('StreamingApi', () => {
     expect((await reader.read()).value).toEqual(new TextEncoder().encode('bar'))
   })
 
+  it('pipe() re-acquires writer lock when pipeTo() throws', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+    const reader = api.responseReadable.getReader()
+
+    const erroringReadable = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('upstream error'))
+      },
+    })
+
+    await expect(api.pipe(erroringReadable)).rejects.toThrow('upstream error')
+    api.write('after pipe')
+    expect((await reader.read()).value).toEqual(new TextEncoder().encode('after pipe'))
+  })
+
+  it('pipe() can be called again after a previous pipe() throws', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+    const reader = api.responseReadable.getReader()
+
+    const erroringReadable = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('upstream error'))
+      },
+    })
+    await expect(api.pipe(erroringReadable)).rejects.toThrow('upstream error')
+
+    const src = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('second pipe'))
+        controller.close()
+      },
+    })
+    await api.pipe(src)
+    expect((await reader.read()).value).toEqual(new TextEncoder().encode('second pipe'))
+  })
+
   it('close()', async () => {
     const { readable, writable } = new TransformStream()
     const api = new StreamingApi(writable, readable)

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -77,8 +77,11 @@ export class StreamingApi {
 
   async pipe(body: ReadableStream) {
     this.writer.releaseLock()
-    await body.pipeTo(this.writable, { preventClose: true })
-    this.writer = this.writable.getWriter()
+    try {
+      await body.pipeTo(this.writable, { preventClose: true, preventAbort: true })
+    } finally {
+      this.writer = this.writable.getWriter()
+    }
   }
 
   onAbort(listener: () => void | Promise<void>) {


### PR DESCRIPTION
## Fix: Writer lock not re-acquired after `pipeTo()` failure

### Problem

`pipe()` calls `releaseLock()` before `await pipeTo()` but only re-acquires
the writer on the success path. If `pipeTo()` rejects (source error, client
disconnect), the writer is left released and subsequent `write()` / `close()`
calls are silently lost.

### Fix

- Wraps `pipeTo()` in `try/finally` so the writer is always re-acquired
- Adds `preventAbort: true` so the destination stays writable after a source
  error — without it, the re-acquired writer targets an aborted stream and
  writes are still dropped

### Tests

The added tests assert that a `write()` after a failed `pipe()` is delivered;
they fail without either part of the fix.

---

Fixes #4981

### Checklist

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix`
- [ ] Add TSDoc/JSDoc to document the code