### PR TITLE
fix(jsx): preserve context through intermediate DOM elements in precompile mode

### DIFF
--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource ../../src/jsx */
 import { assertEquals } from '@std/assert'
 import { Style, css } from '../../src/helper/css/index.ts'
+import { createContext, useContext } from '../../src/jsx/context.ts'
 import { Suspense, renderToReadableStream } from '../../src/jsx/streaming.ts'
+import type { FC, PropsWithChildren } from '../../src/jsx/types.ts'
 import type { HtmlEscapedString } from '../../src/utils/html.ts'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../../src/utils/html.ts'
 
@@ -186,4 +188,58 @@ Deno.test('JSX: number', async () => {
 Deno.test('JSX: style', async () => {
   const html = <div style={{ fontSize: '12px', color: null }}></div>
   assertEquals(html.toString(), '<div style="font-size:12px"></div>')
+})
+
+// Regression for honojs/hono#4326: a Context value must survive an intermediate
+// plain DOM element (e.g. <div>) sitting between the Provider and the consumer.
+// In precompile mode the intermediate <div> is emitted as a `jsxTemplate(...)`
+// call whose interpolated component children were stringified eagerly — before
+// the enclosing Provider pushed its value — so the consumer read the default.
+Deno.test('JSX: Context survives an intermediate DOM element (#4326)', () => {
+  // Given a context with a null default and a consumer that reads it
+  const MyContext = createContext<{ greeting: string } | null>(null)
+
+  const MyConsumer: FC = () => {
+    const context = useContext(MyContext)
+    if (!context) {
+      return <div>No context provided</div>
+    }
+    return <div>{context.greeting}</div>
+  }
+
+  // And a component-based wrapper between Provider and consumer
+  const Box: FC<PropsWithChildren> = ({ children }) => <div class='box'>{children}</div>
+
+  // When the consumer is rendered directly under the Provider (no wrapper)
+  const NoExtraDiv: FC = () => (
+    <MyContext.Provider value={{ greeting: 'I do not have an extra div' }}>
+      <MyConsumer />
+    </MyContext.Provider>
+  )
+
+  // And when the consumer is wrapped by a *component* that renders a <div>
+  const ExtraDivAsComponent: FC = () => (
+    <MyContext.Provider value={{ greeting: 'I have an extra div as a component' }}>
+      <Box>
+        <MyConsumer />
+      </Box>
+    </MyContext.Provider>
+  )
+
+  // And when the consumer is wrapped by a *plain DOM element* <div>
+  const ExtraDiv: FC = () => (
+    <MyContext.Provider value={{ greeting: 'I have an extra div' }}>
+      <div>
+        <MyConsumer />
+      </div>
+    </MyContext.Provider>
+  )
+
+  // Then every path must observe the provided value, not the default.
+  assertEquals((<NoExtraDiv />).toString(), '<div>I do not have an extra div</div>')
+  assertEquals(
+    (<ExtraDivAsComponent />).toString(),
+    '<div class="box"><div>I have an extra div as a component</div></div>'
+  )
+  assertEquals((<ExtraDiv />).toString(), '<div><div>I have an extra div</div></div>')
 })

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -6,12 +6,39 @@
 export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
 export { jsxDEV as jsxs } from './jsx-dev-runtime'
 export type { JSX } from './jsx-dev-runtime'
-import { html, raw } from '../helper/html'
+import { raw } from '../helper/html'
 import type { HtmlEscapedString, StringBuffer, HtmlEscaped } from '../utils/html'
 import { escapeToBuffer, stringBufferToString } from '../utils/html'
+import { JSXFragmentNode } from './base'
+import type { Child } from './base'
 import { isValidAttributeName, styleObjectForEach } from './utils'
 
-export { html as jsxTemplate }
+/**
+ * Runtime for the "precompile" JSX transform (Deno's `jsx: "precompile"`).
+ *
+ * The transform emits a static template split into `strings` with the dynamic
+ * parts hoisted into `values`, e.g. `<div><Consumer/></div>` becomes
+ * `jsxTemplate(['<div>', '</div>'], jsx(Consumer, null))`.
+ *
+ * Interpolated values are wrapped in a lazy `JSXFragmentNode` rather than being
+ * stringified here, so a component `value` only renders when the surrounding
+ * tree is stringified — not eagerly at call time. This mirrors the classic
+ * `react-jsx` runtime, where an intermediate DOM element is itself a lazy
+ * `JSXNode`. Eager stringification broke context propagation whenever a plain
+ * DOM element sat between a `<Context.Provider>` and its consumer, because the
+ * consumer was rendered before the Provider pushed its value (honojs/hono#4326).
+ */
+export const jsxTemplate = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): HtmlEscapedString => {
+  const children: Child[] = []
+  for (let i = 0, len = strings.length - 1; i < len; i++) {
+    children.push(raw(strings[i]), values[i] as Child)
+  }
+  children.push(raw(strings[strings.length - 1]))
+  return new JSXFragmentNode('', {}, children) as unknown as HtmlEscapedString
+}
 
 export const jsxAttr = (
   key: string,


### PR DESCRIPTION
## Summary

Fixes the context loss in JSX **precompile** mode reported in #4326: when a plain DOM element sits between a `<Context.Provider>` and its consumer, the consumer received the default value instead of the provided one. `react-jsx` mode was already correct; only precompile was affected.

## Root cause

Deno's precompile transform emits an intermediate `<div>` as `jsxTemplate(['<div>','</div>'], jsx(Consumer, null))`. Because that call is the `children` **argument** of `jsx(Ctx.Provider, …)`, JS evaluates it first. `jsxTemplate` was aliased to the `html` helper, which **eagerly** stringifies interpolated values — so the consumer rendered *before* the Provider pushed its value onto the context stack, and `useContext` returned the default. The no-wrapper and component-wrapper cases worked because their `children` stay lazy `JSXNode`s, rendered later inside the Provider's push/pop window. Only the plain-DOM case took the eager `html` path.

## Fix

Make `jsxTemplate` build a lazy `JSXFragmentNode` from the template strings + interpolated values instead of stringifying eagerly, so rendering defers until the surrounding tree stringifies (inside the Provider window) — mirroring the classic (`react-jsx`) runtime. The public `html` helper is untouched, and interpolated values still flow through the exact same shared escaping primitives (`escapeToBuffer`, `raw`, `childrenToStringToBuffer`), so escaping is unchanged.

## Before / after (issue's `ExtraDiv` case)

`<div><div>No context provided</div></div>` → `<div><div>I have an extra div</div></div>`

## Test evidence

Regression test added in `runtime-tests/deno-jsx/jsx.test.tsx` covering no-wrapper / component-wrapper / plain-DOM shapes, run under **both** the precompile and react-jsx configs. Verified: precompile 13/13, react-jsx 13/13, full vitest suite 1902 passed / 0 failed, `tsc` clean, lint clean. Negative control confirmed (the test fails on `main` without the fix).

## Note

First contribution to Hono — I decoupled `jsxTemplate` from `html` (rather than changing `html`) to preserve the public helper's eager semantics. Happy to adjust the layering if you'd prefer a different approach. Refs #4326.
