### PR TITLE
fix(jsx): render precompiled templates lazily so context providers apply

### DIFF
--- a/runtime-tests/deno-jsx/jsx.test.tsx
+++ b/runtime-tests/deno-jsx/jsx.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource ../../src/jsx */
 import { assertEquals } from '@std/assert'
 import { Style, css } from '../../src/helper/css/index.ts'
+import { createContext, useContext } from '../../src/jsx/context.ts'
 import { Suspense, renderToReadableStream } from '../../src/jsx/streaming.ts'
 import type { HtmlEscapedString } from '../../src/utils/html.ts'
 import { HtmlEscapedCallbackPhase, resolveCallback } from '../../src/utils/html.ts'
@@ -16,6 +17,34 @@ Deno.test('JSX', () => {
   )
 
   assertEquals(html.toString(), '<div><h1 id="&lt;Hello&gt;"><span>&lt;Hono&gt;</span></h1></div>')
+})
+
+Deno.test('JSX: Context with an element between the provider and the consumer', () => {
+  const Context = createContext('default')
+  const Consumer = () => <span>{useContext(Context)}</span>
+  const html = (
+    <Context.Provider value='provided'>
+      <div>
+        <Consumer />
+      </div>
+    </Context.Provider>
+  )
+
+  assertEquals(html.toString(), '<div><span>provided</span></div>')
+})
+
+Deno.test('JSX: Context with an element between the provider and an async consumer', async () => {
+  const Context = createContext('default')
+  const Consumer = async () => <span>{useContext(Context)}</span>
+  const html = (
+    <Context.Provider value='provided'>
+      <div>
+        <Consumer />
+      </div>
+    </Context.Provider>
+  )
+
+  assertEquals(String(await html.toString()), '<div><span>provided</span></div>')
 })
 
 Deno.test('JSX: Fragment', () => {

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -301,6 +301,31 @@ export class JSXFragmentNode extends JSXNode {
   }
 }
 
+/**
+ * A precompiled template: static HTML chunks interleaved with the JSX children
+ * hoisted out of them. Rendering is deferred to `toStringToBuffer()` like any
+ * other node, so children are evaluated in their tree position — inside the
+ * enclosing `<Context.Provider>`, not before it.
+ */
+export class JSXTemplateNode extends JSXNode {
+  #strings: readonly string[]
+
+  constructor(strings: readonly string[], values: Child[]) {
+    super('', {}, values)
+    this.#strings = strings
+  }
+
+  override toStringToBuffer(buffer: StringBufferWithCallbacks): void {
+    const strings = this.#strings
+    const values = this.children
+    for (let i = 0, len = strings.length - 1; i < len; i++) {
+      buffer[0] += strings[i]
+      childrenToStringToBuffer([values[i]], buffer)
+    }
+    buffer[0] += strings[strings.length - 1]
+  }
+}
+
 export const jsx = (tag: string | Function, props: Props | null, ...children: Child[]): JSXNode => {
   props ??= {}
   if (children.length) {

--- a/src/jsx/jsx-runtime.test.tsx
+++ b/src/jsx/jsx-runtime.test.tsx
@@ -1,7 +1,9 @@
 /** @jsxRuntime automatic **/
 /** @jsxImportSource . **/
+import { html } from '../helper/html'
 import { Hono } from '../hono'
-import { jsxAttr } from './jsx-runtime'
+import { createContext, useContext } from './context'
+import { jsx, jsxAttr, jsxTemplate } from './jsx-runtime'
 
 describe('jsx-runtime', () => {
   let app: Hono
@@ -69,6 +71,72 @@ describe('jsx-runtime', () => {
         })
       )
     ).toBe('style="background-color:white"')
+  })
+
+  // A precompiling JSX transform (e.g. Deno's `"jsx": "precompile"`) hoists
+  // static elements into `jsxTemplate(tpl, ...children)` calls. Those calls are
+  // argument expressions, so they are evaluated *before* the enclosing
+  // component runs — rendering them eagerly would resolve their children
+  // outside the tree position they belong to.
+  describe('jsxTemplate()', () => {
+    const tpl = (...strings: string[]) => strings
+
+    it('Should render static chunks and interpolated values', () => {
+      expect(jsxTemplate(tpl('<hr/>')).toString()).toBe('<hr/>')
+      expect(jsxTemplate(tpl('<div>', '</div>'), 'hello').toString()).toBe('<div>hello</div>')
+    })
+
+    it('Should read context provided by an enclosing Provider', () => {
+      const Context = createContext('default')
+      const Consumer = () => <span>{useContext(Context)}</span>
+
+      const node = jsx(Context.Provider, {
+        value: 'provided',
+        children: jsxTemplate(tpl('<div>', '</div>'), jsx(Consumer, {})),
+      })
+
+      expect(node.toString()).toBe('<div><span>provided</span></div>')
+    })
+
+    it('Should read context in an async component under a Provider', async () => {
+      const Context = createContext('default')
+      const Consumer = async () => <span>{useContext(Context)}</span>
+
+      const node = jsx(Context.Provider, {
+        value: 'provided',
+        children: jsxTemplate(tpl('<div>', '</div>'), jsx(Consumer, {})),
+      })
+
+      expect(String(await node.toString())).toBe('<div><span>provided</span></div>')
+    })
+
+    it('Should render the same output as the equivalent JSX', async () => {
+      const cases: [unknown, string][] = [
+        ['<script>alert(1)</script>', 'escaped string'],
+        [0, 'zero'],
+        [42, 'number'],
+        [true, 'true'],
+        [false, 'false'],
+        [null, 'null'],
+        [undefined, 'undefined'],
+        [['a', <b>b</b>, ['c', ['d']]], 'nested array'],
+        [html`<b>bold &amp; raw</b>`, 'html fragment'],
+      ]
+
+      for (const [value, label] of cases) {
+        const fromJsx = (<div>{value as never}</div>).toString()
+        const fromTemplate = jsxTemplate(tpl('<div>', '</div>'), value as never).toString()
+        expect(fromTemplate, label).toBe(fromJsx)
+      }
+    })
+
+    it('Should resolve async children instead of stringifying the promise', async () => {
+      const Async = async () => <span>async</span>
+      const rendered = String(await jsxTemplate(tpl('<div>', '</div>'), jsx(Async, {})).toString())
+
+      expect(rendered).toBe('<div><span>async</span></div>')
+      expect(rendered).not.toContain('[object Promise]')
+    })
   })
 
   // https://en.reactjs.org/docs/jsx-in-depth.html#booleans-null-and-undefined-are-ignored

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -6,12 +6,19 @@
 export { jsxDEV as jsx, Fragment } from './jsx-dev-runtime'
 export { jsxDEV as jsxs } from './jsx-dev-runtime'
 export type { JSX } from './jsx-dev-runtime'
-import { html, raw } from '../helper/html'
+import { raw } from '../helper/html'
 import type { HtmlEscapedString, StringBuffer, HtmlEscaped } from '../utils/html'
 import { escapeToBuffer, stringBufferToString } from '../utils/html'
+import { JSXTemplateNode } from './base'
+import type { Child, JSXNode } from './base'
 import { isValidAttributeName, styleObjectForEach } from './utils'
 
-export { html as jsxTemplate }
+/**
+ * Build a node from the static HTML chunks and children produced by a
+ * precompiling JSX transform, such as Deno's `"jsx": "precompile"`.
+ */
+export const jsxTemplate = (strings: readonly string[], ...values: Child[]): JSXNode =>
+  new JSXTemplateNode(strings, values)
 
 export const jsxAttr = (
   key: string,


### PR DESCRIPTION
## What this fixes

Closes #4326.

Under a precompiling JSX transform — Deno's `"jsx": "precompile"`, which [hono.dev currently recommends for Deno](https://hono.dev/docs/getting-started/deno) — a context consumer returns the context **default** instead of the provided value whenever a host element sits between the provider and the consumer:

```tsx
const Ctx = createContext('default')
const Consumer = () => <span>{useContext(Ctx)}</span>

<Ctx.Provider value='provided'>
  <div>
    <Consumer />
  </div>
</Ctx.Provider>

// got:      <div><span>default</span></div>
// expected: <div><span>provided</span></div>
```

With an **async** consumer the same path emits the literal string `[object Promise]` into the response body.

Both failures are silent — no error is thrown, the page just renders wrong. The consumer works correctly when it is a direct child of the provider, or when the element in between is a component rather than a host element, which is what made this hard to pin down in the issue thread.

## Root cause

The precompile transform hoists static elements into `jsxTemplate(tpl, ...children)` calls:

```js
const $$_tpl_1 = ['<div>', '</div>']
jsx(Ctx.Provider, { value: 'provided', children: jsxTemplate($$_tpl_1, jsx(Consumer, {})) })
```

`jsxTemplate` was a bare alias for the `html` tagged-template helper (`src/jsx/jsx-runtime.ts`), and `html` is **eager** — it calls `child.toString()` on every interpolated value at call time (`src/helper/html/index.ts`).

Because `jsxTemplate(...)` is an argument expression, JavaScript evaluates it *before* `jsx(Ctx.Provider, ...)` is even constructed, let alone before the provider pushes its value in `createContext`. By the time the provider runs, the consumer's HTML is already a frozen string, so `useContext` had read the default. For an async consumer, `toString()` on a pending promise produced `[object Promise]`.

Everything else in the server renderer is lazy (`JSXNode.toStringToBuffer`), so the provider's push/pop window lines up correctly — `jsxTemplate` was the one eager outlier.

## The fix

`jsxTemplate` now returns a `JSXTemplateNode` that holds the static chunks and defers rendering to `toStringToBuffer()` like every other node. Children are therefore evaluated in their tree position, inside the provider's push/pop window, and promises flow through the existing buffer machinery instead of being stringified standalone.

Interpolated values are routed through the same `childrenToStringToBuffer` used for ordinary JSX children. That is the point of the change beyond the bug itself: a precompiling transform should not alter rendering semantics, so precompiled output is now byte-identical to the equivalent non-precompiled JSX.

## Testing

**`runtime-tests/deno-jsx/jsx.test.tsx`** — two tests covering the sync and async cases. This file is run under both `deno.precompile.json` and `deno.react-jsx.json`, so it pins the behaviour on the transform that actually exhibits the bug and confirms the react-jsx path is unaffected.

**`src/jsx/jsx-runtime.test.tsx`** — a `jsxTemplate()` block that exercises the transform's output shape directly, including a parity test asserting `jsxTemplate` and plain JSX produce identical output for escaped strings, numbers, booleans, `null`/`undefined`, nested arrays, `html` fragments and async components.

Verified against the real Deno precompile transform. Before the fix, 4 of 5 scenarios fail; after, all pass:

```
sync consumer under <div>     <div><span>default</span></div>   ->  <div><span>provided</span></div>
async consumer under <div>    [object Promise]                  ->  <div><span>provided</span></div>
deeply nested consumer        <b>default</b>                    ->  <b>deep</b>
sibling consumers             <i>default</i><i>default</i>      ->  <i>v</i><i>v</i>
interpolated string escaped   (already correct, unchanged)
```

Full suite: 145 files / 4625 tests passing, `tsc -p tsconfig.spec.json` clean, ESLint clean.

## Compatibility

`jsxTemplate` returns a `JSXNode` rather than an `HtmlEscapedString`. It is a transform target rather than a documented user-facing API, and `JSXNode` is already `isEscaped: true` with a working `toString()`, so it flows through `html`, `c.html()` and `renderToString` unchanged. The parameter type widened to `readonly string[]`, which still accepts a `TemplateStringsArray`.

One nuance worth flagging for review: values carrying `callbacks` (e.g. `hono/css`) now behave exactly as they do as ordinary JSX children rather than as `html` interpolations. I verified precompiled and non-precompiled output match in both cases, so this removes a divergence rather than introducing one — but it is the one intentional behavioural difference in the change.
