### PR TITLE
refactor(aws-lambada): remove FIXME in `@ts-expect-error`

### DIFF
--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -248,7 +248,7 @@ export const handle = <E extends Env = Env, S extends Schema = {}, BasePath exte
       ? WithMultiValueHeaders
       : WithHeaders)
 >) => {
-  // @ts-expect-error FIXME: Fix return typing
+  // @ts-expect-error conditional return type is not inferable
   return async (event, lambdaContext?) => {
     const processor = getProcessor(event)
 


### PR DESCRIPTION
`@ts-expect-error` is not bad. We don't have to "fix it"; if so, the type definition, which does not affect users, will be fat.

Closes https://github.com/honojs/hono/issues/5123

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
