### PR TITLE
fix(utils/body,validator): normalize Content-Type media type for case-insensitive matching

### DIFF
--- a/src/utils/body.test.ts
+++ b/src/utils/body.test.ts
@@ -42,6 +42,32 @@ describe('Parse Body Util', () => {
     expect(await parseBody(req)).toEqual({ message: 'hello' })
   })
 
+  it('should parse mixed-case `x-www-form-urlencoded`', async () => {
+    const searchParams = new URLSearchParams()
+    searchParams.append('message', 'hello')
+
+    const req = createRequest(SEARCH_URL, 'POST', searchParams, {
+      'Content-Type': 'Application/X-WWW-Form-Urlencoded',
+    })
+
+    expect(await parseBody(req)).toEqual({ message: 'hello' })
+  })
+
+  it('should parse mixed-case `multipart/form-data`', async () => {
+    const data = new FormData()
+    data.append('message', 'hello')
+
+    const source = createRequest(FORM_URL, 'POST', data)
+    const contentType = source.headers
+      .get('Content-Type')!
+      .replace('multipart/form-data', 'Multipart/Form-Data')
+    const req = createRequest(FORM_URL, 'POST', await source.arrayBuffer(), {
+      'Content-Type': contentType,
+    })
+
+    expect(await parseBody(req)).toEqual({ message: 'hello' })
+  })
+
   it('should not parse multiple values in default', async () => {
     const data = new FormData()
     data.append('file', 'bbb')
@@ -60,17 +86,10 @@ describe('Parse Body Util', () => {
       type: 'application/octet-stream',
     })
     const data = new FormData()
+    data.append('file', file)
+    data.append('file.hoo', 'hoo')
 
     const req = createRequest(FORM_URL, 'POST', data)
-    vi.spyOn(req, 'formData').mockImplementation(
-      async () =>
-        ({
-          forEach: (cb) => {
-            cb(file, 'file', data)
-            cb('hoo', 'file.hoo', data)
-          },
-        }) as FormData
-    )
 
     const parsedData = await parseBody(req, { dot: true })
     expect(parsedData.file).not.instanceOf(File)

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -4,6 +4,7 @@
  */
 
 import { HonoRequest } from '../request'
+import { bufferToFormData } from './buffer'
 
 type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot }
 type BodyDataValueDotAll = {
@@ -100,10 +101,9 @@ export const parseBody: ParseBody = async (
   const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
   const contentType = headers.get('Content-Type')
 
-  if (
-    contentType?.startsWith('multipart/form-data') ||
-    contentType?.startsWith('application/x-www-form-urlencoded')
-  ) {
+  const mediaType = contentType?.split(';')[0].trim().toLowerCase()
+
+  if (mediaType === 'multipart/form-data' || mediaType === 'application/x-www-form-urlencoded') {
     return parseFormData(request, { all, dot })
   }
 
@@ -122,7 +122,14 @@ async function parseFormData<T extends BodyData>(
   request: HonoRequest | Request,
   options: ParseBodyOptions
 ): Promise<T> {
-  const formData = await (request as Request).formData()
+  const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
+  const arrayBuffer = await (request as Request).arrayBuffer()
+  const formDataPromise = bufferToFormData(arrayBuffer, headers.get('Content-Type') || '')
+  if (request instanceof HonoRequest) {
+    // Cache so that a later `c.req.formData()` reuses the already-consumed body
+    request.bodyCache.formData = formDataPromise as unknown as FormData
+  }
+  const formData = await formDataPromise
 
   if (formData) {
     return convertFormDataToBodyData<T>(formData, options)

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -117,6 +117,20 @@ describe('bufferToFormData', () => {
     expect(result.get('test')).toBe('Hello')
   })
 
+  it('Should parse mixed-case multipart/form-data media type while keeping the boundary', async () => {
+    const encoder = new TextEncoder()
+    const testData =
+      '--sampleBoundary\r\nContent-Disposition: form-data; name="test"\r\n\r\nHello\r\n--sampleBoundary--'
+    const arrayBuffer = encoder.encode(testData).buffer
+
+    const result = await bufferToFormData(
+      arrayBuffer,
+      'Multipart/Form-Data; boundary=sampleBoundary'
+    )
+
+    expect(result.get('test')).toBe('Hello')
+  })
+
   it('Should parse application/x-www-form-urlencoded from ArrayBuffer', async () => {
     const encoder = new TextEncoder()
     const searchParams = new URLSearchParams()

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -109,7 +109,8 @@ export const bufferToFormData = (
 ): Promise<FormData> => {
   const response = new Response(arrayBuffer, {
     headers: {
-      'Content-Type': contentType,
+      // Normalize the media type (case-insensitive) while keeping parameters like the boundary
+      'Content-Type': contentType.replace(/^[^;]+/, (mediaType) => mediaType.toLowerCase()),
     },
   })
   return response.formData()

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -146,6 +146,18 @@ describe('JSON', () => {
     expect(data).toEqual({ foo: 'bar' })
   })
 
+  it('Should validate if Content-Type media type is mixed-case', async () => {
+    const res = await app.request('http://localhost/post', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar' }),
+      headers: {
+        'Content-Type': 'Application/JSON',
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ foo: 'bar' })
+  })
+
   it('Should not validate if Content-Type is not set', async () => {
     const res = await app.request('http://localhost/post', {
       method: 'POST',
@@ -270,6 +282,42 @@ describe('FormData', () => {
       body: params,
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      foo: 'bar',
+    })
+  })
+
+  it('Should validate mixed-case URL Encoded Content-Type', async () => {
+    const params = new URLSearchParams()
+    params.append('foo', 'bar')
+    const res = await app.request('/post', {
+      method: 'POST',
+      body: params,
+      headers: {
+        'content-type': 'Application/X-WWW-Form-Urlencoded; charset=UTF-8',
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      foo: 'bar',
+    })
+  })
+
+  it('Should validate mixed-case multipart/form-data Content-Type', async () => {
+    const formData = new FormData()
+    formData.append('foo', 'bar')
+    const source = new Request('http://localhost/post', { method: 'POST', body: formData })
+    const contentType = source.headers
+      .get('Content-Type')!
+      .replace('multipart/form-data', 'Multipart/Form-Data')
+    const res = await app.request('/post', {
+      method: 'POST',
+      body: await source.arrayBuffer(),
+      headers: {
+        'content-type': contentType,
       },
     })
     expect(res.status).toBe(200)

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -21,9 +21,9 @@ export type ValidationFunction<
   c: Context<E, P>
 ) => OutputType | TypedResponse | Promise<OutputType> | Promise<TypedResponse>
 
-const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
-const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
-const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+const jsonRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/i
+const multipartRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/i
+const urlencodedRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/i
 
 export type ExtractValidationResponse<VF> = VF extends (value: any, c: any) => infer R
   ? R extends Promise<infer PR>


### PR DESCRIPTION
Fixes #5060

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
