### PR TITLE
feat(client): add detailed response inference type

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -14,6 +14,7 @@ import type {
   ClientResponse,
   InferRequestType,
   InferResponseType,
+  InferResponseTypeWithDetail,
   ApplyGlobalResponse,
   PickResponseByStatusCode,
 } from './types'
@@ -1011,6 +1012,40 @@ describe('Infer the response type with different status codes', () => {
     type Expected = {
       data: string
     } | null
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+})
+
+describe('Infer the response type with details', () => {
+  const condition = () => true
+  const app = new Hono().get('/', (c) => {
+    if (condition()) {
+      return c.json({ successMessage: 'Success!' }, 200)
+    }
+    return c.json({ errorMessage: 'Error!' }, 500)
+  })
+
+  const client = hc<typeof app>('', { fetch: app.request })
+
+  it('Should infer response body, status code, format, and ok state', () => {
+    type Actual = InferResponseTypeWithDetail<typeof client.index.$get>
+    type Expected =
+      | {
+          body: {
+            successMessage: string
+          }
+          statusCode: 200
+          format: 'json'
+          ok: true
+        }
+      | {
+          body: {
+            errorMessage: string
+          }
+          statusCode: 500
+          format: 'json'
+          ok: false
+        }
     type verify = Expect<Equal<Expected, Actual>>
   })
 })

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -7,6 +7,7 @@ export { hc } from './client'
 export { parseResponse, DetailedError } from './utils'
 export type {
   InferResponseType,
+  InferResponseTypeWithDetail,
   InferRequestType,
   Fetch,
   ClientRequestOptions,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -253,6 +253,19 @@ export type InferResponseType<T, U extends StatusCode = StatusCode> = InferRespo
   U
 >
 
+/**
+ * Infer response details from a Hono client method as a discriminated union.
+ * Includes the response body, status code, format, and whether the status is successful.
+ *
+ * @example
+ * ```ts
+ * type Response = InferResponseTypeWithDetail<typeof client.index.$get>
+ * ```
+ */
+export type InferResponseTypeWithDetail<T> = InferResponseTypeWithDetailFromEndpoint<
+  InferEndpointType<T>
+>
+
 type InferResponseTypeFromEndpoint<T extends Endpoint, U extends StatusCode> = T extends {
   output: infer O
   status: infer S
@@ -260,6 +273,19 @@ type InferResponseTypeFromEndpoint<T extends Endpoint, U extends StatusCode> = T
   ? S extends U
     ? O
     : never
+  : never
+
+type InferResponseTypeWithDetailFromEndpoint<T extends Endpoint> = T extends {
+  output: infer O
+  outputFormat: infer F
+  status: infer S
+}
+  ? {
+      body: O
+      statusCode: S
+      format: F
+      ok: S extends SuccessStatusCode ? true : false
+    }
   : never
 
 export type InferRequestType<T> = T extends (


### PR DESCRIPTION
Closes #4270

Adds `InferResponseTypeWithDetail`, which infers RPC response details as a
discriminated union containing the response body, status code, response format,
and `ok` state.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Verification

- `bunx tsc -p tsconfig.spec.json --noEmit --pretty false`
- `env -u NO_COLOR bunx vitest --run --project main`
