### PR TITLE
fix(cache): deduplicate Cache-Control directives case-insensitively

### DIFF
--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -154,6 +154,12 @@ describe('Cache Middleware', () => {
     return c.text('cached')
   })
 
+  app.use('/wait5/*', cache({ cacheName: 'my-app-v1', wait: true, cacheControl: 'max-age=10' }))
+  app.get('/wait5/', (c) => {
+    c.header('Cache-Control', 'Max-Age=3600')
+    return c.text('cached')
+  })
+
   app.use('/vary1/*', cache({ cacheName: 'my-app-v1', wait: true, vary: ['Accept'] }))
   app.get('/vary1/', (c) => {
     return c.text('cached')
@@ -273,6 +279,15 @@ describe('Cache Middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe('private, max-age=10')
+  })
+
+  it('Should not duplicate a Cache-Control directive that differs only in case', async () => {
+    const res = await app.request('/wait5/')
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    // Directive names are case-insensitive (RFC 7234 §5.2); the handler's
+    // `Max-Age` must suppress the middleware's configured `max-age`.
+    expect(res.headers.get('cache-control')).toBe('Max-Age=3600')
   })
 
   it('Should correctly apply a single Vary header from middleware', async () => {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -108,7 +108,10 @@ export const cache = (options: {
         c.res.headers
           .get('Cache-Control')
           ?.split(',')
-          .map((d) => d.trim().split('=', 1)[0]) ?? []
+          // Directive names are case-insensitive (RFC 7234 §5.2); lower-case so
+          // the case-insensitive de-dup check below matches handler-set names
+          // like `Max-Age`.
+          .map((d) => d.trim().split('=', 1)[0].toLowerCase()) ?? []
       for (const directive of cacheControlDirectives) {
         let [name, value] = directive.trim().split('=', 2)
         name = name.toLowerCase()


### PR DESCRIPTION
## What

The cache middleware composes its configured `cacheControl` directives onto an
existing `Cache-Control` header, de-duplicating by directive name. But it
extracts the existing directive names **without lower-casing them**
(`src/middleware/cache/index.ts`), while lower-casing its own name before the
membership check:

```ts
const existingDirectives = c.res.headers.get('Cache-Control')
  ?.split(',').map((d) => d.trim().split('=', 1)[0]) ?? []   // not lowercased
for (const directive of cacheControlDirectives) {
  let [name, value] = directive.trim().split('=', 2)
  name = name.toLowerCase()                                   // lowercased
  if (!existingDirectives.includes(name)) { ... }             // case-sensitive miss
}
```

Cache-Control directive names are case-insensitive (RFC 7234 §5.2). So when a
route handler sets e.g. `Cache-Control: Max-Age=3600` and the middleware is
configured with `cacheControl: 'max-age=10'`, the duplicate isn't detected and a
contradictory directive is appended:

```
Cache-Control: Max-Age=3600, max-age=10
```

The existing `/wait2/` de-dup test only passes because both directives there are
written lower-case by the middleware itself; the handler-set path was the gap.

## Fix

Lower-case the extracted existing directive names so the case-insensitive de-dup
check matches handler-set names like `Max-Age`.

## Test

Added a `Cache Middleware` case (`/wait5/`) where the handler sets
`Cache-Control: Max-Age=3600` against a middleware `max-age=10`. It fails on
`main` (`Max-Age=3600, max-age=10`) and passes with the fix (`Max-Age=3600`).
All cache middleware tests pass (139). Prettier + ESLint clean.
