### PR TITLE
fix: close quote in combine JSDoc example

### DIFF
--- a/src/middleware/combine/index.ts
+++ b/src/middleware/combine/index.ts
@@ -128,7 +128,7 @@ export const every = (...middleware: (MiddlewareHandler | Condition)[]): Middlew
  * @example
  * ```ts
  * import { except } from 'hono/combine'
- * import { bearerAuth } from 'hono/bearer-auth
+ * import { bearerAuth } from 'hono/bearer-auth'
  *
  * // If client is accessing public API, then skip authentication.
  * // Otherwise, require a valid token.


### PR DESCRIPTION
Fixes a missing closing quote in the combine middleware JSDoc example.