### PR TITLE
fix(trie-router): match empty wildcard remainder after regexp param

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -550,6 +550,19 @@ export const runTest = ({
       })
     })
 
+    describe('Capture regex param with trailing wildcard on empty remainder', () => {
+      beforeEach(() => {
+        router.add('GET', '/:id{[0-9]+}/*', 'regexp')
+      })
+
+      it('GET /123', () => {
+        const res = match('GET', '/123')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('regexp')
+        expect(res[0].params['id']).toBe('123')
+      })
+    })
+
     describe('Capture complex multiple directories', () => {
       beforeEach(() => {
         router.add('GET', '/:first{.+}/middle-a/:reference?', '1')

--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -563,6 +563,20 @@ export const runTest = ({
       })
     })
 
+    describe('Capture regex param with trailing wildcard and sibling route', () => {
+      beforeEach(() => {
+        router.add('GET', '/regex-abc/:id{[0-9]+}/*', 'middleware')
+        router.add('GET', '/regex-abc/:id{[0-9]+}/def', 'regexp')
+      })
+
+      it('GET /regex-abc/123/ghi', () => {
+        const res = match('GET', '/regex-abc/123/ghi')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('middleware')
+        expect(res[0].params['id']).toBe('123')
+      })
+    })
+
     describe('Capture complex multiple directories', () => {
       beforeEach(() => {
         router.add('GET', '/:first{.+}/middle-a/:reference?', '1')

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -11,6 +11,7 @@ describe('LinearRouter', () => {
           'Multi match > `params` per a handler > GET /entry/123/show',
           'Capture regex pattern has trailing wildcard > GET /foo/bar/file.html',
           'Capture regex param with trailing wildcard on empty remainder > GET /123',
+          'Capture regex param with trailing wildcard and sibling route > GET /regex-abc/123/ghi',
           'Complex > Parameter with {.*} regexp',
         ],
       },

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -10,6 +10,7 @@ describe('LinearRouter', () => {
         tests: [
           'Multi match > `params` per a handler > GET /entry/123/show',
           'Capture regex pattern has trailing wildcard > GET /foo/bar/file.html',
+          'Capture regex param with trailing wildcard on empty remainder > GET /123',
           'Complex > Parameter with {.*} regexp',
         ],
       },

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -418,10 +418,11 @@ describe('Multi match', () => {
       expect(res[1][0]).toEqual('regexp')
       expect(res[1][1]['id']).toBe('123')
     })
-    it('/regexp-abc/123', () => {
-      const [res] = node.search('get', '/regex-abc/123/ghi')
+    it('/regex-abc/123', () => {
+      const [res] = node.search('get', '/regex-abc/123')
       expect(res.length).toBe(1)
       expect(res[0][0]).toEqual('middleware a')
+      expect(res[0][1]['id']).toBe('123')
     })
   })
   describe('Trailing slash', () => {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -410,7 +410,7 @@ describe('Multi match', () => {
     const node = new Node()
     node.insert('get', '/regex-abc/:id{[0-9]+}/*', 'middleware a')
     node.insert('get', '/regex-abc/:id{[0-9]+}/def', 'regexp')
-    it('/regexp-abc/123/def', () => {
+    it('/regex-abc/123/def', () => {
       const [res] = node.search('get', '/regex-abc/123/def')
       expect(res.length).toBe(2)
       expect(res[0][0]).toEqual('middleware a')
@@ -418,7 +418,7 @@ describe('Multi match', () => {
       expect(res[1][0]).toEqual('regexp')
       expect(res[1][1]['id']).toBe('123')
     })
-    it('/regexp-abc/123/ghi', () => {
+    it('/regex-abc/123/ghi', () => {
       const [res] = node.search('get', '/regex-abc/123/ghi')
       expect(res.length).toBe(1)
       expect(res[0][0]).toEqual('middleware a')

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -418,6 +418,12 @@ describe('Multi match', () => {
       expect(res[1][0]).toEqual('regexp')
       expect(res[1][1]['id']).toBe('123')
     })
+    it('/regexp-abc/123/ghi', () => {
+      const [res] = node.search('get', '/regex-abc/123/ghi')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toEqual('middleware a')
+      expect(res[0][1]['id']).toBe('123')
+    })
     it('/regex-abc/123', () => {
       const [res] = node.search('get', '/regex-abc/123')
       expect(res.length).toBe(1)

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -187,6 +187,17 @@ export class Node<T> {
               params[name] = m[0]
               this.#pushHandlerSets(handlerSets, child, method, node.#params, params)
 
+              // '/:id{[0-9]+}/*' => match '/123'
+              if (m[0].length === restPathString.length && child.#children['*']) {
+                this.#pushHandlerSets(
+                  handlerSets,
+                  child.#children['*'],
+                  method,
+                  node.#params,
+                  params
+                )
+              }
+
               if (hasChildren(child.#children)) {
                 child.#params = params
                 const componentCount = m[0].match(/\//)?.length ?? 0


### PR DESCRIPTION
fixes #5087

* The implementation ultimately matches #5088, as this is the simplest and clearest way to express the fix.
* Corrected an apparent typo in src/router/trie-router/node.test.ts.
* Added only the minimal common-router test needed to cover this regression.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code