### PR TITLE
feat(cors): allow QUERY by default as a first-class method

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -145,13 +145,26 @@ describe('CORS by Middleware', () => {
   })
 
   it('Preflight default', async () => {
-    const req = new Request('https://localhost/api/abc', { method: 'OPTIONS' })
-    req.headers.append('Access-Control-Request-Headers', 'X-PINGOTHER, Content-Type')
+    const req = new Request('https://localhost/api/abc', {
+      method: 'OPTIONS',
+      headers: {
+        'Access-Control-Request-Method': 'QUERY',
+        'Access-Control-Request-Headers': 'X-PINGOTHER, Content-Type',
+      },
+    })
     const res = await app.request(req)
 
     expect(res.status).toBe(204)
     expect(res.statusText).toBe('No Content')
-    expect(res.headers.get('Access-Control-Allow-Methods')?.split(',')[0]).toBe('GET')
+    expect(res.headers.get('Access-Control-Allow-Methods')?.split(',')).toEqual([
+      'GET',
+      'HEAD',
+      'PUT',
+      'POST',
+      'DELETE',
+      'PATCH',
+      'QUERY',
+    ])
     expect(res.headers.get('Access-Control-Allow-Headers')?.split(',')).toEqual([
       'X-PINGOTHER',
       'Content-Type',

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -28,7 +28,7 @@ type CORSOptions = {
  *
  * @param {CORSOptions} [options] - The options for the CORS middleware.
  * @param {string | string[] | ((origin: string, c: Context) => Promise<string | undefined | null> | string | undefined | null)} [options.origin='*'] - The value of "Access-Control-Allow-Origin" CORS header.
- * @param {string[] | ((origin: string, c: Context) => Promise<string[]> | string[])} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']] - The value of "Access-Control-Allow-Methods" CORS header.
+ * @param {string[] | ((origin: string, c: Context) => Promise<string[]> | string[])} [options.allowMethods=['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH', 'QUERY']] - The value of "Access-Control-Allow-Methods" CORS header.
  * @param {string[]} [options.allowHeaders=[]] - The value of "Access-Control-Allow-Headers" CORS header.
  * @param {number} [options.maxAge] - The value of "Access-Control-Max-Age" CORS header.
  * @param {boolean} [options.credentials] - The value of "Access-Control-Allow-Credentials" CORS header.
@@ -63,7 +63,7 @@ type CORSOptions = {
 export const cors = (options?: CORSOptions): MiddlewareHandler => {
   const opts = {
     origin: '*',
-    allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
+    allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH', 'QUERY'],
     allowHeaders: [],
     exposeHeaders: [],
     ...options,


### PR DESCRIPTION
#5048

### Important behavioral change

> [!IMPORTANT]
> This PR adds `QUERY` to the default `allowMethods` list used by the CORS middleware.
>
> As a result, applications using `cors()` without an explicit `allowMethods` option will advertise `QUERY` in the `Access-Control-Allow-Methods` response header. This expands the default set of methods permitted for cross-origin requests.

This is not a breaking API change in the strict sense, but it is a security-relevant change to the default behavior and should be highlighted in the release notes. Applications that explicitly configure `allowMethods` are not affected.

### Rationale

Hono now treats `QUERY` as a first-class HTTP method. For that support to be consistent across the framework, the built-in CORS middleware should allow `QUERY` by default, just as it does for the other first-class methods.

Requiring every application to add `QUERY` to `allowMethods` manually would make the support incomplete and less discoverable. Expanding the default list is therefore considered appropriate for first-class `QUERY` support.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
