### PR TITLE
fix(request,utils/body): break request.ts <-> utils/body.ts import cycle

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -381,6 +381,33 @@ describe('Body methods with caching', () => {
       expect(async () => await req.blob()).not.toThrow()
     })
 
+    it('should cache the parsed FormData so a later req.formData() reuses it', async () => {
+      // `parseBody()` consumes `req.raw`'s body stream via `arrayBuffer()`.
+      // Internally it recognizes `req` as a `HonoRequest` (as opposed to a
+      // bare `Request`) and caches the resulting FormData on
+      // `req.bodyCache.formData` so that a later `req.formData()` call reuses
+      // it instead of re-reading the already-consumed raw stream (which
+      // would throw). This test exercises that HonoRequest-recognition path.
+      const data = new FormData()
+      data.append('foo', 'bar')
+      const req = new HonoRequest(
+        new Request('http://localhost', {
+          method: 'POST',
+          body: data,
+        })
+      )
+
+      const parsed = await req.parseBody()
+      expect(parsed['foo']).toBe('bar')
+
+      // If `req` were not correctly recognized as a `HonoRequest`, the
+      // FormData would not have been cached and this would try to read the
+      // raw body a second time and throw.
+      const formData = await req.formData()
+      expect(formData.get('foo')).toBe('bar')
+      expect(req.bodyCache.formData).toBeDefined()
+    })
+
     describe('should not break body methods after parseBody() with non-form content-type', () => {
       const createReq = () =>
         new HonoRequest(

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { HTTPException } from './http-exception'
-import { GET_MATCH_RESULT } from './request/constants'
+import { GET_MATCH_RESULT, HONO_REQUEST } from './request/constants'
 import type { Result } from './router'
 import type {
   Input,
@@ -389,6 +389,13 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   get [GET_MATCH_RESULT](): Result<[unknown, RouterRoute]> {
     return this.#matchResult
   }
+
+  /**
+   * Marker used by `utils/body.ts` to duck-type a `HonoRequest` without
+   * importing the class at runtime (which would create a circular import).
+   * See `HONO_REQUEST` in `./request/constants.ts`.
+   */
+  readonly [HONO_REQUEST] = true as const
 
   /**
    * `.matchedRoutes()` can return a matched route in the handler

--- a/src/request/constants.ts
+++ b/src/request/constants.ts
@@ -1,1 +1,15 @@
 export const GET_MATCH_RESULT: unique symbol = Symbol()
+
+/**
+ * Symbol used to identify a `HonoRequest` instance (as opposed to a raw
+ * `Request`) without importing the `HonoRequest` class itself.
+ *
+ * `../request.ts` imports `../utils/body.ts` (for `parseBody`) at runtime, so
+ * `utils/body.ts` importing `HonoRequest` back from `../request.ts` for an
+ * `instanceof` check would create a circular import between the two modules.
+ * Depending on this marker (declared in this dependency-free module) instead
+ * lets `utils/body.ts` duck-type a `HonoRequest` while only needing a
+ * type-only import of the `HonoRequest` class, which breaks the runtime
+ * cycle. See https://github.com/honojs/hono/issues/5068.
+ */
+export const HONO_REQUEST: unique symbol = Symbol()

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -3,8 +3,20 @@
  * Body utility.
  */
 
-import { HonoRequest } from '../request'
+import type { HonoRequest } from '../request'
+import { HONO_REQUEST } from '../request/constants'
 import { bufferToFormData } from './buffer'
+
+/**
+ * Duck-types a `HonoRequest` without an `instanceof` check against the
+ * `HonoRequest` class, so this module only needs a type-only import of
+ * `HonoRequest` (erased at compile time). A runtime (value) import of
+ * `HonoRequest` here would create a circular import, since `../request.ts`
+ * imports `parseBody` from this module. See
+ * https://github.com/honojs/hono/issues/5068.
+ */
+const isHonoRequest = (request: HonoRequest | Request): request is HonoRequest =>
+  HONO_REQUEST in request
 
 type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot }
 type BodyDataValueDotAll = {
@@ -98,7 +110,7 @@ export const parseBody: ParseBody = async (
 ) => {
   const { all = false, dot = false } = options
 
-  const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
+  const headers = isHonoRequest(request) ? request.raw.headers : request.headers
   const contentType = headers.get('Content-Type')
 
   const mediaType = contentType?.split(';')[0].trim().toLowerCase()
@@ -122,10 +134,10 @@ async function parseFormData<T extends BodyData>(
   request: HonoRequest | Request,
   options: ParseBodyOptions
 ): Promise<T> {
-  const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
+  const headers = isHonoRequest(request) ? request.raw.headers : request.headers
   const arrayBuffer = await (request as Request).arrayBuffer()
   const formDataPromise = bufferToFormData(arrayBuffer, headers.get('Content-Type') || '')
-  if (request instanceof HonoRequest) {
+  if (isHonoRequest(request)) {
     // Cache so that a later `c.req.formData()` reuses the already-consumed body
     request.bodyCache.formData = formDataPromise as unknown as FormData
   }


### PR DESCRIPTION
## Summary

Fixes #5068. `src/utils/body.ts` imported the `HonoRequest` class from `../request` at runtime solely to run `instanceof HonoRequest` checks, while `src/request.ts` imports `parseBody` from `./utils/body` at runtime. This creates a circular import between the two compiled modules, which bundlers like Rollup flag:

```
(!) Circular dependency
dist/request.js -> dist/utils/body.js -> dist/request.js
```

Reproduced against a real `bun run build` output with `rollup` — the warning is gone after this change.

## Root cause

Two-way runtime dependency:
- `request.ts` → `utils/body.ts` (imports `parseBody`)
- `utils/body.ts` → `request.ts` (imports `HonoRequest` for `instanceof`)

## Fix

Duck-type `HonoRequest` instead of `instanceof`, following the same pattern already used in this codebase for `GET_MATCH_RESULT` in `src/request/constants.ts` (a symbol-only module with no other dependencies).

- Added `HONO_REQUEST: unique symbol` to `src/request/constants.ts`.
- `HonoRequest` now exposes `readonly [HONO_REQUEST] = true as const`.
- `utils/body.ts` imports `HonoRequest` as a **type-only** import (erased at compile time — no runtime edge) and checks `HONO_REQUEST in request` instead of `instanceof HonoRequest`.

The marker is only present on `HonoRequest` instances, never on a plain `Request`, so discrimination for the `HonoRequest | Request` union in `parseBody`/`parseFormData` is exact.

## Test evidence

- Added a regression test in `request.test.ts` for the behavior the `instanceof` check protected (after `req.parseBody()` consumes the body, `req.formData()` must reuse the cached FormData). Verified it fails under a negative control (cache-guard disabled) and passes before and after the refactor.
- Full suite: `bun run test` → 145/145 files, 4579/4579 tests passing.
- `bun run lint` / `bun run format`: clean, no new warnings.
- Rebuilt `dist/` and re-ran Rollup: circular-dependency warning gone.

Closes #5068
