### PR TITLE
test(context): assert case-insensitive header names in response helpers

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -492,6 +492,21 @@ describe('Context header', () => {
     })
     expect(res.headers.get('X-Test')).toBeNull()
   })
+
+  it('Should override the default Content-Type even if the header name casing differs', async () => {
+    const res = c.json({ type: 'urn:example:error' }, 400, {
+      'content-type': 'application/problem+json',
+    })
+    expect(res.headers.get('Content-Type')).toBe('application/problem+json')
+  })
+
+  it('Should apply the last value when header names differ only in casing', async () => {
+    const res = c.body('foo', 200, {
+      'X-Custom': 'first',
+      'x-custom': 'second',
+    })
+    expect(res.headers.get('X-Custom')).toBe('second')
+  })
 })
 
 describe('Pass a ResponseInit to respond methods', () => {


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
