### PR TITLE
fix(bun): report the requested subprotocol on WSContext.protocol

### DIFF
--- a/src/adapter/bun/websocket.test.ts
+++ b/src/adapter/bun/websocket.test.ts
@@ -65,6 +65,28 @@ describe('upgradeWebSocket()', () => {
     )
     expect(upgraded).toBeFalsy()
   })
+  it('Should expose the requested subprotocol on WSContext.protocol', async () => {
+    let data: BunWebSocketData | undefined
+    await upgradeWebSocket(() => ({}))(
+      new Context(
+        new Request('http://localhost/ws', {
+          headers: { 'sec-websocket-protocol': 'chat, superchat' },
+        }),
+        {
+          env: {
+            upgrade(_req: Request, options: { data: BunWebSocketData }) {
+              data = options.data
+              return true
+            },
+          },
+        }
+      ),
+      () => Promise.resolve()
+    )
+
+    const ws = createWSContext({ data, readyState: 1 } as BunServerWebSocket<BunWebSocketData>)
+    expect(ws.protocol).toBe('chat')
+  })
   it('Should events are called', async () => {
     const open = vi.fn()
     const message = vi.fn()

--- a/src/adapter/bun/websocket.test.ts
+++ b/src/adapter/bun/websocket.test.ts
@@ -87,6 +87,23 @@ describe('upgradeWebSocket()', () => {
     const ws = createWSContext({ data, readyState: 1 } as BunServerWebSocket<BunWebSocketData>)
     expect(ws.protocol).toBe('chat')
   })
+  it('Should set protocol to an empty string when no subprotocol is requested', async () => {
+    let data: BunWebSocketData | undefined
+    await upgradeWebSocket(() => ({}))(
+      new Context(new Request('http://localhost/ws'), {
+        env: {
+          upgrade(_req: Request, options: { data: BunWebSocketData }) {
+            data = options.data
+            return true
+          },
+        },
+      }),
+      () => Promise.resolve()
+    )
+
+    const ws = createWSContext({ data, readyState: 1 } as BunServerWebSocket<BunWebSocketData>)
+    expect(ws.protocol).toBe('')
+  })
   it('Should events are called', async () => {
     const open = vi.fn()
     const message = vi.fn()

--- a/src/adapter/bun/websocket.ts
+++ b/src/adapter/bun/websocket.ts
@@ -62,7 +62,9 @@ export const upgradeWebSocket: UpgradeWebSocket<any> = defineWebSocketHelper((c,
     data: {
       events,
       url: new URL(c.req.url),
-      protocol: c.req.url,
+      // The first requested subprotocol, exposed via WSContext.protocol to
+      // match the deno and cloudflare adapters.
+      protocol: c.req.header('sec-websocket-protocol')?.split(',')[0]?.trim() ?? '',
     },
   })
   if (upgradeResult) {


### PR DESCRIPTION
The Bun WebSocket adapter sets `WSContext.protocol` to the request URL:

```ts
protocol: c.req.url,
```

`WSContext.protocol` is supposed to mirror the standard `WebSocket.protocol` property (the connection's subprotocol), so on Bun it currently returns something like `http://localhost/ws` instead of the subprotocol. The deno and cloudflare adapters read it from the platform socket (`socket.protocol` and `server.protocol`), so this is a Bun-only inconsistency.

This reads the first value of the `Sec-WebSocket-Protocol` header, the same way the deno adapter does (#4955), and stores it on the data that backs `WSContext.protocol`.

Added a test that upgrades with `Sec-WebSocket-Protocol: chat, superchat` and asserts `wsContext.protocol` is `chat`. Without this change it fails with `expected 'http://localhost/ws' to be 'chat'`.

- [x] Add tests
- [x] Run tests
- [x] Format with Prettier
