### PR TITLE
feat(reg-exp-router): throw UnsupportedPathError during route registration

### DIFF
--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -25,9 +25,9 @@ function compareKey(a: string, b: string): number {
     return 1
   }
 
-  // wildcard
+  // wildcard: the only wildcard (.*) precedes the tail wildcard
   if (a === ONLY_WILDCARD_REG_EXP_STR || a === TAIL_WILDCARD_REG_EXP_STR) {
-    return 1
+    return b === TAIL_WILDCARD_REG_EXP_STR ? -1 : 1
   } else if (b === ONLY_WILDCARD_REG_EXP_STR || b === TAIL_WILDCARD_REG_EXP_STR) {
     return -1
   }

--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -43,6 +43,7 @@ function compareKey(a: string, b: string): number {
 }
 
 export class Node {
+  // handler index of a dynamic path, or -1 for a static path terminal
   #index?: number
   #varIndex?: number
   #children: Record<string, Node> = Object.create(null)
@@ -52,99 +53,106 @@ export class Node {
     index: number,
     paramMap: ParamAssocArray,
     context: Context,
-    pathErrorCheckOnly: boolean
+    isStatic: boolean
   ): void {
-    if (tokens.length === 0) {
-      if (this.#index !== undefined) {
-        throw PATH_ERROR
-      }
-      if (pathErrorCheckOnly) {
-        return
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let node: Node = this
+    for (let i = 0, len = tokens.length; i < len; i++) {
+      const token = tokens[i]
+      const pattern =
+        token.length === 1
+          ? token === '*'
+            ? i === len - 1
+              ? ['', '', ONLY_WILDCARD_REG_EXP_STR] // '*' matches to all the trailing paths
+              : ['', '', LABEL_REG_EXP_STR]
+            : null
+          : token === '/*'
+            ? ['', '', TAIL_WILDCARD_REG_EXP_STR] // '/path/to/*' is /\/path\/to(?:|/.*)$
+            : token.match(/^\:([^\{\}]+)(?:\{(.+)\})?$/)
+
+      let nextNode: Node
+      if (pattern) {
+        const name = pattern[1]
+        let regexpStr = pattern[2] || LABEL_REG_EXP_STR
+        if (name && pattern[2]) {
+          if (regexpStr === '.*') {
+            throw PATH_ERROR
+          }
+          regexpStr = regexpStr.replace(/^\((?!\?:)(?=[^)]+\)$)/, '(?:') // (a|b) => (?:a|b)
+          if (/\((?!\?:)/.test(regexpStr)) {
+            // prefix(?:a|b) is allowed, but prefix(a|b) is not
+            throw PATH_ERROR
+          }
+          if (regexpStr.length === 1 && regExpMetaChars.has(regexpStr)) {
+            // a single-char pattern like :x{.} is ambiguous with a literal character
+            throw PATH_ERROR
+          }
+        }
+
+        nextNode = node.#children[regexpStr]
+        if (!nextNode) {
+          if (regexpStr !== ONLY_WILDCARD_REG_EXP_STR && regexpStr !== TAIL_WILDCARD_REG_EXP_STR) {
+            for (const k in node.#children) {
+              if (
+                // a single-char pattern coexists with single-char literals as a literal does
+                (regexpStr.length > 1 || k.length > 1) &&
+                k !== ONLY_WILDCARD_REG_EXP_STR &&
+                k !== TAIL_WILDCARD_REG_EXP_STR
+              ) {
+                throw PATH_ERROR
+              }
+            }
+          }
+          nextNode = node.#children[regexpStr] = new Node()
+        }
+        if (name !== '') {
+          nextNode.#varIndex ??= context.varIndex++
+          paramMap.push([name, nextNode.#varIndex])
+        }
+      } else {
+        nextNode = node.#children[token]
+        if (!nextNode) {
+          for (const k in node.#children) {
+            if (
+              k.length > 1 &&
+              k !== ONLY_WILDCARD_REG_EXP_STR &&
+              k !== TAIL_WILDCARD_REG_EXP_STR
+            ) {
+              throw PATH_ERROR
+            }
+          }
+          nextNode = node.#children[token] = new Node()
+        }
       }
 
-      this.#index = index
-      return
+      node = nextNode
     }
 
-    const [token, ...restTokens] = tokens
-    const pattern =
-      token === '*'
-        ? restTokens.length === 0
-          ? ['', '', ONLY_WILDCARD_REG_EXP_STR] // '*' matches to all the trailing paths
-          : ['', '', LABEL_REG_EXP_STR]
-        : token === '/*'
-          ? ['', '', TAIL_WILDCARD_REG_EXP_STR] // '/path/to/*' is /\/path\/to(?:|/.*)$
-          : token.match(/^\:([^\{\}]+)(?:\{(.+)\})?$/)
-
-    let node
-    if (pattern) {
-      const name = pattern[1]
-      let regexpStr = pattern[2] || LABEL_REG_EXP_STR
-      if (name && pattern[2]) {
-        if (regexpStr === '.*') {
-          throw PATH_ERROR
-        }
-        regexpStr = regexpStr.replace(/^\((?!\?:)(?=[^)]+\)$)/, '(?:') // (a|b) => (?:a|b)
-        if (/\((?!\?:)/.test(regexpStr)) {
-          // prefix(?:a|b) is allowed, but prefix(a|b) is not
-          throw PATH_ERROR
-        }
-      }
-
-      node = this.#children[regexpStr]
-      if (!node) {
-        if (
-          Object.keys(this.#children).some(
-            (k) => k !== ONLY_WILDCARD_REG_EXP_STR && k !== TAIL_WILDCARD_REG_EXP_STR
-          )
-        ) {
-          throw PATH_ERROR
-        }
-        if (pathErrorCheckOnly) {
-          return
-        }
-        node = this.#children[regexpStr] = new Node()
-      }
-      if (!pathErrorCheckOnly && name !== '') {
-        node.#varIndex ??= context.varIndex++
-        paramMap.push([name, node.#varIndex])
-      }
-    } else {
-      node = this.#children[token]
-      if (!node) {
-        if (
-          Object.keys(this.#children).some(
-            (k) =>
-              k.length > 1 && k !== ONLY_WILDCARD_REG_EXP_STR && k !== TAIL_WILDCARD_REG_EXP_STR
-          )
-        ) {
-          throw PATH_ERROR
-        }
-        if (pathErrorCheckOnly) {
-          return
-        }
-        node = this.#children[token] = new Node()
-      }
+    if (node.#index !== undefined) {
+      throw PATH_ERROR
     }
-
-    node.insert(restTokens, index, paramMap, context, pathErrorCheckOnly)
+    node.#index = isStatic ? -1 : index
   }
 
   buildRegExpStr(): string {
     const childKeys = Object.keys(this.#children).sort(compareKey)
 
-    const strList = childKeys.map((k) => {
-      const c = this.#children[k]
-      return (
-        (typeof c.#varIndex === 'number'
-          ? `(${k})@${c.#varIndex}`
-          : regExpMetaChars.has(k)
-            ? `\\${k}`
-            : k) + c.buildRegExpStr()
-      )
-    })
+    const strList = childKeys
+      .map((k) => {
+        const c = this.#children[k]
+        const childStr = c.buildRegExpStr()
+        // an empty childStr means a static-only branch, which is handled by staticMap
+        return childStr === ''
+          ? ''
+          : (typeof c.#varIndex === 'number'
+              ? `(${k})@${c.#varIndex}`
+              : regExpMetaChars.has(k)
+                ? `\\${k}`
+                : k) + childStr
+      })
+      .filter(Boolean)
 
-    if (typeof this.#index === 'number') {
+    if (typeof this.#index === 'number' && this.#index !== -1) {
       strList.unshift(`#${this.#index}`)
     }
 

--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -104,12 +104,10 @@ export class Node {
           return
         }
         node = this.#children[regexpStr] = new Node()
-        if (name !== '') {
-          node.#varIndex = context.varIndex++
-        }
       }
       if (!pathErrorCheckOnly && name !== '') {
-        paramMap.push([name, node.#varIndex as number])
+        node.#varIndex ??= context.varIndex++
+        paramMap.push([name, node.#varIndex])
       }
     } else {
       node = this.#children[token]

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -108,12 +108,30 @@ describe('RegExpRouter', () => {
       }).toThrowError(UnsupportedPathError)
     })
 
-    it('ALL and specific method', () => {
+    it('ALL route added after a specific-method route', () => {
       const router = new RegExpRouter<string>()
       router.add('GET', '/foo/:a', 'foo')
       expect(() => {
         router.add('ALL', '/foo/:b', 'bar')
       }).toThrowError(UnsupportedPathError)
+    })
+
+    it('specific-method route added after an ALL route', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/reg-exp/router', 'foo')
+
+      expect(() => {
+        router.add('GET', '/reg-exp/:id', 'bar')
+      }).toThrowError(UnsupportedPathError)
+    })
+
+    it('different methods do not conflict', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/reg-exp/router', 'foo')
+      router.add('POST', '/reg-exp/:id', 'bar')
+
+      expect(router.match('GET', '/reg-exp/router')[0][0][0]).toBe('foo')
+      expect(router.match('POST', '/reg-exp/router')[0][0][0]).toBe('bar')
     })
 
     describe('Capture Group', () => {

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -39,29 +39,21 @@ describe('RegExpRouter', () => {
 
   describe('UnsupportedPathError', () => {
     describe('Ambiguous', () => {
-      const router = new RegExpRouter<string>()
-
-      router.add('GET', '/:user/entries', 'get user entries')
-      router.add('GET', '/entry/:name', 'get entry')
-      router.add('POST', '/entry', 'create entry')
-
-      it('GET /entry/entries', () => {
+      it('GET /entry/:name', () => {
+        const router = new RegExpRouter<string>()
+        router.add('GET', '/:user/entries', 'get user entries')
         expect(() => {
-          router.match('GET', '/entry/entries')
+          router.add('GET', '/entry/:name', 'get entry')
         }).toThrowError(UnsupportedPathError)
       })
     })
 
     describe('Multiple handlers with different label', () => {
-      const router = new RegExpRouter<string>()
-
-      router.add('GET', '/:type/:id', ':type')
-      router.add('GET', '/:class/:id', ':class')
-      router.add('GET', '/:model/:id', ':model')
-
-      it('GET /entry/123', () => {
+      it('GET /:class/:id', () => {
+        const router = new RegExpRouter<string>()
+        router.add('GET', '/:type/:id', ':type')
         expect(() => {
-          router.match('GET', '/entry/123')
+          router.add('GET', '/:class/:id', ':class')
         }).toThrowError(UnsupportedPathError)
       })
     })
@@ -69,19 +61,16 @@ describe('RegExpRouter', () => {
     it('parent', () => {
       const router = new RegExpRouter<string>()
       router.add('GET', '/:id/:action', 'foo')
-      router.add('GET', '/posts/:id', 'bar')
       expect(() => {
-        router.match('GET', '/')
+        router.add('GET', '/posts/:id', 'bar')
       }).toThrowError(UnsupportedPathError)
     })
 
     it('child', () => {
       const router = new RegExpRouter<string>()
       router.add('GET', '/posts/:id', 'foo')
-      router.add('GET', '/:id/:action', 'bar')
-
       expect(() => {
-        router.match('GET', '/')
+        router.add('GET', '/:id/:action', 'bar')
       }).toThrowError(UnsupportedPathError)
     })
 
@@ -89,30 +78,24 @@ describe('RegExpRouter', () => {
       it('static first', () => {
         const router = new RegExpRouter<string>()
         router.add('GET', '/reg-exp/router', 'foo')
-        router.add('GET', '/reg-exp/:id', 'bar')
-
         expect(() => {
-          router.match('GET', '/')
+          router.add('GET', '/reg-exp/:id', 'bar')
         }).toThrowError(UnsupportedPathError)
       })
 
       it('long label', () => {
         const router = new RegExpRouter<string>()
         router.add('GET', '/reg-exp/router', 'foo')
-        router.add('GET', '/reg-exp/:service', 'bar')
-
         expect(() => {
-          router.match('GET', '/')
+          router.add('GET', '/reg-exp/:service', 'bar')
         }).toThrowError(UnsupportedPathError)
       })
 
       it('dynamic first', () => {
         const router = new RegExpRouter<string>()
         router.add('GET', '/reg-exp/:id', 'bar')
-        router.add('GET', '/reg-exp/router', 'foo')
-
         expect(() => {
-          router.match('GET', '/')
+          router.add('GET', '/reg-exp/router', 'foo')
         }).toThrowError(UnsupportedPathError)
       })
     })
@@ -120,9 +103,16 @@ describe('RegExpRouter', () => {
     it('different regular expression', () => {
       const router = new RegExpRouter<string>()
       router.add('GET', '/:id/:action{create|update}', 'foo')
-      router.add('GET', '/:id/:action{delete}', 'bar')
       expect(() => {
-        router.match('GET', '/')
+        router.add('GET', '/:id/:action{delete}', 'bar')
+      }).toThrowError(UnsupportedPathError)
+    })
+
+    it('ALL and specific method', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/foo/:a', 'foo')
+      expect(() => {
+        router.add('ALL', '/foo/:b', 'bar')
       }).toThrowError(UnsupportedPathError)
     })
 
@@ -130,12 +120,99 @@ describe('RegExpRouter', () => {
       describe('Complex capturing group', () => {
         it('GET request', () => {
           const router = new RegExpRouter<string>()
-          router.add('GET', '/foo/:capture{ba(r|z)}', 'ok')
           expect(() => {
-            router.match('GET', '/foo/bar')
+            router.add('GET', '/foo/:capture{ba(r|z)}', 'ok')
           }).toThrowError(UnsupportedPathError)
         })
       })
+    })
+  })
+
+  describe('Wildcard after label', () => {
+    it('Should be able to add a tail wildcard after a label', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/api/:x', 'label')
+      router.add('GET', '/api/*', 'wildcard')
+
+      const [res] = router.match('GET', '/api/foo')
+      expect(res.length).toBe(2)
+      expect(res[0][0]).toBe('label')
+      expect(res[1][0]).toBe('wildcard')
+    })
+
+    it('Should prioritize the only wildcard over the tail wildcard regardless of the order', () => {
+      for (const paths of [
+        ['/a*', '/a/*'],
+        ['/a/*', '/a*'],
+      ]) {
+        const router = new RegExpRouter<string>()
+        for (const path of paths) {
+          router.add('GET', path, path)
+        }
+        const [res] = router.match('GET', '/a')
+        expect(res[0][0]).toBe('/a*')
+      }
+    })
+  })
+
+  describe('Single character regexp pattern', () => {
+    it('Should capture a param even if a static path created the node first', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/a/c', 'static')
+      router.add('GET', '/:x{a}/b', 'pattern')
+
+      const [res, stash] = router.match('GET', '/a/b')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('pattern')
+      expect((stash as ParamStash)[(res[0][1] as ParamIndexMap)['x']]).toBe('a')
+    })
+
+    it('Should throw an error when a pattern terminal conflicts with a static terminal', () => {
+      for (const paths of [
+        ['/a', '/:x{a}'],
+        ['/:x{a}', '/a'],
+      ]) {
+        const router = new RegExpRouter<string>()
+        router.add('GET', paths[0], paths[0])
+        expect(() => {
+          router.add('GET', paths[1], paths[1])
+        }).toThrowError(UnsupportedPathError)
+      }
+    })
+
+    it('Should coexist with static paths regardless of the order', () => {
+      for (const paths of [
+        ['/foo/bar', '/:y{b}'],
+        ['/:y{b}', '/foo/bar'],
+      ]) {
+        const router = new RegExpRouter<string>()
+        for (const path of paths) {
+          router.add('GET', path, path)
+        }
+        expect(router.match('GET', '/foo/bar')[0][0][0]).toBe('/foo/bar')
+        expect(router.match('GET', '/b')[0][0][0]).toBe('/:y{b}')
+      }
+    })
+
+    it('Should coexist with dynamic paths regardless of the order', () => {
+      for (const paths of [
+        ['/foo/:p', '/:x{a}'],
+        ['/:x{a}', '/foo/:p'],
+      ]) {
+        const router = new RegExpRouter<string>()
+        for (const path of paths) {
+          router.add('GET', path, path)
+        }
+        expect(router.match('GET', '/a')[0][0][0]).toBe('/:x{a}')
+        expect(router.match('GET', '/foo/v')[0][0][0]).toBe('/foo/:p')
+      }
+    })
+
+    it('Should throw an error for a single meta character pattern', () => {
+      const router = new RegExpRouter<string>()
+      expect(() => {
+        router.add('GET', '/:x{.}', 'meta')
+      }).toThrowError(UnsupportedPathError)
     })
   })
 
@@ -149,6 +226,22 @@ describe('RegExpRouter', () => {
       expect(res.length).toBe(1)
       expect(res[0][0]).toBe('label')
       expect((stash as ParamStash)[(res[0][1] as ParamIndexMap)['id']]).toBe('123')
+    })
+  })
+
+  describe('Static path including a colon in the middle', () => {
+    it('Should be treated as a static path', () => {
+      for (const paths of [
+        ['/v1/name:activate', '/v1/name2'],
+        ['/v1/name2', '/v1/name:activate'],
+      ]) {
+        const router = new RegExpRouter<string>()
+        for (const path of paths) {
+          router.add('GET', path, path)
+        }
+        expect(router.match('GET', '/v1/name:activate')[0][0][0]).toBe('/v1/name:activate')
+        expect(router.match('GET', '/v1/name2')[0][0][0]).toBe('/v1/name2')
+      }
     })
   })
 })

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -1,4 +1,4 @@
-import type { ParamStash } from '../../router'
+import type { ParamIndexMap, ParamStash } from '../../router'
 import { UnsupportedPathError } from '../../router'
 import { runTest } from '../common.case.test'
 import { RegExpRouter } from './router'
@@ -136,6 +136,19 @@ describe('RegExpRouter', () => {
           }).toThrowError(UnsupportedPathError)
         })
       })
+    })
+  })
+
+  describe('Capture a param of a label node created by a middle wildcard', () => {
+    it('Should capture the param', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/w/*/x', 'wildcard')
+      router.add('GET', '/w/:id/y', 'label')
+
+      const [res, stash] = router.match('GET', '/w/123/y')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('label')
+      expect((stash as ParamStash)[(res[0][1] as ParamIndexMap)['id']]).toBe('123')
     })
   })
 })

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -8,13 +8,9 @@ import { checkOptionalParameter } from '../../utils/url'
 import type { HandlerData, StaticMap, Matcher, MatcherMap } from './matcher'
 import { match, emptyParam } from './matcher'
 import { PATH_ERROR } from './node'
-import type { ParamAssocArray } from './node'
 import { Trie } from './trie'
 
 type HandlerWithMetadata<T> = [T, number] // [handler, paramCount]
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const nullMatcher: Matcher<any> = [/^$/, [], Object.create(null)]
 
 let wildcardRegExpCache: Record<string, RegExp> = Object.create(null)
 function buildWildcardRegExp(path: string): RegExp {
@@ -29,77 +25,6 @@ function buildWildcardRegExp(path: string): RegExp {
 
 function clearWildcardRegExpCache() {
   wildcardRegExpCache = Object.create(null)
-}
-
-function buildMatcherFromPreprocessedRoutes<T>(
-  routes: [string, HandlerWithMetadata<T>[]][]
-): Matcher<T> {
-  const trie = new Trie()
-  const handlerData: HandlerData<T>[] = []
-  if (routes.length === 0) {
-    return nullMatcher
-  }
-
-  const routesWithStaticPathFlag = routes
-    .map(
-      (route) => [!/\*|\/:/.test(route[0]), ...route] as [boolean, string, HandlerWithMetadata<T>[]]
-    )
-    .sort(([isStaticA, pathA], [isStaticB, pathB]) =>
-      isStaticA ? 1 : isStaticB ? -1 : pathA.length - pathB.length
-    )
-
-  const staticMap: StaticMap<T> = Object.create(null)
-  for (let i = 0, j = -1, len = routesWithStaticPathFlag.length; i < len; i++) {
-    const [pathErrorCheckOnly, path, handlers] = routesWithStaticPathFlag[i]
-    if (pathErrorCheckOnly) {
-      staticMap[path] = [handlers.map(([h]) => [h, Object.create(null)]), emptyParam]
-    } else {
-      j++
-    }
-
-    let paramAssoc: ParamAssocArray
-    try {
-      paramAssoc = trie.insert(path, j, pathErrorCheckOnly)
-    } catch (e) {
-      throw e === PATH_ERROR ? new UnsupportedPathError(path) : e
-    }
-
-    if (pathErrorCheckOnly) {
-      continue
-    }
-
-    handlerData[j] = handlers.map(([h, paramCount]) => {
-      const paramIndexMap: ParamIndexMap = Object.create(null)
-      paramCount -= 1
-      for (; paramCount >= 0; paramCount--) {
-        const [key, value] = paramAssoc[paramCount]
-        paramIndexMap[key] = value
-      }
-      return [h, paramIndexMap]
-    })
-  }
-
-  const [regexp, indexReplacementMap, paramReplacementMap] = trie.buildRegExp()
-  for (let i = 0, len = handlerData.length; i < len; i++) {
-    for (let j = 0, len = handlerData[i].length; j < len; j++) {
-      const map = handlerData[i][j]?.[1]
-      if (!map) {
-        continue
-      }
-      const keys = Object.keys(map)
-      for (let k = 0, len = keys.length; k < len; k++) {
-        map[keys[k]] = paramReplacementMap[map[keys[k]]]
-      }
-    }
-  }
-
-  const handlerMap: HandlerData<T>[] = []
-  // using `in` because indexReplacementMap is a sparse array
-  for (const i in indexReplacementMap) {
-    handlerMap[i] = handlerData[indexReplacementMap[i]]
-  }
-
-  return [regexp, handlerMap, staticMap] as Matcher<T>
 }
 
 function findMiddleware<T>(
@@ -123,10 +48,20 @@ export class RegExpRouter<T> implements Router<T> {
   name: string = 'RegExpRouter'
   #middleware?: Record<string, Record<string, HandlerWithMetadata<T>[]>>
   #routes?: Record<string, Record<string, HandlerWithMetadata<T>[]>>
+  #tries?: Record<string, Trie>
 
   constructor() {
     this.#middleware = { [METHOD_NAME_ALL]: Object.create(null) }
     this.#routes = { [METHOD_NAME_ALL]: Object.create(null) }
+    this.#tries = { [METHOD_NAME_ALL]: new Trie() }
+  }
+
+  #insertPath(method: string, path: string) {
+    try {
+      this.#tries![method].insert(path, !/\*|\/:/.test(path))
+    } catch (e) {
+      throw e === PATH_ERROR ? new UnsupportedPathError(path) : e
+    }
   }
 
   add(method: string, path: string, handler: T) {
@@ -138,10 +73,12 @@ export class RegExpRouter<T> implements Router<T> {
     }
 
     if (!middleware[method]) {
+      this.#tries![method] = new Trie()
       ;[middleware, routes].forEach((handlerMap) => {
         handlerMap[method] = Object.create(null)
         Object.keys(handlerMap[METHOD_NAME_ALL]).forEach((p) => {
           handlerMap[method][p] = [...handlerMap[METHOD_NAME_ALL][p]]
+          this.#insertPath(method, p)
         })
       })
     }
@@ -154,19 +91,15 @@ export class RegExpRouter<T> implements Router<T> {
 
     if (/\*$/.test(path)) {
       const re = buildWildcardRegExp(path)
-      if (method === METHOD_NAME_ALL) {
-        Object.keys(middleware).forEach((m) => {
-          middleware[m][path] ||=
+      Object.keys(middleware).forEach((m) => {
+        if ((method === METHOD_NAME_ALL || method === m) && !middleware[m][path]) {
+          this.#insertPath(m, path)
+          middleware[m][path] =
             findMiddleware(middleware[m], path) ||
             findMiddleware(middleware[METHOD_NAME_ALL], path) ||
             []
-        })
-      } else {
-        middleware[method][path] ||=
-          findMiddleware(middleware[method], path) ||
-          findMiddleware(middleware[METHOD_NAME_ALL], path) ||
-          []
-      }
+        }
+      })
       Object.keys(middleware).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
           Object.keys(middleware[m]).forEach((p) => {
@@ -192,11 +125,14 @@ export class RegExpRouter<T> implements Router<T> {
 
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
-          routes[m][path] ||= [
-            ...(findMiddleware(middleware[m], path) ||
-              findMiddleware(middleware[METHOD_NAME_ALL], path) ||
-              []),
-          ]
+          if (!routes[m][path]) {
+            this.#insertPath(m, path)
+            routes[m][path] = [
+              ...(findMiddleware(middleware[m], path) ||
+                findMiddleware(middleware[METHOD_NAME_ALL], path) ||
+                []),
+            ]
+          }
           routes[m][path].push([handler, paramCount - len + i + 1])
         }
       })
@@ -215,38 +151,61 @@ export class RegExpRouter<T> implements Router<T> {
       })
 
     // Release cache
-    this.#middleware = this.#routes = undefined
+    this.#middleware = this.#routes = this.#tries = undefined
     clearWildcardRegExpCache()
 
     return matchers
   }
 
-  #buildMatcher(method: string): Matcher<T> | null {
-    const routes: [string, HandlerWithMetadata<T>[]][] = []
+  #buildMatcher(method: string): Matcher<T> {
+    const middleware = this.#middleware![method]
+    const routes = this.#routes![method]
 
-    let hasOwnRoute = method === METHOD_NAME_ALL
+    const trie = this.#tries![method]
+    const staticMap: StaticMap<T> = Object.create(null)
+    const handlerData: HandlerData<T>[] = []
 
-    ;[this.#middleware!, this.#routes!].forEach((r) => {
-      const ownRoute = r[method]
-        ? Object.keys(r[method]).map((path) => [path, r[method][path]])
-        : []
-      if (ownRoute.length !== 0) {
-        hasOwnRoute ||= true
-        routes.push(...(ownRoute as [string, HandlerWithMetadata<T>[]][]))
-      } else if (method !== METHOD_NAME_ALL) {
-        routes.push(
-          ...(Object.keys(r[METHOD_NAME_ALL]).map((path) => [path, r[METHOD_NAME_ALL][path]]) as [
-            string,
-            HandlerWithMetadata<T>[],
-          ][])
-        )
+    ;[middleware, routes].forEach((r) => {
+      for (const path in r) {
+        const handlers = r[path]
+        const pathData = trie.paths[path]
+        if (!pathData) {
+          staticMap[path] = [handlers.map(([h]) => [h, Object.create(null)]), emptyParam]
+          continue
+        }
+        const paramAssoc = pathData[1]
+        handlerData[pathData[0]] = handlers.map(([h, paramCount]) => {
+          const paramIndexMap: ParamIndexMap = Object.create(null)
+          paramCount -= 1
+          for (; paramCount >= 0; paramCount--) {
+            const [key, value] = paramAssoc[paramCount]
+            paramIndexMap[key] = value
+          }
+          return [h, paramIndexMap]
+        })
       }
     })
 
-    if (!hasOwnRoute) {
-      return null
-    } else {
-      return buildMatcherFromPreprocessedRoutes(routes)
+    const [regexp, indexReplacementMap, paramReplacementMap] = trie.buildRegExp()
+    for (let i = 0, len = handlerData.length; i < len; i++) {
+      for (let j = 0, len = handlerData[i].length; j < len; j++) {
+        const map = handlerData[i][j]?.[1]
+        if (!map) {
+          continue
+        }
+        const keys = Object.keys(map)
+        for (let k = 0, len = keys.length; k < len; k++) {
+          map[keys[k]] = paramReplacementMap[map[keys[k]]]
+        }
+      }
     }
+
+    const handlerMap: HandlerData<T>[] = []
+    // using `in` because indexReplacementMap is a sparse array
+    for (const i in indexReplacementMap) {
+      handlerMap[i] = handlerData[indexReplacementMap[i]]
+    }
+
+    return [regexp, handlerMap, staticMap] as Matcher<T>
   }
 }

--- a/src/router/reg-exp-router/trie.ts
+++ b/src/router/reg-exp-router/trie.ts
@@ -6,14 +6,24 @@ export type ReplacementMap = number[]
 export class Trie {
   #context: Context = { varIndex: 0 }
   #root: Node = new Node()
+  #index: number = 0
+  // dynamic path -> [handler index, param assoc]; static paths are not registered
+  paths: Record<string, [number, ParamAssocArray]> = Object.create(null)
 
-  insert(path: string, index: number, pathErrorCheckOnly: boolean): ParamAssocArray {
+  insert(path: string, isStatic: boolean): void {
+    if (isStatic) {
+      // a static path has no pattern; every character is a literal token
+      this.#root.insert(path.split(''), 0, [], this.#context, true)
+      return
+    }
+
     const paramAssoc: ParamAssocArray = []
 
     const groups: [string, string][] = [] // [mark, original string]
+    let markedPath = path
     for (let i = 0; ; ) {
       let replaced = false
-      path = path.replace(/\{[^}]+\}/g, (m) => {
+      markedPath = markedPath.replace(/\{[^}]+\}/g, (m) => {
         const mark = `@\\${i}`
         groups[i] = [mark, m]
         i++
@@ -30,7 +40,7 @@ export class Trie {
      *  - /* wildcard
      *  - character
      */
-    const tokens = path.match(/(?::[^\/]+)|(?:\/\*$)|./g) || []
+    const tokens = markedPath.match(/(?::[^\/]+)|(?:\/\*$)|./g) || []
     for (let i = groups.length - 1; i >= 0; i--) {
       const [mark] = groups[i]
       for (let j = tokens.length - 1; j >= 0; j--) {
@@ -41,9 +51,8 @@ export class Trie {
       }
     }
 
-    this.#root.insert(tokens, index, paramAssoc, this.#context, pathErrorCheckOnly)
-
-    return paramAssoc
+    this.#root.insert(tokens, this.#index, paramAssoc, this.#context, false)
+    this.paths[path] = [this.#index++, paramAssoc]
   }
 
   buildRegExp(): [RegExp, ReplacementMap, ReplacementMap] {


### PR DESCRIPTION
Unlike the other routers, `RegExpRouter` currently defers `UnsupportedPathError` until the matcher is built by the first `match()` call. This PR brings it in line with the other routers by reporting unsupported paths early, during route registration.

Although this changes when the error is thrown, the implementation is otherwise largely a restructuring of the existing matcher-building process. The generated matcher, routing behavior, steady-state matching path, and post-build memory cleanup remain unchanged.

`PreparedRegExpRouter` also continues to use the same matcher format and runtime behavior.

### Changes

- Throw `UnsupportedPathError` during route registration
- Preserve existing matching behavior and matcher representation
- Add regression tests for route ordering and method inheritance

### Performance

Local Bun benchmark results:

| Scenario | Before | After |
|---|---:|---:|
| Register 12 routes | 1.47 µs | 5.16 µs |
| Register 12 routes + first match | 17.77 µs | 14.45 µs |
| Register 500 routes + first match | 0.620 ms | 0.541 ms |
| Steady-state match | 45.3 ns | 46.0 ns |

Validation is moved from the first match to route registration. Registration alone is therefore slower, while registration plus matcher construction is faster and steady-state matching remains effectively unchanged.

<details>
<summary>Benchmark methodology and scripts</summary>

- Bun 1.3.12
- Before: `224d2f5cb`
- After: `18cde15bc`
- Measurements were run in clean worktrees on the same machine.
- Reported values are medians after warmup.

#### 12 routes and steady-state matching

```ts
import { RegExpRouter } from './src/router/reg-exp-router/router.ts'

const routes = [
  ['GET', '/user'],
  ['GET', '/user/comments'],
  ['GET', '/user/avatar'],
  ['GET', '/user/lookup/username/:username'],
  ['GET', '/user/lookup/email/:address'],
  ['GET', '/event/:id'],
  ['GET', '/event/:id/comments'],
  ['POST', '/event/:id/comment'],
  ['GET', '/map/:location/events'],
  ['GET', '/status'],
  ['GET', '/very/deeply/nested/route/hello/there'],
  ['GET', '/static/*'],
] as const

let sink = 0

const createRouter = (match = false) => {
  const router = new RegExpRouter<number>()
  for (let i = 0; i < routes.length; i++) {
    router.add(routes[i][0], routes[i][1], i)
  }
  if (match) {
    sink += router.match('GET', '/event/abcd1234/comments')[0].length
  }
  return router
}

const median = (values: number[]) =>
  values.sort((a, b) => a - b)[values.length >> 1]

const measure = (name: string, iterations: number, fn: () => void) => {
  for (let i = 0; i < Math.max(100, iterations / 20); i++) {
    fn()
  }

  const samples: number[] = []
  for (let sample = 0; sample < 9; sample++) {
    const start = Bun.nanoseconds()
    for (let i = 0; i < iterations; i++) {
      fn()
    }
    samples.push((Bun.nanoseconds() - start) / iterations)
  }

  console.log(`${name}\t${median(samples).toFixed(2)} ns/op`)
}

measure('add', 20_000, () => {
  sink += createRouter().name.length
})

measure('add+first-match', 20_000, () => {
  createRouter(true)
})

const router = createRouter(true)
measure('steady-match', 2_000_000, () => {
  sink += router.match('GET', '/event/abcd1234/comments')[0].length
})
```

#### 500 routes

```ts
import { RegExpRouter } from './src/router/reg-exp-router/router.ts'

const routes: [string, string][] = []
for (let i = 0; i < 250; i++) {
  routes.push(['GET', `/static-${i}`])
  routes.push(['GET', `/resource-${i}/:id`])
}

let sink = 0

const createRouter = (match = false) => {
  const router = new RegExpRouter<number>()
  for (let i = 0; i < routes.length; i++) {
    router.add(routes[i][0], routes[i][1], i)
  }
  if (match) {
    sink += router.match('GET', '/resource-249/value')[0].length
  }
  return router
}

const median = (values: number[]) =>
  values.sort((a, b) => a - b)[values.length >> 1]

for (let i = 0; i < 10; i++) {
  createRouter(true)
}

const samples: number[] = []
for (let sample = 0; sample < 7; sample++) {
  const start = Bun.nanoseconds()
  for (let i = 0; i < 250; i++) {
    createRouter(true)
  }
  samples.push((Bun.nanoseconds() - start) / 250)
}

console.log(`${(median(samples) / 1_000_000).toFixed(3)} ms/router`)
```

</details>


### Bundle size

Measured using the repository's minified bundle-size check (uncompressed).

| Before | After | Difference |
|---:|---:|---:|
| 19,032 B | 18,989 B | -43 B (-0.23%) |


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code