### PR TITLE
perf(url/request): replace regex tests with `indexOf`

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -106,7 +106,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   #getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
     const param = this.#getParamValue(paramKey)
-    return param && /\%/.test(param) ? tryDecodeURIComponent(param) : param
+    return param && param.indexOf('%') !== -1 ? tryDecodeURIComponent(param) : param
   }
 
   #getAllDecodedParams(): Record<string, string> {
@@ -116,7 +116,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     for (const key of keys) {
       const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value !== undefined) {
-        decoded[key] = /\%/.test(value) ? tryDecodeURIComponent(value) : value
+        decoded[key] = value.indexOf('%') !== -1 ? tryDecodeURIComponent(value) : value
       }
     }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -207,9 +207,6 @@ export const checkOptionalParameter = (path: string): string[] | null => {
 
 // Optimized
 const _decodeURI = (value: string) => {
-  if (!/[%+]/.test(value)) {
-    return value
-  }
   if (value.indexOf('+') !== -1) {
     value = value.replace(/\+/g, ' ')
   }
@@ -223,7 +220,7 @@ const _getQueryParam = (
 ): string | undefined | Record<string, string> | string[] | Record<string, string[]> => {
   let encoded
 
-  if (!multiple && key && !/[%+]/.test(key)) {
+  if (!multiple && key && key.indexOf('%') === -1 && key.indexOf('+') === -1) {
     // optimized for unencoded key
 
     let keyIndex = url.indexOf('?', 8)


### PR DESCRIPTION
This PR is one of the performance improvements.

I measured that `indexOf('%')` is faster than `/\%/.test()`. So replaced them in param/query decoding. This affects `query GET /id/1?name=bun`.

### Bun

```
$ ROUNDS=5 ./compare.sh
round 1/5: main -> dev
round 2/5: dev -> main
round 3/5: main -> dev
round 4/5: dev -> main
round 5/5: main -> dev
• ping GET /
  main             median  291.99 ns  rounds: [291.99 ns, 298.62 ns, 282.07 ns, 292.98 ns, 282.14 ns]
  dev              median  297.78 ns  rounds: [291.81 ns, 304.84 ns, 297.78 ns, 294.95 ns, 297.89 ns]
  summary: dev is 1.02x slower than main (median of round avgs)

• query GET /id/1?name=bun
  main             median  754.64 ns  rounds: [736.16 ns, 757.47 ns, 757.85 ns, 754.64 ns, 746.27 ns]
  dev              median  713.22 ns  rounds: [699.01 ns, 713.22 ns, 711.30 ns, 733.74 ns, 725.09 ns]
  summary: dev is 1.06x faster than main (median of round avgs)

• body POST /json
  main             median    1.29 µs  rounds: [1.29 µs, 1.31 µs, 1.32 µs, 1.28 µs, 1.29 µs]
  dev              median    1.30 µs  rounds: [1.30 µs, 1.29 µs, 1.30 µs, 1.29 µs, 1.31 µs]
  summary: dev is 1.00x slower than main (median of round avgs)
```

### Node.js

```
$ ROUNDS=5 RUNTIME=node ./compare.sh
round 1/5: main -> dev
round 2/5: dev -> main
round 3/5: main -> dev
round 4/5: dev -> main
round 5/5: main -> dev
• ping GET /
  main             median  912.56 ns  rounds: [862.88 ns, 941.91 ns, 912.56 ns, 892.33 ns, 941.43 ns]
  dev              median  892.78 ns  rounds: [875.07 ns, 882.54 ns, 897.88 ns, 892.78 ns, 932.69 ns]
  summary: dev is 1.02x faster than main (median of round avgs)

• query GET /id/1?name=bun
  main             median    1.59 µs  rounds: [1.59 µs, 1.65 µs, 1.61 µs, 1.59 µs, 1.59 µs]
  dev              median    1.55 µs  rounds: [1.55 µs, 1.49 µs, 1.55 µs, 1.56 µs, 1.59 µs]
  summary: dev is 1.02x faster than main (median of round avgs)

• body POST /json
  main             median    5.68 µs  rounds: [5.57 µs, 5.73 µs, 5.68 µs, 5.68 µs, 5.66 µs]
  dev              median    5.60 µs  rounds: [5.60 µs, 5.54 µs, 5.69 µs, 5.65 µs, 5.58 µs]
  summary: dev is 1.01x faster than main (median of round avgs)
```


### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
