### PR TITLE
fix(timing): handle immutable headers by cloning response when needed

### DIFF
--- a/src/middleware/timing/timing.ts
+++ b/src/middleware/timing/timing.ts
@@ -110,7 +110,13 @@ export const timing = (config?: TimingOptions): MiddlewareHandler => {
     const enabled = typeof options.enabled === 'function' ? options.enabled(c) : options.enabled
 
     if (enabled) {
-      c.res.headers.append('Server-Timing', headers.join(','))
+      // Ensure response headers are mutable (raw Response objects may have immutable headers)
+      try {
+        c.res.headers.append('Server-Timing', headers.join(','))
+      } catch {
+        c.res = new Response(c.res.body, c.res)
+        c.res.headers.append('Server-Timing', headers.join(','))
+      }
 
       const crossOrigin =
         typeof options.crossOrigin === 'function' ? options.crossOrigin(c) : options.crossOrigin


### PR DESCRIPTION
## Problem

When a raw `Response` object is returned from a handler (e.g. not using `c.json()`), its headers may be immutable. The `timing` middleware then throws `TypeError: Can't modify immutable headers` when trying to append `Server-Timing` headers.

Users have been working around this by wrapping the timing middleware to clone the response manually.

## Fix

Wrap the first `headers.append()` call in a try/catch. If it fails due to immutable headers, clone the response with mutable headers before appending.

```diff
  if (enabled) {
-   c.res.headers.append('Server-Timing', headers.join(','))
+   try {
+     c.res.headers.append('Server-Timing', headers.join(','))
+   } catch {
+     c.res = new Response(c.res.body, c.res)
+     c.res.headers.append('Server-Timing', headers.join(','))
+   }
```

This matches the workaround users were already applying manually and is backward-compatible.

Fixes #4454
