### PR TITLE
fix(utils,validator): match Content-Type media types case-insensitively

### DIFF
--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -42,6 +42,17 @@ describe('Parse Body Util', () => {
     expect(await parseBody(req)).toEqual({ message: 'hello' })
   })
 
+  it('should parse mixed-case `x-www-form-urlencoded` content type', async () => {
+    const searchParams = new URLSearchParams()
+    searchParams.append('message', 'hello')
+
+    const req = createRequest(SEARCH_URL, 'POST', searchParams, {
+      'Content-Type': 'Application/X-WWW-Form-Urlencoded',
+    })
+
+    expect(await parseBody(req)).toEqual({ message: 'hello' })
+  })
+
   it('should not parse multiple values in default', async () => {
     const data = new FormData()
     data.append('file', 'bbb')

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -100,10 +100,9 @@ export const parseBody: ParseBody = async (
   const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
   const contentType = headers.get('Content-Type')
 
-  if (
-    contentType?.startsWith('multipart/form-data') ||
-    contentType?.startsWith('application/x-www-form-urlencoded')
-  ) {
+  const mediaType = contentType?.split(';')[0].trim().toLowerCase()
+
+  if (mediaType === 'multipart/form-data' || mediaType === 'application/x-www-form-urlencoded') {
     return parseFormData(request, { all, dot })
   }
 

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -146,6 +146,19 @@ describe('JSON', () => {
     expect(data).toEqual({ foo: 'bar' })
   })
 
+  it('Should validate if Content-Type media type is mixed-case application/json', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar' }),
+      headers: {
+        'Content-Type': 'Application/JSON',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ foo: 'bar' })
+  })
+
   it('Should not validate if Content-Type is not set', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
@@ -272,6 +285,24 @@ describe('FormData', () => {
         'content-type': 'application/x-www-form-urlencoded',
       },
     })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      foo: 'bar',
+    })
+  })
+
+  it('Should validate mixed-case URL Encoded Content-Type', async () => {
+    const params = new URLSearchParams()
+    params.append('foo', 'bar')
+
+    const res = await app.request('/post', {
+      method: 'POST',
+      body: params,
+      headers: {
+        'content-type': 'Application/X-WWW-Form-Urlencoded; charset=UTF-8',
+      },
+    })
+
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       foo: 'bar',

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -21,9 +21,9 @@ export type ValidationFunction<
   c: Context<E, P>
 ) => OutputType | TypedResponse | Promise<OutputType> | Promise<TypedResponse>
 
-const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
-const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
-const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/i
+const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/i
+const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/i
 
 export type ExtractValidationResponse<VF> = VF extends (value: any, c: any) => infer R
   ? R extends Promise<infer PR>


### PR DESCRIPTION
### What changed

* Match supported `Content-Type` media types case-insensitively in `validator()`.
* Normalize the media type portion of `Content-Type` in `parseBody()` before checking form content types.
* Add regression tests for mixed-case JSON and URL-encoded form media types.

### Why

`Content-Type` media types are case-insensitive, but mixed-case values such as `Application/JSON` and `Application/X-WWW-Form-Urlencoded` were skipped by `validator()` and `parseBody()`.

Fixes #5060.

### Tests

- `bunx vitest --run src/utils/body.test.ts src/validator/validator.test.ts`
- `bun run test`
- `bun run lint`

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
