### PR TITLE
perf: Low-hanging optimizations

### DIFF
--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -37,6 +37,11 @@ const makeApp = async (src: string): Promise<any> => {
       c.header('x-powered-by', 'benchmark')
       return c.text(`${id} ${name}`)
     })
+    .get('/user', (c: any) => c.json({ id: 123, name: 'Alice', roles: ['admin', 'editor'] }))
+    .use('/mw/*', async (_c: any, next: any) => {
+      await next()
+    })
+    .get('/mw/hello', (c: any) => c.text('mw'))
   return app
 }
 
@@ -44,6 +49,8 @@ const app = await makeApp(src)
 
 const ping = new Request('http://localhost/')
 const query = new Request('http://localhost/id/1?name=bun')
+const user = new Request('http://localhost/user')
+const mw = new Request('http://localhost/mw/hello')
 
 let sink: unknown
 
@@ -51,6 +58,8 @@ let sink: unknown
 const cases: [string, (app: any) => Promise<unknown>][] = [
   ['ping GET /', (app) => app.fetch(ping)],
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],
+  ['json GET /user', (app) => app.fetch(user)],
+  ['middleware GET /mw/hello', (app) => app.fetch(mw)],
   [
     'body POST /json',
     (app) =>

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -15,9 +15,9 @@
 // Runs on both Bun and Node.
 import './ts-resolve.mjs'
 import { run, bench } from 'mitata'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const src = process.env.HONO_SRC ?? new URL('../../src', import.meta.url).pathname
+const src = process.env.HONO_SRC ?? fileURLToPath(new URL('../../src', import.meta.url))
 const label = process.env.HONO_LABEL ?? 'hono'
 const asJson = process.env.HONO_JSON === '1'
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -312,7 +312,7 @@ export class Context<
    * })
    * ```
    */
-  env: E['Bindings'] = {}
+  env: E['Bindings']
   #var: Map<unknown, unknown> | undefined
   finalized: boolean = false
   /**
@@ -357,6 +357,8 @@ export class Context<
       this.#notFoundHandler = options.notFoundHandler
       this.#path = options.path
       this.#matchResult = options.matchResult
+    } else {
+      this.env = {}
     }
   }
 
@@ -622,7 +624,8 @@ export class Context<
     }
 
     if (headers) {
-      for (const [k, v] of Object.entries(headers)) {
+      for (const k of Object.keys(headers)) {
+        const v = (headers as Record<string, string | string[]>)[k]
         if (typeof v === 'string') {
           responseHeaders.set(k, v)
         } else {
@@ -713,10 +716,11 @@ export class Context<
     arg?: U | ResponseOrInit<U>,
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
-    return this.#newResponse(
-      JSON.stringify(object),
-      arg,
-      setDefaultContentType('application/json', headers)
+    const body = JSON.stringify(object)
+    return (
+      !this.#preparedHeaders && !this.#status && !arg && !headers && !this.finalized
+        ? new Response(body, { headers: { 'content-type': 'application/json' } })
+        : this.#newResponse(body, arg, setDefaultContentType('application/json', headers))
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any
   }
 
@@ -726,7 +730,9 @@ export class Context<
     headers?: HeaderRecord
   ): Response | Promise<Response> => {
     const res = (html: string) =>
-      this.#newResponse(html, arg, setDefaultContentType('text/html; charset=UTF-8', headers))
+      !this.#preparedHeaders && !this.#status && !arg && !headers && !this.finalized
+        ? new Response(html, { headers: { 'content-type': 'text/html; charset=UTF-8' } })
+        : this.#newResponse(html, arg, setDefaultContentType('text/html; charset=UTF-8', headers))
     return typeof html === 'object'
       ? resolveCallback(html, HtmlEscapedCallbackPhase.Stringify, false, {}).then(res)
       : res(html)

--- a/src/request.ts
+++ b/src/request.ts
@@ -50,7 +50,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   raw: Request
 
-  #validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
+  #validatedData: { [K in keyof ValidationTargets]?: {} } | undefined // Short name of validatedData
   #matchResult: Result<[unknown, RouterRoute]>
   routeIndex: number = 0
   /**
@@ -76,7 +76,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     this.raw = request
     this.path = path
     this.#matchResult = matchResult
-    this.#validatedData = {}
   }
 
   /**
@@ -106,7 +105,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   #getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
     const param = this.#getParamValue(paramKey)
-    return param && /\%/.test(param) ? tryDecodeURIComponent(param) : param
+    return param && param.indexOf('%') !== -1 ? tryDecodeURIComponent(param) : param
   }
 
   #getAllDecodedParams(): Record<string, string> {
@@ -116,7 +115,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     for (const key of keys) {
       const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value !== undefined) {
-        decoded[key] = /\%/.test(value) ? tryDecodeURIComponent(value) : value
+        decoded[key] = value.indexOf('%') !== -1 ? tryDecodeURIComponent(value) : value
       }
     }
 
@@ -225,8 +224,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
       return cachedBody
     }
 
-    const anyCachedKey = Object.keys(bodyCache)[0]
-    if (anyCachedKey) {
+    for (const anyCachedKey in bodyCache) {
       return (bodyCache[anyCachedKey as keyof Body] as Promise<BodyInit>).then((body) => {
         if (anyCachedKey === 'json') {
           body = JSON.stringify(body)
@@ -337,7 +335,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @param data - The validated data to add.
    */
   addValidatedData(target: keyof ValidationTargets, data: {}) {
-    this.#validatedData[target] = data
+    ;(this.#validatedData ??= {})[target] = data
   }
 
   /**
@@ -350,7 +348,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   valid<T extends keyof I & keyof ValidationTargets>(target: T): InputToDataByTarget<I, T>
   valid(target: keyof ValidationTargets) {
-    return this.#validatedData[target] as unknown
+    return this.#validatedData?.[target] as unknown
   }
 
   /**


### PR DESCRIPTION
This PR removes several per-request allocations from Hono's core request/response cycle, reducing `app.fetch()` overhead by **7-11%** across text, JSON, and param/query workloads. It also fixes a Windows path bug that made the
`benchmarks/fetch` harness unrunnable on Windows, and extends it with two new cases that isolate the paths touched here.

No public API or observable behavior changes. All unit tests, the Node runtime tests, and `tsc` pass unchanged.

## Benchmark results

Measured with the existing `benchmarks/fetch` harness (`compare.sh`), which runs each variant in a fresh process and reverses variant order every round to cancel JIT/GC warm-up bias. Values are medians of per-round averages over 7 rounds.

Environment: Node.js 24.15.0 (x64-win32), i7-13700HX. `RUNTIME=node ROUNDS=7 ./compare.sh`

| Case | `main` | this PR | Change |
| --- | ---: | ---: | --- |
| `ping GET /` (plain text) | 8.90 µs | 8.04 µs | **1.11x faster** |
| `query GET /id/1?name=bun` (param + query + header) | 12.68 µs | 11.82 µs | **1.07x faster** |
| `json GET /user` (`c.json()` response) | 10.42 µs | 9.51 µs | **1.10x faster** |
| `body POST /json` (`req.json()` + `c.json()`) | 33.43 µs | 30.74 µs | **1.09x faster** |
| `middleware GET /mw/hello` (compose path) | 8.69 µs | 8.80 µs | neutral (within noise) |

## Changes and rationale

### 1. Fast path for `c.json()` and `c.html()` (`src/context.ts`)

`c.text()` already short-circuits to a bare `new Response(text)` when no headers, status, or init have been set. `c.json()` and `c.html()` had no such path: every call allocated a header-record object (`setDefaultContentType`), a `Headers` instance, an `Object.entries` array of `[key, value]` pairs, mutated the `Headers`, and then constructed the `Response` from it, even for the overwhelmingly common `return c.json(obj)` case with no customization.

They now use the same guard as `c.text()`:

```ts
!this.#preparedHeaders && !this.#status && !arg && !headers && !this.finalized
  ? new Response(body, { headers: { 'content-type': 'application/json' } })
  : /* existing slow path, unchanged */
```

Passing a plain-object headers init lets the runtime fill its internal header list directly, instead of Hono building and mutating an intermediate `Headers` wrapper first.

Safety: the guard is copied verbatim from the battle-tested `c.text()` fast path. `#res` can only be set after `#preparedHeaders` or `finalized` is set (via the `res` getter/setter or `c.header()`), so no code path can reach the fast path with pending response state. Header-name casing is irrelevant - `Headers` normalizes to lowercase in both paths.

### 2. Remove the throwaway `env = {}` field initializer (`src/context.ts`)

`Context` declared `env: E['Bindings'] = {}` as a field initializer, so **every request allocated an object that `#dispatch` immediately overwrote** with the real `env`. The initializer only ever mattered for `new Context(req)` without options; that case now gets its `{}` in the constructor's `else` branch instead. Semantics are identical, including `env` being `undefined` when `options.env` is `undefined` (as before).

This change benefits every request regardless of route or response type, which is why even the plain-text `ping` case improved by ~11%.

### 3. Lazy `#validatedData` (`src/request.ts`)

`HonoRequest` allocated `#validatedData = {}` in its constructor, paying for the validator feature on every request whether or not validators are used. It is now allocated on first `addValidatedData()` call; `valid()` reads through optional chaining and still returns `undefined` for unvalidated targets, exactly as before.

### 4. Allocation-free cache probe in `#cachedBody` (`src/request.ts`)

`Object.keys(bodyCache)[0]` allocated a fresh array on every body read (`req.json()`, `req.text()`, …) just to find the first cached key. Replaced with a `for ... in` loop which has same insertion-order semantics, but no allocation.
`bodyCache` is a plain object literal, so there are no enumerable prototype keys to worry about.

### 5. `indexOf` instead of regex in param decoding (`src/request.ts`)

`c.req.param()` used `/\%/.test(param)` to decide whether a value needs percent-decoding. `param.indexOf('%') !== -1` performs the same check without regex-engine overhead on typically short strings.

### 6. `Object.keys` instead of `Object.entries` in `#newResponse` (`src/context.ts`)

The slow-path header merge iterated `Object.entries(headers)`, allocating one pair-array per header. `Object.keys` allocates a single array and reads values by key, with the same own-enumerable iteration semantics.

## Benchmark harness changes (`benchmarks/fetch/bench.mts`)

- **Windows fix:** the default src path was computed with `URL.pathname` (`/C:/sources/hono/src`) and then passed through `pathToFileURL`, producing the broken `C:\C:\sources\hono\src`. Now uses `fileURLToPath`, which is correct on all platforms.
- **New case `json GET /user`:** isolates the `c.json()` response path.
  Previously JSON serialization was only measured inside `body POST /json`, mixed with request-body parsing.
- **New case `middleware GET /mw/hello`:** covers the multi-handler `compose` dispatch path, which none of the existing cases exercised.


### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
