### PR TITLE
fix(method-override,compress): add duplex:half for query body, skip compress on 206

### DIFF
--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -93,6 +93,7 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
       ctx.res.headers.has('Content-Encoding') || // already encoded
       ctx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
       ctx.req.method === 'HEAD' || // HEAD request
+      ctx.res.status === 206 || // partial content (range response)
       (contentLength && Number(contentLength) < threshold) || // content-length below threshold
       !shouldCompress(ctx.res) || // not compressible type
       !shouldTransform(ctx.res) // cache-control: no-transform

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -128,6 +128,8 @@ export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandle
           body: c.req.raw.body,
           headers: c.req.raw.headers,
           method,
+          // duplex is required when body is a ReadableStream (Fetch spec)
+          duplex: 'half',
         })
         return app.fetch(request, c.env, getExecutionCtx(c))
       }


### PR DESCRIPTION
## Problem (from #5010)

Two reliability issues in middleware:

### 1. `methodOverride({ query })` returns 500 on any request with a body

The query branch rebuilds the request from the raw `ReadableStream` without `duplex: 'half'`. Per Fetch spec, undici throws `TypeError: RequestInit: duplex option is required when sending a body`, surfaced as 500.

The `form` and `header` branches build non-stream bodies, so only `query` is affected. Since an HTML form always sends a body, every form POST to a query-override route returns 500.

### 2. `compress()` encodes 206 Partial Content and strips Content-Length

The compress middleware skips on `Content-Encoding` / `Transfer-Encoding` / HEAD / threshold / type, but not on status 206. A 206 ends up gzipped while `Content-Range` describes the *uncompressed* byte range — range clients reassemble corrupted data.

## Fix

```diff
// method-override: query branch
  const request = new Request(url.toString(), {
    body: c.req.raw.body,
    headers: c.req.raw.headers,
    method,
+   duplex: 'half',
  })

// compress: add 206 skip
  if (
    ctx.res.headers.has('Content-Encoding') ||
    ctx.res.headers.has('Transfer-Encoding') ||
    ctx.req.method === 'HEAD' ||
+   ctx.res.status === 206 ||
    (contentLength && Number(contentLength) < threshold) ||
    !shouldCompress(ctx.res) ||
    !shouldTransform(ctx.res)
  ) {
    return
  }
```

Fixes #5010
