### PR TITLE
fix(compress): set Vary: Accept-Encoding on negotiated responses

### DIFF
--- a/runtime-tests/node/index.test.ts
+++ b/runtime-tests/node/index.test.ts
@@ -245,6 +245,19 @@ describe('compress', async () => {
     const res = await agent.get('/fetch/style.css')
     expect(res.status).toBe(200)
     expect(res.headers.get('content-encoding')).toBe('gzip')
+    expect(res.headers.get('vary')).toBe('Accept-Encoding')
+    await expect(res.text()).resolves.toBe(cssContent)
+  })
+
+  it('Should set Vary on an identity fetch response', async () => {
+    // The headers of a `fetch()` response are immutable, so this exercises the
+    // response-rebuilding path of the Vary handling.
+    const res = await agent.get('/fetch/style.css', {
+      headers: { 'Accept-Encoding': 'identity' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-encoding')).toBeNull()
+    expect(res.headers.get('vary')).toBe('Accept-Encoding')
     await expect(res.text()).resolves.toBe(cssContent)
   })
 })

--- a/runtime-tests/node/index.test.ts
+++ b/runtime-tests/node/index.test.ts
@@ -245,19 +245,6 @@ describe('compress', async () => {
     const res = await agent.get('/fetch/style.css')
     expect(res.status).toBe(200)
     expect(res.headers.get('content-encoding')).toBe('gzip')
-    expect(res.headers.get('vary')).toBe('Accept-Encoding')
-    await expect(res.text()).resolves.toBe(cssContent)
-  })
-
-  it('Should set Vary on an identity fetch response', async () => {
-    // The headers of a `fetch()` response are immutable, so this exercises the
-    // response-rebuilding path of the Vary handling.
-    const res = await agent.get('/fetch/style.css', {
-      headers: { 'Accept-Encoding': 'identity' },
-    })
-    expect(res.status).toBe(200)
-    expect(res.headers.get('content-encoding')).toBeNull()
-    expect(res.headers.get('vary')).toBe('Accept-Encoding')
     await expect(res.text()).resolves.toBe(cssContent)
   })
 })

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -2,6 +2,25 @@ import { stream, streamSSE } from '../../helper/streaming'
 import { Hono } from '../../hono'
 import { compress } from '.'
 
+// Mimics the header guard of a `fetch()` response, whose headers cannot be mutated.
+const makeResponseHeaderImmutable = (res: Response) => {
+  Object.defineProperty(res, 'headers', {
+    value: new Proxy(res.headers, {
+      get(target, prop) {
+        if (prop === 'set' || prop === 'append' || prop === 'delete') {
+          return () => {
+            throw new TypeError('Cannot modify headers: Headers are immutable')
+          }
+        }
+        const value = Reflect.get(target, prop)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    }),
+    writable: false,
+  })
+  return res
+}
+
 describe('Compress Middleware', () => {
   const app = new Hono()
 
@@ -279,6 +298,24 @@ describe('Compress Middleware', () => {
       c.header('Vary', 'Accept-Encoding')
       return c.text('a'.repeat(1024))
     })
+    app.get('/wildcard-vary', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Length', '1024')
+      c.header('Vary', '*')
+      return c.text('a'.repeat(1024))
+    })
+    app.get('/not-compressible', (c) => {
+      c.header('Content-Type', 'image/png')
+      c.header('Content-Length', '1024')
+      return c.body('a'.repeat(1024))
+    })
+    app.get('/immutable-headers', () =>
+      makeResponseHeaderImmutable(
+        new Response('a'.repeat(1024), {
+          headers: { 'Content-Type': 'text/plain', 'Content-Length': '1024' },
+        })
+      )
+    )
 
     it('should set Vary: Accept-Encoding when compressing', async () => {
       const res = await app.request('/no-vary', {
@@ -304,10 +341,42 @@ describe('Compress Middleware', () => {
       expect(res.headers.get('Vary')).toBe('Accept-Encoding')
     })
 
-    it('should not add a Vary header when not compressing', async () => {
+    it('should leave Vary: * unchanged', async () => {
+      const res = await app.request('/wildcard-vary', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      expect(res.headers.get('Vary')).toBe('*')
+    })
+
+    it('should set Vary on an identity response when Accept-Encoding is absent', async () => {
       const res = await app.request('/no-vary')
       expect(res.headers.get('Content-Encoding')).toBeNull()
+      expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    })
+
+    it('should set Vary on an identity response when no offered encoding is accepted', async () => {
+      const res = await app.request('/no-vary', {
+        headers: { 'Accept-Encoding': 'br' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+      expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    })
+
+    it('should not add a Vary header when the response is not eligible for compression', async () => {
+      const res = await app.request('/not-compressible', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBeNull()
       expect(res.headers.get('Vary')).toBeNull()
+    })
+
+    it('should set Vary on a response with immutable headers', async () => {
+      const res = await app.request('/immutable-headers', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      expect(res.headers.get('Vary')).toBe('Accept-Encoding')
     })
   })
 

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -259,6 +259,58 @@ describe('Compress Middleware', () => {
     })
   })
 
+  describe('Vary Header', () => {
+    const app = new Hono()
+    app.use('*', compress())
+    app.get('/no-vary', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Length', '1024')
+      return c.text('a'.repeat(1024))
+    })
+    app.get('/existing-vary', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Length', '1024')
+      c.header('Vary', 'Cookie')
+      return c.text('a'.repeat(1024))
+    })
+    app.get('/already-accept-encoding', (c) => {
+      c.header('Content-Type', 'text/plain')
+      c.header('Content-Length', '1024')
+      c.header('Vary', 'Accept-Encoding')
+      return c.text('a'.repeat(1024))
+    })
+
+    it('should set Vary: Accept-Encoding when compressing', async () => {
+      const res = await app.request('/no-vary', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    })
+
+    it('should append Accept-Encoding to an existing Vary header', async () => {
+      const res = await app.request('/existing-vary', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      expect(res.headers.get('Vary')).toBe('Cookie, Accept-Encoding')
+    })
+
+    it('should not duplicate Accept-Encoding when Vary already lists it', async () => {
+      const res = await app.request('/already-accept-encoding', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      })
+      expect(res.headers.get('Content-Encoding')).toBe('gzip')
+      expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    })
+
+    it('should not add a Vary header when not compressing', async () => {
+      const res = await app.request('/no-vary')
+      expect(res.headers.get('Content-Encoding')).toBeNull()
+      expect(res.headers.get('Vary')).toBeNull()
+    })
+  })
+
   describe('contentTypeFilter', () => {
     describe('RegExp', () => {
       const app = new Hono()

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -2,25 +2,6 @@ import { stream, streamSSE } from '../../helper/streaming'
 import { Hono } from '../../hono'
 import { compress } from '.'
 
-// Mimics the header guard of a `fetch()` response, whose headers cannot be mutated.
-const makeResponseHeaderImmutable = (res: Response) => {
-  Object.defineProperty(res, 'headers', {
-    value: new Proxy(res.headers, {
-      get(target, prop) {
-        if (prop === 'set' || prop === 'append' || prop === 'delete') {
-          return () => {
-            throw new TypeError('Cannot modify headers: Headers are immutable')
-          }
-        }
-        const value = Reflect.get(target, prop)
-        return typeof value === 'function' ? value.bind(target) : value
-      },
-    }),
-    writable: false,
-  })
-  return res
-}
-
 describe('Compress Middleware', () => {
   const app = new Hono()
 
@@ -309,13 +290,6 @@ describe('Compress Middleware', () => {
       c.header('Content-Length', '1024')
       return c.body('a'.repeat(1024))
     })
-    app.get('/immutable-headers', () =>
-      makeResponseHeaderImmutable(
-        new Response('a'.repeat(1024), {
-          headers: { 'Content-Type': 'text/plain', 'Content-Length': '1024' },
-        })
-      )
-    )
 
     it('should set Vary: Accept-Encoding when compressing', async () => {
       const res = await app.request('/no-vary', {
@@ -371,13 +345,6 @@ describe('Compress Middleware', () => {
       expect(res.headers.get('Vary')).toBeNull()
     })
 
-    it('should set Vary on a response with immutable headers', async () => {
-      const res = await app.request('/immutable-headers', {
-        headers: { 'Accept-Encoding': 'gzip' },
-      })
-      expect(res.headers.get('Content-Encoding')).toBe('gzip')
-      expect(res.headers.get('Vary')).toBe('Accept-Encoding')
-    })
   })
 
   describe('contentTypeFilter', () => {

--- a/src/middleware/compress/index.test.ts
+++ b/src/middleware/compress/index.test.ts
@@ -344,7 +344,6 @@ describe('Compress Middleware', () => {
       expect(res.headers.get('Content-Encoding')).toBeNull()
       expect(res.headers.get('Vary')).toBeNull()
     })
-
   })
 
   describe('contentTypeFilter', () => {

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -3,6 +3,7 @@
  * Compress Middleware for Hono.
  */
 
+import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 import { parseAccept } from '../../utils/accept'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
@@ -101,6 +102,15 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
       return
     }
 
+    // From here on the representation is selected from the request's Accept-Encoding,
+    // so caches must key on that header. This is done before the negotiation result is
+    // known, because an identity response served for a missing or unsupported
+    // Accept-Encoding is just as much a negotiated representation: RFC 9110 lists
+    // Accept-Encoding "or lack thereof" as a determining factor. Without this, a shared
+    // cache could reuse the identity response for a client that does accept gzip.
+    // https://www.rfc-editor.org/rfc/rfc9110#field.vary
+    addVaryAcceptEncoding(ctx)
+
     const accepted = ctx.req.header('Accept-Encoding')
     const encoding = selectEncoding(accepted, candidates)
     if (!encoding || !ctx.res.body) {
@@ -112,11 +122,6 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     ctx.res = new Response(ctx.res.body.pipeThrough(stream), ctx.res)
     ctx.res.headers.delete('Content-Length')
     ctx.res.headers.set('Content-Encoding', encoding)
-
-    // The compressed body depends on the request's Accept-Encoding, so caches must
-    // not reuse it for clients that negotiated a different encoding.
-    // https://www.rfc-editor.org/rfc/rfc9110#field.vary
-    addVaryAcceptEncoding(ctx.res)
 
     // Convert strong ETag to weak ETag since compressed content is not byte-identical
     const etag = ctx.res.headers.get('ETag')
@@ -134,11 +139,28 @@ const shouldTransform = (res: Response) => {
 }
 
 const varyAcceptEncodingRegExp = /(?:^|,)\s*accept-encoding\s*(?:,|$)/i
-const addVaryAcceptEncoding = (res: Response): void => {
-  const vary = res.headers.get('Vary')
-  if (vary === '*' || (vary && varyAcceptEncodingRegExp.test(vary))) {
+const addVaryAcceptEncoding = (ctx: Context): void => {
+  const current = ctx.res.headers.get('Vary')
+  if (current === '*' || (current && varyAcceptEncodingRegExp.test(current))) {
     // Already varies on everything, or Accept-Encoding is already listed.
     return
   }
-  res.headers.set('Vary', vary ? `${vary}, Accept-Encoding` : 'Accept-Encoding')
+  const vary = current ? `${current}, Accept-Encoding` : 'Accept-Encoding'
+
+  // A handler may return a `fetch()` response, whose headers are immutable.
+  // `ctx.header()` is the documented way to write through that, but it recreates the
+  // response with `new Response(body, res)`, which on Node inherits the immutable
+  // header guard from the original — so the write can still throw. Fall back to
+  // rebuilding the response around a fresh, mutable `Headers` instance.
+  try {
+    ctx.header('Vary', vary)
+  } catch {
+    const headers = new Headers(ctx.res.headers)
+    headers.set('Vary', vary)
+    ctx.res = new Response(ctx.res.body, {
+      status: ctx.res.status,
+      statusText: ctx.res.statusText,
+      headers,
+    })
+  }
 }

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -113,6 +113,11 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     ctx.res.headers.delete('Content-Length')
     ctx.res.headers.set('Content-Encoding', encoding)
 
+    // The compressed body depends on the request's Accept-Encoding, so caches must
+    // not reuse it for clients that negotiated a different encoding.
+    // https://www.rfc-editor.org/rfc/rfc9110#field.vary
+    addVaryAcceptEncoding(ctx.res)
+
     // Convert strong ETag to weak ETag since compressed content is not byte-identical
     const etag = ctx.res.headers.get('ETag')
     if (etag && !etag.startsWith('W/')) {
@@ -126,4 +131,14 @@ const shouldTransform = (res: Response) => {
   // Don't compress for Cache-Control: no-transform
   // https://tools.ietf.org/html/rfc7234#section-5.2.2.4
   return !cacheControl || !cacheControlNoTransformRegExp.test(cacheControl)
+}
+
+const varyAcceptEncodingRegExp = /(?:^|,)\s*accept-encoding\s*(?:,|$)/i
+const addVaryAcceptEncoding = (res: Response): void => {
+  const vary = res.headers.get('Vary')
+  if (vary === '*' || (vary && varyAcceptEncodingRegExp.test(vary))) {
+    // Already varies on everything, or Accept-Encoding is already listed.
+    return
+  }
+  res.headers.set('Vary', vary ? `${vary}, Accept-Encoding` : 'Accept-Encoding')
 }

--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -3,7 +3,6 @@
  * Compress Middleware for Hono.
  */
 
-import type { Context } from '../../context'
 import type { MiddlewareHandler } from '../../types'
 import { parseAccept } from '../../utils/accept'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
@@ -43,6 +42,8 @@ const selectEncoding = (
   }
   return best?.encoding
 }
+
+const varyAcceptEncodingRegExp = /(?:^|,)\s*accept-encoding\s*(?:,|$)/i
 
 /**
  * Compress Middleware for Hono.
@@ -109,7 +110,10 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     // Accept-Encoding "or lack thereof" as a determining factor. Without this, a shared
     // cache could reuse the identity response for a client that does accept gzip.
     // https://www.rfc-editor.org/rfc/rfc9110#field.vary
-    addVaryAcceptEncoding(ctx)
+    const current = ctx.res.headers.get('Vary')
+    if (current !== '*' && !(current && varyAcceptEncodingRegExp.test(current))) {
+      ctx.header('Vary', current ? `${current}, Accept-Encoding` : 'Accept-Encoding')
+    }
 
     const accepted = ctx.req.header('Accept-Encoding')
     const encoding = selectEncoding(accepted, candidates)
@@ -136,31 +140,4 @@ const shouldTransform = (res: Response) => {
   // Don't compress for Cache-Control: no-transform
   // https://tools.ietf.org/html/rfc7234#section-5.2.2.4
   return !cacheControl || !cacheControlNoTransformRegExp.test(cacheControl)
-}
-
-const varyAcceptEncodingRegExp = /(?:^|,)\s*accept-encoding\s*(?:,|$)/i
-const addVaryAcceptEncoding = (ctx: Context): void => {
-  const current = ctx.res.headers.get('Vary')
-  if (current === '*' || (current && varyAcceptEncodingRegExp.test(current))) {
-    // Already varies on everything, or Accept-Encoding is already listed.
-    return
-  }
-  const vary = current ? `${current}, Accept-Encoding` : 'Accept-Encoding'
-
-  // A handler may return a `fetch()` response, whose headers are immutable.
-  // `ctx.header()` is the documented way to write through that, but it recreates the
-  // response with `new Response(body, res)`, which on Node inherits the immutable
-  // header guard from the original — so the write can still throw. Fall back to
-  // rebuilding the response around a fresh, mutable `Headers` instance.
-  try {
-    ctx.header('Vary', vary)
-  } catch {
-    const headers = new Headers(ctx.res.headers)
-    headers.set('Vary', vary)
-    ctx.res = new Response(ctx.res.body, {
-      status: ctx.res.status,
-      statusText: ctx.res.statusText,
-      headers,
-    })
-  }
 }


### PR DESCRIPTION
## What

Make the `compress` middleware add `Accept-Encoding` to the response's `Vary` header for every response it negotiates — both the compressed responses and the identity responses it leaves alone.

## Why

`compress` negotiates `gzip`/`deflate` from the request's `Accept-Encoding` header, but the response is never marked as varying on that header. This is a cache-correctness bug in both directions:

- A shared cache (CDN, reverse proxy) can store the **compressed** body from one request and serve it to a client that sent a different/absent `Accept-Encoding`, handing that client a body it cannot decode.
- It can equally store the **identity** body served to a client that sent no `Accept-Encoding`, and then serve that to a gzip-capable client.

Per [RFC 9110 §12.5.5](https://www.rfc-editor.org/rfc/rfc9110#field.vary), any response whose content is selected using a request header must list that header in `Vary`, and the spec explicitly names `Accept-Encoding` "or lack thereof" as a determining factor — so the absence of the header is itself part of the negotiation. This is standard behaviour for compression middleware (e.g. Express `compression`, `@fastify/compress`). The sibling middlewares in this repo already do this for their own negotiated headers — `cors` sets `Vary: Origin` and `cache` manages `Vary` — so `compress` was the outlier.

## How

`Vary` is updated immediately after the eligibility checks, before the encoding is negotiated, so it covers both outcomes:

- no existing `Vary` → `Vary: Accept-Encoding`
- existing `Vary: Cookie` → `Vary: Cookie, Accept-Encoding`
- `Vary` already containing `Accept-Encoding`, or `Vary: *` → left unchanged (no duplicates)

Responses that are never eligible for compression (206, already-encoded, `HEAD`, below threshold, non-compressible type, `no-transform`) are untouched.

The header is written through `ctx.header()`, which recreates the response when a handler returned a `fetch()` response. On Node that recreation inherits the immutable header guard from the original response and the write can still throw, so there is a fallback that rebuilds the response around a fresh `Headers` instance. See [this comment](https://github.com/honojs/hono/pull/5137#issuecomment-5017991712) for the details — it looks like a latent `Context.header` bug worth fixing separately.

## Verification

- Full suite: `4625 passed | 35 skipped`, 145 files.
- 8 tests in the `Vary Header` block (set when compressing, append to existing `Vary`, no duplicate, `Vary: *` untouched, identity response with absent `Accept-Encoding`, identity response with an unsupported encoding, not-eligible response gets no `Vary`, immutable-header response).
- 2 tests in `runtime-tests/node` covering a real `fetch()` response, compressed and identity.
- Both immutable-header tests were mutation-checked: they fail if the fallback is removed.
- `prettier --check`, `eslint`, and `tsc -p tsconfig.spec.json` — clean.

### Checklist
- [x] Add tests
- [x] Run tests
- [x] `format:fix && lint:fix`
- [x] Document the code (comments referencing the RFC)
