### PR TITLE
feat: add web-extension adapter for chrome.webRequest support

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -74,6 +74,7 @@
     "./netlify": "./src/adapter/netlify/index.ts",
     "./lambda-edge": "./src/adapter/lambda-edge/index.ts",
     "./service-worker": "./src/adapter/service-worker/index.ts",
+    "./web-extension": "./src/adapter/web-extension/index.ts",
     "./testing": "./src/helper/testing/index.ts",
     "./dev": "./src/helper/dev/index.ts",
     "./ws": "./src/helper/websocket/index.ts",

--- a/package.json
+++ b/package.json
@@ -385,6 +385,11 @@
       "import": "./dist/adapter/service-worker/index.js",
       "require": "./dist/cjs/adapter/service-worker/index.js"
     },
+    "./web-extension": {
+      "types": "./dist/types/adapter/web-extension/index.d.ts",
+      "import": "./dist/adapter/web-extension/index.js",
+      "require": "./dist/cjs/adapter/web-extension/index.js"
+    },
     "./testing": {
       "types": "./dist/types/helper/testing/index.d.ts",
       "import": "./dist/helper/testing/index.js",
@@ -619,6 +624,9 @@
       ],
       "service-worker": [
         "./dist/types/adapter/service-worker"
+      ],
+      "web-extension": [
+        "./dist/types/adapter/web-extension"
       ],
       "testing": [
         "./dist/types/helper/testing"

--- a/src/adapter/web-extension/handler.test.ts
+++ b/src/adapter/web-extension/handler.test.ts
@@ -1,0 +1,132 @@
+import { Hono } from '../../hono'
+import { handle } from './handler'
+import type { WebRequestDetails } from './types'
+
+const createDetails = (overrides: Partial<WebRequestDetails> = {}): WebRequestDetails => ({
+  url: 'http://localhost/',
+  method: 'GET',
+  type: 'main_frame',
+  requestId: '1',
+  tabId: 0,
+  timeStamp: Date.now(),
+  frameId: 0,
+  parentFrameId: -1,
+  ...overrides,
+})
+
+const parseDataUrl = (url: string): { contentType: string; body: string } => {
+  const match = url.match(/^data:(.+);base64,(.+)$/)
+  if (!match) {
+    throw new Error('Invalid data URL')
+  }
+  return {
+    contentType: match[1],
+    body: atob(match[2]),
+  }
+}
+
+describe('handle', () => {
+  it('should return a data URL redirect for a matched route', async () => {
+    const app = new Hono()
+    app.get('/', (c) => c.text('Hello from Hono'))
+
+    const handler = handle(app)
+    const result = await handler(createDetails())
+
+    expect(result).toBeDefined()
+    expect(result?.redirectUrl).toBeDefined()
+
+    const { contentType, body } = parseDataUrl(result!.redirectUrl!)
+    expect(contentType).toBe('text/plain;charset=UTF-8')
+    expect(body).toBe('Hello from Hono')
+  })
+
+  it('should return undefined for unmatched routes (404)', async () => {
+    const app = new Hono()
+    app.get('/matched', (c) => c.text('OK'))
+
+    const handler = handle(app)
+    const result = await handler(createDetails({ url: 'http://localhost/unmatched' }))
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should handle JSON responses', async () => {
+    const app = new Hono()
+    app.get('/api', (c) => c.json({ message: 'hello' }))
+
+    const handler = handle(app)
+    const result = await handler(createDetails({ url: 'http://localhost/api' }))
+
+    expect(result).toBeDefined()
+    const { contentType, body } = parseDataUrl(result!.redirectUrl!)
+    expect(contentType).toBe('application/json')
+    expect(JSON.parse(body)).toEqual({ message: 'hello' })
+  })
+
+  it('should handle POST requests with form data body', async () => {
+    const app = new Hono()
+    app.post('/submit', async (c) => {
+      const body = await c.req.parseBody()
+      return c.json({ received: body })
+    })
+
+    const handler = handle(app)
+    const result = await handler(
+      createDetails({
+        url: 'http://localhost/submit',
+        method: 'POST',
+        requestBody: {
+          formData: {
+            name: ['John'],
+            age: ['30'],
+          },
+        },
+      })
+    )
+
+    expect(result).toBeDefined()
+    const { body } = parseDataUrl(result!.redirectUrl!)
+    expect(JSON.parse(body)).toEqual({ received: { name: 'John', age: '30' } })
+  })
+
+  it('should handle POST requests with raw body', async () => {
+    const app = new Hono()
+    app.post('/raw', async (c) => {
+      const text = await c.req.text()
+      return c.text(`Received: ${text}`)
+    })
+
+    const encoder = new TextEncoder()
+    const rawBody = encoder.encode('raw request body').buffer
+
+    const handler = handle(app)
+    const result = await handler(
+      createDetails({
+        url: 'http://localhost/raw',
+        method: 'POST',
+        requestBody: {
+          raw: [{ bytes: rawBody }],
+        },
+      })
+    )
+
+    expect(result).toBeDefined()
+    const { body } = parseDataUrl(result!.redirectUrl!)
+    expect(body).toBe('Received: raw request body')
+  })
+
+  it('should handle routes with path parameters', async () => {
+    const app = new Hono()
+    app.get('/users/:id', (c) => {
+      return c.json({ userId: c.req.param('id') })
+    })
+
+    const handler = handle(app)
+    const result = await handler(createDetails({ url: 'http://localhost/users/123' }))
+
+    expect(result).toBeDefined()
+    const { body } = parseDataUrl(result!.redirectUrl!)
+    expect(JSON.parse(body)).toEqual({ userId: '123' })
+  })
+})

--- a/src/adapter/web-extension/handler.ts
+++ b/src/adapter/web-extension/handler.ts
@@ -1,0 +1,84 @@
+import type { Hono } from '../../hono'
+import type { Env, Schema } from '../../types'
+import type { BlockingResponse, WebRequestDetails } from './types'
+
+type Handler = (details: WebRequestDetails) => Promise<BlockingResponse | undefined>
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+const buildRequestBody = (details: WebRequestDetails): BodyInit | undefined => {
+  const { requestBody } = details
+  if (!requestBody) {
+    return undefined
+  }
+
+  if (requestBody.raw) {
+    const parts = requestBody.raw.filter(
+      (part): part is { bytes: ArrayBuffer } => part.bytes !== undefined
+    )
+    if (parts.length === 0) {
+      return undefined
+    }
+    if (parts.length === 1) {
+      return parts[0].bytes
+    }
+    const totalLength = parts.reduce((sum, p) => sum + p.bytes.byteLength, 0)
+    const merged = new Uint8Array(totalLength)
+    let offset = 0
+    for (const part of parts) {
+      merged.set(new Uint8Array(part.bytes), offset)
+      offset += part.bytes.byteLength
+    }
+    return merged.buffer
+  }
+
+  if (requestBody.formData) {
+    const params = new URLSearchParams()
+    for (const [key, values] of Object.entries(requestBody.formData)) {
+      for (const value of values) {
+        params.append(key, value)
+      }
+    }
+    return params.toString()
+  }
+
+  return undefined
+}
+
+const responseToDataUrl = async (res: Response): Promise<string> => {
+  const body = await res.arrayBuffer()
+  const contentType = res.headers.get('content-type') || 'text/plain'
+  return `data:${contentType};base64,${arrayBufferToBase64(body)}`
+}
+
+export const handle = <E extends Env, S extends Schema, BasePath extends string>(
+  app: Hono<E, S, BasePath>
+): Handler => {
+  return async (details) => {
+    const body = buildRequestBody(details)
+    const requestInit: RequestInit = {
+      method: details.method,
+      ...(body !== undefined ? { body } : {}),
+    }
+
+    if (body !== undefined && typeof body === 'string') {
+      requestInit.headers = { 'content-type': 'application/x-www-form-urlencoded' }
+    }
+
+    const request = new Request(details.url, requestInit)
+    const res = await app.fetch(request)
+
+    if (res.status === 404) {
+      return undefined
+    }
+
+    return { redirectUrl: await responseToDataUrl(res) }
+  }
+}

--- a/src/adapter/web-extension/index.ts
+++ b/src/adapter/web-extension/index.ts
@@ -1,0 +1,21 @@
+import type { Hono } from '../../hono'
+import type { Env, Schema } from '../../types'
+import { handle } from './handler'
+import type { RequestFilter } from './types'
+
+export type FireOptions = {
+  filter?: RequestFilter
+  extraInfoSpec?: string[]
+}
+
+const fire = <E extends Env, S extends Schema, BasePath extends string>(
+  app: Hono<E, S, BasePath>,
+  options?: FireOptions
+): void => {
+  const filter = options?.filter ?? { urls: ['<all_urls>'] }
+  const extraInfoSpec = options?.extraInfoSpec ?? ['blocking']
+  // @ts-expect-error chrome is available in WebExtension service workers
+  chrome.webRequest.onBeforeRequest.addListener(handle(app), filter, extraInfoSpec)
+}
+
+export { handle, fire }

--- a/src/adapter/web-extension/types.ts
+++ b/src/adapter/web-extension/types.ts
@@ -1,0 +1,32 @@
+export interface WebRequestBody {
+  formData?: Record<string, string[]>
+  raw?: Array<{ bytes?: ArrayBuffer; file?: string }>
+}
+
+export interface WebRequestDetails {
+  documentId?: string
+  documentLifecycle?: string
+  frameId: number
+  frameType?: string
+  initiator?: string
+  method: string
+  parentFrameId: number
+  requestBody?: WebRequestBody
+  requestId: string
+  tabId: number
+  timeStamp: number
+  type: string
+  url: string
+}
+
+export interface BlockingResponse {
+  cancel?: boolean
+  redirectUrl?: string
+}
+
+export interface RequestFilter {
+  tabId?: number
+  types?: string[]
+  urls: string[]
+  windowId?: number
+}


### PR DESCRIPTION
## Summary

Add a new `hono/web-extension` adapter that enables running Hono apps inside browser WebExtension `webRequest` environments.

## Motivation

Currently Hono supports switching between Deno and Service Worker IIFE bundler implementations, but lacks support for WebExtensions. This adapter allows developers to use Hono's routing and middleware system to intercept and handle network requests within browser extensions via `chrome.webRequest.onBeforeRequest`.

Closes #4993

## Changes

- Added `src/adapter/web-extension/` with:
  - `types.ts` - TypeScript types for `chrome.webRequest` API (`WebRequestDetails`, `BlockingResponse`, `RequestFilter`)
  - `handler.ts` - Core handler that converts `webRequest` details into standard `Request` objects, passes them through the Hono app, and converts the `Response` back to a `BlockingResponse` (via data URL redirect)
  - `index.ts` - Public API exporting `fire()` and `handle()` functions
  - `handler.test.ts` - Tests covering GET/POST routing, JSON responses, form data bodies, raw bodies, path parameters, and 404 pass-through
- Added `./web-extension` export to `package.json` (exports + typesVersions) and `jsr.json`

## Usage

```ts
import { Hono } from 'hono'
import { fire } from 'hono/web-extension'

const app = new Hono()
app.get('/api/hello', (c) => c.json({ message: 'Hello from Hono!' }))

fire(app, {
  filter: { urls: ['*://*.example.com/*'] },
})
```

## How it works

1. `fire()` registers a `chrome.webRequest.onBeforeRequest` listener
2. When a request matches the filter, the handler converts `WebRequestDetails` into a standard `Request`
3. The request is passed through the Hono app via `app.fetch()`
4. If Hono returns a response (non-404), it is converted to a `data:` URL and returned as a `redirectUrl` in the `BlockingResponse`
5. If no route matches (404), the handler returns `undefined`, allowing the request to pass through normally