### PR TITLE
ci: measure the bundle size of `hono/tiny` and `hono/quick`

### DIFF
--- a/perf-measures/bundle-check/scripts/check-bundle-size.ts
+++ b/perf-measures/bundle-check/scripts/check-bundle-size.ts
@@ -3,36 +3,57 @@ import * as fs from 'node:fs'
 import * as os from 'os'
 import * as path from 'path'
 
+/**
+ * Entry points to measure. `hono` is the full package; `hono/tiny` and
+ * `hono/quick` are presets, and `hono/tiny` is the one we watch to tell whether
+ * the smallest build stays small.
+ *
+ * `keyPrefix` is empty for `hono` so its metric keys stay `bundle-size-b` and
+ * `bundle-size-kb`, keeping the recorded history comparable.
+ */
+const targets = [
+  { name: 'hono', entryPoint: 'dist/index.js', keyPrefix: '' },
+  { name: 'hono/tiny', entryPoint: 'dist/preset/tiny.js', keyPrefix: 'tiny-' },
+  { name: 'hono/quick', entryPoint: 'dist/preset/quick.js', keyPrefix: 'quick-' },
+]
+
+const measure = async (entryPoint: string, outfile: string): Promise<number> => {
+  await esbuild.build({
+    entryPoints: [entryPoint],
+    bundle: true,
+    minify: true,
+    format: 'esm' as esbuild.Format,
+    target: 'es2022',
+    outfile,
+  })
+
+  return fs.statSync(outfile).size
+}
+
 async function main() {
   const tempDir = os.tmpdir()
   const tempFilePath = path.join(tempDir, 'bundle.tmp.js')
 
   try {
-    await esbuild.build({
-      entryPoints: ['dist/index.js'],
-      bundle: true,
-      minify: true,
-      format: 'esm' as esbuild.Format,
-      target: 'es2022',
-      outfile: tempFilePath,
-    })
-
-    const bundleSize = fs.statSync(tempFilePath).size
     const metrics = []
 
-    metrics.push({
-      key: 'bundle-size-b',
-      name: 'Bundle Size (B)',
-      value: bundleSize,
-      unit: 'B',
-    })
+    for (const { name, entryPoint, keyPrefix } of targets) {
+      const bundleSize = await measure(entryPoint, tempFilePath)
 
-    metrics.push({
-      key: 'bundle-size-kb',
-      name: 'Bundle Size (KB)',
-      value: parseFloat((bundleSize / 1024).toFixed(2)),
-      unit: 'K',
-    })
+      metrics.push({
+        key: `bundle-size-${keyPrefix}b`,
+        name: `${name} Bundle Size (B)`,
+        value: bundleSize,
+        unit: 'B',
+      })
+
+      metrics.push({
+        key: `bundle-size-${keyPrefix}kb`,
+        name: `${name} Bundle Size (KB)`,
+        value: parseFloat((bundleSize / 1024).toFixed(2)),
+        unit: 'K',
+      })
+    }
 
     const benchmark = {
       key: 'bundle-size-check',


### PR DESCRIPTION
## Problem

Bundle Check currently measures only `dist/index.js`, so a change that grows the
smallest preset doesn't show up anywhere. As described in the issue, `hono/tiny`
is the preset we watch to tell whether the smallest build stays small.

## Changes

`perf-measures/bundle-check/scripts/check-bundle-size.ts` now measures three
entry points and emits a pair of metrics for each:

| target | entry point | key prefix |
| --- | --- | --- |
| `hono` | `dist/index.js` | *(unchanged)* |
| `hono/tiny` | `dist/preset/tiny.js` | `tiny-` |
| `hono/quick` | `dist/preset/quick.js` | `quick-` |

`hono/quick` is included per @EdamAme-x's suggestion in the thread that it's
best to check each preset. Happy to drop it and report only `hono` and
`hono/tiny` if you'd prefer to keep the report narrow.

Two details worth flagging:

- **The `hono` metric keys are unchanged** (`bundle-size-b` / `bundle-size-kb`),
  so the sizes already recorded in the octocov datastore stay comparable and the
  existing trend isn't reset. Only the display name gained a `hono` prefix.
- **No octocov config change is needed.** The new metrics are nested under the
  existing `bundle-size-check` benchmark, which
  `.octocov.consolidated.perf-measures.yml` already declares by key.

## Verification

Output of `bun perf-measures/bundle-check/scripts/check-bundle-size.ts` after
`bun run build`:

```json
{
  "key": "bundle-size-check",
  "name": "Bundle size check",
  "metrics": [
    { "key": "bundle-size-b",        "name": "hono Bundle Size (B)",        "value": 18998, "unit": "B" },
    { "key": "bundle-size-kb",       "name": "hono Bundle Size (KB)",       "value": 18.55, "unit": "K" },
    { "key": "bundle-size-tiny-b",   "name": "hono/tiny Bundle Size (B)",   "value": 11304, "unit": "B" },
    { "key": "bundle-size-tiny-kb",  "name": "hono/tiny Bundle Size (KB)",  "value": 11.04, "unit": "K" },
    { "key": "bundle-size-quick-b",  "name": "hono/quick Bundle Size (B)",  "value": 16186, "unit": "B" },
    { "key": "bundle-size-quick-kb", "name": "hono/quick Bundle Size (KB)", "value": 15.81, "unit": "K" }
  ]
}
```

The `hono/tiny` figure matches the command in the issue exactly:

```console
$ bunx esbuild --minify --bundle --format=esm dist/preset/tiny.js | wc -c
11304
```

`bun run test` passes (145 files, 4616 tests), `bun tsc --build` is clean, and
`bun run lint` reports no errors.

No tests were added: this is a CI measurement script, and `perf-measures` is
outside the vitest and `tsconfig.spec.json` scopes. The output above is the
verification instead.

Closes #3676

---

### The author should do the following, if applicable

- [ ] Add tests — n/a, CI script outside the test scope (see note above)
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
