### PR TITLE
fix(context): throw TypeError when c.json() receives a non-serializable value

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,17 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws on non-serializable value (undefined)', () => {
+    // JSON.stringify(undefined) returns undefined (not a string), which previously
+    // caused c.json() to return an empty response body instead of throwing.
+    // See: https://github.com/honojs/hono/issues/2343
+    expect(() => c.json(undefined as never)).toThrow(TypeError)
+  })
+
+  it('c.json() throws on non-serializable value (function)', () => {
+    expect(() => c.json((() => {}) as never)).toThrow(TypeError)
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable.')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
## What

`c.json()` silently returned an empty response body when passed a value that `JSON.stringify` cannot serialize (e.g. `undefined`, a function, or a Symbol). This happened because `JSON.stringify(undefined)` returns `undefined` — not a string — so the response body was set to `undefined`, which became an empty body on most runtimes (and `"undefined"` as a string on Cloudflare Workers).

## Why it matters

The caller gets a `200 OK` with no body and no error, making it very hard to debug a mistake like accidentally returning `undefined` from a handler.

## Fix

Follow [Deno's approach](https://github.com/denoland/deno/blob/0d43a63636c97886c10c6b8ce05fdb67cd2d8b91/ext/web/00_infra.js#L382-L388): after calling `JSON.stringify`, check whether the result is `undefined` and throw a `TypeError('Value is not JSON serializable.')` if so. This catches `undefined`, functions, and Symbols — all values for which `JSON.stringify` returns `undefined`.

```ts
const body = JSON.stringify(object)
if (body === undefined) {
  throw new TypeError('Value is not JSON serializable.')
}
```

## Tests

Two new tests in `src/context.test.ts` prove the bug and verify the fix:

- `c.json() throws on non-serializable value (undefined)` — was failing (no throw) before the fix
- `c.json() throws on non-serializable value (function)` — was failing (no throw) before the fix

Both tests pass after the fix; no existing tests were changed or broken.

Closes #2343