### PR TITLE
feat(etag): support conditional requests for the QUERY method

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -226,6 +226,53 @@ describe('Etag Middleware', () => {
     expect(res.status).toBe(304)
   })
 
+  it('Should handle conditional QUERY requests', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    app.on('QUERY', '/etag/query', (c) => c.text('Hono is great'))
+
+    // unconditional QUERY
+    let res = await app.request('http://localhost/etag/query', {
+      method: 'QUERY',
+      body: 'select *',
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('ETag')).not.toBeFalsy()
+    const etagHeaderValue = res.headers.get('ETag') || ''
+
+    // conditional QUERY with the wrong ETag:
+    res = await app.request('http://localhost/etag/query', {
+      method: 'QUERY',
+      body: 'select *',
+      headers: {
+        'If-None-Match': '"not the right etag"',
+      },
+    })
+    expect(res.status).toBe(200)
+
+    // conditional QUERY with matching ETag:
+    res = await app.request('http://localhost/etag/query', {
+      method: 'QUERY',
+      body: 'select *',
+      headers: {
+        'If-None-Match': etagHeaderValue,
+      },
+    })
+    expect(res.status).toBe(304)
+    expect(res.headers.get('ETag')).toBe(etagHeaderValue)
+    expect(await res.text()).toBe('')
+
+    // conditional QUERY with `*` wildcard:
+    res = await app.request('http://localhost/etag/query', {
+      method: 'QUERY',
+      body: 'select *',
+      headers: {
+        'If-None-Match': '*',
+      },
+    })
+    expect(res.status).toBe(304)
+  })
+
   it('Should not return 304 for `If-None-Match: *` on unsafe methods or error responses', async () => {
     const app = new Hono()
     app.use('/etag/*', etag())

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -106,7 +106,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
 
     const matched =
       ifNoneMatch === '*'
-        ? (c.req.method === 'GET' || c.req.method === 'HEAD') && res.ok
+        ? (c.req.method === 'GET' || c.req.method === 'HEAD' || c.req.method === 'QUERY') && res.ok
         : etagMatches(etag, ifNoneMatch)
 
     if (matched) {


### PR DESCRIPTION
Similar to https://github.com/expressjs/express/issues/7365, but for Hono. Extends the etag middleware etag support conditional validation for QUERY methods as well as GET/HEAd.

`QUERY` is a safe, idempotent, cacheable method whose responses explicitly support conditional revalidation, as per datatracker.ietf.org/doc/rfc10008, so it should behave like GET/HEAD here.

Will pair nicely with https://github.com/honojs/hono/pull/5070 once that lands. Includes tests.