### PR TITLE
fix(context): return \
ull\ instead of empty string for undefined JSON body

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -714,7 +714,7 @@ export class Context<
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
     return this.#newResponse(
-      JSON.stringify(object),
+      JSON.stringify(object) ?? 'null',
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
﻿When a \ilter\ function is provided to \qs.stringify\, Date values are silently dropped from the output even when the filter returns the Date unchanged (e.g. identity filter or filter that only modifies non-Date values).

**Root cause:** The filter application and Date serialization were in an \if...else if\ chain, so when a filter was present, the \obj instanceof Date\ check was never reached. This caused the stringify function to fall through to the \Object.keys(obj)\ path, which returns \[]\ for Date objects.

**Fix:** Split the \if...else if\ chain so Date serialization runs after filter processing. If the filter returns a Date (or doesn't modify it), it is now properly serialized via \serializeDate\.

Fixes #475
