### PR TITLE
docs(context-storage): fix broken example in JSDoc

### DIFF
--- a/src/middleware/context-storage/index.ts
+++ b/src/middleware/context-storage/index.ts
@@ -29,11 +29,11 @@ const asyncLocalStorage = new AsyncLocalStorage<Context>()
  * app.use(contextStorage())
  *
  * app.use(async (c, next) => {
- *   c.set('message', 'Hono is hot!!)
+ *   c.set('message', 'Hono is hot!!')
  *   await next()
  * })
  *
- * app.get('/', async (c) => { c.text(getMessage()) })
+ * app.get('/', async (c) => { return c.text(getMessage()) })
  *
  * const getMessage = () => {
  *   return getContext<Env>().var.message


### PR DESCRIPTION
The JSDoc `@example` for `contextStorage` does not compile or run as written.

Two problems in the snippet:

- `c.set('message', 'Hono is hot!!)` has an unterminated string literal (missing the closing quote).
- `app.get('/', async (c) => { c.text(getMessage()) })` builds the response but never returns it, so the route would respond with a 404 instead of the text.

This is the example that shows up in editor tooltips and on the docs page for the middleware. Closed the string and added the missing `return` so the example is valid and does what the surrounding text describes. No code or runtime behavior changes, only the doc comment.