### PR TITLE
fix(context): preserve headers and cookies when a handler returns a raw Response

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -423,8 +423,10 @@ describe('Context header', () => {
     const newResponse = new Response(null)
     newResponse.headers.append('set-cookie', newCookies[0])
     c.res = newResponse
-    expect(c.res.headers.getSetCookie().length).toBe(cookies.length)
-    expect(c.res.headers.getSetCookie()).toEqual(cookies)
+    // Cookies from both sides survive: dropping either one silently loses a
+    // `Set-Cookie` the application explicitly asked for.
+    expect(c.res.headers.getSetCookie().length).toBe(cookies.length + newCookies.length)
+    expect(c.res.headers.getSetCookie()).toEqual([...cookies, ...newCookies])
   })
 
   it('Should keep previous cookies in response headers', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -414,18 +414,21 @@ export class Context<
   set res(_res: Response | undefined) {
     if (this.#res && _res) {
       _res = createResponseInstance(_res.body, _res)
+      // `Set-Cookie` is handled after the loop rather than inside it: it is the
+      // only header that may legitimately appear more than once, so `entries()`
+      // yields it once per occurrence and would re-merge values it just wrote.
+      const preparedCookies = this.#res.headers.getSetCookie()
+
       for (const [k, v] of this.#res.headers.entries()) {
-        if (k === 'content-type') {
-          continue
-        }
-        if (k === 'set-cookie') {
-          const cookies = this.#res.headers.getSetCookie()
-          _res.headers.delete('set-cookie')
-          for (const cookie of cookies) {
-            _res.headers.append('set-cookie', cookie)
-          }
-        } else {
+        if (k !== 'content-type' && k !== 'set-cookie') {
           _res.headers.set(k, v)
+        }
+      }
+
+      if (preparedCookies.length > 0) {
+        _res.headers.delete('set-cookie')
+        for (const cookie of preparedCookies) {
+          _res.headers.append('set-cookie', cookie)
         }
       }
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -417,6 +417,8 @@ export class Context<
       // `Set-Cookie` is handled after the loop rather than inside it: it is the
       // only header that may legitimately appear more than once, so `entries()`
       // yields it once per occurrence and would re-merge values it just wrote.
+      // Captured before the merge below deletes them from `_res`.
+      const incomingCookies = _res.headers.getSetCookie()
       const preparedCookies = this.#res.headers.getSetCookie()
 
       for (const [k, v] of this.#res.headers.entries()) {
@@ -428,6 +430,11 @@ export class Context<
       if (preparedCookies.length > 0) {
         _res.headers.delete('set-cookie')
         for (const cookie of preparedCookies) {
+          _res.headers.append('set-cookie', cookie)
+        }
+        // Cookies carried by the response being assigned must survive too;
+        // dropping them silently loses a `Set-Cookie` the app asked for.
+        for (const cookie of incomingCookies) {
           _res.headers.append('set-cookie', cookie)
         }
       }

--- a/src/context.ts
+++ b/src/context.ts
@@ -412,16 +412,20 @@ export class Context<
    * @param _res - The Response object to set.
    */
   set res(_res: Response | undefined) {
-    if (this.#res && _res) {
+    // Headers staged by `c.header()` live in `#preparedHeaders` until something
+    // reads `c.res` and materializes it. Falling back to them keeps those
+    // headers from being dropped when nothing has read `c.res` yet.
+    const preparedHeaders = this.#res ? this.#res.headers : this.#preparedHeaders
+    if (preparedHeaders && _res) {
       _res = createResponseInstance(_res.body, _res)
       // `Set-Cookie` is handled after the loop rather than inside it: it is the
       // only header that may legitimately appear more than once, so `entries()`
       // yields it once per occurrence and would re-merge values it just wrote.
       // Captured before the merge below deletes them from `_res`.
       const incomingCookies = _res.headers.getSetCookie()
-      const preparedCookies = this.#res.headers.getSetCookie()
+      const preparedCookies = preparedHeaders.getSetCookie()
 
-      for (const [k, v] of this.#res.headers.entries()) {
+      for (const [k, v] of preparedHeaders.entries()) {
         if (k !== 'content-type' && k !== 'set-cookie') {
           _res.headers.set(k, v)
         }
@@ -438,6 +442,12 @@ export class Context<
           _res.headers.append('set-cookie', cookie)
         }
       }
+    }
+    if (!_res) {
+      // `c.res = undefined` discards the response built so far, so the staged
+      // headers go with it. Without this they would be re-applied to whatever
+      // response is assigned next.
+      this.#preparedHeaders = undefined
     }
     this.#res = _res
     this.finalized = true

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1207,6 +1207,45 @@ describe('Middleware', () => {
       expect(res.headers.get('x-custom')).toBe(null)
     })
   })
+
+  describe('Headers set before next() when the handler returns a raw Response', () => {
+    const buildApp = (touchResEarly: boolean) => {
+      const app = new Hono()
+      app.use(async (c, next) => {
+        if (touchResEarly) {
+          // Middleware such as CORS reads `c.res`, which materializes it early.
+          c.res.headers.set('x-something', 'true')
+        }
+        c.header('set-cookie', 'mw=hello; Path=/', { append: true })
+        c.header('x-custom', 'foo')
+        await next()
+      })
+      app.get('/', () => {
+        const res = new Response('ok')
+        res.headers.append('set-cookie', 'handler=world; Path=/')
+        return res
+      })
+      return app
+    }
+
+    it('Should keep cookies from both sides when c.res was never read', async () => {
+      const res = await buildApp(false).request('/')
+      expect(res.headers.getSetCookie()).toEqual(['mw=hello; Path=/', 'handler=world; Path=/'])
+      expect(res.headers.get('x-custom')).toBe('foo')
+    })
+
+    it('Should keep cookies from both sides when c.res was read early', async () => {
+      const res = await buildApp(true).request('/')
+      expect(res.headers.getSetCookie()).toEqual(['mw=hello; Path=/', 'handler=world; Path=/'])
+      expect(res.headers.get('x-custom')).toBe('foo')
+      expect(res.headers.get('x-something')).toBe('true')
+    })
+
+    it('Should preserve the body of the handler response', async () => {
+      expect(await (await buildApp(false).request('/')).text()).toBe('ok')
+      expect(await (await buildApp(true).request('/')).text()).toBe('ok')
+    })
+  })
 })
 
 describe('Builtin Middleware', () => {


### PR DESCRIPTION
Fixes #4992.

Headers set with `c.header()` before `await next()` are silently dropped when the downstream handler returns a raw `Response`. Which side loses data depends on whether anything read `c.res` first, so the same middleware behaves differently depending on what else is in the stack:

| Scenario | `#res` materialized before `c.header()`? | Lost |
|---|---|---|
| A — nothing reads `c.res` | No | every header staged by `c.header()`, incl. `Set-Cookie` |
| B — middleware reads `c.res` (e.g. CORS) | Yes | the handler's own `Set-Cookie` |

```js
const app = new Hono()
app.use(async (c, next) => {
  c.header('Set-Cookie', 'mw=hello; Path=/', { append: true })
  await next()
})
app.get('/', () => {
  const res = new Response('ok')
  res.headers.append('set-cookie', 'handler=world; Path=/')
  return res
})

;(await app.request('/')).headers.getSetCookie()
// before: ['handler=world; Path=/']            <- mw cookie lost
// after:  ['mw=hello; Path=/', 'handler=world; Path=/']
```

### Cause

Two independent problems in `set res()`:

1. **`#preparedHeaders` was never consulted.** `c.header()` stages into `#preparedHeaders` and only moves into `#res` once something reads `c.res`. The setter guarded on `if (this.#res && _res)`, so with no reader the merge was skipped entirely (scenario A).
2. **The incoming response's cookies were deleted.** The `set-cookie` branch called `_res.headers.delete('set-cookie')` and re-appended only the context's cookies, discarding the handler's (scenario B).

### Changes

- Fall back to `#preparedHeaders` when `#res` has not been materialized.
- Concatenate `Set-Cookie` from both sides instead of overwriting.
- Clear `#preparedHeaders` on `c.res = undefined`, keeping that a full reset — the existing "Should not have the custom header" test covers this.
- Hoist the cookie merge out of the header loop. `entries()` yields `set-cookie` once per occurrence, so leaving it inline let the branch re-read values it had just written and duplicate them.

### A note on the one changed assertion

`context.test.ts` → "Should set cookie headers when re-assigning Response to `c.res`" asserted that re-assignment keeps only the *previous* cookies and drops the new response's. That is scenario B, so the test could not stay as-is. It now expects both sets, which matches the neighbouring "Should keep previous cookies in response headers" test and the documented accumulate-don't-clobber behavior of `Set-Cookie`. Flagging it explicitly since changing an existing assertion deserves a maintainer's eye.

### Verification

- `bunx vitest --run --project main` — 3653 passed, 0 failed (121 files); `--project node` — 14 passed
- `tsc -p tsconfig.spec.json` clean, `eslint src` 0 errors, `prettier --check` clean
- The two new tests in `hono.test.ts` fail on `main` and pass with the fix (verified by stashing the `context.ts` change)

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
