### PR TITLE
feat(cache): add first-class support for QUERY requests

### DIFF
--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -101,7 +101,9 @@ describe('Customizing Caching Keys', () => {
   it('Should use dynamically generated cache key', async () => {
     await app.request('http://localhost/dynamic-cache-key/')
     const cache = await caches.open('my-app-v1')
-    const response = await cache.match(dynamicCacheKey)
+    const response = await cache.match(
+      'http://localhost/.hono/cache?__hono_cache_key=dynamic-cache-key&__hono_cache_method=GET'
+    )
     expect(response).not.toBeNull()
   })
 
@@ -896,6 +898,86 @@ describe('Cache Skipping Logic', () => {
     expect(await getRes.text()).toBe('get response')
     expect(await queryRes.text()).toBe('query response')
     expect(mockCache.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('Should not let a GET URL alias an internally generated QUERY cache key', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    app.use('*', cache({ cacheName: 'method-collision-test', wait: true }))
+    app.get('/resource', (c) => c.text('get response'))
+    app.get('*', (c) => c.text('get response'))
+    app.on('QUERY', '/resource', (c) => c.text('query response'))
+
+    await app.request('/resource', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+
+    const queryKey = mockCache.put.mock.calls[0][0] as string
+    const getRes = await app.request(queryKey)
+    const queryRes = await app.request('/resource', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+
+    expect(await getRes.text()).toBe('get response')
+    expect(await queryRes.text()).toBe('query response')
+    expect(mockCache.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('Should not resolve a custom cache key as a request URL', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    app.use(
+      '/resource',
+      cache({
+        cacheName: 'custom-key-collision-test',
+        wait: true,
+        keyGenerator: () => 'query-key',
+      })
+    )
+    app.use('/query-key', cache({ cacheName: 'custom-key-collision-test', wait: true }))
+    app.get('/resource', (c) => c.text('custom key response'))
+    app.get('/query-key', (c) => c.text('request URL response'))
+
+    expect(await (await app.request('/resource')).text()).toBe('custom key response')
+    expect(await (await app.request('/query-key')).text()).toBe('request URL response')
+    expect(mockCache.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('Should keep QUERY digest and vary values with a fragmented custom cache key', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use(
+      '*',
+      cache({
+        cacheName: 'query-fragment-test',
+        wait: true,
+        vary: 'X-Variant',
+        keyGenerator: (c) => `${c.req.url}#custom-fragment`,
+      })
+    )
+    app.on('QUERY', '/resource', async (c) => {
+      queryCount++
+      return c.text(`${await c.req.text()}:${c.req.header('X-Variant')}`)
+    })
+
+    const request = (body: string, variant: string) =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'text/plain', 'X-Variant': variant },
+        body,
+      })
+
+    expect(await (await request('one', 'a')).text()).toBe('one:a')
+    expect(await (await request('two', 'a')).text()).toBe('two:a')
+    expect(await (await request('one', 'b')).text()).toBe('one:b')
+    expect(await (await request('one', 'a')).text()).toBe('one:a')
+    expect(queryCount).toBe(3)
+    expect(mockCache.put).toHaveBeenCalledTimes(3)
   })
 
   it('Should bypass QUERY caching when Web Crypto is not available', async () => {

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -405,6 +405,9 @@ describe('Cache Middleware', () => {
     const res = await app.request('/')
     expect(res.status).toBe(200)
     expect(spy).toHaveBeenCalledOnce()
+    expect(spy).toHaveBeenCalledWith(
+      'Cache Middleware is not enabled because caches is not defined.'
+    )
     vi.unstubAllGlobals()
   })
 
@@ -900,14 +903,34 @@ describe('Cache Skipping Logic', () => {
     vi.stubGlobal('crypto', undefined)
 
     try {
+      const { mockCache } = stubStoreBackedCache()
       const app = new Hono()
       let queryCount = 0
-      app.use('*', cache({ cacheName: 'query-no-crypto-test', wait: true }))
+      let getCount = 0
+      const onCacheNotAvailable = vi.fn()
+      app.use(
+        '*',
+        cache({
+          cacheName: 'query-no-crypto-test',
+          wait: true,
+          onCacheNotAvailable,
+        })
+      )
+      app.get('/resource', (c) => {
+        getCount++
+        c.header('X-Count', `${getCount}`)
+        return c.text('get response')
+      })
       app.on('QUERY', '/resource', (c) => {
         queryCount++
         c.header('X-Count', `${queryCount}`)
         return c.text('query response')
       })
+
+      expect(onCacheNotAvailable).toHaveBeenCalledOnce()
+      expect(onCacheNotAvailable).toHaveBeenCalledWith(
+        'Cache Middleware cannot cache QUERY requests because Web Crypto is not available.'
+      )
 
       const request = () =>
         app.request('/resource', {
@@ -921,6 +944,13 @@ describe('Cache Skipping Logic', () => {
 
       expect(res.headers.get('X-Count')).toBe('2')
       expect(caches.open).not.toHaveBeenCalled()
+      expect(onCacheNotAvailable).toHaveBeenCalledOnce()
+
+      await app.request('/resource')
+      const getRes = await app.request('/resource')
+
+      expect(getRes.headers.get('X-Count')).toBe('1')
+      expect(mockCache.put).toHaveBeenCalledOnce()
     } finally {
       vi.stubGlobal('crypto', originalCrypto)
     }

--- a/src/middleware/cache/index.test.ts
+++ b/src/middleware/cache/index.test.ts
@@ -741,6 +741,287 @@ describe('Cache Skipping Logic', () => {
     expect(putSpy).not.toHaveBeenCalled()
   })
 
+  it('Should cache QUERY responses without consuming the handler request body', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use('*', cache({ cacheName: 'query-test', wait: true, cacheControl: 'max-age=10' }))
+    app.on('QUERY', '/resource', async (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text(await c.req.raw.text())
+    })
+
+    const request = () =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"query":"hono"}',
+      })
+
+    await request()
+    const res = await request()
+
+    expect(await res.text()).toBe('{"query":"hono"}')
+    expect(res.headers.get('X-Count')).toBe('1')
+    expect(res.headers.get('Cache-Control')).toBe('max-age=10')
+    expect(mockCache.put).toHaveBeenCalledOnce()
+  })
+
+  it('Should bypass QUERY caching when the measured body exceeds the configured limit', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use('*', cache({ cacheName: 'query-body-limit-test', wait: true, maxQueryBodySize: 4 }))
+    app.on('QUERY', '/resource', async (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text(await c.req.text())
+    })
+
+    const request = () => {
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('ab'))
+          controller.enqueue(new TextEncoder().encode('cde'))
+          controller.close()
+        },
+      })
+      return app.request('/resource', {
+        method: 'QUERY',
+        headers: {
+          'Content-Length': '1',
+          'Content-Type': 'text/plain',
+        },
+        body,
+        duplex: 'half',
+      } as RequestInit & { duplex: 'half' })
+    }
+
+    await request()
+    const res = await request()
+
+    expect(await res.text()).toBe('abcde')
+    expect(res.headers.get('X-Count')).toBe('2')
+    expect(caches.open).not.toHaveBeenCalled()
+    expect(mockCache.put).not.toHaveBeenCalled()
+  })
+
+  it('Should cache QUERY requests at the configured body size limit', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use(
+      '*',
+      cache({ cacheName: 'query-body-limit-boundary-test', wait: true, maxQueryBodySize: 4 })
+    )
+    app.on('QUERY', '/resource', async (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text(await c.req.text())
+    })
+
+    const request = () =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'abcd',
+      })
+
+    await request()
+    const res = await request()
+
+    expect(await res.text()).toBe('abcd')
+    expect(res.headers.get('X-Count')).toBe('1')
+    expect(mockCache.put).toHaveBeenCalledOnce()
+  })
+
+  it('Should keep QUERY request content and Content-Type in separate cache variants', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use(
+      '*',
+      cache({ cacheName: 'query-variant-test', wait: true, keyGenerator: () => 'query-key' })
+    )
+    app.on('QUERY', '/resource', async (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text(`${c.req.header('Content-Type')}:${await c.req.text()}`)
+    })
+
+    const request = (body: string, contentType: string) =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': contentType },
+        body,
+      })
+
+    await request('one', 'text/plain')
+    const same = await request('one', 'text/plain')
+    await request('two', 'text/plain')
+    const differentContent = await request('two', 'text/plain')
+    await request('one', 'application/json')
+    const differentContentType = await request('one', 'application/json')
+
+    expect(same.headers.get('X-Count')).toBe('1')
+    expect(differentContent.headers.get('X-Count')).toBe('2')
+    expect(differentContentType.headers.get('X-Count')).toBe('3')
+    expect(mockCache.put).toHaveBeenCalledTimes(3)
+  })
+
+  it('Should keep GET and QUERY responses in separate cache entries', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    app.use('*', cache({ cacheName: 'method-test', wait: true }))
+    app.get('/resource', (c) => c.text('get response'))
+    app.on('QUERY', '/resource', (c) => c.text('query response'))
+
+    await app.request('/resource')
+    await app.request('/resource', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    const getRes = await app.request('/resource')
+    const queryRes = await app.request('/resource', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+
+    expect(await getRes.text()).toBe('get response')
+    expect(await queryRes.text()).toBe('query response')
+    expect(mockCache.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('Should bypass QUERY caching when Web Crypto is not available', async () => {
+    const originalCrypto = globalThis.crypto
+    vi.stubGlobal('crypto', undefined)
+
+    try {
+      const app = new Hono()
+      let queryCount = 0
+      app.use('*', cache({ cacheName: 'query-no-crypto-test', wait: true }))
+      app.on('QUERY', '/resource', (c) => {
+        queryCount++
+        c.header('X-Count', `${queryCount}`)
+        return c.text('query response')
+      })
+
+      const request = () =>
+        app.request('/resource', {
+          method: 'QUERY',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        })
+
+      await request()
+      const res = await request()
+
+      expect(res.headers.get('X-Count')).toBe('2')
+      expect(caches.open).not.toHaveBeenCalled()
+    } finally {
+      vi.stubGlobal('crypto', originalCrypto)
+    }
+  })
+
+  it('Should bypass QUERY caching when the request content cannot be read', async () => {
+    const app = new Hono()
+    let queryCount = 0
+    app.use('*', async (c, next) => {
+      await c.req.raw.text()
+      await next()
+    })
+    app.use('*', cache({ cacheName: 'query-consumed-body-test', wait: true }))
+    app.on('QUERY', '/resource', (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text('query response')
+    })
+
+    const request = () =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+
+    await request()
+    const res = await request()
+
+    expect(res.headers.get('X-Count')).toBe('2')
+    expect(caches.open).not.toHaveBeenCalled()
+  })
+
+  it('Should bypass QUERY caching after the body was read directly as FormData', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use('*', async (c, next) => {
+      expect((await c.req.formData()).get('query')).toBe('hono')
+      await next()
+    })
+    app.use('*', cache({ cacheName: 'query-cached-form-data-test', wait: true }))
+    app.on('QUERY', '/resource', (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text('query response')
+    })
+
+    const body = [
+      '--hono-boundary',
+      'Content-Disposition: form-data; name="query"',
+      '',
+      'hono',
+      '--hono-boundary--',
+      '',
+    ].join('\r\n')
+    const request = () =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'multipart/form-data; boundary=hono-boundary' },
+        body,
+      })
+
+    await request()
+    const res = await request()
+
+    expect(res.headers.get('X-Count')).toBe('2')
+    expect(caches.open).not.toHaveBeenCalled()
+    expect(mockCache.put).not.toHaveBeenCalled()
+  })
+
+  it('Should cache QUERY after the body was read through HonoRequest', async () => {
+    const { mockCache } = stubStoreBackedCache()
+    const app = new Hono()
+    let queryCount = 0
+    app.use('*', async (c, next) => {
+      expect(await c.req.text()).toBe('{}')
+      await next()
+    })
+    app.use('*', cache({ cacheName: 'query-cached-body-test', wait: true }))
+    app.on('QUERY', '/resource', async (c) => {
+      queryCount++
+      c.header('X-Count', `${queryCount}`)
+      return c.text(await c.req.text())
+    })
+
+    const request = () =>
+      app.request('/resource', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+
+    await request()
+    const res = await request()
+
+    expect(await res.text()).toBe('{}')
+    expect(res.headers.get('X-Count')).toBe('1')
+    expect(mockCache.put).toHaveBeenCalledOnce()
+  })
+
   it('Should not use or store cache for POST requests', async () => {
     const app = new Hono()
     let postCount = 0

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -171,7 +171,7 @@ const createQueryDigest = async (
  *
  * @example
  * ```ts
- * app.get(
+ * app.use(
  *   '*',
  *   cache({
  *     cacheName: 'my-app',

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -16,6 +16,19 @@ const defaultCacheableStatusCodes: ReadonlyArray<StatusCode> = [200]
 
 const defaultMaxQueryBodySize = 64 * 1024
 
+const cacheKeyPath = '/.hono/cache'
+const cacheKeyParameter = '__hono_cache_key'
+const cacheMethodKeyParameter = '__hono_cache_method'
+const queryDigestKeyParameter = '__hono_query_digest'
+const cacheVaryKeyParameter = '__hono_cache_vary'
+
+type CacheKeyRequest =
+  | { method: 'GET' }
+  | {
+      method: 'QUERY'
+      digest: string
+    }
+
 const queryRepresentationMetadataHeaders = [
   'content-type',
   'content-encoding',
@@ -33,6 +46,27 @@ const parseVaryDirectives = (vary: string | string[] | null | undefined): string
   return (Array.isArray(vary) ? vary : vary.split(','))
     .map((directive) => directive.trim().toLowerCase())
     .filter(Boolean)
+}
+
+const createCacheKey = (
+  key: string,
+  requestUrl: string,
+  request: CacheKeyRequest,
+  varyHeaders: [string, string][]
+): string => {
+  const url = new URL(cacheKeyPath, requestUrl)
+  url.searchParams.append(cacheKeyParameter, key.split('#', 1)[0])
+  url.searchParams.append(cacheMethodKeyParameter, request.method)
+
+  if (request.method === 'QUERY') {
+    url.searchParams.append(queryDigestKeyParameter, request.digest)
+  }
+
+  for (const header of varyHeaders) {
+    url.searchParams.append(cacheVaryKeyParameter, JSON.stringify(header))
+  }
+
+  return url.href
 }
 
 const shouldSkipCache = (
@@ -58,12 +92,12 @@ const reportCacheNotAvailable = (
   }
 }
 
-const createQueryCacheKey = async (
+const createQueryDigest = async (
   c: Context,
   maxQueryBodySize: number
-): Promise<string | null> => {
+): Promise<string | undefined> => {
   if (!globalThis.crypto?.subtle) {
-    return null
+    return undefined
   }
 
   if (c.req.raw.bodyUsed && Object.keys(c.req.bodyCache)[0] === 'formData') {
@@ -97,7 +131,7 @@ const createQueryCacheKey = async (
           // Do not await cancellation because a cloned stream's cancellation
           // can wait for the original request stream to finish.
           void reader.cancel().catch(() => {})
-          return null
+          return undefined
         }
         chunks.push(value)
       }
@@ -111,10 +145,10 @@ const createQueryCacheKey = async (
       offset += chunk.byteLength
     }
 
-    return await sha256(data)
+    return (await sha256(data)) ?? undefined
   } catch {
     // A QUERY response cannot be cached safely if its content cannot be read.
-    return null
+    return undefined
   }
 }
 
@@ -238,26 +272,28 @@ export const cache = (options: {
       return
     }
 
-    const queryCacheKey =
-      c.req.method === 'QUERY' ? await createQueryCacheKey(c, maxQueryBodySize) : undefined
-    if (queryCacheKey === null) {
-      await next()
-      return
+    let cacheKeyRequest: CacheKeyRequest = { method: 'GET' }
+    if (c.req.method === 'QUERY') {
+      const digest = await createQueryDigest(c, maxQueryBodySize)
+      if (digest === undefined) {
+        await next()
+        return
+      }
+      cacheKeyRequest = { method: 'QUERY', digest }
     }
 
     let key = c.req.url
     if (options.keyGenerator) {
       key = await options.keyGenerator(c)
     }
-    if (queryCacheKey) {
-      key += `::query=${queryCacheKey}`
-    }
+    const varyHeaders: [string, string][] = []
     if (varyDirectives) {
       for (const directive of varyDirectives) {
         const value = c.req.raw.headers.get(directive) ?? ''
-        key += `::${directive}=${encodeURIComponent(value)}`
+        varyHeaders.push([directive, value])
       }
     }
+    key = createCacheKey(key, c.req.url, cacheKeyRequest, varyHeaders)
 
     const cacheName =
       typeof options.cacheName === 'function' ? await options.cacheName(c) : options.cacheName

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -45,6 +45,19 @@ const shouldSkipCache = (
   shouldSkipCacheControl(res.headers.get('Cache-Control')) ||
   res.headers.has('Set-Cookie')
 
+const reportCacheNotAvailable = (
+  onCacheNotAvailable: ((reason: string) => void) | false | undefined,
+  reason: string
+): void => {
+  if (onCacheNotAvailable === false) {
+    // suppress log
+  } else if (onCacheNotAvailable) {
+    onCacheNotAvailable(reason)
+  } else {
+    console.log(reason)
+  }
+}
+
 const createQueryCacheKey = async (
   c: Context,
   maxQueryBodySize: number
@@ -118,7 +131,7 @@ const createQueryCacheKey = async (
  * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters. QUERY keys additionally include a digest of the request content and its representation metadata.
  * @param {number} [options.maxQueryBodySize=65536] - The maximum QUERY request body size in bytes that can be cached. Larger QUERY requests bypass the cache.
  * @param {number[]} [options.cacheableStatusCodes=[200]] - An array of status codes that can be cached.
- * @param {Function | false} [options.onCacheNotAvailable] - A callback invoked when `globalThis.caches` is not available. By default, a message is logged to the console. Set to `false` to suppress the log, or provide a custom function.
+ * @param {Function | false} [options.onCacheNotAvailable] - A callback invoked with the reason when `globalThis.caches` is not available or QUERY caching cannot use Web Crypto. By default, the reason is logged to the console. Set to `false` to suppress the log, or provide a custom function.
  * @returns {MiddlewareHandler} The middleware handler function.
  * @throws {Error} If the `vary` option includes "*".
  *
@@ -141,17 +154,21 @@ export const cache = (options: {
   keyGenerator?: (c: Context) => Promise<string> | string
   maxQueryBodySize?: number
   cacheableStatusCodes?: StatusCode[]
-  onCacheNotAvailable?: (() => void) | false
+  onCacheNotAvailable?: ((reason: string) => void) | false
 }): MiddlewareHandler => {
   if (!globalThis.caches) {
-    if (options.onCacheNotAvailable === false) {
-      // suppress log
-    } else if (options.onCacheNotAvailable) {
-      options.onCacheNotAvailable()
-    } else {
-      console.log('Cache Middleware is not enabled because caches is not defined.')
-    }
+    reportCacheNotAvailable(
+      options.onCacheNotAvailable,
+      'Cache Middleware is not enabled because caches is not defined.'
+    )
     return async (_c, next) => await next()
+  }
+
+  if (!globalThis.crypto?.subtle) {
+    reportCacheNotAvailable(
+      options.onCacheNotAvailable,
+      'Cache Middleware cannot cache QUERY requests because Web Crypto is not available.'
+    )
   }
 
   if (options.wait === undefined) {

--- a/src/middleware/cache/index.ts
+++ b/src/middleware/cache/index.ts
@@ -4,13 +4,24 @@
  */
 
 import type { Context } from '../../context'
+import { cloneRawRequest } from '../../request'
 import type { MiddlewareHandler } from '../../types'
+import { sha256 } from '../../utils/crypto'
 import type { StatusCode } from '../../utils/http-status'
 
 /**
  * status codes that can be cached by default.
  */
 const defaultCacheableStatusCodes: ReadonlyArray<StatusCode> = [200]
+
+const defaultMaxQueryBodySize = 64 * 1024
+
+const queryRepresentationMetadataHeaders = [
+  'content-type',
+  'content-encoding',
+  'content-language',
+  'content-location',
+] as const
 
 const shouldSkipCacheControl = (cacheControl: string | null): boolean =>
   !!cacheControl && /(?:^|,\s*)(?:private|no-(?:store|cache))(?:\s*(?:=|,|$))/i.test(cacheControl)
@@ -34,6 +45,66 @@ const shouldSkipCache = (
   shouldSkipCacheControl(res.headers.get('Cache-Control')) ||
   res.headers.has('Set-Cookie')
 
+const createQueryCacheKey = async (
+  c: Context,
+  maxQueryBodySize: number
+): Promise<string | null> => {
+  if (!globalThis.crypto?.subtle) {
+    return null
+  }
+
+  if (c.req.raw.bodyUsed && Object.keys(c.req.bodyCache)[0] === 'formData') {
+    // FormData cannot be reserialized with a stable multipart boundary after
+    // the original request body has been consumed.
+    return undefined
+  }
+
+  try {
+    // RFC 10008 Section 2.7 requires QUERY cache keys to incorporate the
+    // request content and its related representation metadata.
+    const requestHeaders = c.req.raw.headers
+    const metadata = new TextEncoder().encode(
+      JSON.stringify(
+        queryRepresentationMetadataHeaders.map((header) => [header, requestHeaders.get(header)])
+      )
+    )
+    const body = (await cloneRawRequest(c.req)).body
+    const chunks: Uint8Array[] = []
+    let bodySize = 0
+
+    if (body) {
+      const reader = body.getReader()
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        bodySize += value.byteLength
+        if (bodySize > maxQueryBodySize) {
+          // Do not await cancellation because a cloned stream's cancellation
+          // can wait for the original request stream to finish.
+          void reader.cancel().catch(() => {})
+          return null
+        }
+        chunks.push(value)
+      }
+    }
+
+    const data = new Uint8Array(metadata.byteLength + bodySize)
+    data.set(metadata)
+    let offset = metadata.byteLength
+    for (const chunk of chunks) {
+      data.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+
+    return await sha256(data)
+  } catch {
+    // A QUERY response cannot be cached safely if its content cannot be read.
+    return null
+  }
+}
+
 /**
  * Cache Middleware for Hono.
  *
@@ -44,7 +115,8 @@ const shouldSkipCache = (
  * @param {boolean} [options.wait=false] - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. Required to be true for the Deno environment.
  * @param {string} [options.cacheControl] - A string of directives for the `Cache-Control` header.
  * @param {string | string[]} [options.vary] - Adds the configured request headers to the cache key variants and sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates.
- * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters.
+ * @param {Function} [options.keyGenerator] - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters. QUERY keys additionally include a digest of the request content and its representation metadata.
+ * @param {number} [options.maxQueryBodySize=65536] - The maximum QUERY request body size in bytes that can be cached. Larger QUERY requests bypass the cache.
  * @param {number[]} [options.cacheableStatusCodes=[200]] - An array of status codes that can be cached.
  * @param {Function | false} [options.onCacheNotAvailable] - A callback invoked when `globalThis.caches` is not available. By default, a message is logged to the console. Set to `false` to suppress the log, or provide a custom function.
  * @returns {MiddlewareHandler} The middleware handler function.
@@ -67,6 +139,7 @@ export const cache = (options: {
   cacheControl?: string
   vary?: string | string[]
   keyGenerator?: (c: Context) => Promise<string> | string
+  maxQueryBodySize?: number
   cacheableStatusCodes?: StatusCode[]
   onCacheNotAvailable?: (() => void) | false
 }): MiddlewareHandler => {
@@ -101,6 +174,7 @@ export const cache = (options: {
   const cacheableStatusCodes = new Set<number>(
     options.cacheableStatusCodes ?? defaultCacheableStatusCodes
   )
+  const maxQueryBodySize = options.maxQueryBodySize ?? defaultMaxQueryBodySize
 
   const addHeader = (c: Context, responseVary: string[]) => {
     if (cacheControlDirectives) {
@@ -139,7 +213,17 @@ export const cache = (options: {
   }
 
   return async function cache(c, next) {
-    if (c.req.method !== 'GET' || c.req.raw.headers.has('Authorization')) {
+    if (
+      (c.req.method !== 'GET' && c.req.method !== 'QUERY') ||
+      c.req.raw.headers.has('Authorization')
+    ) {
+      await next()
+      return
+    }
+
+    const queryCacheKey =
+      c.req.method === 'QUERY' ? await createQueryCacheKey(c, maxQueryBodySize) : undefined
+    if (queryCacheKey === null) {
       await next()
       return
     }
@@ -147,6 +231,9 @@ export const cache = (options: {
     let key = c.req.url
     if (options.keyGenerator) {
       key = await options.keyGenerator(c)
+    }
+    if (queryCacheKey) {
+      key += `::query=${queryCacheKey}`
     }
     if (varyDirectives) {
       for (const directive of varyDirectives) {


### PR DESCRIPTION
https://github.com/honojs/hono/issues/5048

This PR adds first-class support for the `QUERY` method to the cache middleware.

Following RFC 10008 and related HTTP caching specifications, QUERY cache keys incorporate the request method, a SHA-256 digest of the request body, relevant representation metadata (`Content-Type`, `Content-Encoding`, `Content-Language`, and `Content-Location`), and configured `Vary` values.

### Notes

- Cache keys now use a new internal format for both `GET` and `QUERY`. Existing cache entries will not be reused after upgrading.
- QUERY request bodies are limited by `maxQueryBodySize` (64 KiB by default). Larger or unreadable bodies bypass caching.
- QUERY caching requires Web Crypto; GET caching remains available without it.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
