### PR TITLE
chore(benchmarks): correct src path on Windows, add json and middleware cases

### DIFF
--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -15,9 +15,9 @@
 // Runs on both Bun and Node.
 import './ts-resolve.mjs'
 import { run, bench } from 'mitata'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const src = process.env.HONO_SRC ?? new URL('../../src', import.meta.url).pathname
+const src = process.env.HONO_SRC ?? fileURLToPath(new URL('../../src', import.meta.url))
 const label = process.env.HONO_LABEL ?? 'hono'
 const asJson = process.env.HONO_JSON === '1'
 
@@ -37,6 +37,11 @@ const makeApp = async (src: string): Promise<any> => {
       c.header('x-powered-by', 'benchmark')
       return c.text(`${id} ${name}`)
     })
+    .get('/user', (c: any) => c.json({ id: 123, name: 'Alice', roles: ['admin', 'editor'] }))
+    .use('/mw/*', async (_c: any, next: any) => {
+      await next()
+    })
+    .get('/mw/hello', (c: any) => c.text('mw'))
   return app
 }
 
@@ -44,6 +49,8 @@ const app = await makeApp(src)
 
 const ping = new Request('http://localhost/')
 const query = new Request('http://localhost/id/1?name=bun')
+const user = new Request('http://localhost/user')
+const mw = new Request('http://localhost/mw/hello')
 
 let sink: unknown
 
@@ -51,6 +58,8 @@ let sink: unknown
 const cases: [string, (app: any) => Promise<unknown>][] = [
   ['ping GET /', (app) => app.fetch(ping)],
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],
+  ['json GET /user', (app) => app.fetch(user)],
+  ['middleware GET /mw/hello', (app) => app.fetch(mw)],
   [
     'body POST /json',
     (app) =>


### PR DESCRIPTION
Split out of #5134 as requested in https://github.com/honojs/hono/pull/5134#issuecomment-5058932909. This is part 1 of 4: benchmark harness only, no `src/` changes. The three remaining optimizations (env initializer, lazy `#validatedData`, allocation-free cache probe) follow as separate PRs against `next`.

## Windows fix

The default src path was computed with `URL.pathname`:

```ts
const src = process.env.HONO_SRC ?? new URL('../../src', import.meta.url).pathname
```

On Windows that yields `/C:/sources/hono/src`, and passing it back through `pathToFileURL` produces `C:\C:\sources\hono\src`, so `benchmarks/fetch` could not run at all. `fileURLToPath` returns the correct native path on every platform.

## New cases

- `json GET /user` isolates the `c.json()` response path. Previously JSON serialization was only measured inside `body POST /json`, mixed together with request body parsing, so a change to either one moved the same number.
- `middleware GET /mw/hello` covers the multi-handler `compose` dispatch path, which none of the existing cases exercised.

Verified with `node bench.mts` on Node.js 24.16.0 (x64-win32); all five cases report.

### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
