### PR TITLE
fix(aws-lambda): treat any non-identity content-encoding as binary

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -118,8 +118,10 @@ describe('isContentEncodingBinary', () => {
     expect(isContentEncodingBinary('deflate')).toBe(true)
     expect(isContentEncodingBinary('br')).toBe(true)
     expect(isContentEncodingBinary('deflate, gzip')).toBe(true)
+    expect(isContentEncodingBinary('zstd')).toBe(true)
     expect(isContentEncodingBinary('')).toBe(false)
-    expect(isContentEncodingBinary('unknown')).toBe(false)
+    expect(isContentEncodingBinary('identity')).toBe(false)
+    expect(isContentEncodingBinary(null)).toBe(false)
   })
 })
 

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -670,8 +670,5 @@ export const defaultIsContentTypeBinary = (contentType: string): boolean => {
 }
 
 export const isContentEncodingBinary = (contentEncoding: string | null) => {
-  if (contentEncoding === null) {
-    return false
-  }
-  return /^(gzip|deflate|compress|br)/.test(contentEncoding)
+  return !!contentEncoding && !/^identity$/i.test(contentEncoding)
 }


### PR DESCRIPTION
Made the same behavior with https://github.com/honojs/hono/pull/5099

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
