### PR TITLE
fix(compress): do not compress 206 Partial Content responses

### DIFF
--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -58,6 +58,12 @@ describe('Compress Middleware', () => {
     c.header('Content-Length', '1024')
     return c.body(new Uint8Array(1024)) // Simulated chunked data
   })
+  app.get('/partial', (c) => {
+    c.header('Content-Type', 'text/plain')
+    c.header('Content-Length', '1024')
+    c.header('Content-Range', 'bytes 0-1023/2048')
+    return c.body('a'.repeat(1024), 206)
+  })
   app.get('/stream', (c) =>
     stream(c, async (stream) => {
       c.header('Content-Type', 'text/plain')
@@ -156,6 +162,14 @@ describe('Compress Middleware', () => {
       const res = await testCompression('/chunked', 'gzip', null)
       expect(res.headers.get('Content-Length')).toBe('1024')
       expect(res.headers.get('Transfer-Encoding')).toBe('chunked')
+    })
+
+    it('should not compress 206 Partial Content responses', async () => {
+      const res = await testCompression('/partial', 'gzip', null)
+      expect(res.status).toBe(206)
+      expect(res.headers.get('Content-Length')).toBe('1024')
+      expect(res.headers.get('Content-Range')).toBe('bytes 0-1023/2048')
+      expect(await res.text()).toBe('a'.repeat(1024))
     })
   })
 

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -90,6 +90,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
 
     // Check if response should be compressed
     if (
+      ctx.res.status === 206 || // partial content, Content-Range refers to the uncompressed bytes
       ctx.res.headers.has('Content-Encoding') || // already encoded
       ctx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
       ctx.req.method === 'HEAD' || // HEAD request


### PR DESCRIPTION
This addresses the second of the three problems reported in #5010 (compress encodes 206 Partial Content).

The middleware bails out for already-encoded, chunked, HEAD, small, non-compressible and no-transform responses, but it never checks the status code. A 206 ends up gzipped while its Content-Range header still refers to the uncompressed byte range, and the Content-Length that matched the partial body gets dropped. A range client stitching parts together from such responses gets corrupted data. This is easy to hit with a handler that does its own range handling, or when proxying an upstream that serves ranges, since the proxy helper passes the upstream status through.

The fix skips compression when the status is 206.

The new test serves a 1024 byte text/plain part with Content-Range and asserts it comes back uncompressed with status, Content-Length and Content-Range intact. It fails without the guard.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code