### PR TITLE
chore: remove undici in favor of global fetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,6 @@
         "prettier": "3.7.4",
         "publint": "0.3.15",
         "typescript": "^6.0.3",
-        "undici": "^6.27.0",
         "vite-plugin-fastly-js-compute": "^0.4.2",
         "vitest": "^4.1.9",
         "wrangler": "4.107.0",
@@ -1462,7 +1461,7 @@
 
     "unbzip2-stream": ["unbzip2-stream@1.4.3", "", { "dependencies": { "buffer": "^5.2.1", "through": "^2.3.8" } }, "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg=="],
 
-    "undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
+    "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
@@ -1659,8 +1658,6 @@
     "@jsdevtools/ez-spawn/cross-spawn": ["cross-spawn@7.0.3", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w=="],
 
     "@napi-rs/lzma-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.4", "", { "dependencies": { "@emnapi/core": "^1.1.0", "@emnapi/runtime": "^1.1.0", "@tybys/wasm-util": "^0.9.0" } }, "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ=="],
-
-    "@octokit/action/undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
     "@octokit/auth-action/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 

--- a/package.json
+++ b/package.json
@@ -685,7 +685,6 @@
     "prettier": "3.7.4",
     "publint": "0.3.15",
     "typescript": "^6.0.3",
-    "undici": "^6.27.0",
     "vite-plugin-fastly-js-compute": "^0.4.2",
     "vitest": "^4.1.9",
     "wrangler": "4.107.0",

--- a/runtime-tests/node/index.test.ts
+++ b/runtime-tests/node/index.test.ts
@@ -1,5 +1,4 @@
 import { createAdaptorServer, serve } from '@hono/node-server'
-import * as undici from 'undici'
 import { once } from 'node:events'
 import type { Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
@@ -278,10 +277,10 @@ function createAgent(app: Hono) {
   const listening = once(server.listen(), 'listening')
 
   return {
-    async get(path: string, init?: undici.RequestInit) {
+    async get(path: string, init?: RequestInit) {
       await listening
       const url = new URL(path, getOrigin())
-      return undici.fetch(url, init)
+      return fetch(url, init)
     },
   }
 


### PR DESCRIPTION
`undici` is only used in `runtime-tests/node/index.test.ts` to call `fetch`, which has been global since Node 18. The test stack already requires Node >= 20, so the dependency can be dropped and the test can just use the global `fetch`.

It still appears in `bun.lock` as a transitive dep, so the version line changes there instead of going away

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code