### PR TITLE
docs(MIGRATION): fix req.raw.headers reference (property, not method)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -34,7 +34,7 @@ There are some breaking changes.
 - Hono - `app.head()` is no longer used. `app.get()` implicitly handles the HEAD method.
 - Hono - `app.handleEvent()` is obsolete. Use `app.fetch()` instead.
 - HonoRequest - `req.cookie()` is obsolete. Use `getCookie()` in `hono/cookie` instead.
-- HonoRequest - `headers()`, `body()`, `bodyUsed()`, `integrity()`, `keepalive()`, `referrer()`, and `signal()` are obsolete. Use the methods in `req.raw` such as `req.raw.headers()`.
+- HonoRequest - `headers()`, `body()`, `bodyUsed()`, `integrity()`, `keepalive()`, `referrer()`, and `signal()` are obsolete. Use the equivalent properties on `req.raw` such as `req.raw.headers`.
 
 ### `serveStatic` in Cloudflare Workers Adapter requires `manifest`
 


### PR DESCRIPTION
In the v3.12 → v4.0 migration notes:

> - HonoRequest - `headers()`, `body()`, ... are obsolete. Use the methods in `req.raw` such as `req.raw.headers()`.

`req.raw` is a Fetch API [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request), and its `headers`, `body`, `bodyUsed`, `integrity`, `keepalive`, `referrer` and `signal` are **properties (getters), not methods**. Copy-pasting `req.raw.headers()` produces `TypeError: req.raw.headers is not a function`.

Hono's own `src/request.ts` accesses it as a property (e.g. `this.raw.headers.get(name)`).

This PR fixes the example to `req.raw.headers` and refers to them as *properties* instead of *methods*.

Docs-only change.
