### PR TITLE
perf(context): skip Headers creation when there are no headers to merge

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -606,14 +606,12 @@ export class Context<
     arg?: StatusCode | ResponseOrInit,
     headers?: HeaderRecord
   ): Response {
-    const responseHeaders = this.#res
-      ? new Headers(this.#res.headers)
-      : (this.#preparedHeaders ?? new Headers())
+    let responseHeaders = this.#res ? new Headers(this.#res.headers) : this.#preparedHeaders
 
-    if (typeof arg === 'object' && 'headers' in arg) {
-      const argHeaders = arg.headers instanceof Headers ? arg.headers : new Headers(arg.headers)
-      for (const [key, value] of argHeaders) {
-        if (key.toLowerCase() === 'set-cookie') {
+    if (typeof arg === 'object' && arg.headers) {
+      responseHeaders ??= new Headers()
+      for (const [key, value] of new Headers(arg.headers)) {
+        if (key === 'set-cookie') {
           responseHeaders.append(key, value)
         } else {
           responseHeaders.set(key, value)
@@ -622,20 +620,34 @@ export class Context<
     }
 
     if (headers) {
-      for (const [k, v] of Object.entries(headers)) {
-        if (typeof v === 'string') {
-          responseHeaders.set(k, v)
-        } else {
-          responseHeaders.delete(k)
-          for (const v2 of v) {
-            responseHeaders.append(k, v2)
+      if (!responseHeaders) {
+        let count = 0
+        for (const k in headers) {
+          if (++count > 1 || typeof headers[k as keyof HeaderRecord] !== 'string') {
+            responseHeaders = new Headers()
+            break
+          }
+        }
+      }
+      if (responseHeaders) {
+        for (const [k, v] of Object.entries(headers)) {
+          if (typeof v === 'string') {
+            responseHeaders.set(k, v)
+          } else {
+            responseHeaders.delete(k)
+            for (const v2 of v) {
+              responseHeaders.append(k, v2)
+            }
           }
         }
       }
     }
 
     const status = typeof arg === 'number' ? arg : (arg?.status ?? this.#status)
-    return createResponseInstance(data, { status, headers: responseHeaders })
+    return createResponseInstance(data, {
+      status,
+      headers: responseHeaders ?? (headers as Record<string, string> | undefined),
+    })
   }
 
   newResponse: NewResponse = (...args) => this.#newResponse(...(args as Parameters<NewResponse>))


### PR DESCRIPTION
This PR is one of the performance improvements.

This approach is the same as https://github.com/honojs/hono/pull/5112

Avoid creating a `Headers` when possible and pass the plain record to `Response` directly. This is fast on Bun, which consumes the record natively. On Node.js there is no difference since it builds `Headers` internally anyway. This affects only `body POST /json` on Bun.

Regarding [the problem of "Case-insensitive header overrides"](https://github.com/honojs/hono/pull/5112#issuecomment-4969693658) as @usualoma pointed out: records with a single entry cannot have case-insensitive key conflicts, so only those take the fast path. Anything else still goes through Headers.




### Bun

```
$ ROUNDS=5 ./compare.sh
round 1/5: main -> dev
round 2/5: dev -> main
round 3/5: main -> dev
round 4/5: dev -> main
round 5/5: main -> dev
• ping GET /
  main             median  290.70 ns  rounds: [290.60 ns, 296.60 ns, 290.67 ns, 290.70 ns, 295.50 ns]
  dev              median  293.41 ns  rounds: [293.41 ns, 298.21 ns, 291.92 ns, 273.94 ns, 300.55 ns]
  summary: dev is 1.01x slower than main (median of round avgs)

• query GET /id/1?name=bun
  main             median  759.86 ns  rounds: [757.80 ns, 763.35 ns, 759.86 ns, 756.65 ns, 760.02 ns]
  dev              median  744.66 ns  rounds: [772.45 ns, 729.72 ns, 737.35 ns, 744.66 ns, 745.54 ns]
  summary: dev is 1.02x faster than main (median of round avgs)

• body POST /json
  main             median    1.30 µs  rounds: [1.29 µs, 1.30 µs, 1.30 µs, 1.31 µs, 1.32 µs]
  dev              median    1.12 µs  rounds: [1.12 µs, 1.12 µs, 1.12 µs, 1.14 µs, 1.15 µs]
  summary: dev is 1.16x faster than main (median of round avgs)
```

### Node.js

```
$ ROUNDS=5 RUNTIME=node ./compare.sh
round 1/5: main -> dev
round 2/5: dev -> main
round 3/5: main -> dev
round 4/5: dev -> main
round 5/5: main -> dev
• ping GET /
  main             median  905.37 ns  rounds: [915.77 ns, 912.07 ns, 905.37 ns, 890.70 ns, 895.37 ns]
  dev              median  896.36 ns  rounds: [898.71 ns, 896.36 ns, 881.03 ns, 920.26 ns, 881.61 ns]
  summary: dev is 1.01x faster than main (median of round avgs)

• query GET /id/1?name=bun
  main             median    1.62 µs  rounds: [1.63 µs, 1.62 µs, 1.60 µs, 1.60 µs, 1.63 µs]
  dev              median    1.59 µs  rounds: [1.59 µs, 1.59 µs, 1.59 µs, 1.63 µs, 1.59 µs]
  summary: dev is 1.02x faster than main (median of round avgs)

• body POST /json
  main             median    5.75 µs  rounds: [5.77 µs, 5.75 µs, 5.78 µs, 5.72 µs, 5.55 µs]
  dev              median    5.54 µs  rounds: [5.49 µs, 5.54 µs, 5.48 µs, 5.56 µs, 5.54 µs]
  summary: dev is 1.04x faster than main (median of round avgs)
```

---

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
