### PR TITLE
fix(lambda-edge): validate CloudFront event structure before accessing properties

### DIFF
--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -150,6 +150,11 @@ const createResult = async (res: Response): Promise<CloudFrontResult> => {
 }
 
 const createRequest = (event: CloudFrontEdgeEvent): Request => {
+  if (!event?.Records?.[0]?.cf?.request) {
+    throw new Error(
+      'Malformed CloudFront event: expected event.Records[0].cf.request to be defined'
+    )
+  }
   const queryString = event.Records[0].cf.request.querystring
   const host =
     event.Records[0].cf.request.headers?.host?.[0]?.value ||


### PR DESCRIPTION
## Problem

The `createRequest` function in the lambda-edge adapter assumes `event.Records[0].cf.request` exists. When testing with malformed events (e.g. AWS console sample payloads), it throws a cryptic `TypeError: Cannot read properties of undefined (reading '0')` with no useful context.

## Fix

Add an early validation check that throws a descriptive error message when the CloudFront event structure is invalid:

```diff
  const createRequest = (event: CloudFrontEdgeEvent): Request => {
+   if (!event?.Records?.[0]?.cf?.request) {
+     throw new Error(
+       'Malformed CloudFront event: expected event.Records[0].cf.request to be defined'
+     )
+   }
    const queryString = event.Records[0].cf.request.querystring
```

This makes debugging much easier when the event structure is unexpected.

Fixes #4417
