### PR TITLE
ci: publish to npm from CI with OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  npm:
+    name: publish-to-npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.tool-versions'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: '.tool-versions'
+      - run: npm install -g npm@11.17.0
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+
   jsr:
     name: publish-to-jsr
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "bun run --shell bun remove-dist && bun ./build/build.ts --watch && bun run copy:package.cjs.json",
     "coverage": "vitest --run --coverage",
     "prerelease": "bun test:deno && bun run build",
-    "release": "np",
+    "release": "np --no-publish",
     "remove-dist": "rm -rf dist"
   },
   "exports": {


### PR DESCRIPTION
Currently, I publish an npm package manually using the `release` script, which runs the `np` command on my local machine. This has a risk of enabling supply chain attacks. If my machine is hijacked, the package may contain malicious things.

In this PR, switch the `release` to `np --no-publish` so the local step only bumps the version and pushes the tag. Plus, I added the CI script to `release.yml` to release to npm using OIDC trusted publishing with provenance. 

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
