### PR TITLE
fix(utils/ipaddr): render the unspecified address binary as "::"

### DIFF
--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -136,4 +136,11 @@ describe('convertIPv6ToString', () => {
   `('convertIPv6ToString($input) === $expected', ({ input, expected }) => {
     expect(convertIPv6BinaryToString(convertIPv6ToBinary(input))).toBe(expected)
   })
+
+  it('Should compress the unspecified address (all zero groups) to "::"', () => {
+    expect(convertIPv6BinaryToString(0n)).toBe('::')
+    expect(convertIPv6BinaryToString(convertIPv6ToBinary('::'))).toBe('::')
+    // The output must round-trip back to the same binary value.
+    expect(convertIPv6ToBinary(convertIPv6BinaryToString(0n))).toBe(0n)
+  })
 })

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -325,6 +325,12 @@ export const convertIPv4MappedIPv6ToIPv4 = (ipv6binary: bigint): bigint => ipv6b
  * @return normalized IPv6 Address in string
  */
 export const convertIPv6BinaryToString = (ipV6: bigint): string => {
+  if (ipV6 === 0n) {
+    // The unspecified address compresses every group, which the generic
+    // logic below would render as a single ":". Handle it explicitly.
+    return '::'
+  }
+
   if (isIPv4MappedIPv6(ipV6)) {
     return `::ffff:${convertIPv4BinaryToString(convertIPv4MappedIPv6ToIPv4(ipV6))}`
   }


### PR DESCRIPTION
## What this fixes

`convertIPv6BinaryToString(0n)` returns a single `":"` instead of the canonical `"::"` for the IPv6 unspecified address (all-zero groups).

```ts
import { convertIPv6BinaryToString, convertIPv6ToBinary } from './src/utils/ipaddr'

convertIPv6BinaryToString(0n) // => ":"   (expected "::")
```

The resulting string is not a valid IPv6 address (`net.isIP(':')` is `0`) and it does not round-trip: feeding it back into `convertIPv6ToBinary` throws `Invalid IPv6 address: :`.

## Root cause

For the all-zero value every one of the 8 groups is `"0"`, so the longest zero-run spans the whole address. The compression logic replaces that run with a single `":"` placeholder via `sections.splice(0, 8, ':')`, leaving `sections === [':']`. Joining that with `":"` yields `":"`, and the trailing `value.replace(/:{2,}/, '::')` cannot help because there is only one colon to collapse — the regex only matches runs of two or more colons.

The existing IPv4-mapped case is already handled with an early return at the top of the function; the all-zero case has the same "every group compresses" property and needs the same treatment. The recently merged RFC 5952 work (#4971 for single zero groups, #4973 for expanding `::`) guards `maxZeroEnd - maxZeroStart > 1`, which still routes the all-zero value through the broken 8-group splice.

## The fix

Add a 5-line early return for `0n` in `convertIPv6BinaryToString`, mirroring the existing IPv4-mapped early return:

```ts
if (ipV6 === 0n) {
  return '::'
}
```

This also keeps the ip-restriction middleware's string rule map consistent: the unspecified address now canonicalizes to `"::"` rather than the bogus key `":"`, so a rule such as `denyList: ['::']` is registered under the correct key.

## Tests

Added a focused regression test asserting `"::"` output and a successful round-trip:

```ts
it('Should compress the unspecified address (all zero groups) to "::"', () => {
  expect(convertIPv6BinaryToString(0n)).toBe('::')
  expect(convertIPv6BinaryToString(convertIPv6ToBinary('::'))).toBe('::')
  expect(convertIPv6ToBinary(convertIPv6BinaryToString(0n))).toBe(0n)
})
```

Verified locally:

- `tsc --noEmit` — exit 0
- `vitest run src/utils/ipaddr.test.ts` — 41 passed
- `prettier --check` on the touched files — clean
- `eslint` on the touched files — clean

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code