### PR TITLE
fix(docs): correct wording in CONTRIBUTING.md install step

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To enforce this, and regardless of whether AI was actually used, a maintainer ma
 
 The `honojs/hono` project uses [Bun](https://bun.sh/) as its package manager. Developers should install Bun.
 
-After that, please install the dependency environment.
+After that, please install the dependencies.
 
 ```bash
 bun install --frozen-lockfile


### PR DESCRIPTION
"Please install the dependency environment" → "please install the dependencies" — the previous wording reads like a leftover from editing and could confuse new contributors.

No other changes.
