### PR TITLE
Remove dead InterfaceToType type, non-standard Method-Check headers, and clarify single-handler dispatch logic

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -439,10 +439,15 @@ class Hono<
 
       return res instanceof Promise
         ? res
-            .then(
-              (resolved: Response | undefined) =>
-                resolved || (c.finalized ? c.res : this.#notFoundHandler(c))
-            )
+            .then((resolved: Response | undefined) => {
+              if (resolved) {
+                return resolved
+              }
+              if (c.finalized) {
+                return c.res
+              }
+              return this.#notFoundHandler(c)
+            })
             .catch((err: Error) => this.#handleError(err, c))
         : (res ?? this.#notFoundHandler(c))
     }

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -140,8 +140,6 @@ export type RequestHeader =
   | 'Max-Forwards'
   | 'Memento-Datetime'
   | 'Meter'
-  | 'Method-Check'
-  | 'Method-Check-Expires'
   | 'MIME-Version'
   | 'Negotiate'
   | 'NEL'

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -95,8 +95,6 @@ export type SimplifyDeepArray<T> = T extends any[]
   ? { [E in keyof T]: SimplifyDeepArray<T[E]> }
   : Simplify<T>
 
-export type InterfaceToType<T> = T extends Function ? T : { [K in keyof T]: InterfaceToType<T[K]> }
-
 export type RequiredKeysOf<BaseType extends object> = Exclude<
   {
     [Key in keyof BaseType]: BaseType extends Record<Key, BaseType[Key]> ? Key : never


### PR DESCRIPTION
Three small housekeeping changes:

- Removed InterfaceToType from src/utils/types.ts --> it's exported but never imported anywhere in the codebase.

- Removed Method-Check and Method-Check-Expires from the RequestHeader type union in src/utils/headers.ts. These aren't registered in the IANA HTTP field name registry and appear to be leftover from older Cloudflare Workers types.

- Expanded the one-liner ternary in the single-handler async path of hono-base.ts into explicit if/else blocks. Same logic, just easier to follow.