### PR TITLE
perf(context): drop the throwaway `env` field initializer

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -312,7 +312,7 @@ export class Context<
    * })
    * ```
    */
-  env: E['Bindings'] = {}
+  env: E['Bindings']
   #var: Map<unknown, unknown> | undefined
   finalized: boolean = false
   /**
@@ -357,6 +357,8 @@ export class Context<
       this.#notFoundHandler = options.notFoundHandler
       this.#path = options.path
       this.#matchResult = options.matchResult
+    } else {
+      this.env = {}
     }
   }
 


### PR DESCRIPTION
Split out of #5134 as requested in https://github.com/honojs/hono/pull/5134#issuecomment-5058932909. This is item 2 of the three remaining optimizations; items 3 and 4 are separate PRs. Benchmark harness changes are in #5173.

`Context` declared its `env` field as:

```ts
env: E['Bindings'] = {}
```

Field initializers run on every construction, so every request allocated an object that `#dispatch` then immediately overwrote with the real `env` via `options.env`. The allocation was never read.

The initializer only ever mattered for `new Context(req)` called without options, so that case now gets its `{}` from the constructor's `else` branch:

```ts
constructor(req: Request, options?: ContextOptions<E>) {
  this.#rawRequest = req
  if (options) {
    // ...
    this.env = options.env
    // ...
  } else {
    this.env = {}
  }
}
```

Semantics are identical. In particular `c.env` is still `undefined` when `options.env` is `undefined`, exactly as before, since the `options` branch assigns unconditionally in both the old and new code.

This one helps every request regardless of route or response type, which is why it shows up even on the plain-text case.

`tsc -p tsconfig.json` and the full `vitest` main project (121 files, 3654 tests) pass unchanged.

### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
