### PR TITLE
fix(etag): treat If-None-Match: `*` as a match

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -216,6 +216,14 @@ describe('Etag Middleware', () => {
       },
     })
     expect(res.status).toBe(304)
+
+    // conditional GET with `*` wildcard:
+    res = await app.request('http://localhost/etag/ghi', {
+      headers: {
+        'If-None-Match': '*',
+      },
+    })
+    expect(res.status).toBe(304)
   })
 
   it('Should not return duplicate etag header values', async () => {

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -226,6 +226,31 @@ describe('Etag Middleware', () => {
     expect(res.status).toBe(304)
   })
 
+  it('Should not return 304 for `If-None-Match: *` on unsafe methods or error responses', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    app.put('/etag/put', (c) => c.text('created', 201))
+    app.get('/etag/not-found', (c) => c.text('not found', 404))
+
+    // `*` does not apply to unsafe methods:
+    let res = await app.request('http://localhost/etag/put', {
+      method: 'PUT',
+      headers: {
+        'If-None-Match': '*',
+      },
+    })
+    expect(res.status).toBe(201)
+    expect(await res.text()).toBe('created')
+
+    // `*` does not apply when there is no current representation:
+    res = await app.request('http://localhost/etag/not-found', {
+      headers: {
+        'If-None-Match': '*',
+      },
+    })
+    expect(res.status).toBe(404)
+  })
+
   it('Should not return duplicate etag header values', async () => {
     const app = new Hono()
     app.use('/etag/*', etag())

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -31,7 +31,8 @@ const stripWeak = (tag: string) => tag.replace(/^W\//, '')
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {
   return (
-    ifNoneMatch != null && ifNoneMatch.split(/,\s*/).some((t) => stripWeak(t) === stripWeak(etag))
+    ifNoneMatch != null &&
+    ifNoneMatch.split(/,\s*/).some((t) => t === '*' || stripWeak(t) === stripWeak(etag))
   )
 }
 

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -31,8 +31,7 @@ const stripWeak = (tag: string) => tag.replace(/^W\//, '')
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {
   return (
-    ifNoneMatch != null &&
-    ifNoneMatch.split(/,\s*/).some((t) => t === '*' || stripWeak(t) === stripWeak(etag))
+    ifNoneMatch != null && ifNoneMatch.split(/,\s*/).some((t) => stripWeak(t) === stripWeak(etag))
   )
 }
 
@@ -105,7 +104,12 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
       etag = weak ? `W/"${hash}"` : `"${hash}"`
     }
 
-    if (etagMatches(etag, ifNoneMatch)) {
+    const matched =
+      ifNoneMatch === '*'
+        ? (c.req.method === 'GET' || c.req.method === 'HEAD') && res.ok
+        : etagMatches(etag, ifNoneMatch)
+
+    if (matched) {
       c.res = new Response(null, {
         status: 304,
         statusText: 'Not Modified',


### PR DESCRIPTION
Fixes #5083

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
