### PR TITLE
docs: fix broken clone URL and obsolete cookie examples for newcomers

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,5 +56,5 @@ If you want to do it, create an issue about your middleware.
 ## Local Development
 
 ```bash
-git clone git@github.com:honojs/hono.git && cd hono && bun install --frozen-lockfile
+git clone https://github.com/honojs/hono.git && cd hono && bun install --frozen-lockfile
 ```

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -239,19 +239,21 @@ import { cookie } from 'hono/cookie' // <--- Obsolete!
 ```
 
 You do not have to use Cookie middleware to parse or set cookies.
-They become default functions:
+Use the cookie helpers imported from `hono/cookie`:
 
 ```ts
+import { getCookie, setCookie } from 'hono/cookie'
+
 // Parse cookie
 app.get('/entry/:id', (c) => {
-  const value = c.req.cookie('name')
+  const value = getCookie(c, 'name')
   ...
 })
 ```
 
 ```ts
 app.get('/', (c) => {
-  c.cookie('delicious_cookie', 'choco')
+  setCookie(c, 'delicious_cookie', 'choco')
   return c.text('Do you like cookie?')
 })
 ```


### PR DESCRIPTION
## Description
Two good-first-PR documentation fixes identified while scouting the repo as a new external contributor:

- **`docs/CONTRIBUTING.md`**: switched the `git clone` instruction from the SSH URL (`git@github.com:honojs/hono.git`) to the HTTPS URL (`https://github.com/honojs/hono.git`), so newcomers without SSH keys configured can clone the repo.
- **`docs/MIGRATION.md`**: replaced the obsolete `c.cookie()` / `c.req.cookie()` examples (these methods do not exist in the current API) with the real `getCookie` / `setCookie` helpers imported from `hono/cookie`.

Both changes are documentation-only and were validated by adversarial review (API signatures, import path, and diff scope all verified).

## Type of change
- [x] Documentation update

## Checklist
- [x] I've read the contributing guide
- [x] I've added/updated docs (where needed)