### PR TITLE
chore(benchmark): add app.fetch() overhead benchmark

### DIFF
--- a/benchmarks/fetch/.gitignore
+++ b/benchmarks/fetch/.gitignore
@@ -1,0 +1,2 @@
+bun.lock
+.claude

--- a/benchmarks/fetch/README.md
+++ b/benchmarks/fetch/README.md
@@ -1,0 +1,19 @@
+# fetch benchmark
+
+Measure `app.fetch()` overhead in-process.
+
+```sh
+bun bench.mts
+node bench.mts
+```
+
+Compare working tree vs a git ref (default: `main`):
+
+```sh
+./compare.sh
+./compare.sh v4.12.0
+RUNTIME=node ./compare.sh
+ROUNDS=5 ./compare.sh
+```
+
+`compare.sh` runs each variant in a fresh process and reverses the variant order on every round, so that same-process JIT/GC warm-up and execution order do not bias the results. The summary reports the median of the per-round averages along with the raw values of every round.

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -1,0 +1,89 @@
+// Measure app.fetch() overhead in-process.
+//
+//   bun bench.mts / node bench.mts   ... benchmark the working tree
+//   ./compare.sh [ref]               ... also benchmark <ref> and compare
+//
+// Each invocation benchmarks a single variant so that results are not
+// affected by same-process JIT/GC order effects. compare.sh spawns one
+// process per variant per round and aggregates the results.
+//
+// Env:
+//   HONO_SRC    ... path to the hono `src` directory to benchmark (default: ../../src)
+//   HONO_LABEL  ... label used in the output (default: hono)
+//   HONO_JSON=1 ... suppress mitata output and print a single JSON line instead
+//
+// Runs on both Bun and Node.
+import './ts-resolve.mjs'
+import { run, bench } from 'mitata'
+import { pathToFileURL } from 'node:url'
+
+const src = process.env.HONO_SRC ?? new URL('../../src', import.meta.url).pathname
+const label = process.env.HONO_LABEL ?? 'hono'
+const asJson = process.env.HONO_JSON === '1'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeApp = async (src: string): Promise<any> => {
+  const { Hono } = await import(pathToFileURL(`${src}/index.ts`).href)
+  const { RegExpRouter } = await import(pathToFileURL(`${src}/router/reg-exp-router/index.ts`).href)
+
+  const app = new Hono({ router: new RegExpRouter() })
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  app
+    .get('/', (c: any) => c.text('Hi'))
+    .post('/json', (c: any) => c.req.json().then(c.json))
+    .get('/id/:id', (c: any) => {
+      const id = c.req.param('id')
+      const name = c.req.query('name')
+      c.header('x-powered-by', 'benchmark')
+      return c.text(`${id} ${name}`)
+    })
+  return app
+}
+
+const app = await makeApp(src)
+
+const ping = new Request('http://localhost/')
+const query = new Request('http://localhost/id/1?name=bun')
+
+let sink: unknown
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const cases: [string, (app: any) => Promise<unknown>][] = [
+  ['ping GET /', (app) => app.fetch(ping)],
+  ['query GET /id/1?name=bun', (app) => app.fetch(query)],
+  [
+    'body POST /json',
+    (app) =>
+      app.fetch(
+        new Request('http://localhost/json', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{"hello":"world"}',
+        })
+      ),
+  ],
+]
+
+for (const [name, fn] of cases) {
+  bench(name, async () => {
+    sink = await fn(app)
+  })
+}
+
+if (asJson) {
+  const { benchmarks } = await run({ format: 'quiet' })
+  const results: Record<string, { avg: number; min: number; p75: number }> = {}
+  for (const b of benchmarks) {
+    const { stats, error } = b.runs[0]
+    if (error || !stats) {
+      throw error ?? new Error(`no stats for ${b.alias}`)
+    }
+    results[b.alias] = { avg: stats.avg, min: stats.min, p75: stats.p75 }
+  }
+  console.log(JSON.stringify({ label, cases: results }))
+  console.error(typeof sink)
+} else {
+  console.log(`benchmarking: ${label} (${src})`)
+  await run()
+  console.log(typeof sink)
+}

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -47,7 +47,7 @@ const query = new Request('http://localhost/id/1?name=bun')
 
 let sink: unknown
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const cases: [string, (app: any) => Promise<unknown>][] = [
   ['ping GET /', (app) => app.fetch(ping)],
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],

--- a/benchmarks/fetch/compare.sh
+++ b/benchmarks/fetch/compare.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Compare app.fetch() between the working tree and a git ref (default: main).
+#
+# Each measurement runs in a fresh process, and the variant order is
+# reversed on every round, so that same-process JIT/GC warm-up and
+# execution order do not bias the results.
+#
+# Usage: ./compare.sh [ref]
+#        RUNTIME=node ROUNDS=5 ./compare.sh [ref]
+set -e
+cd "$(dirname "$0")"
+
+REF=${1:-main}
+RUNTIME=${RUNTIME:-bun}
+ROUNDS=${ROUNDS:-3}
+ROOT=$(git rev-parse --show-toplevel)
+WT=$(mktemp -d)/hono-base
+RESULTS=$(mktemp)
+
+cleanup() {
+  git -C "$ROOT" worktree remove --force "$WT" 2>/dev/null || true
+  rm -f "$RESULTS"
+}
+trap cleanup EXIT
+
+git -C "$ROOT" worktree add --detach -q "$WT" "$REF"
+
+run_variant() { # <label> <src>
+  HONO_JSON=1 HONO_LABEL="$1" HONO_SRC="$2" $RUNTIME ./bench.mts >>"$RESULTS" 2>/dev/null
+}
+
+for ((i = 1; i <= ROUNDS; i++)); do
+  if ((i % 2)); then
+    echo "round $i/$ROUNDS: $REF -> dev" >&2
+    run_variant "$REF" "$WT/src"
+    run_variant "dev" "$ROOT/src"
+  else
+    echo "round $i/$ROUNDS: dev -> $REF" >&2
+    run_variant "dev" "$ROOT/src"
+    run_variant "$REF" "$WT/src"
+  fi
+done
+
+$RUNTIME ./summarize.mts "$RESULTS" "$REF"

--- a/benchmarks/fetch/package.json
+++ b/benchmarks/fetch/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "mitata": "^1.0.34"
+  }
+}

--- a/benchmarks/fetch/summarize.mts
+++ b/benchmarks/fetch/summarize.mts
@@ -1,0 +1,50 @@
+// Summarize NDJSON results produced by `HONO_JSON=1 bench.mts`.
+// Usage: bun summarize.mts <results.ndjson> <base-label>
+import { readFileSync } from 'node:fs'
+
+const [file, baseLabel = 'base'] = process.argv.slice(2)
+
+type Stats = { avg: number; min: number; p75: number }
+type Line = { label: string; cases: Record<string, Stats> }
+
+const lines: Line[] = readFileSync(file, 'utf8')
+  .trim()
+  .split('\n')
+  .map((l) => JSON.parse(l))
+
+// case name -> label -> avg per round
+const byCase = new Map<string, Map<string, number[]>>()
+for (const line of lines) {
+  for (const [name, stats] of Object.entries(line.cases)) {
+    const byLabel = byCase.get(name) ?? new Map<string, number[]>()
+    byCase.set(name, byLabel)
+    const avgs = byLabel.get(line.label) ?? []
+    byLabel.set(line.label, avgs)
+    avgs.push(stats.avg)
+  }
+}
+
+const median = (xs: number[]): number => {
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+}
+
+const fmt = (ns: number): string =>
+  ns >= 1000 ? `${(ns / 1000).toFixed(2)} µs` : `${ns.toFixed(2)} ns`
+
+for (const [name, byLabel] of byCase) {
+  console.log(`• ${name}`)
+  for (const [label, avgs] of byLabel) {
+    const rounds = avgs.map(fmt).join(', ')
+    console.log(`  ${label.padEnd(16)} median ${fmt(median(avgs)).padStart(10)}  rounds: [${rounds}]`)
+  }
+  const dev = byLabel.get('dev')
+  const base = byLabel.get(baseLabel)
+  if (dev && base) {
+    const ratio = median(base) / median(dev)
+    const [verb, x] = ratio >= 1 ? ['faster', ratio] : ['slower', 1 / ratio]
+    console.log(`  summary: dev is ${x.toFixed(2)}x ${verb} than ${baseLabel} (median of round avgs)`)
+  }
+  console.log('')
+}

--- a/benchmarks/fetch/ts-resolve.mjs
+++ b/benchmarks/fetch/ts-resolve.mjs
@@ -1,0 +1,26 @@
+// Resolve extensionless TypeScript imports (e.g. `./request` -> `./request.ts`)
+// so that Node's built-in type stripping can run hono's src directly.
+// Import this once at the top of a bench file, then load hono via dynamic import().
+// No-op on Bun, which resolves extensionless imports natively.
+import * as mod from 'node:module'
+
+if (typeof mod.registerHooks === 'function') {
+  mod.registerHooks({
+    resolve(specifier, context, nextResolve) {
+      try {
+        return nextResolve(specifier, context)
+      } catch (err) {
+        if (specifier.startsWith('.') || specifier.startsWith('file:')) {
+          for (const suffix of ['.ts', '/index.ts']) {
+            try {
+              return nextResolve(specifier + suffix, context)
+            } catch {
+              // try the next suffix
+            }
+          }
+        }
+        throw err
+      }
+    },
+  })
+}

--- a/benchmarks/fetch/tsconfig.json
+++ b/benchmarks/fetch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "module": "NodeNext",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./*.mts", "./*.mjs"]
+}


### PR DESCRIPTION
These benchmark scripts enable measuring the performance of `app.fetch()`. This means it does not cover the HTTP layer and enables strict measurement of the application handler's speed.

`compare.sh` can run the benchmark multiple times to avoid inconsistency with order or conditions.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
