### PR TITLE
test(method-override): preserve query parameters during query override

### DIFF
--- a/src/middleware/method-override/index.test.ts
+++ b/src/middleware/method-override/index.test.ts
@@ -173,6 +173,13 @@ describe('Method Override Middleware', () => {
         queryValue: c.req.query('_method') ?? null,
       })
     })
+    app.on(['post', 'delete'], '/posts/details', async (c) => {
+      return c.json({
+        method: c.req.method,
+        page: c.req.query('page') ?? null,
+        queryValue: c.req.query('_method') ?? null,
+      })
+    })
 
     it('Should override POST to DELETE', async () => {
       const res = await app.request('/posts?_method=delete', {
@@ -181,6 +188,18 @@ describe('Method Override Middleware', () => {
       expect(res.status).toBe(200)
       expect(await res.json()).toEqual({
         method: 'DELETE',
+        queryValue: null,
+      })
+    })
+
+    it('Should preserve other query parameters when overriding method', async () => {
+      const res = await app.request('/posts/details?_method=delete&page=2', {
+        method: 'POST',
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        method: 'DELETE',
+        page: '2',
         queryValue: null,
       })
     })


### PR DESCRIPTION
### What this adds

Adds one test for query-based `methodOverride()`.

The test verifies that the `_method` query parameter is removed before the request is re-dispatched, while unrelated query parameters are preserved for the overridden route.

This is a test-only change.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

Verified locally with:

- `npx vitest --run src/middleware/method-override/index.test.ts`
- `npx eslint src/middleware/method-override/index.test.ts`
- `npx prettier --check src/middleware/method-override/index.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
