### PR TITLE
feat: add first-class support for the HTTP QUERY method

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -12,7 +12,7 @@ type MethodNameAll = `$${typeof METHOD_NAME_ALL_LOWERCASE}`
 
 /**
  * Type representing all standard HTTP methods prefixed with '$'
- * e.g., '$get' | '$post' | '$put' | '$delete' | '$options' | '$patch'
+ * e.g., '$get' | '$post' | '$put' | '$delete' | '$options' | '$patch' | '$query'
  */
 type StandardMethods = `$${(typeof METHODS)[number]}`
 

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -107,6 +107,7 @@ class Hono<
   delete!: HandlerInterface<E, 'delete', S, BasePath, CurrentPath>
   options!: HandlerInterface<E, 'options', S, BasePath, CurrentPath>
   patch!: HandlerInterface<E, 'patch', S, BasePath, CurrentPath>
+  query!: HandlerInterface<E, 'query', S, BasePath, CurrentPath>
   all!: HandlerInterface<E, 'all', S, BasePath, CurrentPath>
   on: OnHandlerInterface<E, S, BasePath>
   use: MiddlewareHandlerInterface<E, S, BasePath>

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -2009,6 +2009,70 @@ describe('Hono with `app.route`', () => {
   })
 })
 
+describe('Using QUERY method with `app.query`', () => {
+  it('Should handle QUERY method with RegExpRouter', async () => {
+    const app = new Hono({ router: new RegExpRouter() })
+
+    app.query('/search', (c) => c.text('Query accepted', 200))
+
+    const req = new Request('http://localhost/search', {
+      method: 'QUERY',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Query accepted')
+  })
+
+  it('Should handle QUERY method with TrieRouter', async () => {
+    const app = new Hono({ router: new TrieRouter() })
+
+    app.query('/search', (c) => c.text('Query accepted', 200))
+
+    const req = new Request('http://localhost/search', {
+      method: 'QUERY',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Query accepted')
+  })
+
+  it('Should handle QUERY method with `app.on`', async () => {
+    const app = new Hono()
+
+    app.on('QUERY', '/search', (c) => c.text('Query accepted via on', 200))
+
+    const req = new Request('http://localhost/search', {
+      method: 'QUERY',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('Query accepted via on')
+  })
+
+  it('Should return 404 for unregistered QUERY path', async () => {
+    const app = new Hono()
+
+    const req = new Request('http://localhost/search', {
+      method: 'QUERY',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(404)
+  })
+
+  it('Should handle path parameters with app.query', async () => {
+    const app = new Hono()
+
+    app.query('/users/:id', (c) => c.json({ id: c.req.param('id') }))
+
+    const req = new Request('http://localhost/users/42', {
+      method: 'QUERY',
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: '42' })
+  })
+})
+
 describe('Using other methods with `app.on`', () => {
   it('Should handle PURGE method with RegExpRouter', async () => {
     const app = new Hono({ router: new RegExpRouter() })

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,7 +14,7 @@ export const METHOD_NAME_ALL_LOWERCASE = 'all' as const
 /**
  * Array of supported HTTP methods.
  */
-export const METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch'] as const
+export const METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch', 'query'] as const
 /**
  * Error message indicating that a route cannot be added because the matcher is already built.
  */


### PR DESCRIPTION
## Summary
- Add `query` to the built-in `METHODS` array and expose `app.query()` alongside existing method helpers
- Add tests for `app.query()`, `app.on('QUERY')`, 404 handling, and path parameters

Fixes #5048

## Test plan
- [x] `bunx vitest --run --coverage.enabled=false src/hono.test.ts -t "QUERY"` (5/5 passing)