### PR TITLE
fix(types): strip extra properties from array types in JSONParsed

### DIFF
--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -116,6 +116,16 @@ describe('JSONParsed', () => {
       type Expected = { key: readonly number[] }
       expectTypeOf<Actual>().toEqualTypeOf<Expected>()
     })
+    it('should convert T[] with additional properties to T[]', () => {
+      type Actual = JSONParsed<{ foo: 'bar' }[] & { meta: 'v1' }>
+      type Expected = { foo: 'bar' }[]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
+    it('should convert elements of T[] with additional properties', () => {
+      type Actual = JSONParsed<(number | undefined)[] & { meta: 'v1' }>
+      type Expected = (number | null)[]
+      expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+    })
   })
 
   describe('tuple', () => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -63,7 +63,11 @@ export type JSONParsed<T, TError = bigint | ReadonlyArray<bigint>> = T extends {
     : T extends InvalidJSONValue
       ? never
       : T extends ReadonlyArray<unknown>
-        ? { [K in keyof T]: JSONParsed<InvalidToNull<T[K]>, TError> }
+        ? { [K in keyof T]: JSONParsed<InvalidToNull<T[K]>, TError> } extends infer A
+          ? A extends ReadonlyArray<unknown>
+            ? A // plain array or tuple; the mapped type preserves array-ness
+            : JSONParsed<InvalidToNull<T[number]>, TError>[] // array with extra properties; JSON.stringify drops them
+          : never
         : T extends Set<unknown> | Map<unknown, unknown> | Record<string, never>
           ? {}
           : T extends object


### PR DESCRIPTION
Fixes #3677

When an array type is intersected with additional properties (e.g. postgres.js's `RowList`, which is `Row[] & { count: number, ... }`), `JSONParsed` mapped over all keys of the intersection — including array methods and the extra properties — producing a broken object type instead of an array:

```ts
type Broken = JSONParsed<{ foo: 'bar' }[] & { meta: 'v1' }>
// { [x: number]: { foo: "bar" }; length: number; pop: null; push: {}; ...; meta: "v1" }
```

The homomorphic mapped type in the `ReadonlyArray` branch (`src/utils/types.ts:66`) only preserves array-ness when `T` is exactly an array or tuple type, not for intersections. Since `JSON.stringify` serializes such values as plain arrays and drops the extra properties, the parsed type should be a plain array too:

```ts
type Fixed = JSONParsed<{ foo: 'bar' }[] & { meta: 'v1' }>
// { foo: 'bar' }[]
```

The fix keeps the mapped type result when it is still an array (plain arrays and tuples are unchanged, including element conversion and readonly modifiers) and only falls back to element-wise mapping over `T[number]` when the mapped result lost array-ness, i.e. when extra properties were intersected in.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
