### PR TITLE
fix(lambda-edge): base64 encode compressed response bodies

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -1,9 +1,9 @@
 import { describe } from 'vitest'
 import { setCookie } from '../../helper/cookie'
 import { Hono } from '../../hono'
-import { encodeBase64 } from '../../utils/encode'
+import { decodeBase64, encodeBase64 } from '../../utils/encode'
 import type { Callback, CloudFrontEdgeEvent } from './handler'
-import { createBody, handle, isContentTypeBinary } from './handler'
+import { createBody, handle, isContentEncodingBinary, isContentTypeBinary } from './handler'
 
 describe('isContentTypeBinary', () => {
   it('Should determine whether it is binary', () => {
@@ -18,6 +18,19 @@ describe('isContentTypeBinary', () => {
     expect(isContentTypeBinary('application/json')).toBe(false)
     expect(isContentTypeBinary('application/ld+json')).toBe(false)
     expect(isContentTypeBinary('application/json')).toBe(false)
+  })
+})
+
+describe('isContentEncodingBinary', () => {
+  it('Should determine whether it is binary', () => {
+    expect(isContentEncodingBinary('gzip')).toBe(true)
+    expect(isContentEncodingBinary('br')).toBe(true)
+    expect(isContentEncodingBinary('deflate')).toBe(true)
+    expect(isContentEncodingBinary('compress')).toBe(true)
+    expect(isContentEncodingBinary('deflate, gzip')).toBe(true)
+    expect(isContentEncodingBinary('identity')).toBe(false)
+    expect(isContentEncodingBinary('')).toBe(false)
+    expect(isContentEncodingBinary(null)).toBe(false)
   })
 })
 
@@ -151,5 +164,35 @@ describe('handle', () => {
         },
       ],
     })
+  })
+
+  it('Should base64 encode a compressed response with a textual content-type', async () => {
+    const payload = new TextEncoder().encode('a'.repeat(100))
+    const gzipped = await new Response(
+      new Blob([payload]).stream().pipeThrough(new CompressionStream('gzip'))
+    ).arrayBuffer()
+
+    const app = new Hono()
+    app.get('/test-path', () => {
+      return new Response(gzipped, {
+        headers: {
+          'content-type': 'text/html; charset=UTF-8',
+          'content-encoding': 'gzip',
+        },
+      })
+    })
+    const handler = handle(app)
+
+    const res = await handler(cloudFrontEdgeEvent)
+
+    expect(res.bodyEncoding).toBe('base64')
+    expect(res.body).toBe(encodeBase64(gzipped))
+
+    const decompressed = await new Response(
+      new Blob([decodeBase64(res.body as string)])
+        .stream()
+        .pipeThrough(new DecompressionStream('gzip'))
+    ).text()
+    expect(decompressed).toBe('a'.repeat(100))
   })
 })

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -138,7 +138,15 @@ export const handle = (
 }
 
 const createResult = async (res: Response): Promise<CloudFrontResult> => {
-  const isBase64Encoded = isContentTypeBinary(res.headers.get('content-type') || '')
+  let isBase64Encoded = isContentTypeBinary(res.headers.get('content-type') || '')
+
+  // A compressed response (for example from the compress middleware) may keep a
+  // textual content-type such as text/html while carrying binary bytes. Detect
+  // that via content-encoding so the body is not corrupted by res.text().
+  if (!isBase64Encoded) {
+    isBase64Encoded = isContentEncodingBinary(res.headers.get('content-encoding'))
+  }
+
   const body = isBase64Encoded ? encodeBase64(await res.arrayBuffer()) : await res.text()
 
   return {
@@ -193,4 +201,11 @@ export const isContentTypeBinary = (contentType: string): boolean => {
   return !/^(text\/(plain|html|css|javascript|csv).*|application\/(.*json|.*xml).*|image\/svg\+xml.*)$/.test(
     contentType
   )
+}
+
+export const isContentEncodingBinary = (contentEncoding: string | null): boolean => {
+  if (contentEncoding === null) {
+    return false
+  }
+  return /^(gzip|deflate|compress|br)/.test(contentEncoding)
 }


### PR DESCRIPTION
Fixes #4254

When the lambda-edge adapter builds a CloudFront result, it decides whether to base64 encode the body using only the content-type. A compressed response can keep a textual content-type such as text/html while the actual body is gzip bytes. The compress middleware does exactly this. In that case the adapter calls res.text() on binary data, which corrupts the body, and CloudFront returns an empty or broken response.

This checks the content-encoding header as a fallback when the content-type is not detected as binary. If the response is gzip, deflate, compress, or br encoded, the body is base64 encoded with bodyEncoding set to base64. The aws-lambda adapter already does the same thing in its createResult, so this brings lambda-edge in line with it.

I added a small isContentEncodingBinary helper that mirrors the one in the aws-lambda adapter, with unit tests, plus a handle test that runs a gzip-encoded text/html response through the adapter and verifies the body comes back base64 encoded and decompresses to the original payload.

Note: a previous attempt at this issue (#4874) was closed for including unrelated changes. This PR only touches the lambda-edge handler and its test.