### PR TITLE
fix(utils/body): reuse cached formData in `parseBody()`

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -381,6 +381,22 @@ describe('Body methods with caching', () => {
       expect(async () => await req.blob()).not.toThrow()
     })
 
+    it('should parse form data even if formData() is called before parseBody()', async () => {
+      const data = new FormData()
+      data.append('foo', 'bar')
+      data.append('file', new File(['hello'], 't.txt', { type: 'text/plain' }))
+      const req = new HonoRequest(
+        new Request('http://localhost', {
+          method: 'POST',
+          body: data,
+        })
+      )
+      await req.formData()
+      const body = await req.parseBody()
+      expect(body['foo']).toBe('bar')
+      expect(body['file']).toBeInstanceOf(File)
+    })
+
     describe('should not break body methods after parseBody() with non-form content-type', () => {
       const createReq = () =>
         new HonoRequest(

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -124,6 +124,12 @@ async function parseFormData<T extends BodyData>(
   request: HonoRequest | Request,
   options: ParseBodyOptions
 ): Promise<T> {
+  if (!isRawRequest(request) && request.bodyCache.formData) {
+    return convertFormDataToBodyData<T>(
+      await (request.bodyCache.formData as FormData | Promise<FormData>),
+      options
+    )
+  }
   const headers = isRawRequest(request) ? request.headers : request.raw.headers
   const arrayBuffer = await (request as Request).arrayBuffer()
   const formDataPromise = bufferToFormData(arrayBuffer, headers.get('Content-Type') || '')


### PR DESCRIPTION
Fixes #5129 

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
