### PR TITLE
fix: make query() return type include undefined for missing params

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -146,7 +146,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * ```
    */
   query(key: string): string | undefined
-  query(): Record<string, string>
+  query(): Record<string, string | undefined>
   query(key?: string) {
     return getQueryParam(this.url, key)
   }


### PR DESCRIPTION
Closes #3426

The `query()` method returns an object from `getQueryParam()`, which can have undefined values when a query parameter is missing. But the return type says `Record<string, string>`, which lets code like this compile but crash at runtime:

```
const { name } = c.req.query();
return c.text(name.toUpperCase());
```

Changing the return type to `Record<string, string | undefined>` forces users to handle the undefined case before using the value.

This is a one-line type change and is backward compatible since widening the value type is safe.