### PR TITLE
fix(aws-lambda): add globalThis.crypto polyfill for older Node Lambda runtimes

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,6 +1,12 @@
+import crypto from 'node:crypto'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
 import { decodeBase64, encodeBase64 } from '../../utils/encode'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+globalThis.crypto ??= crypto
+
 import type {
   ALBRequestContext,
   ApiGatewayRequestContext,


### PR DESCRIPTION
## Problem (from #5010)

`src/adapter/lambda-edge/handler.ts` polyfills `globalThis.crypto` for older Node Lambda runtimes, but `src/adapter/aws-lambda/handler.ts` does not.

Functions that rely on `crypto.subtle` (JWT verify, hashing) throw at first request on Node 18 Lambda. This is an inconsistency between two adapters that share the same runtime concern.

## Fix

Add the same polyfill pattern used in `lambda-edge`:

```diff
+import crypto from 'node:crypto'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
 import { decodeBase64, encodeBase64 } from '../../utils/encode'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+globalThis.crypto ??= crypto
```

`globalThis.crypto ??= crypto` uses nullish coalescing assignment, so it only sets the value if it's currently `undefined` or `null`. On Node 19+ where `crypto` is already globally available, this is a no-op.

Fixes part 3 of #5010
