### PR TITLE
fix: reject non-serializable json values

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,12 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() throws for non-serializable values', () => {
+    expect(() => c.json(undefined)).toThrow(TypeError)
+    expect(() => c.json(Symbol('not-json'))).toThrow(TypeError)
+    expect(() => c.json(() => {})).toThrow(TypeError)
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -713,8 +713,12 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
+    const body = JSON.stringify(object)
+    if (body === undefined) {
+      throw new TypeError('Value is not JSON serializable.')
+    }
     return this.#newResponse(
-      JSON.stringify(object),
+      body,
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
Fixes #2343.

This makes `c.json()` throw a `TypeError` when the top-level value cannot be serialized by `JSON.stringify()`. Today those values produce `undefined` from `JSON.stringify()`, which gets passed into the response body and results in an empty response instead of a clear failure.

The check follows the Deno-style behavior discussed in the issue: serialize first, then reject values where JSON serialization returns `undefined`. This covers `undefined`, symbols, and functions while keeping existing serializable values on the same response path.

Verification:

- `/Users/mac/.bun/bin/bunx vitest --run src/context.test.ts`
- `/Users/mac/.bun/bin/bunx tsc --noEmit`
- `/Users/mac/.bun/bin/bun run lint`
- `/Users/mac/.bun/bin/bun run format`