### PR TITLE
fix(method-override): add duplex option when body is a ReadableStream

### DIFF
--- a/src/middleware/method-override/index.test.ts
+++ b/src/middleware/method-override/index.test.ts
@@ -185,6 +185,19 @@ describe('Method Override Middleware', () => {
       })
     })
 
+    it('Should override POST to DELETE with a body', async () => {
+      const res = await app.request('/posts?_method=delete', {
+        method: 'POST',
+        body: 'foo=bar',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        method: 'DELETE',
+        queryValue: null,
+      })
+    })
+
     it('Should not override GET request', async () => {
       const res = await app.request('/posts?_method=delete', {
         method: 'GET',

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -126,6 +126,7 @@ export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandle
         url.searchParams.delete(queryName)
         const request = new Request(url.toString(), {
           body: c.req.raw.body,
+          duplex: 'half',
           headers: c.req.raw.headers,
           method,
         })


### PR DESCRIPTION
fixes #5010

  The `query` override branch passes `c.req.raw.body` (a `ReadableStream`) to `new Request()` without `duplex: 'half'`. The Fetch spec requires `duplex` when sending a stream body — undici enforces this since v6.

  The `form` and `header` branches use non-stream bodies, so they're unaffected.

  Added a regression test for a body-bearing POST with query override.