### PR TITLE
fix(method-override): set duplex when forwarding a stream body in query mode

### DIFF
--- a/src/middleware/method-override/index.test.ts
+++ b/src/middleware/method-override/index.test.ts
@@ -185,6 +185,28 @@ describe('Method Override Middleware', () => {
       })
     })
 
+    it('Should override POST to DELETE when the request has a body', async () => {
+      const app = new Hono()
+      app.use('/posts/*', methodOverride({ app, query: '_method' }))
+      app.on(['post', 'delete'], '/posts', async (c) => {
+        return c.json({
+          method: c.req.method,
+          body: await c.req.text(),
+          queryValue: c.req.query('_method') ?? null,
+        })
+      })
+      const res = await app.request('/posts?_method=delete', {
+        method: 'POST',
+        body: new URLSearchParams({ message: 'Hello' }),
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        method: 'DELETE',
+        body: 'message=Hello',
+        queryValue: null,
+      })
+    })
+
     it('Should not override GET request', async () => {
       const res = await app.request('/posts?_method=delete', {
         method: 'GET',

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -124,11 +124,13 @@ export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandle
       if (method) {
         const url = new URL(c.req.url)
         url.searchParams.delete(queryName)
-        const request = new Request(url.toString(), {
+        const requestInit: RequestInit & { duplex?: 'half' } = {
           body: c.req.raw.body,
           headers: c.req.raw.headers,
           method,
-        })
+          duplex: c.req.raw.body ? 'half' : undefined,
+        }
+        const request = new Request(url.toString(), requestInit)
         return app.fetch(request, c.env, getExecutionCtx(c))
       }
     }


### PR DESCRIPTION
Fixes part of #5010

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
