### PR TITLE
perf(context): skip Headers creation when there are no headers to merge

### DIFF
--- a/benchmarks/fetch/.gitignore
+++ b/benchmarks/fetch/.gitignore
@@ -1,0 +1,2 @@
+bun.lock
+.claude

--- a/benchmarks/fetch/README.md
+++ b/benchmarks/fetch/README.md
@@ -1,0 +1,16 @@
+# fetch benchmark
+
+Measure `app.fetch()` overhead in-process.
+
+```sh
+bun bench.mts
+node bench.mts
+```
+
+Compare working tree vs a git ref (default: `main`):
+
+```sh
+./compare.sh
+./compare.sh v4.12.0
+RUNTIME=node ./compare.sh
+```

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -5,8 +5,8 @@
 //
 // Runs on both Bun and Node.
 import './ts-resolve.mjs'
-import { pathToFileURL } from 'node:url'
 import { run, bench, group, summary } from 'mitata'
+import { pathToFileURL } from 'node:url'
 
 const devSrc = new URL('../../src', import.meta.url).pathname
 const baseSrc = process.env.HONO_BASE_SRC
@@ -31,7 +31,7 @@ const makeApp = async (src: string): Promise<any> => {
   return app
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const apps: Record<string, any> = {}
 if (baseSrc) {
   apps[baseRef] = await makeApp(baseSrc)
@@ -43,7 +43,7 @@ const query = new Request('http://localhost/id/1?name=bun')
 
 let sink: unknown
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const cases: [string, (app: any) => Promise<unknown>][] = [
   ['ping GET /', (app) => app.fetch(ping)],
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -1,0 +1,76 @@
+// Measure app.fetch() overhead in-process.
+//
+//   bun bench.mts / node bench.mts   ... benchmark the working tree
+//   ./compare.sh [ref]               ... also benchmark <ref> and compare
+//
+// Runs on both Bun and Node.
+import './ts-resolve.mjs'
+import { pathToFileURL } from 'node:url'
+import { run, bench, group, summary } from 'mitata'
+
+const devSrc = new URL('../../src', import.meta.url).pathname
+const baseSrc = process.env.HONO_BASE_SRC
+const baseRef = process.env.HONO_BASE_REF ?? 'base'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeApp = async (src: string): Promise<any> => {
+  const { Hono } = await import(pathToFileURL(`${src}/index.ts`).href)
+  const { RegExpRouter } = await import(pathToFileURL(`${src}/router/reg-exp-router/index.ts`).href)
+
+  const app = new Hono({ router: new RegExpRouter() })
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  app
+    .get('/', (c: any) => c.text('Hi'))
+    .post('/json', (c: any) => c.req.json().then(c.json))
+    .get('/id/:id', (c: any) => {
+      const id = c.req.param('id')
+      const name = c.req.query('name')
+      c.header('x-powered-by', 'benchmark')
+      return c.text(`${id} ${name}`)
+    })
+  return app
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const apps: Record<string, any> = {}
+if (baseSrc) {
+  apps[baseRef] = await makeApp(baseSrc)
+}
+apps[baseSrc ? 'dev (working tree)' : 'hono'] = await makeApp(devSrc)
+
+const ping = new Request('http://localhost/')
+const query = new Request('http://localhost/id/1?name=bun')
+
+let sink: unknown
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const cases: [string, (app: any) => Promise<unknown>][] = [
+  ['ping GET /', (app) => app.fetch(ping)],
+  ['query GET /id/1?name=bun', (app) => app.fetch(query)],
+  [
+    'body POST /json',
+    (app) =>
+      app.fetch(
+        new Request('http://localhost/json', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{"hello":"world"}',
+        })
+      ),
+  ],
+]
+
+for (const [name, fn] of cases) {
+  group(name, () => {
+    summary(() => {
+      for (const [label, app] of Object.entries(apps)) {
+        bench(label, async () => {
+          sink = await fn(app)
+        })
+      }
+    })
+  })
+}
+
+await run()
+console.log(typeof sink)

--- a/benchmarks/fetch/compare.sh
+++ b/benchmarks/fetch/compare.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Compare app.fetch() between the working tree and a git ref (default: main).
+# Usage: ./compare.sh [ref]
+#        RUNTIME=node ./compare.sh [ref]
+set -e
+cd "$(dirname "$0")"
+
+REF=${1:-main}
+RUNTIME=${RUNTIME:-bun}
+ROOT=$(git rev-parse --show-toplevel)
+WT=$(mktemp -d)/hono-base
+
+cleanup() {
+  git -C "$ROOT" worktree remove --force "$WT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+git -C "$ROOT" worktree add --detach -q "$WT" "$REF"
+
+HONO_BASE_SRC="$WT/src" HONO_BASE_REF="$REF" $RUNTIME ./bench.mts

--- a/benchmarks/fetch/package.json
+++ b/benchmarks/fetch/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "mitata": "^1.0.34"
+  }
+}

--- a/benchmarks/fetch/ts-resolve.mjs
+++ b/benchmarks/fetch/ts-resolve.mjs
@@ -1,0 +1,26 @@
+// Resolve extensionless TypeScript imports (e.g. `./request` -> `./request.ts`)
+// so that Node's built-in type stripping can run hono's src directly.
+// Import this once at the top of a bench file, then load hono via dynamic import().
+// No-op on Bun, which resolves extensionless imports natively.
+import * as mod from 'node:module'
+
+if (typeof mod.registerHooks === 'function') {
+  mod.registerHooks({
+    resolve(specifier, context, nextResolve) {
+      try {
+        return nextResolve(specifier, context)
+      } catch (err) {
+        if (specifier.startsWith('.') || specifier.startsWith('file:')) {
+          for (const suffix of ['.ts', '/index.ts']) {
+            try {
+              return nextResolve(specifier + suffix, context)
+            } catch {
+              // try the next suffix
+            }
+          }
+        }
+        throw err
+      }
+    },
+  })
+}

--- a/benchmarks/fetch/tsconfig.json
+++ b/benchmarks/fetch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "module": "NodeNext",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./*.mts", "./*.mjs"]
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -606,14 +606,12 @@ export class Context<
     arg?: StatusCode | ResponseOrInit,
     headers?: HeaderRecord
   ): Response {
-    const responseHeaders = this.#res
-      ? new Headers(this.#res.headers)
-      : (this.#preparedHeaders ?? new Headers())
+    let responseHeaders = this.#res ? new Headers(this.#res.headers) : this.#preparedHeaders
 
-    if (typeof arg === 'object' && 'headers' in arg) {
-      const argHeaders = arg.headers instanceof Headers ? arg.headers : new Headers(arg.headers)
-      for (const [key, value] of argHeaders) {
-        if (key.toLowerCase() === 'set-cookie') {
+    if (typeof arg === 'object' && arg.headers) {
+      responseHeaders ??= new Headers()
+      for (const [key, value] of new Headers(arg.headers)) {
+        if (key === 'set-cookie') {
           responseHeaders.append(key, value)
         } else {
           responseHeaders.set(key, value)
@@ -622,20 +620,32 @@ export class Context<
     }
 
     if (headers) {
-      for (const [k, v] of Object.entries(headers)) {
-        if (typeof v === 'string') {
-          responseHeaders.set(k, v)
-        } else {
-          responseHeaders.delete(k)
-          for (const v2 of v) {
-            responseHeaders.append(k, v2)
+      if (!responseHeaders) {
+        for (const k in headers) {
+          if (typeof headers[k as keyof HeaderRecord] !== 'string') {
+            responseHeaders = new Headers()
+          }
+        }
+      }
+      if (responseHeaders) {
+        for (const k in headers) {
+          const v = headers[k as keyof HeaderRecord]
+          if (typeof v === 'string') {
+            responseHeaders.set(k, v)
+          } else {
+            responseHeaders.delete(k)
+            for (const v2 of v) {
+              responseHeaders.append(k, v2)
+            }
           }
         }
       }
     }
 
-    const status = typeof arg === 'number' ? arg : (arg?.status ?? this.#status)
-    return createResponseInstance(data, { status, headers: responseHeaders })
+    return createResponseInstance(data, {
+      status: typeof arg === 'number' ? arg : (arg?.status ?? this.#status),
+      headers: responseHeaders ?? (headers as Record<string, string> | undefined),
+    })
   }
 
   newResponse: NewResponse = (...args) => this.#newResponse(...(args as Parameters<NewResponse>))


### PR DESCRIPTION
This PR includes performance improvements for `context.ts` and benchmark scripts to measure performance with `app.fetch()`.

The core idea is to delay creation of the `Headers` object as long as possible or skip creation of the `Headers` if it is not needed.

To measure the performance, you can use `benchmarks/router`.

The results with it:

```
clk: ~4.31 GHz
cpu: Apple M4 Pro
runtime: bun 1.4.0 (arm64-darwin)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• ping GET /
------------------------------------------- -------------------------------
main                         301.42 ns/iter 334.00 ns  █
                    (125.00 ns … 129.96 µs)   1.25 µs  █
                    (  0.00  b …  48.00 kb) 230.28  b ▁█▄▄▅▄▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁

dev (working tree)           283.46 ns/iter 333.00 ns  █▂
                    (125.00 ns … 132.92 µs) 875.00 ns  ██
                    (  0.00  b …  32.00 kb)  17.64  b ▁██▆▆▁▅▅▅▃▂▂▂▁▁▁▁▁▁▁▁

summary
  dev (working tree)
   1.06x faster than main

• query GET /id/1?name=bun
------------------------------------------- -------------------------------
main                         732.76 ns/iter 731.93 ns    ██
                    (667.73 ns … 963.16 ns) 939.99 ns    ██▆
                    (  0.00  b …   2.20 kb)  57.82  b ▁▄████▄▂▂▂▂▂▂▃▁▁▁▁▁▁▂

dev (working tree)           707.97 ns/iter 711.24 ns    █▇
                    (646.62 ns … 939.25 ns) 922.95 ns    ██▆
                    (  0.00  b …  80.00  b)   1.73  b ▃▆▇███▅▁▁▁▂▂▂▁▂▂▁▁▁▁▂

summary
  dev (working tree)
   1.04x faster than main

• body POST /json
------------------------------------------- -------------------------------
main                           1.24 µs/iter   1.25 µs      ▃█
                        (1.16 µs … 1.45 µs)   1.39 µs      ████
                    (  0.00  b … 740.00  b)  34.01  b ▂▂▂▃▅████▆▂▂▂▂▃▁▂▂▂▁▂

dev (working tree)             1.09 µs/iter   1.10 µs             █▆
                        (1.03 µs … 1.15 µs)   1.14 µs          ▃▂▆██▃
                    (  0.00  b … 348.00  b)   6.41  b ▃▁▁▃▁▃▄▆████████▅▄▂▂▂

summary
  dev (working tree)
   1.14x faster than main
```

And the bundle size is slightly reduced:

```
$ ls -lB hello-bundle-*
.rw-r--r--@ 19,037 yusuke 14 7月  09:15 hello-bundle-5112.js
.rw-r--r--@ 19,042 yusuke 14 7月  09:15 hello-bundle-main.js
```


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
