### PR TITLE
fix(aws-lambda): detect V2 events by request context, not rawPath alone

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -372,6 +372,24 @@ describe('EventProcessor.createRequest', () => {
 })
 
 describe('handle', () => {
+  it('Should route a V1 REST event by its path even when a base path mapping adds rawPath', async () => {
+    const app = new Hono()
+    app.get('/my/path', (c) => c.text('Hello'))
+    const handler = handle(app)
+
+    // A custom domain base path mapping makes API Gateway add a `rawPath` to the
+    // V1 (REST API) event, holding the path before the mapping was stripped. The
+    // event is still V1: it carries `path` and a V1 request context with no `http`.
+    const event: LambdaEvent = {
+      ...baseV1Event,
+      rawPath: '/base/my/path',
+    }
+
+    const result = await handler(event)
+    expect(result.statusCode).toBe(200)
+    expect(result.body).toBe('Hello')
+  })
+
   it('Should return 400 when request contains invalid header names (v2)', async () => {
     const app = new Hono()
     app.get('/my/path', (c) => c.text('Hello'))

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -658,7 +658,10 @@ const isProxyEventALB = (event: LambdaEvent): event is ALBProxyEvent => {
 }
 
 const isProxyEventV2 = (event: LambdaEvent): event is APIGatewayProxyEventV2 => {
-  return Object.hasOwn(event, 'rawPath')
+  // A V1 (REST API) event behind a custom domain base path mapping also carries a
+  // `rawPath`, so `rawPath` alone is not enough to identify a V2 event. Every V2
+  // (HTTP API / function URL) event has an `http` object on its request context.
+  return Object.hasOwn(event, 'rawPath') && Object.hasOwn(event.requestContext ?? {}, 'http')
 }
 
 const isLatticeEventV2 = (event: LambdaEvent): event is LatticeProxyEventV2 => {


### PR DESCRIPTION
Fixes #5015

### What this fixes

When a Lambda is served through an API Gateway REST API (V1) with a custom domain base path mapping, API Gateway adds a `rawPath` to the event. `isProxyEventV2` only checked whether `rawPath` was present, so these V1 events were treated as V2 (HTTP API). The handler then routed on `rawPath` and read `requestContext.http`, which a V1 event does not have, so the request never reached its route.

Every genuine V2 event (HTTP API and Lambda function URLs) carries an `http` object on its request context; a V1 REST event does not. Checking for that alongside `rawPath` keeps real V2 events working and stops a V1 event with a base-path `rawPath` from being misread as V2.

### Test

Added a `handle` test that sends a V1 event carrying a base-path `rawPath` and asserts it routes by its `path`. It fails before the change (the event is handled as V2) and passes after.

---

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code

