### PR TITLE
fix(router): treat `**` as wildcard in TrieRouter

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -27,6 +27,20 @@ describe('Get with *', () => {
     expect(node.search('get', '/hello')[0].length).toBe(1)
   })
 })
+describe('Get with **', () => {
+  const node = new Node()
+  node.insert('get', '/auth/**', 'auth wildcard')
+  it('matches a single path segment', () => {
+    expect(node.search('get', '/auth/hello')[0].length).toBe(1)
+    expect(node.search('get', '/auth/hello')[0][0][0]).toEqual('auth wildcard')
+  })
+  it('matches multiple path segments', () => {
+    expect(node.search('get', '/auth/a/b/c')[0].length).toBe(1)
+  })
+  it('does not match paths outside the prefix', () => {
+    expect(node.search('get', '/other/hello')[0].length).toBe(0)
+  })
+})
 
 describe('Get with * including JS reserved words', () => {
   const node = new Node()

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -54,7 +54,7 @@ export class Node<T> {
       const p: string = parts[i]
       const nextP = parts[i + 1]
       const pattern = getPattern(p, nextP)
-      const key = Array.isArray(pattern) ? pattern[0] : p
+      const key = Array.isArray(pattern) ? pattern[0] : pattern === '*' ? '*' : p
 
       if (key in curNode.#children) {
         curNode = curNode.#children[key]

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -89,6 +89,15 @@ describe('url', () => {
       const res = getPattern('*', 'next')
       expect(res).toBe('*')
     })
+    it('double wildcard', () => {
+      const res = getPattern('**')
+      expect(res).toBe('*')
+    })
+
+    it('double wildcard with next', () => {
+      const res = getPattern('**', 'next')
+      expect(res).toBe('*')
+    })
   })
 
   describe('getPath', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -53,7 +53,7 @@ export const getPattern = (label: string, next?: string): Pattern | null => {
   // :id{[0-9]+}  => ([0-9]+)
   // :id          => (.+)
 
-  if (label === '*') {
+  if (label === '*' || label === '**') {
     return '*'
   }
 


### PR DESCRIPTION
## Bug

`getPattern('**')` returned `null` because only `'*'` was recognised as the wildcard token.  As a result, routes such as `/auth/**` were silently stored under the child key `'**'` instead of `'*'`, so the search path (which looks up `children['*']`) never found them — returning 404 for every request.

This inconsistency is documented in #4623: RegExpRouter, PatternRouter, and LinearRouter all normalise `**` to a single-wildcard correctly; TrieRouter did not.

## Root cause

Two issues in the insertion path (`src/utils/url.ts` + `src/router/trie-router/node.ts`):

1. `getPattern` only treated `'*'` as the wildcard token; `'**'` fell through to the parameterised-segment regex, which did not match, so `null` was returned.
2. Even if `getPattern` had returned `'*'`, the key calculation `Array.isArray(pattern) ? pattern[0] : p` would have stored the child under `'**'` (the raw path part) rather than `'*'` (the key the search code looks up).

## Fix

- **`src/utils/url.ts`**: extend the wildcard check to also accept `'**'`  (`if (label === '*' || label === '**')`)
- **`src/router/trie-router/node.ts`**: when the resolved pattern is `'*'`, always use `'*'` as the child-node key regardless of the raw segment

## Verification

```
npx vitest run src/router/trie-router/node.test.ts src/utils/url.test.ts
```

**Before fix:** 4 failed | 114 passed (new tests fail with `expected +0 to be 1` / `expected null to be '*'`)  
**After fix:** 118 passed

> AI-assisted implementation.