### PR TITLE
fix(stream): restore the writer when StreamingApi.pipe() fails

### DIFF
--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -65,6 +65,42 @@ describe('StreamingApi', () => {
     expect((await reader.read()).done).toBe(true)
   })
 
+  it('pipe() should keep the writer usable when the source errors', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+
+    const erroringBody = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('upstream failure'))
+      },
+    })
+
+    await expect(api.pipe(erroringBody)).rejects.toThrow('upstream failure')
+
+    // The writer is re-acquired, so it is still bound to the writable. Before
+    // this was fixed, touching it threw "Writer is not bound to a WritableStream".
+    // @ts-expect-error -- reaching into the private writer to assert its state
+    expect(() => api.writer.desiredSize).not.toThrow()
+  })
+
+  it('pipe() should not break write()/close() when the source errors', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+
+    const erroringBody = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('upstream failure'))
+      },
+    })
+
+    await expect(api.pipe(erroringBody)).rejects.toThrow('upstream failure')
+
+    // These swallow their own errors; the point is that they must not reject
+    // with a TypeError from a writer that is bound to nothing.
+    await expect(api.write('after pipe')).resolves.toBe(api)
+    await expect(api.close()).resolves.toBeUndefined()
+  })
+
   it('should not throw an error in write()', async () => {
     const { readable, writable } = new TransformStream()
     const api = new StreamingApi(writable, readable)

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -77,8 +77,20 @@ export class StreamingApi {
 
   async pipe(body: ReadableStream) {
     this.writer.releaseLock()
-    await body.pipeTo(this.writable, { preventClose: true })
-    this.writer = this.writable.getWriter()
+    try {
+      await body.pipeTo(this.writable, { preventClose: true })
+    } finally {
+      // Re-acquire the writer even when pipeTo() rejects — a client disconnect,
+      // an erroring source or a fired abort signal all land here. Without this
+      // the released writer stays on the instance and every later write(),
+      // writeln() or close() fails against a writer bound to nothing.
+      try {
+        this.writer = this.writable.getWriter()
+      } catch {
+        // The writable is unusable (already locked elsewhere); keep the current
+        // writer rather than masking the original pipeTo() rejection.
+      }
+    }
   }
 
   onAbort(listener: () => void | Promise<void>) {


### PR DESCRIPTION
Fixes #4981.

`StreamingApi.pipe()` releases the writer lock before `pipeTo()` but only re-acquires it on the success path:

```ts
async pipe(body: ReadableStream) {
  this.writer.releaseLock()
  await body.pipeTo(this.writable, { preventClose: true })
  this.writer = this.writable.getWriter()   // skipped when pipeTo() rejects
}
```

When `pipeTo()` rejects — an erroring source, a fired abort signal, or the client disconnecting mid-stream — the instance is left holding a writer bound to nothing. Reading `this.writer.desiredSize` at that point throws:

```
Invalid state: Writer is not bound to a WritableStream
```

`write()`, `writeln()` and `close()` all swallow their own errors, so nothing surfaces to the application — the stream simply goes quiet. A client disconnecting during an active `pipe()` is ordinary browser behavior (tab close, navigation), so this is reachable in normal operation.

### Fix

Re-acquire the writer in a `finally`, so the instance stays consistent however `pipeTo()` settles:

```ts
async pipe(body: ReadableStream) {
  this.writer.releaseLock()
  try {
    await body.pipeTo(this.writable, { preventClose: true })
  } finally {
    try {
      this.writer = this.writable.getWriter()
    } catch {
      // writable unusable; keep the current writer rather than masking
      // the original pipeTo() rejection
    }
  }
}
```

The inner guard matters: if the writable can no longer hand out a writer, throwing from `finally` would replace the real `pipeTo()` rejection with a confusing `TypeError`. Keeping the existing writer lets the original error propagate untouched.

### Scope

This restores the object's invariant — it does not resurrect a stream the runtime has already errored. Once `pipeTo()` aborts the destination, later `write()` calls are still no-ops (they were before too). What changes is that the failure is now a quiet no-op on a valid writer instead of a `TypeError` against an unbound one, and `pipe()`'s rejection reaches the caller unchanged.

### Verification

- `bunx vitest --run --project main` — 3652 passed, 0 failed (121 files)
- `tsc -p tsconfig.spec.json` clean, `eslint` 0 errors, `prettier` clean
- Two tests added to `stream.test.ts`. The first ("should keep the writer usable when the source errors") fails on `main` and passes with the fix — confirmed by stashing the `stream.ts` change. The second is a guard on `write()`/`close()` not throwing.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
