### PR TITLE
fix(jsx): add useRef overloads so non-null init returns MutableRefObject

### DIFF
--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -316,7 +316,11 @@ export const useCallback = <T extends Function>(callback: T, deps: readonly unkn
 }
 
 export type RefObject<T> = { current: T | null }
-export const useRef = <T>(initialValue: T | null): RefObject<T> => {
+export type MutableRefObject<T> = { current: T }
+export function useRef<T>(initialValue: T): MutableRefObject<T>
+export function useRef<T>(initialValue: T | null): RefObject<T>
+export function useRef<T = undefined>(): MutableRefObject<T | undefined>
+export function useRef<T>(initialValue?: T | null): MutableRefObject<T | undefined> | RefObject<T> {
   const buildData = buildDataStack.at(-1) as [unknown, NodeObject]
   if (!buildData) {
     return { current: initialValue }

--- a/src/jsx/types.ts
+++ b/src/jsx/types.ts
@@ -5,7 +5,7 @@ import type { Child, JSXNode } from './base'
 import type { JSX } from './intrinsic-elements'
 
 export type { Child, JSXNode, FC } from './base'
-export type { RefObject } from './hooks'
+export type { RefObject, MutableRefObject } from './hooks'
 export type { Context } from './context'
 
 export type PropsWithChildren<P = unknown> = P & { children?: Child | undefined }


### PR DESCRIPTION
## Problem

`useRef` in `hono/jsx` has a single signature:

```ts
export const useRef = <T>(initialValue: T | null): RefObject<T>
// RefObject<T> = { current: T | null }
```

This means even when a non-null value is passed, `.current` is always typed as `T | null`, forcing unnecessary null-checks:

```ts
const ref = useRef(new Map<string, number>())
ref.current.set('a', 1) // ❌ TS error: 'ref.current' is possibly 'null'
```

## Fix

Add the same three overloads React uses, and export `MutableRefObject<T>` from `types.ts`:

```ts
export type MutableRefObject<T> = { current: T }

export function useRef<T>(initialValue: T): MutableRefObject<T>
export function useRef<T>(initialValue: T | null): RefObject<T>
export function useRef<T = undefined>(): MutableRefObject<T | undefined>
```

The runtime implementation is unchanged — only the types change.

**After this fix:**

```ts
const ref = useRef(new Map<string, number>())
ref.current.set('a', 1) // ✅ no error — current is Map<string, number>

const domRef = useRef<HTMLDivElement>(null)
domRef.current?.focus()  // ✅ still nullable — RefObject<HTMLDivElement>

const noInit = useRef<number>()
noInit.current // ✅ number | undefined
```

Closes #5056