### PR TITLE
fix(jsx): rename ReactNode export to HonoReactNode

### DIFF
--- a/src/jsx/types.ts
+++ b/src/jsx/types.ts
@@ -21,10 +21,10 @@ type ReactElement<P = any, T = string | Function> = JSXNode & {
   props: P
   key: string | null
 }
-type ReactNode = ReactElement | string | number | boolean | null | undefined
+type HonoReactNode = ReactElement | string | number | boolean | null | undefined
 type ComponentClass<_P = {}, _S = {}> = unknown
 
-export type { ReactElement, ReactNode, ComponentClass }
+export type { ReactElement, HonoReactNode, ComponentClass }
 
 export type Event = globalThis.Event
 export type MouseEvent = globalThis.MouseEvent


### PR DESCRIPTION
## Summary
- Rename Hono's `ReactNode` type export to `HonoReactNode` to avoid shadowing React's `ReactNode` in editor autocomplete

Fixes #4455

## Test plan
- [x] Type-only change; no runtime behavior affected