### PR TITLE
feat(middleware): method not allowed

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -46,6 +46,7 @@
     "./timing": "./src/middleware/timing/timing.ts",
     "./logger": "./src/middleware/logger/index.ts",
     "./method-override": "./src/middleware/method-override/index.ts",
+    "./method-not-allowed": "./src/middleware/method-not-allowed/index.ts",
     "./powered-by": "./src/middleware/powered-by/index.ts",
     "./pretty-json": "./src/middleware/pretty-json/index.ts",
     "./request-id": "./src/middleware/request-id/request-id.ts",

--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
       "import": "./dist/middleware/method-override/index.js",
       "require": "./dist/cjs/middleware/method-override/index.js"
     },
+    "./method-not-allowed": {
+      "types": "./dist/types/middleware/method-not-allowed/index.d.ts",
+      "import": "./dist/middleware/method-not-allowed/index.js",
+      "require": "./dist/cjs/middleware/method-not-allowed/index.js"
+    },
     "./powered-by": {
       "types": "./dist/types/middleware/powered-by/index.d.ts",
       "import": "./dist/middleware/powered-by/index.js",

--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -1,0 +1,121 @@
+import { Hono } from '../../hono'
+import { methodNotAllowed } from './index'
+
+describe('Method Not Allowed Middleware', () => {
+  it('Should return 405 with an Allow header when the method is not allowed', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/', (c) => c.text('Hello World!'))
+
+    const res = await app.request('/', { method: 'POST' })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET')
+    expect(await res.text()).toBe('Method Not Allowed')
+  })
+
+  it('Should not affect a request whose method is allowed', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/', (c) => c.text('Hello World!'))
+
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(res.headers.has('Allow')).toBe(false)
+    expect(await res.text()).toBe('Hello World!')
+  })
+
+  it('Should return 404 when the path does not exist', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/', (c) => c.text('Hello World!'))
+
+    const res = await app.request('/nonexistent', { method: 'POST' })
+    expect(res.status).toBe(404)
+  })
+
+  it('Should list every allowed method for a path', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.post('/resource', (c) => c.text('POST'))
+    app.delete('/resource', (c) => c.text('DELETE'))
+
+    const res = await app.request('/resource', { method: 'PUT' })
+    expect(res.status).toBe(405)
+    const allow = res.headers.get('Allow')?.split(', ').sort()
+    expect(allow).toEqual(['DELETE', 'GET', 'POST'])
+  })
+
+  it('Should exclude the requested method from the Allow header', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.post('/resource', (c) => c.text('POST'))
+
+    const res = await app.request('/resource', { method: 'POST', body: '' })
+    // POST is registered, so this should not be a 405; falls through to handler
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('POST')
+  })
+
+  it('Should not produce duplicate methods in the Allow header', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    // Two routes match `/resource` via wildcard and exact path, both GET
+    app.get('*', (_c, next) => next())
+    app.get('/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/resource', { method: 'DELETE' })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET')
+  })
+
+  it('Should work with routes that have parameters', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/user/:id', (c) => c.text(`User ${c.req.param('id')}`))
+
+    const res = await app.request('/user/123', { method: 'POST' })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET')
+  })
+
+  it('Should work alongside other middleware', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.use(async (c, next) => {
+      await next()
+      c.header('X-Powered-By', 'Hono')
+    })
+    app.get('/', (c) => c.text('Hello World!'))
+
+    const res = await app.request('/', { method: 'POST' })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET')
+  })
+
+  it('Should work with app.route()', async () => {
+    const app = new Hono()
+    const api = new Hono()
+    api.get('/hello', (c) => c.text('hello'))
+    app.use(methodNotAllowed({ app }))
+    app.route('/api', api)
+
+    const res = await app.request('/api/hello', { method: 'POST' })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET')
+  })
+
+  it('Should support a HEAD request mapped from a GET route', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/', (c) => c.text('Hello World!'))
+
+    const headRes = await app.request('/', { method: 'HEAD' })
+    expect(headRes.status).toBe(200)
+
+    const postRes = await app.request('/', { method: 'POST' })
+    expect(postRes.status).toBe(405)
+    expect(postRes.headers.get('Allow')).toBe('GET')
+  })
+})

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -1,0 +1,84 @@
+/**
+ * @module
+ * Method Not Allowed Middleware for Hono.
+ */
+
+import type { Hono } from '../../hono'
+import { HTTPException } from '../../http-exception'
+import { METHOD_NAME_ALL } from '../../router'
+import { TrieRouter } from '../../router/trie-router'
+import type { MiddlewareHandler } from '../../types'
+
+type MethodNotAllowedOptions = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: Hono<any, any, any>
+}
+
+/**
+ * Method Not Allowed Middleware for Hono.
+ *
+ * @param {MethodNotAllowedOptions} options - The options for the method not allowed middleware.
+ * @param {Hono} options.app - The instance of Hono is used in your application.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(methodNotAllowed({ app }))
+ *
+ * app.get('/', (c) => c.text('Hello World!'))
+ * // A `POST /` request now returns `405 Method Not Allowed` with `Allow: GET`.
+ * ```
+ */
+export const methodNotAllowed = (options: MethodNotAllowedOptions): MiddlewareHandler => {
+  const { app } = options
+  let methodRouter: TrieRouter<string[]> | undefined
+
+  return async function methodNotAllowed(c, next) {
+    await next()
+
+    if (c.res.status !== 404) {
+      return
+    }
+
+    if (!methodRouter) {
+      const methodsByPath = new Map<string, string[]>()
+      for (const route of app.routes) {
+        // Skip middleware registered with `app.use()` and `app.all()`.
+        if (route.method === METHOD_NAME_ALL) {
+          continue
+        }
+        const methods = methodsByPath.get(route.path) ?? []
+        methods.push(route.method.toUpperCase())
+        methodsByPath.set(route.path, methods)
+      }
+      methodRouter = new TrieRouter<string[]>()
+      for (const [path, methods] of methodsByPath) {
+        methodRouter.add(METHOD_NAME_ALL, path, methods)
+      }
+    }
+
+    const requestMethod = c.req.method.toUpperCase()
+    // A path can match several routes (e.g. `*` and an exact path), so use a Set to drop duplicates.
+    const allowedMethods = new Set<string>()
+    for (const [methods] of methodRouter.match(METHOD_NAME_ALL, c.req.path)[0]) {
+      for (const method of methods) {
+        allowedMethods.add(method)
+      }
+    }
+    allowedMethods.delete(requestMethod)
+
+    if (allowedMethods.size === 0) {
+      return
+    }
+
+    const res = new Response('Method Not Allowed', {
+      status: 405,
+      headers: {
+        Allow: Array.from(allowedMethods).join(', '),
+      },
+    })
+    throw new HTTPException(405, { res })
+  }
+}


### PR DESCRIPTION
### Why?

When a request hits a path that exists but with an unsupported HTTP method, Hono returns `404 Not Found`. Per HTTP semantics this should be `405 Method Not Allowed` with an `Allow` header, so clients can tell "route missing" apart from "method not supported".

In the discussion on #4633, the maintainers agreed this should ship as a standalone middleware that receives `app`, rather than a change to the Hono core. The existing PR #4637 takes the core approach (`app.methodNotAllowed()`); this PR implements the agreed middleware approach instead, picking up from where the issue discussion left off.

### Related Issue(s)

closes #4633

### Description

Adds a `methodNotAllowed({ app })` middleware (`hono/method-not-allowed`).

```ts
import { Hono } from 'hono'
import { methodNotAllowed } from 'hono/method-not-allowed'

const app = new Hono()

app.use(methodNotAllowed({ app }))

app.get('/', (c) => c.text('Hello World!'))
// `POST /` -> 405 Method Not Allowed, `Allow: GET`
// `GET /nonexistent` -> 404 Not Found (path does not exist)
```

- Implemented purely as middleware; no change to the Hono core.
- On the first 404, it builds a `path -> methods` lookup (a `TrieRouter`) from
  `app.routes` and caches it for subsequent requests.
- The requested method is excluded from `Allow`, and methods are de-duplicated
  so overlapping routes (e.g. `*` and an exact path) don't produce duplicates.
- Routes registered with `app.use()` / `app.all()` are ignored.
- Must be registered with `app.use()` before the handlers.

### Comment

Claude Code and Google Translate were used for part of the development and for drafting this PR description. All of the code, the tests, and this PR description were reviewed by me before submission.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
