### PR TITLE
fix(router): match wildcard against empty remainder after a regexp param in TrieRouter

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -197,6 +197,31 @@ describe('Named params and a wildcard', () => {
   })
 })
 
+describe('Regexp param and a wildcard', () => {
+  const node = new Node()
+
+  node.insert('get', '/:id{[0-9]+}/*', 'onepart')
+
+  it('get /12 - wildcard matches the empty remainder', () => {
+    const [res] = node.search('get', '/12')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('onepart')
+    expect(res[0][1]['id']).toEqual('12')
+  })
+
+  it('get /12/bar', () => {
+    const [res] = node.search('get', '/12/bar')
+    expect(res.length).toBe(1)
+    expect(res[0][0]).toEqual('onepart')
+    expect(res[0][1]['id']).toEqual('12')
+  })
+
+  it('get /abc - does not match when the regexp fails', () => {
+    const [res] = node.search('get', '/abc')
+    expect(res.length).toBe(0)
+  })
+})
+
 describe('Wildcard', () => {
   const node = new Node()
   node.insert('get', '/wildcard-abc/*/wildcard-efg', 'wildcard')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -187,6 +187,17 @@ export class Node<T> {
               params[name] = m[0]
               this.#pushHandlerSets(handlerSets, child, method, node.#params, params)
 
+              // '/:id{[0-9]+}/*' => match '/12' (wildcard matches the empty remainder)
+              if (m[0].length === restPathString.length && child.#children['*']) {
+                this.#pushHandlerSets(
+                  handlerSets,
+                  child.#children['*'],
+                  method,
+                  node.#params,
+                  params
+                )
+              }
+
               if (hasChildren(child.#children)) {
                 child.#params = params
                 const componentCount = m[0].match(/\//)?.length ?? 0


### PR DESCRIPTION
Fixes #5087

## Problem

In `TrieRouter`, a `/*` wildcard registered after a regexp-constrained param — e.g. `/:id{[0-9]+}/*` — does not match the empty remainder (bare path `/12`), even though the plain-param form `/:id/*` does.

```
/:x/*          @ /12   → matches   (correct)
/:x{[0-9]+}/*  @ /12   → no match  (BUG — expected: matches)
/:x{[0-9]+}/*  @ /12/y → matches   (correct)
/:x{[0-9]+}/*  @ /abc  → no match  (correct)
```

## Cause

In `src/router/trie-router/node.ts`, `Node#search` has two asymmetric branches. The plain-param branch, on the last segment, pushes the child's handlers **and** `child.#children['*']` so the wildcard can match an empty remainder. The RegExp-match branch pushes only the matched child's own handlers and never collects the `*` child, so the empty-remainder case falls through.

## Fix

In the RegExp branch, when the regexp consumes the whole remaining path (`m[0].length === restPathString.length`), also push `child.#children['*']` handler sets — mirroring the plain-param branch and keeping the RegExp branch's own argument order. This only fires when the match reaches the end of the path, so non-empty remainders, the plain-param path, and non-matching inputs are unaffected.

## Tests

Added a `Regexp param and a wildcard` block to `src/router/trie-router/node.test.ts` covering the empty remainder (`/12`), a non-empty remainder (`/12/bar`), and a non-matching input (`/abc`). Without the fix the empty-remainder case fails; with it the trie-router suite passes (156 tests).

### Checklist
- [x] Add tests
- [x] Run tests (`bun run test` — the only failures locally are the `workerd` project, which fails to boot its runtime in my sandbox and fails identically on a clean checkout; the `node` project and the trie-router suite pass)
- [x] `bun run format:fix && bun run lint:fix` (0 lint errors introduced)
- [x] Code is documented with a comment on the new branch

_Disclosure: this fix was prepared with AI assistance (Claude). I've reviewed and verified every line and the reasoning myself._