### PR TITLE
perf(request): allocate `#validatedData` lazily

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -48,7 +48,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   raw: Request
 
-  #validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
+  #validatedData: { [K in keyof ValidationTargets]?: {} } | undefined // Short name of validatedData
   #matchResult: Result<[unknown, RouterRoute]>
   routeIndex: number = 0
   /**
@@ -74,7 +74,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     this.raw = request
     this.path = path
     this.#matchResult = matchResult
-    this.#validatedData = {}
   }
 
   /**
@@ -335,7 +334,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @param data - The validated data to add.
    */
   addValidatedData(target: keyof ValidationTargets, data: {}) {
-    this.#validatedData[target] = data
+    ;(this.#validatedData ??= {})[target] = data
   }
 
   /**
@@ -348,7 +347,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   valid<T extends keyof I & keyof ValidationTargets>(target: T): InputToDataByTarget<I, T>
   valid(target: keyof ValidationTargets) {
-    return this.#validatedData[target] as unknown
+    return this.#validatedData?.[target] as unknown
   }
 
   /**


### PR DESCRIPTION
Split out of #5134 as requested in https://github.com/honojs/hono/pull/5134#issuecomment-5058932909. This is item 3 of the three remaining optimizations; items 2 and 4 are separate PRs. Benchmark harness changes are in #5173.

`HonoRequest` allocated its validated-data record in the constructor:

```ts
constructor(request, path = '/', matchResult = [[]]) {
  this.raw = request
  this.path = path
  this.#matchResult = matchResult
  this.#validatedData = {}   // every request pays for this
}
```

Most requests never run a validator, so that object is usually allocated and then thrown away. It is now created on first write instead:

```ts
addValidatedData(target: keyof ValidationTargets, data: {}) {
  ;(this.#validatedData ??= {})[target] = data
}

valid(target: keyof ValidationTargets) {
  return this.#validatedData?.[target] as unknown
}
```

Behavior is unchanged. `valid()` returned `undefined` for an unvalidated target before (missing property on an empty object) and returns `undefined` now (optional chaining short-circuits), so callers cannot tell the difference. The field type gains `| undefined` to match.

`tsc -p tsconfig.json` and the full `vitest` main project (121 files, 3654 tests, including the validator suites) pass unchanged.

### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
