### PR TITLE
fix(types): infer response type from the last handler in `app.on()` with array paths

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -15,6 +15,7 @@ import type {
   MergePath,
   MergeSchemaPath,
   MiddlewareHandler,
+  Next,
   ParamKeyToRecord,
   ParamKeys,
   RemoveQuestion,
@@ -354,6 +355,50 @@ describe('OnHandlerInterface', () => {
     app.on('GET', ['/a', '/b'], middleware, (c) => {
       expectTypeOf(c.var.foo).toEqualTypeOf<string>()
       return c.json({})
+    })
+  })
+
+  test('app.on(method, path[], middleware, handler) should infer the response type from the last handler', () => {
+    // The middleware resolves to `Promise<void>`, which must not take part in
+    // inferring the response type of the route.
+    const middleware = async (_c: Context, next: Next) => {
+      await next()
+    }
+    const route = app.on('POST', ['/a', '/b'], middleware, (c) => {
+      return c.json({ message: 'Hello' })
+    })
+    type Actual = ExtractSchema<typeof route>
+    type Expected = {
+      '/a': {
+        $post: {
+          input: {}
+          output: {
+            message: string
+          }
+          outputFormat: 'json'
+          status: ContentfulStatusCode
+        }
+      }
+      '/b': {
+        $post: {
+          input: {}
+          output: {
+            message: string
+          }
+          outputFormat: 'json'
+          status: ContentfulStatusCode
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  test('app.on(method[], path[], middleware x2, handler) should not throw a type error', () => {
+    const middleware = async (_c: Context, next: Next) => {
+      await next()
+    }
+    app.on(['GET', 'POST'], ['/a', '/b'], middleware, middleware, (c) => {
+      return c.text('Hello')
     })
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2465,7 +2465,10 @@ export interface OnHandlerInterface<
   >(
     methods: M | M[],
     paths: Ps,
-    ...handlers: H<E2, MergePath<BasePath, Ps[number]>, I, R>[]
+    ...handlers: [
+      ...H<E2, MergePath<BasePath, Ps[number]>, I>[],
+      H<E2, MergePath<BasePath, Ps[number]>, I, R>,
+    ]
   ): HonoBase<
     E,
     S & ToSchema<M, MergePath<BasePath, Ps[number]>, I, MergeTypedResponse<R>>,


### PR DESCRIPTION
Closes #5144

## The problem

Passing a middleware before the route handler to `app.on()` **with an array of paths** fails to compile:

```ts
const middleware = async (c: Context, next: Next) => next()

app.on('POST', ['/route1', '/route2'], middleware, (c) => {
  return c.json({ message: 'Hello from route1 or route2' })
})
```

```
error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type '(c: Context<any, "/route1" | "/route2", {}>) => JSONRespondReturn<{ message: string; }, ContentfulStatusCode>'
    is not assignable to parameter of type 'H<any, "/route1" | "/route2", {}, Promise<void>>'.
```

The same route compiles fine with a single string path — only the array-path form breaks.

## Cause

The `app.on(method | method[], path[], ...handlers[])` overload typed its rest parameter as one homogeneous array:

```ts
...handlers: H<E2, MergePath<BasePath, Ps[number]>, I, R>[]
```

Because every handler shares the same `R`, the type parameter is inferred from *all* of them. The middleware resolves to `Promise<void>`, that becomes the inference winner, and the route handler is then checked against `H<..., Promise<void>>` — which no `c.json()` / `c.text()` return value satisfies.

The single-path overloads don't have this problem: they spell out the middleware positions as a tuple and only infer `R` from the final element. The array-path overload was the one place that didn't.

## The fix

Type the rest parameter as a variadic tuple with a fixed final element, so leading middleware no longer participate in inferring `R`:

```ts
...handlers: [
  ...H<E2, MergePath<BasePath, Ps[number]>, I>[],
  H<E2, MergePath<BasePath, Ps[number]>, I, R>,
]
```

The route handler still determines `R`, so the response type flowing into `ToSchema` — and therefore RPC client inference — is unchanged. Four lines in `src/types.ts`; no runtime code is touched.

## Notes

- **Not a TypeScript 7 regression.** The issue was reported against TS 7.0.2, but it reproduces identically on the TypeScript 6.0.3 this repo pins, so the fix isn't version-specific.
- **Why existing tests missed it.** `types.test.ts` already had a case named `app.on(method, path[], middleware, handler) should not throw a type error`, but it used an explicitly annotated `MiddlewareHandler`, whose `R` defaults to `Response` — and `JSONRespondReturn` *is* assignable to `Response`, so it passed. The failure only shows up with an inferred inline middleware that resolves to `Promise<void>`, which is the shape people actually write.
- **Backwards compatible.** A single-handler call still matches with an empty leading rest, and no existing overload changed.

## Tests

Two cases added to the `OnHandlerInterface` block in `src/types.test.ts`:

1. `app.on(method, path[], middleware, handler)` with an inferred inline middleware — asserts via `Expect<Equal<...>>` that the schema output is `{ message: string }`, so this pins the inferred response type rather than only checking that it compiles.
2. `app.on(method[], path[], middleware x2, handler)` — covers the method-array form with more than one middleware.

Both fail on `main` (the first with `TS2769` *and* a `Type 'false' does not satisfy the constraint 'true'` on the schema assertion) and pass with this change.

## Verification

- `bun run test` — 145 files, 4622 tests passed, 35 skipped (includes `tsc -p tsconfig.spec.json`)
- `bun run lint` — 0 errors
- `prettier --check` on both changed files — no new formatting issues
- Rebased on current `main` (44f8843)
