### PR TITLE
feat(middleware): add method-not-allowed middleware

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -45,6 +45,7 @@
     "./timeout": "./src/middleware/timeout/index.ts",
     "./timing": "./src/middleware/timing/timing.ts",
     "./logger": "./src/middleware/logger/index.ts",
+    "./method-not-allowed": "./src/middleware/method-not-allowed/index.ts",
     "./method-override": "./src/middleware/method-override/index.ts",
     "./powered-by": "./src/middleware/powered-by/index.ts",
     "./pretty-json": "./src/middleware/pretty-json/index.ts",

--- a/package.json
+++ b/package.json
@@ -231,6 +231,11 @@
       "import": "./dist/middleware/logger/index.js",
       "require": "./dist/cjs/middleware/logger/index.js"
     },
+    "./method-not-allowed": {
+      "types": "./dist/types/middleware/method-not-allowed/index.d.ts",
+      "import": "./dist/middleware/method-not-allowed/index.js",
+      "require": "./dist/cjs/middleware/method-not-allowed/index.js"
+    },
     "./method-override": {
       "types": "./dist/types/middleware/method-override/index.d.ts",
       "import": "./dist/middleware/method-override/index.js",
@@ -527,6 +532,9 @@
       ],
       "logger": [
         "./dist/types/middleware/logger"
+      ],
+      "method-not-allowed": [
+        "./dist/types/middleware/method-not-allowed"
       ],
       "method-override": [
         "./dist/types/middleware/method-override"

--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -1,0 +1,292 @@
+import { Hono } from '../../hono'
+import { methodNotAllowed } from '.'
+
+describe('Method Not Allowed Middleware', () => {
+  it('infers the environment from the app', () => {
+    const app = new Hono<{ Variables: { requestId: string } }>()
+    const middleware = methodNotAllowed({
+      app,
+      onMethodNotAllowed: (c) => c.text(c.var.requestId, 405),
+    })
+
+    expect(middleware).toBeTypeOf('function')
+  })
+
+  it('returns 405 with every allowed method for an existing path', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.post('/resource', (c) => c.text('POST'))
+    app.delete('/resource', (c) => c.text('DELETE'))
+
+    const res = await app.request('/resource', { method: 'PUT' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD, POST, DELETE')
+    expect(await res.text()).toBe('Method Not Allowed')
+
+    const resUsingCachedRouter = await app.request('/resource', { method: 'OPTIONS' })
+    expect(resUsingCachedRouter.status).toBe(405)
+    expect(resUsingCachedRouter.headers.get('Allow')).toBe('GET, HEAD, POST, DELETE')
+  })
+
+  it('does not affect an allowed method', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/resource')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.has('Allow')).toBe(false)
+    expect(await res.text()).toBe('GET')
+  })
+
+  it('returns 404 when the path does not exist', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/missing', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+  })
+
+  it('matches parameterized and overlapping routes without duplicate methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/users/:id', (_c, next) => next())
+    app.get('/users/me', (c) => c.text('me'))
+    app.patch('/users/:id', (c) => c.text(c.req.param('id')))
+
+    const res = await app.request('/users/me', { method: 'POST' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD, PATCH')
+  })
+
+  it('preserves an intentional 404 from a handler registered for the request method', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/users/:id', (c) => c.notFound())
+    app.post('/users/:id', (c) => c.text('Created'))
+
+    const res = await app.request('/users/123')
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+  })
+
+  it('preserves an intentional 404 for HEAD when a GET route is registered', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/users/:id', (c) => c.notFound())
+    app.post('/users/:id', (c) => c.text('Created'))
+
+    const res = await app.request('/users/123', { method: 'HEAD' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+  })
+
+  it('preserves a 404 returned by the error handler', async () => {
+    const app = new Hono()
+    app.onError((_error, c) => c.text('Handled error', 404))
+    app.use(methodNotAllowed({ app }))
+    app.use('/resource', () => {
+      throw new Error('boom')
+    })
+    app.get('/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/resource', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+    expect(await res.text()).toBe('Handled error')
+  })
+
+  it('returns 405 for HEAD when the path does not support GET', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.post('/resource', (c) => c.text('POST'))
+
+    const res = await app.request('/resource', { method: 'HEAD' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST')
+    expect(await res.text()).toBe('')
+  })
+
+  it('does not advertise explicit HEAD routes that Hono cannot dispatch', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.on('HEAD', '/resource', (c) => c.text('HEAD'))
+
+    const headRes = await app.request('/resource', { method: 'HEAD' })
+    expect(headRes.status).toBe(404)
+    expect(headRes.headers.has('Allow')).toBe(false)
+
+    const putRes = await app.request('/resource', { method: 'PUT' })
+    expect(putRes.status).toBe(404)
+    expect(putRes.headers.has('Allow')).toBe(false)
+  })
+
+  it('supports custom methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.on('PURGE', '/cache', (c) => c.text('Purged'))
+
+    const res = await app.request('/cache', { method: 'POST' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('PURGE')
+  })
+
+  it('compares request methods case-sensitively', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.patch('/item', (c) => c.text('PATCH'))
+
+    const request = new Request('http://localhost/item', { method: 'PATCH' })
+    Object.defineProperty(request, 'method', { value: 'patch' })
+    const res = await app.request(request)
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('PATCH')
+  })
+
+  it('works with routes mounted using app.route()', async () => {
+    const api = new Hono()
+    api.get('/resource', (c) => c.text('GET'))
+    api.post('/resource', (c) => c.text('POST'))
+
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.route('/api', api)
+
+    const res = await app.request('/api/resource', { method: 'DELETE' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD, POST')
+  })
+
+  it('works when installed in an app mounted using app.route()', async () => {
+    const api = new Hono().basePath('/v1')
+    api.use(methodNotAllowed({ app: api }))
+    api.get('/resource', (c) => c.text('GET'))
+    api.post('/resource', (c) => c.text('POST'))
+
+    const app = new Hono()
+    app.route('/api', api)
+
+    const res = await app.request('/api/v1/resource', { method: 'DELETE' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD, POST')
+  })
+
+  it('ignores ALL routes when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.all('/resource', (_c, next) => next())
+
+    const res = await app.request('/resource', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+  })
+
+  it('does not invoke the error handler for a 405 response', async () => {
+    const app = new Hono()
+    const onError = vi.fn(() => new Response('error', { status: 500 }))
+    app.onError(onError)
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/resource', { method: 'POST' })
+
+    expect(res.status).toBe(405)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('preserves downstream headers and lets outer middleware observe the final status', async () => {
+    const app = new Hono()
+    let observedStatus: number | undefined
+
+    app.use(async (c, next) => {
+      await next()
+      observedStatus = c.res.status
+    })
+    app.use(methodNotAllowed({ app }))
+    app.use(async (c, next) => {
+      await next()
+      c.header('X-Downstream', 'true')
+    })
+    app.get('/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/resource', { method: 'POST' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('X-Downstream')).toBe('true')
+    expect(observedStatus).toBe(405)
+  })
+
+  it('replaces stale representation headers from the not-found response', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.post('/resource', (c) => c.text('POST'))
+    app.notFound((c) =>
+      c.text('Missing', 404, {
+        Allow: 'BOGUS',
+        'Content-Length': '7',
+      })
+    )
+
+    const res = await app.request('/resource', { method: 'PUT' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD, POST')
+    expect(res.headers.has('Content-Length')).toBe(false)
+    expect(await res.text()).toBe('Method Not Allowed')
+  })
+
+  it('supports a custom method-not-allowed response', async () => {
+    const app = new Hono()
+    app.use(
+      methodNotAllowed({
+        app,
+        onMethodNotAllowed: (c, allowedMethods) =>
+          c.json({ error: 'Method Not Allowed', allowedMethods }, 405, {
+            Allow: allowedMethods.join(', '),
+          }),
+      })
+    )
+    app.get('/resource', (c) => c.text('GET'))
+    app.post('/resource', (c) => c.text('POST'))
+
+    const res = await app.request('/resource', { method: 'PUT' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD, POST')
+    expect(res.headers.get('Content-Type')).toMatch(/^application\/json/)
+    expect(await res.json()).toEqual({
+      error: 'Method Not Allowed',
+      allowedMethods: ['GET', 'HEAD', 'POST'],
+    })
+  })
+
+  it('leaves a non-404 custom not-found response unchanged', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.notFound((c) => c.text('Missing', 410))
+
+    const res = await app.request('/resource', { method: 'POST' })
+
+    expect(res.status).toBe(410)
+    expect(res.headers.has('Allow')).toBe(false)
+    expect(await res.text()).toBe('Missing')
+  })
+})

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -1,0 +1,141 @@
+/**
+ * @module
+ * Method Not Allowed Middleware for Hono.
+ */
+
+import type { Context } from '../../context'
+import { basePath, matchedRoutes } from '../../helper/route'
+import type { Hono } from '../../hono'
+import { METHOD_NAME_ALL } from '../../router'
+import { TrieRouter } from '../../router/trie-router'
+import type { Env, MiddlewareHandler } from '../../types'
+
+type MethodNotAllowedHandler<E extends Env> = (
+  c: Context<E>,
+  allowedMethods: string[]
+) => Response | Promise<Response>
+
+type MethodNotAllowedOptions<E extends Env> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: Hono<E, any, any>
+  onMethodNotAllowed?: MethodNotAllowedHandler<E>
+}
+
+/**
+ * Method Not Allowed Middleware for Hono.
+ *
+ * Returns a `405 Method Not Allowed` response with an `Allow` header when the request path
+ * matches a registered route but the request method is not supported.
+ *
+ * @param {MethodNotAllowedOptions} options - The options for the middleware.
+ * @param {Hono} options.app - The Hono instance used by the application.
+ * @param {MethodNotAllowedHandler} [options.onMethodNotAllowed] - Generates the response, including its `Allow` header.
+ * @returns {MiddlewareHandler} The middleware handler function.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono()
+ *
+ * app.use(methodNotAllowed({ app }))
+ *
+ * app.get('/hello', (c) => c.text('Hello!'))
+ * app.post('/hello', (c) => c.text('Posted!'))
+ *
+ * // PUT /hello -> 405 Method Not Allowed
+ * // Allow: GET, HEAD, POST
+ * ```
+ *
+ * @example
+ * ```ts
+ * app.use(
+ *   methodNotAllowed({
+ *     app,
+ *     onMethodNotAllowed: (c, methods) =>
+ *       c.json({ error: 'Method Not Allowed' }, 405, { Allow: methods.join(', ') }),
+ *   })
+ * )
+ * ```
+ */
+export const methodNotAllowed = <E extends Env = Env>(
+  options: MethodNotAllowedOptions<E>
+): MiddlewareHandler<E> => {
+  let methodRouter: TrieRouter<string[]> | undefined
+
+  return async function methodNotAllowed(c, next) {
+    const routeIndex = c.req.routeIndex
+    await next()
+
+    if (c.res.status !== 404) {
+      return
+    }
+
+    if (c.error) {
+      return
+    }
+
+    if (!methodRouter) {
+      const methodsByPath = new Map<string, Set<string>>()
+
+      for (const route of options.app.routes) {
+        // Hono does not distinguish middleware registered with `app.use()` from handlers
+        // registered with `app.all()`, so `ALL` routes cannot contribute to the Allow header.
+        if (route.method === METHOD_NAME_ALL || route.method === 'HEAD') {
+          continue
+        }
+
+        const methods = methodsByPath.get(route.path) ?? new Set<string>()
+        methods.add(route.method)
+
+        // Hono dispatches HEAD requests to GET routes.
+        if (route.method === 'GET') {
+          methods.add('HEAD')
+        }
+
+        methodsByPath.set(route.path, methods)
+      }
+
+      methodRouter = new TrieRouter()
+      for (const [path, methods] of methodsByPath) {
+        methodRouter.add(METHOD_NAME_ALL, path, [...methods])
+      }
+    }
+
+    let requestPath = c.req.path
+    const routes = matchedRoutes(c)
+    const currentRoute = routes[routeIndex]
+    const sourceRoute = options.app.routes.find((route) => route.handler === methodNotAllowed)
+    if (currentRoute && sourceRoute) {
+      const currentBasePathParts = basePath(c, routeIndex).split('/').filter(Boolean)
+      const sourceBasePathLength = sourceRoute.basePath.split('/').filter(Boolean).length
+      const mountBasePathParts = currentBasePathParts.slice(
+        0,
+        currentBasePathParts.length - sourceBasePathLength
+      )
+      if (mountBasePathParts.length > 0) {
+        const mountBasePath = `/${mountBasePathParts.join('/')}`
+        requestPath = c.req.path.slice(mountBasePath.length) || '/'
+      }
+    }
+
+    const allowedMethods = new Set<string>()
+    for (const [methods] of methodRouter.match(METHOD_NAME_ALL, requestPath)[0]) {
+      for (const method of methods) {
+        allowedMethods.add(method)
+      }
+    }
+
+    if (allowedMethods.size === 0 || allowedMethods.has(c.req.method)) {
+      return
+    }
+
+    // Prevent stale headers from being carried over from the 404 response.
+    c.res.headers.delete('Allow')
+    c.res.headers.delete('Content-Length')
+
+    const methods = [...allowedMethods]
+    const allow = methods.join(', ')
+    c.res = options.onMethodNotAllowed
+      ? await options.onMethodNotAllowed(c, methods)
+      : c.text('Method Not Allowed', 405, { Allow: allow })
+  }
+}


### PR DESCRIPTION
#4633

Introduce an opt-in `methodNotAllowed` middleware. It returns `405 Method Not Allowed` with an `Allow` header when the path exists for another method.

Compared with the implementation discussed in the issue, this version:

- accepts `{ app, onMethodNotAllowed? }` to support custom responses
- assigns the response to `c.res` instead of throwing an `HTTPException`, allowing outer middleware to observe the final status without invoking `onError`
- follows Hono's routing behavior for HEAD/GET, custom methods, and case-sensitive method matching
- supports middleware installed in sub-apps composed with `app.route()`
- preserves error-handler 404 responses and removes stale representation headers when replacing a 404

### Why assign the response to `c.res` instead of throwing an `HTTPException`?

This follows the existing response-transforming middleware pattern used by `trailingSlash`, `etag`, and `prettyJSON`, which replace `c.res` after `await next()`.

A `405 Method Not Allowed` response here is a normal routing outcome derived from a downstream `404 Not Found`, rather than an exceptional failure. Assigning it to `c.res` preserves normal middleware unwinding, lets outer middleware observe the final `405` status, and avoids invoking the application's `onError` handler.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
