### PR TITLE
fix(context): preserve prepared Set-Cookie headers when assigning raw Response

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -436,6 +436,19 @@ describe('Context header', () => {
     expect(cookies.includes('foo2=bar2; Path=/')).toBe(true)
   })
 
+  it('Should keep prepared cookies when assigning a raw Response to c.res', () => {
+    setCookie(c, 'foo', 'bar', { path: '/' })
+    c.res = new Response('ok')
+    expect(c.res.headers.getSetCookie()).toEqual(['foo=bar; Path=/'])
+  })
+
+  it('Should not duplicate cookies when assigning a raw Response after reading c.res', () => {
+    setCookie(c, 'foo', 'bar', { path: '/' })
+    c.res
+    c.res = new Response('ok')
+    expect(c.res.headers.getSetCookie()).toEqual(['foo=bar; Path=/'])
+  })
+
   it('Should set set-cookie header values if c.res is already defined', () => {
     c.res = new Response(null, {
       headers: [

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -442,11 +442,38 @@ describe('Context header', () => {
     expect(c.res.headers.getSetCookie()).toEqual(['foo=bar; Path=/'])
   })
 
+  it('Should keep raw Response cookies when assigning a Response with prepared cookies', () => {
+    setCookie(c, 'context', '1', { path: '/' })
+    const res = new Response('ok')
+    res.headers.append('set-cookie', 'handler=1; Path=/; HttpOnly')
+
+    c.res = res
+
+    expect(c.res.headers.getSetCookie()).toEqual([
+      'handler=1; Path=/; HttpOnly',
+      'context=1; Path=/',
+    ])
+  })
+
   it('Should not duplicate cookies when assigning a raw Response after reading c.res', () => {
     setCookie(c, 'foo', 'bar', { path: '/' })
     c.res
     c.res = new Response('ok')
     expect(c.res.headers.getSetCookie()).toEqual(['foo=bar; Path=/'])
+  })
+
+  it('Should keep raw Response cookies when assigning a Response after reading c.res', () => {
+    c.res.headers.set('X-Something', 'true')
+    setCookie(c, 'context', '1', { path: '/' })
+    const res = new Response('ok')
+    res.headers.append('set-cookie', 'handler=1; Path=/; HttpOnly')
+
+    c.res = res
+
+    expect(c.res.headers.getSetCookie()).toEqual([
+      'handler=1; Path=/; HttpOnly',
+      'context=1; Path=/',
+    ])
   })
 
   it('Should set set-cookie header values if c.res is already defined', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -412,20 +412,23 @@ export class Context<
    * @param _res - The Response object to set.
    */
   set res(_res: Response | undefined) {
-    if (this.#res && _res) {
+    if ((this.#res || this.#preparedHeaders) && _res) {
       _res = createResponseInstance(_res.body, _res)
-      for (const [k, v] of this.#res.headers.entries()) {
-        if (k === 'content-type') {
-          continue
-        }
-        if (k === 'set-cookie') {
-          const cookies = this.#res.headers.getSetCookie()
-          _res.headers.delete('set-cookie')
-          for (const cookie of cookies) {
-            _res.headers.append('set-cookie', cookie)
+      const headers = this.#res?.headers ?? this.#preparedHeaders
+      if (headers) {
+        for (const [k, v] of headers.entries()) {
+          if (k === 'content-type' || (!this.#res && k !== 'set-cookie')) {
+            continue
           }
-        } else {
-          _res.headers.set(k, v)
+          if (k === 'set-cookie') {
+            const cookies = headers.getSetCookie()
+            _res.headers.delete('set-cookie')
+            for (const cookie of cookies) {
+              _res.headers.append('set-cookie', cookie)
+            }
+          } else {
+            _res.headers.set(k, v)
+          }
         }
       }
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -415,16 +415,23 @@ export class Context<
     if ((this.#res || this.#preparedHeaders) && _res) {
       _res = createResponseInstance(_res.body, _res)
       const headers = this.#res?.headers ?? this.#preparedHeaders
+      const isPreparedHeaders = !this.#res && !!this.#preparedHeaders
       if (headers) {
         for (const [k, v] of headers.entries()) {
-          if (k === 'content-type' || (!this.#res && k !== 'set-cookie')) {
+          if (k === 'content-type' || (isPreparedHeaders && k !== 'set-cookie')) {
             continue
           }
           if (k === 'set-cookie') {
-            const cookies = headers.getSetCookie()
-            _res.headers.delete('set-cookie')
-            for (const cookie of cookies) {
-              _res.headers.append('set-cookie', cookie)
+            if (isPreparedHeaders) {
+              _res.headers.append('set-cookie', v)
+            } else {
+              const cookies = this.finalized
+                ? headers.getSetCookie()
+                : _res.headers.getSetCookie().concat(headers.getSetCookie())
+              _res.headers.delete('set-cookie')
+              for (const cookie of cookies) {
+                _res.headers.append('set-cookie', cookie)
+              }
             }
           } else {
             _res.headers.set(k, v)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1076,6 +1076,29 @@ describe('Middleware', () => {
       )
     })
 
+    app.use('/raw-response-cookie-with-prepared-headers', async (c, next) => {
+      c.header('Set-Cookie', 'context=1; Path=/', { append: true })
+      await next()
+    })
+
+    app.get('/raw-response-cookie-with-prepared-headers', () => {
+      const res = new Response('ok')
+      res.headers.append('set-cookie', 'handler=1; Path=/; HttpOnly')
+      return res
+    })
+
+    app.use('/raw-response-cookie-after-reading-response', async (c, next) => {
+      c.res.headers.set('X-Something', 'true')
+      c.header('Set-Cookie', 'context=1; Path=/', { append: true })
+      await next()
+    })
+
+    app.get('/raw-response-cookie-after-reading-response', () => {
+      const res = new Response('ok')
+      res.headers.append('set-cookie', 'handler=1; Path=/; HttpOnly')
+      return res
+    })
+
     app.get('/hello/:message', (c) => {
       const message = c.req.param('message')
       return c.text(`${message}`)
@@ -1110,6 +1133,22 @@ describe('Middleware', () => {
       const res = await app.request('http://localhost/json')
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toMatch(/^application\/json/)
+    })
+
+    it('Should keep raw response cookies with prepared headers', async () => {
+      const res = await app.request('/raw-response-cookie-with-prepared-headers')
+      expect(res.headers.getSetCookie()).toEqual([
+        'handler=1; Path=/; HttpOnly',
+        'context=1; Path=/',
+      ])
+    })
+
+    it('Should keep raw response cookies after reading c.res', async () => {
+      const res = await app.request('/raw-response-cookie-after-reading-response')
+      expect(res.headers.getSetCookie()).toEqual([
+        'handler=1; Path=/; HttpOnly',
+        'context=1; Path=/',
+      ])
     })
 
     it('not found', async () => {


### PR DESCRIPTION
Fixes https://github.com/honojs/hono/issues/4992

### What this fixes

When middleware prepares cookies before `next()` and the handler assigns a raw `Response` to `c.res`, the prepared `Set-Cookie` headers can be lost if `c.res` has not been initialized yet.

### Cause

The `Context.res` setter only merged headers from `this.#res`. In this path, cookies added by `setCookie(c, ...)` are still in `#preparedHeaders`, so assigning a raw `Response` skips them.

### Fix

- Preserve prepared `Set-Cookie` values when assigning a raw `Response` before `c.res` is initialized.
- Keep the existing overwrite behavior for ordinary prepared headers.
- Avoid duplicating cookies when `c.res` has already been read.
- Add regression tests for the lost-cookie path and the no-duplicate path.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

Verified locally with:

- `npx vitest --run src/context.test.ts -t "raw Response"`
- `npx vitest --run src/hono.test.ts -t "Overwrite the response from middleware after next"`
- `npx vitest --run src/hono.test.ts src/context.test.ts`
- `npx eslint src/context.ts src/context.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx prettier --check src/context.ts src/context.test.ts`
- `git diff --check`
- `Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue; npx vitest --run`

Full Vitest result: 144 files passed, 4525 tests passed, 33 skipped.
