### PR TITLE
test(utils): add coverage for handler helpers

### DIFF
--- a/src/utils/handler.test.ts
+++ b/src/utils/handler.test.ts
@@ -1,0 +1,34 @@
+import { COMPOSED_HANDLER } from './constants'
+import { findTargetHandler, isMiddleware } from './handler'
+
+describe('isMiddleware', () => {
+  it('returns false for a handler taking no or one argument', () => {
+    expect(isMiddleware(() => {})).toBe(false)
+    expect(isMiddleware((_c: unknown) => {})).toBe(false)
+  })
+
+  it('returns true for a handler taking two or more arguments', () => {
+    expect(isMiddleware((_c: unknown, _next: unknown) => {})).toBe(true)
+    expect(isMiddleware((_a: unknown, _b: unknown, _c: unknown) => {})).toBe(true)
+  })
+})
+
+describe('findTargetHandler', () => {
+  it('returns the handler itself when it is not composed', () => {
+    const handler = () => {}
+    expect(findTargetHandler(handler)).toBe(handler)
+  })
+
+  it('unwraps a single level of composition', () => {
+    const target = () => {}
+    const composed = Object.assign(() => {}, { [COMPOSED_HANDLER]: target })
+    expect(findTargetHandler(composed)).toBe(target)
+  })
+
+  it('recursively unwraps nested composed handlers', () => {
+    const target = () => {}
+    const middle = Object.assign(() => {}, { [COMPOSED_HANDLER]: target })
+    const outer = Object.assign(() => {}, { [COMPOSED_HANDLER]: middle })
+    expect(findTargetHandler(outer)).toBe(target)
+  })
+})


### PR DESCRIPTION
Adds unit tests for the handler utilities in src/utils/handler.ts, which were previously untested.

- isMiddleware: false for handlers taking zero or one argument, true for handlers taking two or more
- findTargetHandler: returns the handler itself when it is not composed, and unwraps single and nested COMPOSED_HANDLER chains