### PR TITLE
fix(cors): evaluate resolved allowOrigin instead of opts.origin for Vary header

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -570,5 +570,33 @@ describe('CORS Vary: Origin header - dynamic origin function', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://sub.example.com')
     expect(res.headers.get('Vary')).toBe('Origin')
   })
+
+  it('Should append Vary: Origin on preflight without overwriting existing Vary headers', async () => {
+    const app = new Hono()
+    app.use('/api/*', async (c, next) => {
+      c.header('Vary', 'Accept-Encoding', { append: true })
+      await next()
+    })
+    app.use(
+      '/api/*',
+      cors({
+        origin: 'http://example.com',
+      })
+    )
+
+    const res = await app.request(
+      new Request('http://localhost/api/test', {
+        method: 'OPTIONS',
+        headers: { origin: 'http://example.com' },
+      })
+    )
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+    expect(res.headers.get('Vary')?.split(/\s*,\s*/)).toEqual(
+      expect.arrayContaining(['Accept-Encoding', 'Origin'])
+    )
+  })
 })
+
 

--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -471,3 +471,104 @@ describe('CORS by Middleware', () => {
     ])
   })
 })
+
+describe('CORS Vary: Origin header - dynamic origin function', () => {
+  it('Should NOT set Vary: Origin when dynamic origin function resolves to "*"', async () => {
+    const app = new Hono()
+    app.use(
+      '/api/*',
+      cors({
+        origin: (origin) => (origin.endsWith('.example.com') ? origin : '*'),
+      })
+    )
+    app.get('/api/test', (c) => c.json({ ok: true }))
+
+    // Request from an origin that causes the function to return '*'
+    const res = await app.request('http://localhost/api/test', {
+      headers: { origin: 'http://untrusted-site.com' },
+    })
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(res.headers.get('Vary')).toBeNull()
+  })
+
+  it('Should set Vary: Origin when dynamic origin function resolves to an explicit origin', async () => {
+    const app = new Hono()
+    app.use(
+      '/api/*',
+      cors({
+        origin: (origin) => (origin.endsWith('.example.com') ? origin : '*'),
+      })
+    )
+    app.get('/api/test', (c) => c.json({ ok: true }))
+
+    // Request from an origin that causes the function to return an explicit origin
+    const res = await app.request('http://localhost/api/test', {
+      headers: { origin: 'http://sub.example.com' },
+    })
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://sub.example.com')
+    expect(res.headers.get('Vary')).toBe('Origin')
+  })
+
+  it('Should NOT set Vary: Origin when dynamic origin function resolves to null (rejected origin)', async () => {
+    const app = new Hono()
+    app.use(
+      '/api/*',
+      cors({
+        origin: () => null,
+      })
+    )
+    app.get('/api/test', (c) => c.json({ ok: true }))
+
+    const res = await app.request('http://localhost/api/test', {
+      headers: { origin: 'http://evil.com' },
+    })
+
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBe(false)
+    expect(res.headers.get('Vary')).toBeNull()
+  })
+
+  it('Should NOT set Vary: Origin on preflight when dynamic origin function resolves to "*"', async () => {
+    const app = new Hono()
+    app.use(
+      '/api/*',
+      cors({
+        origin: (origin) => (origin.endsWith('.example.com') ? origin : '*'),
+      })
+    )
+
+    const res = await app.request(
+      new Request('http://localhost/api/test', {
+        method: 'OPTIONS',
+        headers: { origin: 'http://untrusted-site.com' },
+      })
+    )
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(res.headers.get('Vary')).toBeNull()
+  })
+
+  it('Should set Vary: Origin on preflight when dynamic origin function resolves to an explicit origin', async () => {
+    const app = new Hono()
+    app.use(
+      '/api/*',
+      cors({
+        origin: (origin) => (origin.endsWith('.example.com') ? origin : '*'),
+      })
+    )
+
+    const res = await app.request(
+      new Request('http://localhost/api/test', {
+        method: 'OPTIONS',
+        headers: { origin: 'http://sub.example.com' },
+      })
+    )
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://sub.example.com')
+    expect(res.headers.get('Vary')).toBe('Origin')
+  })
+})
+

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -113,7 +113,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
     if (c.req.method === 'OPTIONS') {
       if (allowOrigin && allowOrigin !== '*') {
-        set('Vary', 'Origin')
+        c.header('Vary', 'Origin', { append: true })
       }
 
       if (opts.maxAge != null) {

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -112,7 +112,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
     }
 
     if (c.req.method === 'OPTIONS') {
-      if (opts.origin !== '*') {
+      if (allowOrigin && allowOrigin !== '*') {
         set('Vary', 'Origin')
       }
 
@@ -150,7 +150,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
     // Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard).
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-    if (opts.origin !== '*') {
+    if (allowOrigin && allowOrigin !== '*') {
       c.header('Vary', 'Origin', { append: true })
     }
   }


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

---

### Related Issue
Fixes #5159

---

### Summary / Motivation

In `src/middleware/cors/index.ts`, the decision to append `Vary: Origin` previously checked `opts.origin !== '*'`.

When `origin` is configured as a dynamic function (e.g. `(origin, c) => ...`):
1. `typeof opts.origin` is `'function'`, causing `opts.origin !== '*'` to **always evaluate to `true`**, even when the function resolves to `'*'`. As a result, `Vary: Origin` was incorrectly appended when returning `Access-Control-Allow-Origin: *`.
2. When the function resolved to `null` (origin disallowed), `Access-Control-Allow-Origin` was omitted, but `Vary: Origin` was still unnecessarily appended.

Per [MDN CORS documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin):
> *"Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard)."*

`Vary: Origin` should only be set/appended when an explicit origin string is returned in `Access-Control-Allow-Origin`.

---

### Key Changes

1. **`src/middleware/cors/index.ts`**:
   - Replaced `if (opts.origin !== '*')` with `if (allowOrigin && allowOrigin !== '*')` in both the preflight (`OPTIONS`) handling block and post-handler (`await next()`) block.
2. **`src/middleware/cors/index.test.ts`**:
   - Added 5 comprehensive test cases covering dynamic origin functions:
     - `GET` request resolving to `'*'` -> asserts `Vary` is `null`.
     - `GET` request resolving to explicit origin -> asserts `Vary` is `'Origin'`.
     - `GET` request resolving to `null` (rejected origin) -> asserts `Vary` is `null`.
     - `OPTIONS` preflight resolving to `'*'` -> asserts `Vary` is `null`.
     - `OPTIONS` preflight resolving to explicit origin -> asserts `Vary` is `'Origin'`.
