### PR TITLE
fix(method-override): add duplex option when body is a ReadableStream

### DIFF
--- a/src/middleware/method-override/index.test.ts
+++ b/src/middleware/method-override/index.test.ts
@@ -185,6 +185,21 @@ describe('Method Override Middleware', () => {
       })
     })
 
+    it('Should override POST to DELETE when request has a body', async () => {
+      const params = new URLSearchParams()
+      params.append('message', 'Hello')
+      const res = await app.request('/posts?_method=DELETE', {
+        method: 'POST',
+        body: params,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        method: 'DELETE',
+        queryValue: null,
+      })
+    })
+
     it('Should not override GET request', async () => {
       const res = await app.request('/posts?_method=delete', {
         method: 'GET',

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -128,7 +128,8 @@ export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandle
           body: c.req.raw.body,
           headers: c.req.raw.headers,
           method,
-        })
+          ...(c.req.raw.body ? { duplex: 'half' } : {}),
+        } as RequestInit)
         return app.fetch(request, c.env, getExecutionCtx(c))
       }
     }


### PR DESCRIPTION
The `query` override branch passes `c.req.raw.body` (a `ReadableStream`) directly to `new Request()` without setting `duplex: 'half'`. The Fetch spec requires this option whenever the request body is a stream, and undici (the native fetch implementation in Node.js) enforces it with:

```
TypeError: RequestInit: duplex option is required when sending a body.
```

This means any HTML form that submits to a route using query-based method override will get a 500, because forms always send a body.

The `form` and `header` branches are not affected. They consume the body into `FormData` or `URLSearchParams` before constructing the new request, so the stream is already resolved by the time `new Request()` is called.

The fix spreads `{ duplex: 'half' }` into the `RequestInit` only when `body` is non-null, and casts to `RequestInit` because the TypeScript lib types do not yet include `duplex`.

Added a regression test: a `POST ?_method=DELETE` with a `application/x-www-form-urlencoded` body. The existing test for the query branch only used a bodyless POST.

Fixes part of #5010.