### PR TITLE
fix: avoid circular dependency between body.ts and request.ts

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -3,7 +3,7 @@
  * Body utility.
  */
 
-import { HonoRequest } from '../request'
+import type { HonoRequest } from '../request'
 import { bufferToFormData } from './buffer'
 
 type BodyDataValueDot = { [x: string]: string | File | BodyDataValueDot }
@@ -74,6 +74,8 @@ export type ParseBodyOptions = {
   dot: boolean
 }
 
+const isRawRequest = (request: HonoRequest | Request): request is Request => 'headers' in request
+
 /**
  * Parses the body of a request based on the provided options.
  *
@@ -98,7 +100,7 @@ export const parseBody: ParseBody = async (
 ) => {
   const { all = false, dot = false } = options
 
-  const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
+  const headers = isRawRequest(request) ? request.headers : request.raw.headers
   const contentType = headers.get('Content-Type')
 
   const mediaType = contentType?.split(';')[0].trim().toLowerCase()
@@ -122,10 +124,10 @@ async function parseFormData<T extends BodyData>(
   request: HonoRequest | Request,
   options: ParseBodyOptions
 ): Promise<T> {
-  const headers = request instanceof HonoRequest ? request.raw.headers : request.headers
+  const headers = isRawRequest(request) ? request.headers : request.raw.headers
   const arrayBuffer = await (request as Request).arrayBuffer()
   const formDataPromise = bufferToFormData(arrayBuffer, headers.get('Content-Type') || '')
-  if (request instanceof HonoRequest) {
+  if (!isRawRequest(request)) {
     // Cache so that a later `c.req.formData()` reuses the already-consumed body
     request.bodyCache.formData = formDataPromise as unknown as FormData
   }

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -74,7 +74,7 @@ export type ParseBodyOptions = {
   dot: boolean
 }
 
-const isRawRequest = (request: HonoRequest | Request): request is Request => 'headers' in request
+const isRawRequest = (request: HonoRequest | Request): request is Request => 'headers' in request // 'headers' method exists only on Request, not on HonoRequest.
 
 /**
  * Parses the body of a request based on the provided options.


### PR DESCRIPTION
fixes #5068

This resolves the circular dependency issue.

Although PR #5069 has also been submitted, that approach is too complex, and I don’t think Hono can accept the overhead of adding properties to `HonoRequest`.

Since it’s likely that `HonoRequest` will never have a `headers` property, I believe this solution will be stable under these conditions.

The bundle size should actually be slightly smaller, since there are fewer imports.

### The author should do the following, if applicable

- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
