### PR TITLE
fix(aws-lambda): add jwt and lambda authorizer types for API Gateway v2

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,13 +1,14 @@
 import { setCookie } from '../../helper/cookie'
 import { Hono } from '../../hono'
 import { bodyLimit } from '../../middleware/body-limit'
-import type { LambdaEvent, LatticeProxyEventV2 } from './handler'
+import type { APIGatewayProxyEventV2, LambdaEvent, LatticeProxyEventV2 } from './handler'
 import {
   getProcessor,
   handle,
   isContentEncodingBinary,
   defaultIsContentTypeBinary,
 } from './handler'
+import type { ApiGatewayRequestContextV2 } from './types'
 
 // Base event objects to reduce duplication
 const baseV1Event: LambdaEvent = {
@@ -570,5 +571,63 @@ describe('handle', () => {
 
     const result = await handler(event)
     expect(result.statusCode).toBe(413)
+  })
+})
+
+describe('V2 request context authorizer', () => {
+  const baseV2RequestContext = baseV2Event.requestContext as ApiGatewayRequestContextV2
+
+  it('Should expose the context of a Lambda (REQUEST) authorizer', async () => {
+    const app = new Hono<{ Bindings: { event: APIGatewayProxyEventV2 } }>()
+    app.get('/my/path', (c) => c.json(c.env.event.requestContext.authorizer.lambda))
+    const handler = handle(app)
+
+    const event: LambdaEvent = {
+      ...baseV2Event,
+      requestContext: {
+        ...baseV2RequestContext,
+        http: { ...baseV2RequestContext.http, method: 'GET' },
+        authorizer: { lambda: { userId: 'user-123', isAdmin: true } },
+      },
+    }
+
+    const result = await handler(event)
+    expect(result.statusCode).toBe(200)
+    expect(JSON.parse(result.body)).toEqual({ userId: 'user-123', isAdmin: true })
+  })
+
+  it('Should expose the claims and scopes of a JWT authorizer', async () => {
+    const app = new Hono<{ Bindings: { event: APIGatewayProxyEventV2 } }>()
+    app.get('/my/path', (c) => c.json(c.env.event.requestContext.authorizer.jwt))
+    const handler = handle(app)
+
+    const event: LambdaEvent = {
+      ...baseV2Event,
+      requestContext: {
+        ...baseV2RequestContext,
+        http: { ...baseV2RequestContext.http, method: 'GET' },
+        authorizer: {
+          jwt: { claims: { sub: 'user-123', email_verified: true }, scopes: ['read'] },
+        },
+      },
+    }
+
+    const result = await handler(event)
+    expect(result.statusCode).toBe(200)
+    expect(JSON.parse(result.body)).toEqual({
+      claims: { sub: 'user-123', email_verified: true },
+      scopes: ['read'],
+    })
+  })
+
+  it('Should type each authorizer variant as optional', () => {
+    const authorizer: ApiGatewayRequestContextV2['authorizer'] = {}
+    expectTypeOf(authorizer.lambda).toEqualTypeOf<Record<string, unknown> | null | undefined>()
+    expectTypeOf(authorizer.jwt).toEqualTypeOf<
+      | { claims: Record<string, string | number | boolean | string[]>; scopes: string[] | null }
+      | undefined
+    >()
+    // A JWT authorizer reports no scopes as `null`.
+    expectTypeOf<null>().toMatchTypeOf<NonNullable<typeof authorizer.jwt>['scopes']>()
   })
 })

--- a/src/adapter/aws-lambda/types.ts
+++ b/src/adapter/aws-lambda/types.ts
@@ -114,6 +114,15 @@ interface Authorizer {
     userArn: string
     userId: string
   }
+  jwt?: {
+    claims: Record<string, string | number | boolean | string[]>
+    scopes: string[] | null
+  }
+  /**
+   * The `context` object returned by a Lambda (REQUEST) authorizer.
+   * It is `null` when the authorizer returns no context.
+   */
+  lambda?: Record<string, unknown> | null
 }
 
 export interface ApiGatewayRequestContextV2 {


### PR DESCRIPTION
## Problem

`ApiGatewayRequestContextV2["authorizer"]` declares only the `iam` variant:

```ts
interface Authorizer {
  iam?: {
    accessKey: string
    accountId: string
    // ...
  }
}
```

API Gateway populates two other keys on that object, so reading either one is a
TypeScript error even though the value is present at runtime:

```ts
app.use(async (ctx, next) => {
  ctx.set('userId', ctx.env.event.requestContext.authorizer.lambda.userId)
  //                                                          ^^^^^^
  // error TS2339: Property 'lambda' does not exist on type 'Authorizer'.
})
```

This affects anyone using an HTTP API (payload format 2.0) with a Lambda
(REQUEST) authorizer or a JWT authorizer. `ApiGatewayRequestContextV2` is
exported from `hono/aws-lambda`, so the gap is user-facing. The reported
workaround is to redeclare the type by hand before using the bindings.

## Why these two keys

- **`jwt`** — AWS's own payload format 2.0 example carries
  `requestContext.authorizer.jwt` with `claims` and `scopes`:
  https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
- **`lambda`** — a Lambda authorizer returns an optional `context` object
  (simple response or IAM policy response), which API Gateway delivers to the
  integration under `requestContext.authorizer.lambda`:
  https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html

The shapes mirror `@types/aws-lambda`
(`APIGatewayEventRequestContextJWTAuthorizer` and
`APIGatewayEventRequestContextLambdaAuthorizer`), which the issue cites as the
reference. `lambda` is typed `Record<string, unknown> | null` rather than
generic to keep the change contained; `null` is what API Gateway sends when the
authorizer returns no context. `scopes` is `string[] | null` because a JWT with
no scope claim yields `null`.

## Changes

```ts
interface Authorizer {
  iam?: { /* unchanged */ }
  jwt?: {
    claims: Record<string, string | number | boolean | string[]>
    scopes: string[] | null
  }
  /**
   * The `context` object returned by a Lambda (REQUEST) authorizer.
   * It is `null` when the authorizer returns no context.
   */
  lambda?: Record<string, unknown> | null
}
```

Both properties are optional and `iam` is untouched, so this is purely additive
and backwards compatible. **Types only — no runtime change.**

## Tests

Added a `V2 request context authorizer` block to
`src/adapter/aws-lambda/handler.test.ts` covering both authorizer variants
end-to-end through `handle()`, plus an `expectTypeOf` check that each variant is
optional and that `scopes` accepts `null`.

Without the type change these fail `tsc -p tsconfig.spec.json` with exactly the
error from the issue:

```
error TS2339: Property 'lambda' does not exist on type 'Authorizer'.
error TS2339: Property 'jwt' does not exist on type 'Authorizer'.
```

`bun run test` passes: 145 files, 4619 tests. `eslint` and `prettier --check`
are clean on the changed files.

Closes #3281

---

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
