### PR TITLE
Add jwk aud validation

### DIFF
--- a/src/middleware/jwk/index.test.ts
+++ b/src/middleware/jwk/index.test.ts
@@ -743,4 +743,100 @@ describe('JWK', () => {
       })
     })
   })
+
+  describe('Audience verification', () => {
+    let handlerExecuted: boolean
+
+    beforeEach(() => {
+      handlerExecuted = false
+    })
+
+    const app = new Hono()
+
+    app.use(
+      '/auth-with-aud/*',
+      jwk({ keys: verify_keys, verification: { aud: 'my-api' } })
+    )
+    app.use(
+      '/auth-with-aud-array/*',
+      jwk({ keys: verify_keys, verification: { aud: ['my-api', 'other-api'] } })
+    )
+
+    app.get('/auth-with-aud/*', (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
+    })
+    app.get('/auth-with-aud-array/*', (c) => {
+      handlerExecuted = true
+      const payload = c.get('jwtPayload')
+      return c.json(payload)
+    })
+
+    it('Should authorize when aud matches', async () => {
+      const credential = await Jwt.sign(
+        { message: 'hello world', aud: 'my-api' },
+        test_keys.private_keys[0]
+      )
+      const req = new Request('http://localhost/auth-with-aud/a')
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ message: 'hello world', aud: 'my-api' })
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should authorize when aud is in token aud array', async () => {
+      const credential = await Jwt.sign(
+        { message: 'hello world', aud: ['my-api', 'other-api'] },
+        test_keys.private_keys[0]
+      )
+      const req = new Request('http://localhost/auth-with-aud/a')
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res.status).toBe(200)
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should authorize when one of the expected aud values matches', async () => {
+      const credential = await Jwt.sign(
+        { message: 'hello world', aud: 'other-api' },
+        test_keys.private_keys[0]
+      )
+      const req = new Request('http://localhost/auth-with-aud-array/a')
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res.status).toBe(200)
+      expect(handlerExecuted).toBeTruthy()
+    })
+
+    it('Should not authorize when aud does not match', async () => {
+      const credential = await Jwt.sign(
+        { message: 'hello world', aud: 'wrong-api' },
+        test_keys.private_keys[0]
+      )
+      const url = 'http://localhost/auth-with-aud/a'
+      const req = new Request(url)
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toEqual(
+        `Bearer realm="${url}",error="invalid_token",error_description="token verification failure"`
+      )
+      expect(handlerExecuted).toBeFalsy()
+    })
+
+    it('Should not authorize when aud claim is missing', async () => {
+      const credential = await Jwt.sign(
+        { message: 'hello world' },
+        test_keys.private_keys[0]
+      )
+      const url = 'http://localhost/auth-with-aud/a'
+      const req = new Request(url)
+      req.headers.set('Authorization', `Bearer ${credential}`)
+      const res = await app.request(req)
+      expect(res.status).toBe(401)
+      expect(handlerExecuted).toBeFalsy()
+    })
+  })
 })

--- a/src/middleware/jwk/index.test.ts
+++ b/src/middleware/jwk/index.test.ts
@@ -753,10 +753,7 @@ describe('JWK', () => {
 
     const app = new Hono()
 
-    app.use(
-      '/auth-with-aud/*',
-      jwk({ keys: verify_keys, verification: { aud: 'my-api' } })
-    )
+    app.use('/auth-with-aud/*', jwk({ keys: verify_keys, verification: { aud: 'my-api' } }))
     app.use(
       '/auth-with-aud-array/*',
       jwk({ keys: verify_keys, verification: { aud: ['my-api', 'other-api'] } })
@@ -827,10 +824,7 @@ describe('JWK', () => {
     })
 
     it('Should not authorize when aud claim is missing', async () => {
-      const credential = await Jwt.sign(
-        { message: 'hello world' },
-        test_keys.private_keys[0]
-      )
+      const credential = await Jwt.sign({ message: 'hello world' }, test_keys.private_keys[0])
       const url = 'http://localhost/auth-with-aud/a'
       const req = new Request(url)
       req.headers.set('Authorization', `Bearer ${credential}`)

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -7,6 +7,7 @@ import * as JWT from './jwt'
 import { verifyWithJwks } from './jwt'
 import {
   JwtAlgorithmNotImplemented,
+  JwtTokenAudience,
   JwtTokenExpired,
   JwtTokenInvalid,
   JwtTokenIssuedAt,
@@ -224,6 +225,132 @@ describe('JWT', () => {
     }
     expect(err).toBeUndefined()
     expect(authorized?.iss).toEqual('hello')
+  })
+
+  it('JwtTokenAudience (none)', async () => {
+    const payload = { iat: 1633046400 }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: 'my-api',
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toEqual(new JwtTokenAudience('my-api', null))
+    expect(authorized).toBeUndefined()
+  })
+
+  it('JwtTokenAudience (wrong - string token aud)', async () => {
+    const payload = { iat: 1633046400, aud: 'other-api' }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: 'my-api',
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toEqual(new JwtTokenAudience('my-api', 'other-api'))
+    expect(authorized).toBeUndefined()
+  })
+
+  it('JwtTokenAudience (wrong - array token aud)', async () => {
+    const payload = { iat: 1633046400, aud: ['other-api', 'another-api'] }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: 'my-api',
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toEqual(new JwtTokenAudience('my-api', ['other-api', 'another-api']))
+    expect(authorized).toBeUndefined()
+  })
+
+  it('JwtTokenAudience (wrong - array options aud, no match)', async () => {
+    const payload = { iat: 1633046400, aud: 'other-api' }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: ['my-api', 'another-api'],
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toEqual(new JwtTokenAudience(['my-api', 'another-api'], 'other-api'))
+    expect(authorized).toBeUndefined()
+  })
+
+  it('JwtTokenAudience (correct - string aud matches string token aud)', async () => {
+    const payload = { iat: 1633046400, aud: 'my-api' }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: 'my-api',
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeUndefined()
+    expect(authorized?.aud).toEqual('my-api')
+  })
+
+  it('JwtTokenAudience (correct - string aud matches array token aud)', async () => {
+    const payload = { iat: 1633046400, aud: ['my-api', 'other-api'] }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: 'my-api',
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeUndefined()
+    expect(authorized?.aud).toEqual(['my-api', 'other-api'])
+  })
+
+  it('JwtTokenAudience (correct - array options aud, one match)', async () => {
+    const payload = { iat: 1633046400, aud: 'my-api' }
+    const secret = 'a-secret'
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    let err
+    let authorized
+    try {
+      authorized = await JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        aud: ['my-api', 'other-api'],
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeUndefined()
+    expect(authorized?.aud).toEqual('my-api')
   })
 
   it('HS256 sign & verify & decode', async () => {

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -12,6 +12,7 @@ import type { HonoJsonWebKey, SignatureKey } from './jws'
 import {
   JwtHeaderInvalid,
   JwtHeaderRequiresKid,
+  JwtTokenAudience,
   JwtTokenExpired,
   JwtTokenInvalid,
   JwtTokenIssuedAt,
@@ -72,6 +73,8 @@ export const sign = async (
 export type VerifyOptions = {
   /** The expected issuer used for verifying the token */
   iss?: string | RegExp
+  /** The expected audience(s) used for verifying the token. Accepts a string or array of strings. Verification passes if the token's `aud` claim contains at least one of the expected values. */
+  aud?: string | string[]
   /** Verify the `nbf` claim (default: `true`) */
   nbf?: boolean
   /** Verify the `exp` claim (default: `true`) */
@@ -87,6 +90,7 @@ export type VerifyOptionsWithAlg = {
 
 type StrictVerifyOptions = {
   iss?: string | RegExp
+  aud?: string | string[]
   nbf: boolean
   exp: boolean
   iat: boolean
@@ -105,6 +109,7 @@ export const verify = async (
   const opts: StrictVerifyOptionsWithAlg = {
     alg: optsIn.alg ?? 'HS256',
     iss: optsIn.iss,
+    aud: optsIn.aud,
     nbf: optsIn.nbf ?? true,
     exp: optsIn.exp ?? true,
     iat: optsIn.iat ?? true,
@@ -138,6 +143,17 @@ export const verify = async (
     }
     if (opts.iss instanceof RegExp && !opts.iss.test(payload.iss)) {
       throw new JwtTokenIssuer(opts.iss, payload.iss)
+    }
+  }
+  if (opts.aud) {
+    const expectedAud = Array.isArray(opts.aud) ? opts.aud : [opts.aud]
+    const tokenAud = payload.aud
+      ? Array.isArray(payload.aud)
+        ? payload.aud
+        : [payload.aud]
+      : null
+    if (!tokenAud || !expectedAud.some((a) => tokenAud.includes(a))) {
+      throw new JwtTokenAudience(opts.aud, payload.aud ?? null)
     }
   }
 

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -147,11 +147,7 @@ export const verify = async (
   }
   if (opts.aud) {
     const expectedAud = Array.isArray(opts.aud) ? opts.aud : [opts.aud]
-    const tokenAud = payload.aud
-      ? Array.isArray(payload.aud)
-        ? payload.aud
-        : [payload.aud]
-      : null
+    const tokenAud = payload.aud ? (Array.isArray(payload.aud) ? payload.aud : [payload.aud]) : null
     if (!tokenAud || !expectedAud.some((a) => tokenAud.includes(a))) {
       throw new JwtTokenAudience(opts.aud, payload.aud ?? null)
     }

--- a/src/utils/jwt/types.ts
+++ b/src/utils/jwt/types.ts
@@ -47,6 +47,15 @@ export class JwtTokenIssuer extends Error {
   }
 }
 
+export class JwtTokenAudience extends Error {
+  constructor(expected: string | string[], aud: string | string[] | null) {
+    const expectedStr = Array.isArray(expected) ? expected.join(', ') : expected
+    const audStr = aud ? (Array.isArray(aud) ? aud.join(', ') : aud) : 'none'
+    super(`expected audience "${expectedStr}", got "${audStr}"`)
+    this.name = 'JwtTokenAudience'
+  }
+}
+
 export class JwtHeaderInvalid extends Error {
   constructor(header: object) {
     super(`jwt header is invalid: ${JSON.stringify(header)}`)
@@ -100,6 +109,10 @@ export type JWTPayload = {
    * The token is checked to ensure it has been issued by a trusted issuer.
    */
   iss?: string
+  /**
+   * The token is checked to ensure it is intended for the expected audience.
+   */
+  aud?: string | string[]
 }
 
 export type { HonoJsonWebKey } from './jws'


### PR DESCRIPTION
While this can be done outside the middleware (by custom middleware) validating the `aud` is a commit requirement and it it useful to have this available in the framework.

This feature can be used by:
```
app.use('/api/*', jwk({
  keys: verify_keys,
  verification: { aud: 'my-api' }  // or aud: ['my-api', 'other-api']
}))
```

This addresses some of #2340 but not all of the original issue.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
