### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,37 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 06:00 UTC - catches new advisories between pushes
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite CLI dependency audit workflow to Hono's CI pipeline.

A scan of the current `bun.lock` found **13 high-severity** and **7 medium-severity** advisories, including several direct dependencies with known vulnerabilities:

**Direct high-severity findings (copy-run fix commands available):**
- `minimatch@3.1.2` - ReDoS via crafted glob pattern (GHSA-f8q6-p94x-37v3) - `bun add minimatch@10.2.3`
- `picomatch@2.3.1` - ReDoS via crafted patterns (GHSA-9h6g-pr28-7cqp) - appears twice with different fix paths
- `undici@6.x` (two versions) - request smuggling / injection (GHSA-3wzh-ggcw-3hpv, GHSA-cqmj-92xf-r6r9)
- `vite@5.x` - server-side request forgery (GHSA-64vr-g452-qvp3)
- `wrangler@3.x` - path traversal via dev server (GHSA-cm93-56gx-m49q)
- `ws@8.x` - DoS via crafted HTTP upgrade request (GHSA-3h5q-q39x-f9x2)

The workflow runs on push, pull request, and weekly schedule. Findings are uploaded to GitHub's Security tab as SARIF so maintainers can triage inline on PRs.

**Tool:** [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli) is an OWASP Lab Project. It reads the lockfile locally, queries the OSV database, and produces actionable fix commands for direct dependencies.
