### PR TITLE
fix(aws-lambda): add globalThis.crypto polyfill

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -507,3 +507,14 @@ describe('handle', () => {
     expect(result.statusCode).toBe(413)
   })
 })
+
+describe('globalThis.crypto polyfill', () => {
+  it('globalThis.crypto is defined', () => {
+    expect(globalThis.crypto).toBeDefined()
+  })
+
+  it('globalThis.crypto.randomUUID() returns a valid UUID', () => {
+    const uuid = globalThis.crypto.randomUUID()
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+  })
+})

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,6 +1,11 @@
+import crypto from 'node:crypto'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
 import { decodeBase64, encodeBase64 } from '../../utils/encode'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+globalThis.crypto ??= crypto
 import type {
   ALBRequestContext,
   ApiGatewayRequestContext,


### PR DESCRIPTION
## What

The `aws-lambda` adapter is missing the `globalThis.crypto ??= crypto`
polyfill that `lambda-edge` already ships (added in
[`lambda-edge/handler.ts:1,8`](https://github.com/honojs/hono/blob/main/src/adapter/lambda-edge/handler.ts)).

Without it, handlers that call Web Crypto APIs
(`crypto.randomUUID()`, `crypto.getRandomValues()`, `crypto.subtle.*`)
will throw on Lambda runtimes where `globalThis.crypto` is not yet
natively available.

Closes item 3 of #5010.

## Changes

- `src/adapter/aws-lambda/handler.ts` — import `node:crypto` and set
  `globalThis.crypto ??= crypto` (same two lines as `lambda-edge`)
- `src/adapter/aws-lambda/handler.test.ts` — add a
  `globalThis.crypto polyfill` describe block verifying the global is
  defined and `randomUUID()` returns a valid v4 UUID

## Checklist

- [x] Tests added
- [x] Tests pass (`npx vitest run src/adapter/aws-lambda/handler.test.ts` → 34/34)
- [x] Formatted (`bun run format`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] ESLint clean (`npx eslint src/adapter/aws-lambda/handler.ts src/adapter/aws-lambda/handler.test.ts`)