### PR TITLE
fix: use `Object.create(null)` when parsing query, headers, and params

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -236,6 +236,12 @@ describe('headers', () => {
     expect(req.header('Content-Type')).toBe('application/json')
     expect(req.header('ApiKey')).toBe('abc')
   })
+
+  test('req.header() is not affected by a `__proto__` header name', () => {
+    const req = new HonoRequest(new Request('http://localhost', { headers: { __proto__: 'evil' } }))
+    const headers = req.header()
+    expect(Object.getPrototypeOf(headers)).toBeNull()
+  })
 })
 
 const text = '{"foo":"bar"}'

--- a/src/request.ts
+++ b/src/request.ts
@@ -190,7 +190,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
       return this.raw.headers.get(name) ?? undefined
     }
 
-    const headerData: Record<string, string | undefined> = {}
+    const headerData: Record<string, string | undefined> = Object.create(null)
     this.raw.headers.forEach((value, key) => {
       headerData[key] = value
     })

--- a/src/utils/accept.test.ts
+++ b/src/utils/accept.test.ts
@@ -70,6 +70,12 @@ describe('parseAccept Comprehensive Tests', () => {
       expect(result[0].params.key).toBe('2')
       expect(result[0].params.KEY).toBe('3')
     })
+
+    test('treats `__proto__` as a normal parameter without changing the prototype', () => {
+      const result = parseAccept('text/html;__proto__=x')
+      expect(Object.getPrototypeOf(result[0].params)).toBeNull()
+      expect(result[0].params['__proto__']).toBe('x')
+    })
   })
 
   describe('Media Type Edge Cases', () => {

--- a/src/utils/accept.ts
+++ b/src/utils/accept.ts
@@ -162,7 +162,7 @@ const getNextAcceptValue = (
 ): [number, Accept | undefined] => {
   const accept: Accept = {
     type: '',
-    params: {},
+    params: Object.create(null),
     q: 1,
   }
   startIndex = consumeWhitespace(acceptHeader, startIndex)

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -359,5 +359,14 @@ describe('url', () => {
         toString: [''],
       })
     })
+
+    it('should treat `__proto__` as a normal key without changing the prototype', () => {
+      const params = getQueryParams('http://example.com/?__proto__=a&__proto__=b') as Record<
+        string,
+        string[]
+      >
+      expect(Object.getPrototypeOf(params)).toBeNull()
+      expect(params['__proto__']).toEqual(['a', 'b'])
+    })
   })
 })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -252,7 +252,7 @@ const _getQueryParam = (
     // fallback to default routine
   }
 
-  const results: Record<string, string> | Record<string, string[]> = {}
+  const results: Record<string, string> | Record<string, string[]> = Object.create(null)
   encoded ??= /[%+]/.test(url)
 
   let keyIndex = url.indexOf('?', 8)


### PR DESCRIPTION
A `__proto__` key in a request could change the prototype of the returned object. I use `Object.create(null)` to keep `__proto__` as a normal key. This is limited to that single object and does not touch `Object.prototype`, so it is not prototype pollution. This is a code-quality fix, not a security fix.

By the way, I am planning to create a utility function to do `Object.create(null)`  to reduce the bundle size.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
