### PR TITLE
fix(context): reject non-serializable JSON responses

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,14 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws for top-level values that are not JSON serializable', () => {
+    const values = [undefined, () => 'Hello', Symbol('Hello')]
+
+    for (const value of values) {
+      expect(() => c.json(value)).toThrow(TypeError)
+    }
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable.')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
Closes #2343.

## Summary
- throw a TypeError when `JSON.stringify()` cannot serialize the top-level `c.json()` value
- cover `undefined`, function, and symbol values so they no longer silently become an empty response body

## Tests
- `BUN_INSTALL_CACHE_DIR=/tmp/hono-2343-bun-cache bunx vitest --run src/context.test.ts -t 'c.json\\(\\) throws for top-level values'`\n- `BUN_INSTALL_CACHE_DIR=/tmp/hono-2343-bun-cache bunx vitest --run src/context.test.ts`\n- `BUN_INSTALL_CACHE_DIR=/tmp/hono-2343-bun-cache bunx eslint src/context.ts src/context.test.ts`\n- `BUN_INSTALL_CACHE_DIR=/tmp/hono-2343-bun-cache bunx prettier --check src/context.ts src/context.test.ts`\n- `git diff --check`\n- `env -u NO_COLOR BUN_INSTALL_CACHE_DIR=/tmp/hono-2343-bun-cache bun run test`\n\nNote: `bun run test` fails in this shell when `NO_COLOR=1` is inherited because color-output tests expect ANSI output. Removing `NO_COLOR` gives 144 passing test files and 4525 passing tests.\n\nDisclosure: AI-assisted, manually reviewed and tested.