### PR TITLE
fix: improve merge header handling in Context.res setter

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -448,6 +448,45 @@ describe('Context header', () => {
     expect(res.headers.get('set-cookie')).toBe('a, b, c')
   })
 
+  it('Should not duplicate set-cookie when assigning a response with context headers', () => {
+    c.header('Set-Cookie', 'a=1')
+    c.res = c.text('Hi')
+
+    expect(c.res.headers.getSetCookie()).toEqual(['a=1'])
+  })
+
+  it('Should keep prepared headers when assigning a raw response', async () => {
+    c.header('X-Powered-By-Before', 'Hono')
+    c.res = new Response('Hi')
+    c.header('X-Powered-By-After', 'Hono')
+
+    expect(await c.res.text()).toBe('Hi')
+    expect(c.res.headers.get('X-Powered-By-Before')).toBe('Hono')
+    expect(c.res.headers.get('X-Powered-By-After')).toBe('Hono')
+  })
+
+  it('Should keep response headers isolated when response methods are called repeatedly', async () => {
+    c.header('X-Powered-By', 'Hono')
+    const res1 = c.text('Hi', {
+      headers: {
+        Res1: 'Value1',
+      },
+    })
+    const res2 = c.text('Hi', {
+      headers: {
+        Res2: 'Value2',
+      },
+    })
+
+    expect(res1.headers.get('X-Powered-By')).toBe('Hono')
+    expect(res1.headers.get('Res1')).toBe('Value1')
+    expect(res1.headers.get('Res2')).toBeNull()
+
+    expect(res2.headers.get('X-Powered-By')).toBe('Hono')
+    expect(res2.headers.get('Res1')).toBeNull()
+    expect(res2.headers.get('Res2')).toBe('Value2')
+  })
+
   it('Should be able to overwrite a fetch response with a new response.', async () => {
     c.res = makeResponseHeaderImmutable(new Response('bar'))
     c.res = new Response('foo', {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -423,8 +423,8 @@ describe('Context header', () => {
     const newResponse = new Response(null)
     newResponse.headers.append('set-cookie', newCookies[0])
     c.res = newResponse
-    expect(c.res.headers.getSetCookie().length).toBe(cookies.length)
-    expect(c.res.headers.getSetCookie()).toEqual(cookies)
+    expect(c.res.headers.getSetCookie().length).toBe(3)
+    expect(c.res.headers.getSetCookie()).toEqual([...cookies, ...newCookies])
   })
 
   it('Should keep previous cookies in response headers', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -276,6 +276,9 @@ interface ResponseInit<T extends StatusCode = StatusCode> {
 
 type ResponseOrInit<T extends StatusCode = StatusCode> = ResponseInit<T> | Response
 
+const contextHeadersSymbol = Symbol()
+type ResponseWithContextHeaders = Response & { [contextHeadersSymbol]?: true }
+
 export const TEXT_PLAIN = 'text/plain; charset=UTF-8'
 
 const setDefaultContentType = (contentType: string, headers?: HeaderRecord): HeaderRecord => {
@@ -412,22 +415,38 @@ export class Context<
    * @param _res - The Response object to set.
    */
   set res(_res: Response | undefined) {
-    if (this.#res && _res) {
-      _res = createResponseInstance(_res.body, _res)
-      for (const [k, v] of this.#res.headers.entries()) {
-        if (k === 'content-type') {
-          continue
-        }
-        if (k === 'set-cookie') {
-          const cookies = this.#res.headers.getSetCookie()
-          _res.headers.delete('set-cookie')
-          for (const cookie of cookies) {
-            _res.headers.append('set-cookie', cookie)
+    if (_res) {
+      if (
+        (this.#res ?? this.#preparedHeaders) &&
+        !(_res as ResponseWithContextHeaders)[contextHeadersSymbol]
+      ) {
+        const headers = new Headers(this.#res?.headers ?? this.#preparedHeaders)
+        headers.delete('content-type')
+
+        let setCookieHandled = false
+        for (const [k, v] of _res.headers.entries()) {
+          if (k === 'set-cookie') {
+            if (setCookieHandled) {
+              continue
+            }
+            setCookieHandled = true
+            for (const cookie of _res.headers.getSetCookie()) {
+              headers.append('set-cookie', cookie)
+            }
+          } else {
+            headers.set(k, v)
           }
-        } else {
-          _res.headers.set(k, v)
         }
+
+        _res = createResponseInstance(_res.body, {
+          headers,
+          status: _res.status,
+          statusText: _res.statusText,
+        })
+        ;(_res as ResponseWithContextHeaders)[contextHeadersSymbol] = true
       }
+    } else {
+      this.#preparedHeaders = undefined
     }
     this.#res = _res
     this.finalized = true
@@ -606,11 +625,12 @@ export class Context<
     arg?: StatusCode | ResponseOrInit,
     headers?: HeaderRecord
   ): Response {
-    const responseHeaders = this.#res
-      ? new Headers(this.#res.headers)
-      : (this.#preparedHeaders ?? new Headers())
+    const existingHeaders = this.#res ? this.#res.headers : this.#preparedHeaders
+    let responseHeaders: Headers | undefined
 
     if (typeof arg === 'object' && 'headers' in arg) {
+      responseHeaders ??= new Headers(existingHeaders)
+
       const argHeaders = arg.headers instanceof Headers ? arg.headers : new Headers(arg.headers)
       for (const [key, value] of argHeaders) {
         if (key.toLowerCase() === 'set-cookie') {
@@ -622,6 +642,8 @@ export class Context<
     }
 
     if (headers) {
+      responseHeaders ??= new Headers(existingHeaders)
+
       for (const [k, v] of Object.entries(headers)) {
         if (typeof v === 'string') {
           responseHeaders.set(k, v)
@@ -635,7 +657,14 @@ export class Context<
     }
 
     const status = typeof arg === 'number' ? arg : (arg?.status ?? this.#status)
-    return createResponseInstance(data, { status, headers: responseHeaders })
+    const response = createResponseInstance(data, {
+      status,
+      headers: responseHeaders ?? (existingHeaders ? new Headers(existingHeaders) : undefined),
+    })
+    if (existingHeaders) {
+      ;(response as ResponseWithContextHeaders)[contextHeadersSymbol] = true
+    }
+    return response
   }
 
   newResponse: NewResponse = (...args) => this.#newResponse(...(args as Parameters<NewResponse>))


### PR DESCRIPTION
fixes #4992

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code