### PR TITLE
perf(context): iterate the header record with for..in

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -622,7 +622,8 @@ export class Context<
     }
 
     if (headers) {
-      for (const [k, v] of Object.entries(headers)) {
+      for (const k in headers) {
+        const v = headers[k as keyof HeaderRecord]
         if (typeof v === 'string') {
           responseHeaders.set(k, v)
         } else {


### PR DESCRIPTION
This PR is one of the performance improvements.

`Object.entries(headers)` creates a throwaway array of `[key, value]` every time, but `for (const k in headers)` does not. So replacing them will introduce improvement. This affects `query GET /id/1?name=bun` and `body POST /json`.


### Bun

```
$ ROUNDS=5 ./compare.sh
round 1/5: main -> dev
round 2/5: dev -> main
round 3/5: main -> dev
round 4/5: dev -> main
round 5/5: main -> dev
• ping GET /
  main             median  300.11 ns  rounds: [295.27 ns, 302.92 ns, 300.11 ns, 311.90 ns, 288.84 ns]
  dev              median  298.71 ns  rounds: [299.84 ns, 315.35 ns, 294.86 ns, 292.81 ns, 298.71 ns]
  summary: dev is 1.00x faster than main (median of round avgs)

• query GET /id/1?name=bun
  main             median  746.01 ns  rounds: [740.26 ns, 739.86 ns, 746.01 ns, 762.05 ns, 764.40 ns]
  dev              median  695.33 ns  rounds: [677.73 ns, 695.33 ns, 705.45 ns, 704.78 ns, 695.18 ns]
  summary: dev is 1.07x faster than main (median of round avgs)

• body POST /json
  main             median    1.30 µs  rounds: [1.25 µs, 1.28 µs, 1.30 µs, 1.32 µs, 1.32 µs]
  dev              median    1.25 µs  rounds: [1.21 µs, 1.24 µs, 1.25 µs, 1.27 µs, 1.26 µs]
  summary: dev is 1.04x faster than main (median of round avgs)
```

### Node.js

```
$ ROUNDS=5 RUNTIME=node ./compare.sh
round 1/5: main -> dev
round 2/5: dev -> main
round 3/5: main -> dev
round 4/5: dev -> main
round 5/5: main -> dev
• ping GET /
  main             median  898.68 ns  rounds: [902.06 ns, 897.78 ns, 897.73 ns, 898.68 ns, 910.96 ns]
  dev              median  890.24 ns  rounds: [889.80 ns, 879.75 ns, 890.24 ns, 896.93 ns, 906.54 ns]
  summary: dev is 1.01x faster than main (median of round avgs)

• query GET /id/1?name=bun
  main             median    1.57 µs  rounds: [1.57 µs, 1.58 µs, 1.57 µs, 1.57 µs, 1.51 µs]
  dev              median    1.52 µs  rounds: [1.50 µs, 1.45 µs, 1.55 µs, 1.52 µs, 1.52 µs]
  summary: dev is 1.03x faster than main (median of round avgs)

• body POST /json
  main             median    5.69 µs  rounds: [5.78 µs, 5.68 µs, 5.69 µs, 5.62 µs, 5.69 µs]
  dev              median    5.56 µs  rounds: [5.49 µs, 5.51 µs, 5.60 µs, 5.56 µs, 5.59 µs]
  summary: dev is 1.02x faster than main (median of round avgs)
```

---

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
