### PR TITLE
fix(cookie): relax name validation when parsing Cookie header

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -80,6 +80,32 @@ describe('Parse cookie', () => {
     expect(cookie['']).toBeUndefined()
   })
 
+  it('Should parse cookies whose names are not RFC 6265 tokens', () => {
+    const cookieString =
+      'paraglide:lang=en; CognitoIdentityServiceProvider.abc.user@example.com.idToken=token; round(brackets)=ok; square[brackets]=ok; curly{brackets}=ok'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['paraglide:lang']).toBe('en')
+    expect(cookie['CognitoIdentityServiceProvider.abc.user@example.com.idToken']).toBe('token')
+    expect(cookie['round(brackets)']).toBe('ok')
+    expect(cookie['square[brackets]']).toBe('ok')
+    expect(cookie['curly{brackets}']).toBe('ok')
+  })
+
+  it('Should parse one cookie specified by a name that is not an RFC 6265 token', () => {
+    const cookieString = 'paraglide:lang=en; test=ok'
+    const cookie: Cookie = parse(cookieString, 'paraglide:lang')
+    expect(cookie['paraglide:lang']).toBe('en')
+    expect(cookie['test']).toBeUndefined()
+  })
+
+  it('Should ignore cookie names containing non-ASCII or control characters', () => {
+    const cookieString = 'yummy_cookie=choco; クッキー=strawberry; bad\x01name=sugar'
+    const cookie: Cookie = parse(cookieString)
+    expect(cookie['yummy_cookie']).toBe('choco')
+    expect(cookie['クッキー']).toBeUndefined()
+    expect(cookie['bad\x01name']).toBeUndefined()
+  })
+
   it('Should ignore invalid cookie values', () => {
     const cookieString = 'yummy_cookie=choco\\nchip; tasty_cookie=strawberry; best_cookie="sugar'
     const cookie: Cookie = parse(cookieString)

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -67,7 +67,14 @@ const verifySignature = async (
 
 // all alphanumeric chars and all of _!#$%&'*.^`|~+-
 // (see: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)
+// used only when producing cookies via serialize(); parsing uses the relaxed regex below
 const validCookieNameRegEx = /^[\w!#$%&'*.^`|~+-]+$/
+
+// all ASCII chars 33-126 except 34, 59, 61, and 92 (i.e. "!" to "~" but not double quote, semicolon, equals, or backslash)
+// the strict RFC 6265 token rule above is a requirement for cookie producers; when consuming
+// the Cookie header we accept the names other producers emit in the wild, e.g. "paraglide:lang"
+// (see: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-5.6 and https://github.com/honojs/hono/issues/3189)
+const relaxedCookieNameRegEx = /^[!#-:<>-[\]-~]+$/
 
 // all ASCII chars 32-126 except 34, 59, and 92 (i.e. space to tilde but not double quote, semicolon, or backslash)
 // (see: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)
@@ -115,7 +122,7 @@ export const parse = (cookie: string, name?: string): Cookie => {
     const cookieName = trimCookieWhitespace(pairStr.substring(0, valueStartPos))
     if (
       (name && name !== cookieName) ||
-      !validCookieNameRegEx.test(cookieName) ||
+      !relaxedCookieNameRegEx.test(cookieName) ||
       cookieName in parsedCookie
     ) {
       continue


### PR DESCRIPTION
Fixes #3189

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
