### PR TITLE
perf(hono-base): avoid rest parameter in `fetch`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -471,17 +471,17 @@ class Hono<
    * @see {@link https://hono.dev/docs/api/hono#fetch}
    *
    * @param {Request} request - request Object of request
-   * @param {Env} Env - env Object
-   * @param {ExecutionContext} - context of execution
+   * @param {Env} env - env Object
+   * @param {ExecutionContext} executionCtx - context of execution
    * @returns {Response | Promise<Response>} response of request
    *
    */
   fetch: (
     request: Request,
-    Env?: E['Bindings'] | {},
+    env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => Response | Promise<Response> = (request, ...rest) => {
-    return this.#dispatch(request, rest[1], rest[0], request.method)
+  ) => Response | Promise<Response> = (request, env, executionCtx) => {
+    return this.#dispatch(request, executionCtx, env, request.method)
   }
 
   /**


### PR DESCRIPTION
Interestingly, the minified size decreased even though the source `.ts` file size increased.

```js
// main
fetch=(e,...t)=>this.#n(e,t[1],t[0],e.method)

// this PR
fetch=(e,t,r)=>this.#n(e,r,t,e.method)
```

```
$ ls -lB hello-bundle-*
.rw-r--r--@ 19,035 yusuke 14 7月  09:51 hello-bundle-5113.js
.rw-r--r--@ 19,042 yusuke 14 7月  09:51 hello-bundle-main.js
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
