### PR TITLE
fix(compress): skip compression for 206 and Content-Range responses

### DIFF
--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -245,6 +245,42 @@ describe('Compress Middleware', () => {
     })
   })
 
+  describe('Range Responses', () => {
+    const app = new Hono()
+    app.use('*', compress())
+    app.get('/partial', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Range', 'bytes 0-1023/4096')
+      c.header('Content-Length', '1024')
+      return c.body('a'.repeat(1024), 206)
+    })
+    app.get('/content-range-200', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Range', 'bytes 0-1023/4096')
+      c.header('Content-Length', '1024')
+      return c.text('a'.repeat(1024))
+    })
+
+    it('should not compress 206 Partial Content responses', async () => {
+      const res = await app.request('/partial', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.status).toBe(206)
+      // Compressing would corrupt the byte range the Content-Range header describes
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+      expect(res.headers.get('Content-Range')).toBe('bytes 0-1023/4096')
+      expect(res.headers.get('Content-Length')).toBe('1024')
+    })
+
+    it('should not compress responses carrying a Content-Range header', async () => {
+      const res = await app.request('/content-range-200', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+      expect(res.headers.get('Content-Range')).toBe('bytes 0-1023/4096')
+    })
+  })
+
   describe('contentTypeFilter', () => {
     describe('RegExp', () => {
       const app = new Hono()

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -93,6 +93,8 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
       ctx.res.headers.has('Content-Encoding') || // already encoded
       ctx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
       ctx.req.method === 'HEAD' || // HEAD request
+      ctx.res.status === 206 || // partial content
+      ctx.res.headers.has('Content-Range') || // byte-range response: Content-Range would describe the uncompressed bytes
       (contentLength && Number(contentLength) < threshold) || // content-length below threshold
       !shouldCompress(ctx.res) || // not compressible type
       !shouldTransform(ctx.res) // cache-control: no-transform


### PR DESCRIPTION
Addresses item 2 of #5010.

`compress()` skips on `Content-Encoding` / `Transfer-Encoding` / HEAD / threshold / type / `no-transform`, but not on partial/range responses. A `206 Partial Content` (or any response carrying `Content-Range`) gets gzipped while its `Content-Range` header still describes the **uncompressed** byte range — so a range client reassembling the stream gets corrupted data. nginx and apache skip compression on range responses for exactly this reason.

### Reproduction (before this PR)

```ts
import { Hono } from 'hono'
import { compress } from 'hono/compress'

const app = new Hono()
app.use(compress())
app.get('/range', (c) => {
  c.header('Content-Type', 'text/plain')
  c.header('Content-Range', 'bytes 1000-2999/5000')
  c.header('Content-Length', '2000')
  return c.body('x'.repeat(2000), 206)
})

const res = await app.request('/range', { headers: { 'Accept-Encoding': 'gzip' } })
res.headers.get('Content-Encoding') // 'gzip'  ❌ — body gzipped, but Content-Range still says bytes 1000-2999
```

### Fix

Add two guards to the existing skip condition:

```ts
ctx.res.status === 206 ||             // partial content
ctx.res.headers.has('Content-Range')  // byte-range response
```

`Content-Range` is checked in addition to the `206` status because it can also appear on a `200` response, and either way the header would no longer match the compressed bytes.

### Tests

Added a `Range Responses` suite asserting a `206` response and a `Content-Range` response are both passed through uncompressed with their `Content-Range` / `Content-Length` intact. Both fail without this change and pass with it; the full compress suite (39 tests) passes, `tsc --noEmit` and eslint are clean.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add TSDoc/JSDoc to document the code (inline comments on the new guards)