### PR TITLE
fix(sse): emit empty id field to reset Last-Event-ID

### DIFF
--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -154,6 +154,17 @@ describe('SSE Streaming helper', () => {
     expect(decodedValue).toContain('retry: 0\n\n')
   })
 
+  it('Should emit an empty id to reset Last-Event-ID', async () => {
+    const res = streamSSE(c, async (stream) => {
+      await stream.writeSSE({
+        data: 'reset',
+        id: '',
+      })
+    })
+
+    expect(await res.text()).toBe('data: reset\nid: \n\n')
+  })
+
   it('Check stream Response if error occurred', async () => {
     const onError = vi.fn()
     const res = streamSSE(

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -35,7 +35,7 @@ export class SSEStreamingApi extends StreamingApi {
       [
         message.event && `event: ${message.event}`,
         dataLines,
-        message.id && `id: ${message.id}`,
+        message.id !== undefined && `id: ${message.id}`,
         message.retry !== undefined && `retry: ${message.retry}`,
       ]
         .filter(Boolean)


### PR DESCRIPTION
## Summary

Emit an SSE `id` field when `SSEMessage.id` is an empty string.

## Problem

`SSEStreamingApi.writeSSE()` currently uses a truthy check when serializing `message.id`:

`message.id && \`id: ${message.id}\``

This omits the field when `id` is an empty string.

In Server-Sent Events, an empty `id` field resets the client's last event ID. After the reset, a subsequent reconnect should not send a `Last-Event-ID` header.

Hono currently cannot express this behavior through `writeSSE()`.

Specification:
https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header

## Change

Use an explicit `undefined` check:

`message.id !== undefined && \`id: ${message.id}\``

This preserves the existing behavior when `id` is omitted while allowing an empty string to be serialized as an empty `id` field.

## Test

Added a regression test using:

`writeSSE({ data: 'reset', id: '' })`

The test verifies the exact output:

    data: reset
    id:

Local result:

    src/helper/streaming/sse.test.tsx
    19 tests passed
