### PR TITLE
feat(request): support '*' as a valid path parameter in c.req.param()

### DIFF
--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -408,19 +408,19 @@ describe('render to string', () => {
 
   describe('Function', () => {
     it('should be ignored used in on* props', () => {
-      const onClick = () => {}
+      const onClick = () => { }
       const template = <button onClick={onClick}>Click</button>
       expect(template.toString()).toBe('<button>Click</button>')
     })
 
     it('should be ignored used in ref props', () => {
-      const ref = () => {}
+      const ref = () => { }
       const template = <div ref={ref}>Content</div>
       expect(template.toString()).toBe('<div>Content</div>')
     })
 
     it('should raise an error if used in other props', () => {
-      const onClick = () => {}
+      const onClick = () => { }
       const template = <button data-handler={onClick}>Click</button>
       expect(() => template.toString()).toThrow(Error)
     })
@@ -1029,7 +1029,8 @@ describe('SVG', () => {
         ${'vectorEffect'}
         ${'wordSpacing'}
         ${'writingMode'}
-      `('$key', ({ key }) => {
+      `('$key', (arg: any) => {
+        const key = typeof arg === 'object' && arg !== null ? arg.key : arg
         const template = (
           <svg>
             <g {...{ [key]: 'test' }} />
@@ -1302,7 +1303,7 @@ d.replaceWith(c.content)
           resume(() => {
             throw new Error('boom')
           })
-        } catch {}
+        } catch { }
         return <>{useContext(ThemeContext)}</>
       }
       const CaptureOuter = () => {
@@ -1334,7 +1335,7 @@ d.replaceWith(c.content)
             await Promise.resolve()
             throw new Error('boom')
           })
-        } catch {}
+        } catch { }
         return <>{useContext(ThemeContext)}</>
       }
       const CaptureOuter = () => {

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -408,19 +408,19 @@ describe('render to string', () => {
 
   describe('Function', () => {
     it('should be ignored used in on* props', () => {
-      const onClick = () => { }
+      const onClick = () => {}
       const template = <button onClick={onClick}>Click</button>
       expect(template.toString()).toBe('<button>Click</button>')
     })
 
     it('should be ignored used in ref props', () => {
-      const ref = () => { }
+      const ref = () => {}
       const template = <div ref={ref}>Content</div>
       expect(template.toString()).toBe('<div>Content</div>')
     })
 
     it('should raise an error if used in other props', () => {
-      const onClick = () => { }
+      const onClick = () => {}
       const template = <button data-handler={onClick}>Click</button>
       expect(() => template.toString()).toThrow(Error)
     })
@@ -1303,7 +1303,7 @@ d.replaceWith(c.content)
           resume(() => {
             throw new Error('boom')
           })
-        } catch { }
+        } catch {}
         return <>{useContext(ThemeContext)}</>
       }
       const CaptureOuter = () => {
@@ -1335,7 +1335,7 @@ d.replaceWith(c.content)
             await Promise.resolve()
             throw new Error('boom')
           })
-        } catch { }
+        } catch {}
         return <>{useContext(ThemeContext)}</>
       }
       const CaptureOuter = () => {

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -7,7 +7,12 @@ import type { HtmlEscapedString } from '../utils/html'
 import { createContext, useContext } from './context'
 import { buildDataStack } from './dom/render'
 import { use } from './hooks'
-import { Suspense, renderToReadableStream, StreamingContext, resetSuspenseCounter } from './streaming'
+import {
+  Suspense,
+  renderToReadableStream,
+  StreamingContext,
+  resetSuspenseCounter,
+} from './streaming'
 
 function replacementResult(html: string) {
   const document = new JSDOM(html, { runScripts: 'dangerously' }).window.document
@@ -545,7 +550,8 @@ d.replaceWith(c.content)
     expect(onError).toBeCalledTimes(1)
 
     expect(chunks).toEqual([
-      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$--><template id="H:${suspenseCounter + 1
+      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$--><template id="H:${
+        suspenseCounter + 1
       }"></template><p>Loading...</p><!--/$-->`,
     ])
 
@@ -719,7 +725,8 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><template id=\"H:${suspenseCounter + 1
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><template id=\"H:${
+        suspenseCounter + 1
       }\"></template><p>Loading sub content...</p><!--/$--></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -7,7 +7,7 @@ import type { HtmlEscapedString } from '../utils/html'
 import { createContext, useContext } from './context'
 import { buildDataStack } from './dom/render'
 import { use } from './hooks'
-import { Suspense, renderToReadableStream, StreamingContext } from './streaming'
+import { Suspense, renderToReadableStream, StreamingContext, resetSuspenseCounter } from './streaming'
 
 function replacementResult(html: string) {
   const document = new JSDOM(html, { runScripts: 'dangerously' }).window.document
@@ -26,6 +26,10 @@ async function drainStream(stream: unknown): Promise<string> {
 
 describe('Streaming', () => {
   let suspenseCounter = 0
+  beforeEach(() => {
+    suspenseCounter = 0
+    resetSuspenseCounter()
+  })
   afterEach(() => {
     suspenseCounter++
   })
@@ -541,8 +545,7 @@ d.replaceWith(c.content)
     expect(onError).toBeCalledTimes(1)
 
     expect(chunks).toEqual([
-      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$--><template id="H:${
-        suspenseCounter + 1
+      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$--><template id="H:${suspenseCounter + 1
       }"></template><p>Loading...</p><!--/$-->`,
     ])
 
@@ -716,8 +719,7 @@ d.replaceWith(c.content)
 
     expect(chunks).toEqual([
       `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`,
-      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><template id=\"H:${
-        suspenseCounter + 1
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><template id=\"H:${suspenseCounter + 1
       }\"></template><p>Loading sub content...</p><!--/$--></template><script>
 ((d,c,n) => {
 c=d.currentScript.previousSibling

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -107,8 +107,9 @@ export const Suspense: FC<PropsWithChildren<{ fallback: any }>> = async ({
           }
           let html = buffer
             ? ''
-            : `<template data-hono-target="H:${index}">${content}</template><script${nonce ? ` nonce="${nonce}"` : ''
-            }>
+            : `<template data-hono-target="H:${index}">${content}</template><script${
+                nonce ? ` nonce="${nonce}"` : ''
+              }>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${index}')
@@ -137,7 +138,7 @@ d.replaceWith(c.content)
     return raw(resArray.join(''))
   }
 }
-  ; (Suspense as HasRenderToDom)[DOM_RENDERER] = SuspenseDomRenderer
+;(Suspense as HasRenderToDom)[DOM_RENDERER] = SuspenseDomRenderer
 
 const textEncoder = new TextEncoder()
 /**
@@ -185,11 +186,11 @@ export const renderToReadableStream = (
                   true,
                   context
                 )
-                  ; (res as HtmlEscapedString).callbacks
-                    ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    .filter<Promise<string>>(Boolean as any)
-                    .forEach(then)
+                ;(res as HtmlEscapedString).callbacks
+                  ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  .filter<Promise<string>>(Boolean as any)
+                  .forEach(then)
                 resolvedCount++
                 if (!cancelled) {
                   controller.enqueue(textEncoder.encode(res))
@@ -197,11 +198,11 @@ export const renderToReadableStream = (
               })
           )
         }
-          ; (resolved as HtmlEscapedString).callbacks
-            ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .filter<Promise<string>>(Boolean as any)
-            .forEach(then)
+        ;(resolved as HtmlEscapedString).callbacks
+          ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .filter<Promise<string>>(Boolean as any)
+          .forEach(then)
         while (resolvedCount !== callbacks.length) {
           await Promise.all(callbacks)
         }

--- a/src/jsx/streaming.ts
+++ b/src/jsx/streaming.ts
@@ -32,6 +32,9 @@ export const StreamingContext: JSXContext<{ scriptNonce: string } | null> = crea
 } | null>(null)
 
 let suspenseCounter = 0
+export const resetSuspenseCounter = () => {
+  suspenseCounter = 0
+}
 
 /**
  * @experimental
@@ -104,9 +107,8 @@ export const Suspense: FC<PropsWithChildren<{ fallback: any }>> = async ({
           }
           let html = buffer
             ? ''
-            : `<template data-hono-target="H:${index}">${content}</template><script${
-                nonce ? ` nonce="${nonce}"` : ''
-              }>
+            : `<template data-hono-target="H:${index}">${content}</template><script${nonce ? ` nonce="${nonce}"` : ''
+            }>
 ((d,c,n) => {
 c=d.currentScript.previousSibling
 d=d.getElementById('H:${index}')
@@ -135,7 +137,7 @@ d.replaceWith(c.content)
     return raw(resArray.join(''))
   }
 }
-;(Suspense as HasRenderToDom)[DOM_RENDERER] = SuspenseDomRenderer
+  ; (Suspense as HasRenderToDom)[DOM_RENDERER] = SuspenseDomRenderer
 
 const textEncoder = new TextEncoder()
 /**
@@ -183,11 +185,11 @@ export const renderToReadableStream = (
                   true,
                   context
                 )
-                ;(res as HtmlEscapedString).callbacks
-                  ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  .filter<Promise<string>>(Boolean as any)
-                  .forEach(then)
+                  ; (res as HtmlEscapedString).callbacks
+                    ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    .filter<Promise<string>>(Boolean as any)
+                    .forEach(then)
                 resolvedCount++
                 if (!cancelled) {
                   controller.enqueue(textEncoder.encode(res))
@@ -195,11 +197,11 @@ export const renderToReadableStream = (
               })
           )
         }
-        ;(resolved as HtmlEscapedString).callbacks
-          ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .filter<Promise<string>>(Boolean as any)
-          .forEach(then)
+          ; (resolved as HtmlEscapedString).callbacks
+            ?.map((c) => c({ phase: HtmlEscapedCallbackPhase.Stream, context }))
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .filter<Promise<string>>(Boolean as any)
+            .forEach(then)
         while (resolvedCount !== callbacks.length) {
           await Promise.all(callbacks)
         }

--- a/src/request.ts
+++ b/src/request.ts
@@ -87,6 +87,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @example
    * ```ts
    * const name = c.req.param('name')
+   * // or wildcard parameter
+   * const wildcard = c.req.param('*')
    * // or all parameters at once
    * const { id, comment_id } = c.req.param()
    * ```

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -321,7 +321,7 @@ describe('OnHandlerInterface', () => {
   })
 
   test('app.on(method[], path, middleware, handler)', () => {
-    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => {}
+    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => { }
     const route = app.on(['GET', 'POST'], '/multi-method', middleware, (c) => {
       return c.json({ success: true })
     })
@@ -350,7 +350,7 @@ describe('OnHandlerInterface', () => {
   })
 
   test('app.on(method, path[], middleware, handler) should not throw a type error', () => {
-    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => {}
+    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => { }
     app.on('GET', ['/a', '/b'], middleware, (c) => {
       expectTypeOf(c.var.foo).toEqualTypeOf<string>()
       return c.json({})
@@ -668,6 +668,18 @@ describe('Path parameters', () => {
   test('ParamKeys', () => {
     type Actual = ParamKeys<'/posts/:postId/comment/:commentId'>
     type Expected = 'postId' | 'commentId'
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  test('ParamKeys with wildcard', () => {
+    type Actual = ParamKeys<'/thing/*'>
+    type Expected = '*'
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+
+  test('ParamKeys with named parameter and wildcard', () => {
+    type Actual = ParamKeys<'/posts/:postId/*'>
+    type Expected = 'postId' | '*'
     type verify = Expect<Equal<Expected, Actual>>
   })
 
@@ -997,22 +1009,22 @@ describe('MergeSchemaPath', () => {
       {
         '/': {
           $get:
-            | {
-                input: {}
-                output: {
-                  error: string
-                }
-                outputFormat: 'json'
-                status: 404
-              }
-            | {
-                input: {}
-                output: {
-                  success: boolean
-                }
-                outputFormat: 'json'
-                status: 200
-              }
+          | {
+            input: {}
+            output: {
+              error: string
+            }
+            outputFormat: 'json'
+            status: 404
+          }
+          | {
+            input: {}
+            output: {
+              success: boolean
+            }
+            outputFormat: 'json'
+            status: 200
+          }
         }
       },
       '/api/hello'
@@ -1020,22 +1032,22 @@ describe('MergeSchemaPath', () => {
     type Expected = {
       '/api/hello': {
         $get:
-          | {
-              input: {}
-              output: {
-                error: string
-              }
-              outputFormat: 'json'
-              status: 404
-            }
-          | {
-              input: {}
-              output: {
-                success: boolean
-              }
-              outputFormat: 'json'
-              status: 200
-            }
+        | {
+          input: {}
+          output: {
+            error: string
+          }
+          outputFormat: 'json'
+          status: 404
+        }
+        | {
+          input: {}
+          output: {
+            success: boolean
+          }
+          outputFormat: 'json'
+          status: 200
+        }
       }
     }
     type verify = Expect<Equal<Expected, Actual>>
@@ -1067,30 +1079,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/': {
           $get:
-            | {
-                input: {}
-                output: {
-                  ng: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
-            | {
-                input: {}
-                output: {
-                  ok: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
-            | {
-                input: {}
-                output: {
-                  default: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
+          | {
+            input: {}
+            output: {
+              ng: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
+          | {
+            input: {}
+            output: {
+              ok: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
+          | {
+            input: {}
+            output: {
+              default: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1123,30 +1135,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/': {
           $get:
-            | {
-                input: {}
-                output: {
-                  ng: true
-                }
-                outputFormat: 'json'
-                status: 400
-              }
-            | {
-                input: {}
-                output: {
-                  ok: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
-            | {
-                input: {}
-                output: {
-                  default: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
+          | {
+            input: {}
+            output: {
+              ng: true
+            }
+            outputFormat: 'json'
+            status: 400
+          }
+          | {
+            input: {}
+            output: {
+              ok: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
+          | {
+            input: {}
+            output: {
+              default: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1177,30 +1189,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/foo': {
           $get:
-            | {
-                input: {}
-                output: {
-                  ng: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
-            | {
-                input: {}
-                output: {
-                  ok: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
-            | {
-                input: {}
-                output: {
-                  default: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
+          | {
+            input: {}
+            output: {
+              ng: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
+          | {
+            input: {}
+            output: {
+              ok: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
+          | {
+            input: {}
+            output: {
+              default: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1233,30 +1245,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/foo': {
           $get:
-            | {
-                input: {}
-                output: {
-                  ng: true
-                }
-                outputFormat: 'json'
-                status: 400
-              }
-            | {
-                input: {}
-                output: {
-                  ok: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
-            | {
-                input: {}
-                output: {
-                  default: true
-                }
-                outputFormat: 'json'
-                status: ContentfulStatusCode
-              }
+          | {
+            input: {}
+            output: {
+              ng: true
+            }
+            outputFormat: 'json'
+            status: 400
+          }
+          | {
+            input: {}
+            output: {
+              ok: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
+          | {
+            input: {}
+            output: {
+              default: true
+            }
+            outputFormat: 'json'
+            status: ContentfulStatusCode
+          }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1324,52 +1336,52 @@ describe('c.var with chaining - test only types', () => {
     { Variables: { foo1: string } },
     string,
     { out: { query: { bar1: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw2 = createMiddleware<
     { Variables: { foo2: string } },
     string,
     { out: { query: { bar2: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw3 = createMiddleware<
     { Variables: { foo3: string } },
     string,
     { out: { query: { bar3: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw4 = createMiddleware<
     { Variables: { foo4: string } },
     string,
     { out: { query: { bar4: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw5 = createMiddleware<
     { Variables: { foo5: string } },
     string,
     { out: { query: { bar5: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw6 = createMiddleware<
     { Variables: { foo6: string } },
     string,
     { out: { query: { bar6: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw7 = createMiddleware<
     { Variables: { foo7: string } },
     string,
     { out: { query: { bar7: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw8 = createMiddleware<
     { Variables: { foo8: string } },
     string,
     { out: { query: { bar8: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw9 = createMiddleware<
     { Variables: { foo9: string } },
     string,
     { out: { query: { bar9: number } } }
-  >(async () => {})
+  >(async () => { })
   const mw10 = createMiddleware<
     { Variables: { foo10: string } },
     string,
     { out: { query: { bar10: number } } }
-  >(async () => {})
+  >(async () => { })
 
   it('Should not throw type errors', () => {
     // app.get(handler...)
@@ -2067,8 +2079,8 @@ describe('c.req.valid() in non-last handler after validator middleware - test on
 describe('Env types with `use` middleware - test only types', () => {
   const app = new Hono()
 
-  const mw1 = createMiddleware<{ Variables: { foo1: string } }>(async () => {})
-  const mw2 = createMiddleware<{ Variables: { foo2: string } }>(async () => {})
+  const mw1 = createMiddleware<{ Variables: { foo1: string } }>(async () => { })
+  const mw2 = createMiddleware<{ Variables: { foo2: string } }>(async () => { })
 
   it('Should not throw a type error', () => {
     app
@@ -3273,7 +3285,7 @@ describe('RPC supports Middleware responses', () => {
   })
 
   describe('Infers types with multiple middlewares but none returning response', () => {
-    const middleware = createMiddleware(async () => {})
+    const middleware = createMiddleware(async () => { })
     const handler = (c: Context) => c.json({ ok: true }, 200)
     type Expected = {
       '/': {
@@ -3413,29 +3425,29 @@ describe('RPC supports Middleware responses', () => {
           )
         }
       }
-      const middleware2 = async () => {}
+      const middleware2 = async () => { }
 
       const routes = new Hono().get('/', middleware1, middleware2, handler)
       type Actual = ExtractSchema<typeof routes>
       type Expected = {
         '/': {
           $get:
-            | {
-                input: {}
-                output: {
-                  ok: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
-            | {
-                input: {}
-                output: {
-                  q: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
+          | {
+            input: {}
+            output: {
+              ok: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
+          | {
+            input: {}
+            output: {
+              q: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -3462,37 +3474,37 @@ describe('RPC supports Middleware responses', () => {
           )
         }
       }
-      const middleware3 = async () => {}
+      const middleware3 = async () => { }
 
       const routes = new Hono().get('/', middleware1, middleware2, middleware3, handler)
       type Actual = ExtractSchema<typeof routes>
       type Expected = {
         '/': {
           $get:
-            | {
-                input: {}
-                output: {
-                  ok: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
-            | {
-                input: {}
-                output: {
-                  q1: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
-            | {
-                input: {}
-                output: {
-                  q2: true
-                }
-                outputFormat: 'json'
-                status: 200
-              }
+          | {
+            input: {}
+            output: {
+              ok: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
+          | {
+            input: {}
+            output: {
+              q1: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
+          | {
+            input: {}
+            output: {
+              q2: true
+            }
+            outputFormat: 'json'
+            status: 200
+          }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -4020,7 +4032,11 @@ describe('Handlers returning Promise<void>', () => {
     type Expected = {
       '*': {
         $post: {
-          input: {}
+          input: {
+            param: {
+              '*': string
+            }
+          }
           output: 'after'
           outputFormat: 'text'
           status: ContentfulStatusCode

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -321,7 +321,7 @@ describe('OnHandlerInterface', () => {
   })
 
   test('app.on(method[], path, middleware, handler)', () => {
-    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => { }
+    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => {}
     const route = app.on(['GET', 'POST'], '/multi-method', middleware, (c) => {
       return c.json({ success: true })
     })
@@ -350,7 +350,7 @@ describe('OnHandlerInterface', () => {
   })
 
   test('app.on(method, path[], middleware, handler) should not throw a type error', () => {
-    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => { }
+    const middleware: MiddlewareHandler<{ Variables: { foo: string } }> = async () => {}
     app.on('GET', ['/a', '/b'], middleware, (c) => {
       expectTypeOf(c.var.foo).toEqualTypeOf<string>()
       return c.json({})
@@ -1009,22 +1009,22 @@ describe('MergeSchemaPath', () => {
       {
         '/': {
           $get:
-          | {
-            input: {}
-            output: {
-              error: string
-            }
-            outputFormat: 'json'
-            status: 404
-          }
-          | {
-            input: {}
-            output: {
-              success: boolean
-            }
-            outputFormat: 'json'
-            status: 200
-          }
+            | {
+                input: {}
+                output: {
+                  error: string
+                }
+                outputFormat: 'json'
+                status: 404
+              }
+            | {
+                input: {}
+                output: {
+                  success: boolean
+                }
+                outputFormat: 'json'
+                status: 200
+              }
         }
       },
       '/api/hello'
@@ -1032,22 +1032,22 @@ describe('MergeSchemaPath', () => {
     type Expected = {
       '/api/hello': {
         $get:
-        | {
-          input: {}
-          output: {
-            error: string
-          }
-          outputFormat: 'json'
-          status: 404
-        }
-        | {
-          input: {}
-          output: {
-            success: boolean
-          }
-          outputFormat: 'json'
-          status: 200
-        }
+          | {
+              input: {}
+              output: {
+                error: string
+              }
+              outputFormat: 'json'
+              status: 404
+            }
+          | {
+              input: {}
+              output: {
+                success: boolean
+              }
+              outputFormat: 'json'
+              status: 200
+            }
       }
     }
     type verify = Expect<Equal<Expected, Actual>>
@@ -1079,30 +1079,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/': {
           $get:
-          | {
-            input: {}
-            output: {
-              ng: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
-          | {
-            input: {}
-            output: {
-              ok: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
-          | {
-            input: {}
-            output: {
-              default: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
+            | {
+                input: {}
+                output: {
+                  ng: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
+            | {
+                input: {}
+                output: {
+                  ok: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
+            | {
+                input: {}
+                output: {
+                  default: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1135,30 +1135,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/': {
           $get:
-          | {
-            input: {}
-            output: {
-              ng: true
-            }
-            outputFormat: 'json'
-            status: 400
-          }
-          | {
-            input: {}
-            output: {
-              ok: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
-          | {
-            input: {}
-            output: {
-              default: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
+            | {
+                input: {}
+                output: {
+                  ng: true
+                }
+                outputFormat: 'json'
+                status: 400
+              }
+            | {
+                input: {}
+                output: {
+                  ok: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  default: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1189,30 +1189,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/foo': {
           $get:
-          | {
-            input: {}
-            output: {
-              ng: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
-          | {
-            input: {}
-            output: {
-              ok: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
-          | {
-            input: {}
-            output: {
-              default: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
+            | {
+                input: {}
+                output: {
+                  ng: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
+            | {
+                input: {}
+                output: {
+                  ok: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
+            | {
+                input: {}
+                output: {
+                  default: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1245,30 +1245,30 @@ describe('Different types using json()', () => {
       type Expected = {
         '/foo': {
           $get:
-          | {
-            input: {}
-            output: {
-              ng: true
-            }
-            outputFormat: 'json'
-            status: 400
-          }
-          | {
-            input: {}
-            output: {
-              ok: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
-          | {
-            input: {}
-            output: {
-              default: true
-            }
-            outputFormat: 'json'
-            status: ContentfulStatusCode
-          }
+            | {
+                input: {}
+                output: {
+                  ng: true
+                }
+                outputFormat: 'json'
+                status: 400
+              }
+            | {
+                input: {}
+                output: {
+                  ok: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  default: true
+                }
+                outputFormat: 'json'
+                status: ContentfulStatusCode
+              }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -1336,52 +1336,52 @@ describe('c.var with chaining - test only types', () => {
     { Variables: { foo1: string } },
     string,
     { out: { query: { bar1: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw2 = createMiddleware<
     { Variables: { foo2: string } },
     string,
     { out: { query: { bar2: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw3 = createMiddleware<
     { Variables: { foo3: string } },
     string,
     { out: { query: { bar3: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw4 = createMiddleware<
     { Variables: { foo4: string } },
     string,
     { out: { query: { bar4: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw5 = createMiddleware<
     { Variables: { foo5: string } },
     string,
     { out: { query: { bar5: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw6 = createMiddleware<
     { Variables: { foo6: string } },
     string,
     { out: { query: { bar6: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw7 = createMiddleware<
     { Variables: { foo7: string } },
     string,
     { out: { query: { bar7: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw8 = createMiddleware<
     { Variables: { foo8: string } },
     string,
     { out: { query: { bar8: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw9 = createMiddleware<
     { Variables: { foo9: string } },
     string,
     { out: { query: { bar9: number } } }
-  >(async () => { })
+  >(async () => {})
   const mw10 = createMiddleware<
     { Variables: { foo10: string } },
     string,
     { out: { query: { bar10: number } } }
-  >(async () => { })
+  >(async () => {})
 
   it('Should not throw type errors', () => {
     // app.get(handler...)
@@ -2079,8 +2079,8 @@ describe('c.req.valid() in non-last handler after validator middleware - test on
 describe('Env types with `use` middleware - test only types', () => {
   const app = new Hono()
 
-  const mw1 = createMiddleware<{ Variables: { foo1: string } }>(async () => { })
-  const mw2 = createMiddleware<{ Variables: { foo2: string } }>(async () => { })
+  const mw1 = createMiddleware<{ Variables: { foo1: string } }>(async () => {})
+  const mw2 = createMiddleware<{ Variables: { foo2: string } }>(async () => {})
 
   it('Should not throw a type error', () => {
     app
@@ -3285,7 +3285,7 @@ describe('RPC supports Middleware responses', () => {
   })
 
   describe('Infers types with multiple middlewares but none returning response', () => {
-    const middleware = createMiddleware(async () => { })
+    const middleware = createMiddleware(async () => {})
     const handler = (c: Context) => c.json({ ok: true }, 200)
     type Expected = {
       '/': {
@@ -3425,29 +3425,29 @@ describe('RPC supports Middleware responses', () => {
           )
         }
       }
-      const middleware2 = async () => { }
+      const middleware2 = async () => {}
 
       const routes = new Hono().get('/', middleware1, middleware2, handler)
       type Actual = ExtractSchema<typeof routes>
       type Expected = {
         '/': {
           $get:
-          | {
-            input: {}
-            output: {
-              ok: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
-          | {
-            input: {}
-            output: {
-              q: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
+            | {
+                input: {}
+                output: {
+                  ok: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  q: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>
@@ -3474,37 +3474,37 @@ describe('RPC supports Middleware responses', () => {
           )
         }
       }
-      const middleware3 = async () => { }
+      const middleware3 = async () => {}
 
       const routes = new Hono().get('/', middleware1, middleware2, middleware3, handler)
       type Actual = ExtractSchema<typeof routes>
       type Expected = {
         '/': {
           $get:
-          | {
-            input: {}
-            output: {
-              ok: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
-          | {
-            input: {}
-            output: {
-              q1: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
-          | {
-            input: {}
-            output: {
-              q2: true
-            }
-            outputFormat: 'json'
-            status: 200
-          }
+            | {
+                input: {}
+                output: {
+                  ok: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  q1: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
+            | {
+                input: {}
+                output: {
+                  q2: true
+                }
+                outputFormat: 'json'
+                status: 200
+              }
         }
       }
       type verify = Expect<Equal<Expected, Actual>>


### PR DESCRIPTION
Fixes #5155

### Summary

This PR adds support for accessing wildcard `*` route captures as a typed parameter via `c.req.param('*')` and `c.req.param()`, as proposed for Hono v5/v4.x.

Previously, accessing `c.req.param('*')` on wildcard routes (e.g. `app.get('/thing/*', ...)`) returned `undefined` or `{}` unless written as a named regex like `/thing/:path{.*}`. This PR enables clean, type-safe wildcard parameter extraction.

### Behavior Matrix

| Route Pattern | Request Path | `c.req.param('*')` | `c.req.param()` | Notes |
|---|---|---|---|---|
| `/a/*` | `/a/b` | `'b'` | `{ '*': 'b' }` | Separating `/` is omitted from capture |
| `/a/*` | `/a/b/c` | `'b/c'` | `{ '*': 'b/c' }` | Captures multiple path segments |
| `/a/*` | `/a/` | `''` | `{ '*': '' }` | Empty wildcard capture |
| `/a/*` | `/a` | `''` | `{ '*': '' }` | Trailing wildcard matching base path |
| `/*` | `/a/b` | `'a/b'` | `{ '*': 'a/b' }` | Captures entire path after leading `/` |
| `*` | `/a/b` | `'a/b'` | `{ '*': 'a/b' }` | Captures entire path after leading `/` |
| `/users/:id/*` | `/users/123/posts/456` | `'posts/456'` | `{ id: '123', '*': 'posts/456' }` | Works alongside named parameters |

### Changes Included

1. **Type Definitions** ([`src/types.ts`](file:///d:/websites/hono-contribution/hono/src/types.ts)):
   - Updated `ParamKey` to recognize `*` component segments so `ParamKeys<'/thing/*'>` infers `'*'` and `ParamKeys<'/users/:id/*'>` infers `'id' | '*'`.
2. **Request Logic & TSDoc** ([`src/request.ts`](file:///d:/websites/hono-contribution/hono/src/request.ts)):
   - Implemented `#getWildcardParam()` in `HonoRequest` to calculate and percent-decode wildcard subpaths.
   - Added wildcard usage examples in TSDoc on `param()`.
3. **Tests**:
   - Added unit tests in `src/request.test.ts`.
   - Added type tests in `src/types.test.ts`.
   - Added end-to-end integration tests in `src/hono.test.ts`.

### Author Checklist

- [x] Add tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
