### PR TITLE
fix(stream): re-acquire writer lock in pipe() when pipeTo() rejects

### DIFF
--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -31,6 +31,21 @@ describe('StreamingApi', () => {
     expect((await reader.read()).value).toEqual(new TextEncoder().encode('bar\n'))
   })
 
+  it('pipe() re-acquires writer after pipeTo() rejects', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+    const reader = api.responseReadable.getReader()
+    const erroringStream = new ReadableStream()
+    erroringStream.pipeTo = () => Promise.reject(new Error('upstream failure'))
+
+    await expect(api.pipe(erroringStream)).rejects.toThrow('upstream failure')
+
+    await api.write('recovered')
+    await api.close()
+    expect((await reader.read()).value).toEqual(new TextEncoder().encode('recovered'))
+    expect((await reader.read()).done).toBe(true)
+  })
+
   it('pipe()', async () => {
     const { readable: senderReadable, writable: senderWritable } = new TransformStream()
 

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -77,8 +77,11 @@ export class StreamingApi {
 
   async pipe(body: ReadableStream) {
     this.writer.releaseLock()
-    await body.pipeTo(this.writable, { preventClose: true })
-    this.writer = this.writable.getWriter()
+    try {
+      await body.pipeTo(this.writable, { preventClose: true })
+    } finally {
+      this.writer = this.writable.getWriter()
+    }
   }
 
   onAbort(listener: () => void | Promise<void>) {


### PR DESCRIPTION
## Summary
- Fix `StreamingApi.pipe()` leaving a stale writer when `pipeTo()` rejects
- Add regression test for post-pipe writes after a failed `pipeTo()`

Fixes #4981

## Test plan
- [x] `bunx vitest --run --coverage.enabled=false src/utils/stream.test.ts` (10/10 passing)