### PR TITLE
fix(stream): re-acquire writer lock in pipe() even when pipeTo() rejects

### DIFF
--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -77,8 +77,11 @@ export class StreamingApi {
 
   async pipe(body: ReadableStream) {
     this.writer.releaseLock()
-    await body.pipeTo(this.writable, { preventClose: true })
-    this.writer = this.writable.getWriter()
+    try {
+      await body.pipeTo(this.writable, { preventClose: true })
+    } finally {
+      this.writer = this.writable.getWriter()
+    }
   }
 
   onAbort(listener: () => void | Promise<void>) {


### PR DESCRIPTION
## Problem

`StreamingApi.pipe()` releases the `WritableStreamDefaultWriter` lock before calling `pipeTo()`, but only re-acquires a new writer on the success path. If `pipeTo()` rejects (client disconnect, upstream error, abort signal), the `getWriter()` call is never reached, leaving `this.writer` pointing to a stale released writer.

Subsequent calls to `write()`, `writeln()`, or `close()` fail with:
- `TypeError: This WritableStream writer has been released and cannot be used`
- `TypeError: Failed to execute 'getWriter' on 'WritableStream': The stream is locked`

## Fix

```diff
  async pipe(body: ReadableStream) {
    this.writer.releaseLock()
-   await body.pipeTo(this.writable, { preventClose: true })
-   this.writer = this.writable.getWriter()
+   try {
+     await body.pipeTo(this.writable, { preventClose: true })
+   } finally {
+     this.writer = this.writable.getWriter()
+   }
  }
```

## Testing

- Existing tests continue to pass (pipe on success path still works)
- The `finally` block ensures the writer is always re-acquired, even on error
- Follows the same error-handling pattern used in `write()` and `close()` methods

Fixes #4981
