### PR TITLE
fix(context): merge preparedHeaders into c.res when #res is not yet created

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -423,8 +423,8 @@ describe('Context header', () => {
     const newResponse = new Response(null)
     newResponse.headers.append('set-cookie', newCookies[0])
     c.res = newResponse
-    expect(c.res.headers.getSetCookie().length).toBe(cookies.length)
-    expect(c.res.headers.getSetCookie()).toEqual(cookies)
+    expect(c.res.headers.getSetCookie().length).toBe(cookies.length + newCookies.length)
+    expect(c.res.headers.getSetCookie()).toEqual([...newCookies, ...cookies])
   })
 
   it('Should keep previous cookies in response headers', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -412,22 +412,33 @@ export class Context<
    * @param _res - The Response object to set.
    */
   set res(_res: Response | undefined) {
-    if (this.#res && _res) {
-      _res = createResponseInstance(_res.body, _res)
-      for (const [k, v] of this.#res.headers.entries()) {
-        if (k === 'content-type') {
-          continue
-        }
-        if (k === 'set-cookie') {
-          const cookies = this.#res.headers.getSetCookie()
-          _res.headers.delete('set-cookie')
-          for (const cookie of cookies) {
-            _res.headers.append('set-cookie', cookie)
+    if (_res) {
+      if (this.#res) {
+        _res = createResponseInstance(_res.body, _res)
+        const cookies = this.#res.headers.getSetCookie()
+        for (const [k, v] of this.#res.headers.entries()) {
+          if (k === 'content-type' || k === 'set-cookie') {
+            continue
           }
-        } else {
           _res.headers.set(k, v)
         }
+        for (const cookie of cookies) {
+          _res.headers.append('set-cookie', cookie)
+        }
+      } else if (this.#preparedHeaders) {
+        const cookies = this.#preparedHeaders.getSetCookie()
+        for (const [k, v] of this.#preparedHeaders.entries()) {
+          if (k === 'set-cookie') {
+            continue
+          }
+          _res.headers.set(k, v)
+        }
+        for (const cookie of cookies) {
+          _res.headers.append('set-cookie', cookie)
+        }
       }
+    } else {
+      this.#preparedHeaders = undefined
     }
     this.#res = _res
     this.finalized = true


### PR DESCRIPTION
## Description

When \c.header()\ is called in middleware before \
ext()\ and the handler returns a raw Response, the prepared headers (including Set-Cookie) were previously lost because \set res()\ only merged headers when \#res\ already existed.

## Changes

- **Merge \#preparedHeaders\ into new Response**: When \#res\ doesn't exist yet, apply \#preparedHeaders\ directly to the handler's raw Response
- **Preserve handler's Set-Cookie**: Removed \_res.headers.delete('set-cookie')\ so handler cookies aren't wiped when merging context headers
- **Clear \#preparedHeaders\ on \c.res = undefined\**: Ensures explicitly clearing the response also discards pending headers

## Related Issues

Fixes #5151 (duplicate)