### PR TITLE
fix(jsx): handle useSyncExternalStore subscription and snapshot changes

### DIFF
--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -674,7 +674,7 @@ describe('Hooks', () => {
       let count = 0
       const unsubscribe = vi.fn()
       const subscribe = vi.fn(() => unsubscribe)
-      const getSnapshot = vi.fn(() => count++)
+      const getSnapshot = vi.fn(() => count)
       const SubApp = () => {
         const count = useSyncExternalStore(subscribe, getSnapshot)
         return <div>{count}</div>
@@ -695,16 +695,46 @@ describe('Hooks', () => {
       await new Promise((r) => setTimeout(r))
       expect(root.innerHTML).toBe('<button>toggle</button>')
       expect(unsubscribe).toBeCalled()
+      count = 1
       root.querySelector('button')?.click()
       await new Promise((r) => setTimeout(r))
       expect(root.innerHTML).toBe('<div>1</div><button>toggle</button>')
+    })
+
+    it('updates the snapshot when subscribe changes', async () => {
+      const unsubscribeA = vi.fn()
+      const subscribeA = vi.fn(() => unsubscribeA)
+      const subscribeB = vi.fn(() => vi.fn())
+      const stores = [
+        { subscribe: subscribeA, getSnapshot: () => 'a1' },
+        { subscribe: subscribeB, getSnapshot: () => 'b0' },
+      ]
+
+      const App = () => {
+        const [index, setIndex] = useState(0)
+        const store = stores[index]
+        const value = useSyncExternalStore(store.subscribe, store.getSnapshot)
+        return <button onClick={() => setIndex(1)}>{value}</button>
+      }
+
+      render(<App />, root)
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>a1</button>')
+      expect(subscribeA).toBeCalledTimes(1)
+
+      root.querySelector('button')?.click()
+      await Promise.resolve()
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>b0</button>')
+      expect(unsubscribeA).toBeCalledTimes(1)
+      expect(subscribeB).toBeCalledTimes(1)
     })
 
     it('with getServerSnapshot', async () => {
       let count = 0
       const unsubscribe = vi.fn()
       const subscribe = vi.fn(() => unsubscribe)
-      const getSnapshot = vi.fn(() => count++)
+      const getSnapshot = vi.fn(() => count)
       const getServerSnapshot = vi.fn(() => 100)
       const SubApp = () => {
         const count = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
@@ -727,6 +757,7 @@ describe('Hooks', () => {
       await new Promise((r) => setTimeout(r))
       expect(root.innerHTML).toBe('<button>toggle</button>')
       expect(unsubscribe).toBeCalled()
+      count = 1
       root.querySelector('button')?.click()
       await new Promise((r) => setTimeout(r))
       expect(root.innerHTML).toBe('<div>1</div><button>toggle</button>')

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -13,6 +13,7 @@ import {
   useDeferredValue,
   useId,
   useImperativeHandle,
+  useLayoutEffect,
   useReducer,
   useState,
   useSyncExternalStore,
@@ -758,6 +759,31 @@ describe('Hooks', () => {
       listeners.forEach((listener) => listener())
       await new Promise((r) => setTimeout(r))
       expect(root.innerHTML).toBe('<button>b1</button>')
+    })
+
+    it('uses the latest getSnapshot when subscribing after a layout effect update', async () => {
+      const state = { a: 'a0', b: 'b0' }
+      const subscribe = vi.fn((_listener: () => void) => vi.fn())
+
+      const App = () => {
+        const [key, setKey] = useState<keyof typeof state>('a')
+        const value = useSyncExternalStore(subscribe, () => state[key])
+
+        useLayoutEffect(() => {
+          setKey('b')
+          queueMicrotask(() => {
+            state.b = 'b1'
+          })
+        }, [])
+
+        return <div>{value}</div>
+      }
+
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<div>a0</div>')
+
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<div>b1</div>')
     })
 
     it('does not loop when subscribe changes on every render', async () => {

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -730,6 +730,62 @@ describe('Hooks', () => {
       expect(subscribeB).toBeCalledTimes(1)
     })
 
+    it('updates the snapshot when getSnapshot changes', async () => {
+      const state: Record<string, string> = { a: 'a0', b: 'b0' }
+      const listeners = new Set<() => void>()
+      const subscribe = vi.fn((listener: () => void) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      })
+
+      const App = () => {
+        const [key, setKey] = useState('a')
+        const value = useSyncExternalStore(subscribe, () => state[key])
+        return <button onClick={() => setKey('b')}>{value}</button>
+      }
+
+      render(<App />, root)
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>a0</button>')
+      expect(subscribe).toBeCalledTimes(1)
+
+      root.querySelector('button')?.click()
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>b0</button>')
+      expect(subscribe).toBeCalledTimes(1)
+
+      state.b = 'b1'
+      listeners.forEach((listener) => listener())
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>b1</button>')
+    })
+
+    it('does not loop when subscribe changes on every render', async () => {
+      const subscribe = vi.fn((_listener: () => void) => vi.fn())
+      const getSnapshot = () => 'snapshot'
+      let renderCount = 0
+
+      const App = () => {
+        const [count, setCount] = useState(0)
+        renderCount++
+        const value = useSyncExternalStore((listener) => subscribe(listener), getSnapshot)
+        return <button onClick={() => setCount((count) => count + 1)}>{`${value}:${count}`}</button>
+      }
+
+      render(<App />, root)
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>snapshot:0</button>')
+      expect(renderCount).toBe(1)
+      expect(subscribe).toBeCalledTimes(1)
+
+      root.querySelector('button')?.click()
+      await Promise.resolve()
+      await new Promise((r) => setTimeout(r))
+      expect(root.innerHTML).toBe('<button>snapshot:1</button>')
+      expect(renderCount).toBe(2)
+      expect(subscribe).toBeCalledTimes(2)
+    })
+
     it('with getServerSnapshot', async () => {
       let count = 0
       const unsubscribe = vi.fn()

--- a/src/jsx/hooks/dom.test.tsx
+++ b/src/jsx/hooks/dom.test.tsx
@@ -705,7 +705,8 @@ describe('Hooks', () => {
     it('updates the snapshot when subscribe changes', async () => {
       const unsubscribeA = vi.fn()
       const subscribeA = vi.fn(() => unsubscribeA)
-      const subscribeB = vi.fn(() => vi.fn())
+      const unsubscribeB = vi.fn()
+      const subscribeB = vi.fn(() => unsubscribeB)
       const stores = [
         { subscribe: subscribeA, getSnapshot: () => 'a1' },
         { subscribe: subscribeB, getSnapshot: () => 'b0' },
@@ -725,10 +726,13 @@ describe('Hooks', () => {
 
       root.querySelector('button')?.click()
       await Promise.resolve()
-      await new Promise((r) => setTimeout(r))
       expect(root.innerHTML).toBe('<button>b0</button>')
+      // the old store stays subscribed until the new subscription is set up at effect flush
+      expect(unsubscribeA).not.toBeCalled()
+      await new Promise((r) => setTimeout(r))
       expect(unsubscribeA).toBeCalledTimes(1)
       expect(subscribeB).toBeCalledTimes(1)
+      expect(unsubscribeB).not.toBeCalled()
     })
 
     it('updates the snapshot when getSnapshot changes', async () => {
@@ -787,7 +791,12 @@ describe('Hooks', () => {
     })
 
     it('does not loop when subscribe changes on every render', async () => {
-      const subscribe = vi.fn((_listener: () => void) => vi.fn())
+      const unsubscribes: ReturnType<typeof vi.fn>[] = []
+      const subscribe = vi.fn((_listener: () => void) => {
+        const unsubscribe = vi.fn()
+        unsubscribes.push(unsubscribe)
+        return unsubscribe
+      })
       const getSnapshot = () => 'snapshot'
       let renderCount = 0
 
@@ -810,6 +819,8 @@ describe('Hooks', () => {
       expect(root.innerHTML).toBe('<button>snapshot:1</button>')
       expect(renderCount).toBe(2)
       expect(subscribe).toBeCalledTimes(2)
+      expect(unsubscribes[0]).toBeCalledTimes(1)
+      expect(unsubscribes[1]).not.toBeCalled()
     })
 
     it('with getServerSnapshot', async () => {

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -413,13 +413,11 @@ export const useSyncExternalStore = <T>(
     serverSnapshotIsUsed ? (getServerSnapshot as () => T)() : getSnapshot()
   )
   useEffect(() => {
-    if (serverSnapshotIsUsed) {
-      setState(getSnapshot())
-    }
-    return subscribe(() => {
-      setState(getSnapshot())
-    })
-  }, [])
+    const update = () => setState(() => getSnapshot())
+    const unsubscribe = subscribe(update)
+    update()
+    return unsubscribe
+  }, [subscribe])
 
   return state
 }

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -411,10 +411,13 @@ export const useSyncExternalStore = <T>(
   const snapshot =
     buildData[0][4] && getServerSnapshot ? (getServerSnapshot as () => T)() : getSnapshot()
   const [, setVersion] = useState(0)
+  const latestSnapshot = useRef<[T, () => T]>([snapshot, getSnapshot])
+  latestSnapshot.current = [snapshot, getSnapshot]
 
   useEffect(() => {
     const update = () => setVersion((version) => version + 1)
     const unsubscribe = subscribe(update)
+    const [snapshot, getSnapshot] = latestSnapshot.current!
     if (!Object.is(snapshot, getSnapshot())) {
       update()
     }

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -413,16 +413,21 @@ export const useSyncExternalStore = <T>(
   const [, setVersion] = useState(0)
   const latestSnapshot = useRef<[T, () => T]>([snapshot, getSnapshot])
   latestSnapshot.current = [snapshot, getSnapshot]
+  const unsubscribeRef = useRef<() => void>(null)
 
+  // Swap subscriptions at effect flush: a returned cleanup would run synchronously
+  // during render when `subscribe` changes, leaving a window with no subscription.
   useEffect(() => {
     const update = () => setVersion((version) => version + 1)
-    const unsubscribe = subscribe(update)
+    unsubscribeRef.current?.()
+    unsubscribeRef.current = subscribe(update)
     const [snapshot, getSnapshot] = latestSnapshot.current!
     if (!Object.is(snapshot, getSnapshot())) {
       update()
     }
-    return unsubscribe
   }, [subscribe])
+
+  useEffect(() => () => unsubscribeRef.current?.(), [])
 
   return snapshot
 }

--- a/src/jsx/hooks/index.ts
+++ b/src/jsx/hooks/index.ts
@@ -408,16 +408,18 @@ export const useSyncExternalStore = <T>(
     return getServerSnapshot()
   }
 
-  const [serverSnapshotIsUsed] = useState<boolean>(!!(buildData[0][4] && getServerSnapshot))
-  const [state, setState] = useState(() =>
-    serverSnapshotIsUsed ? (getServerSnapshot as () => T)() : getSnapshot()
-  )
+  const snapshot =
+    buildData[0][4] && getServerSnapshot ? (getServerSnapshot as () => T)() : getSnapshot()
+  const [, setVersion] = useState(0)
+
   useEffect(() => {
-    const update = () => setState(() => getSnapshot())
+    const update = () => setVersion((version) => version + 1)
     const unsubscribe = subscribe(update)
-    update()
+    if (!Object.is(snapshot, getSnapshot())) {
+      update()
+    }
     return unsubscribe
   }, [subscribe])
 
-  return state
+  return snapshot
 }


### PR DESCRIPTION
fixes #5162

The reported issue can be addressed by making the subscription effect depend on `subscribe`. This PR goes slightly further and also handles changes to `getSnapshot`:

- Re-subscribe when `subscribe` changes.
- Keep the previous subscription active until the new subscription is installed during the effect flush.
- Read the snapshot during render so a changed `getSnapshot` is reflected without waiting for a store notification.
- Re-check the latest snapshot after subscribing to avoid missing an update between render and effect execution.
- Add regression tests for changing `subscribe` and `getSnapshot`.

While investigating this, I also explored fixing the underlying deferred effect and cleanup behavior. Since that would affect all effect hooks and needs broader review, it is intentionally kept out of this PR; see the draft PoC in #5165.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code