### PR TITLE
perf(request): probe the body cache without allocating

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -223,8 +223,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
       return cachedBody
     }
 
-    const anyCachedKey = Object.keys(bodyCache)[0]
-    if (anyCachedKey) {
+    for (const anyCachedKey in bodyCache) {
       return (bodyCache[anyCachedKey as keyof Body] as Promise<BodyInit>).then((body) => {
         if (anyCachedKey === 'json') {
           body = JSON.stringify(body)


### PR DESCRIPTION
Split out of #5134 as requested in https://github.com/honojs/hono/pull/5134#issuecomment-5058932909. This is item 4 of the three remaining optimizations; items 2 and 3 are separate PRs. Benchmark harness changes are in #5173.

`#cachedBody` needs to know whether the body was already read under some *other* key, so it can re-serve it instead of consuming the stream twice. It answered that with:

```ts
const anyCachedKey = Object.keys(bodyCache)[0]
if (anyCachedKey) {
```

`Object.keys` builds a whole array just so the first element can be read, and this runs on every `req.json()`, `req.text()`, `req.arrayBuffer()`, and so on.

A `for ... in` that returns on its first iteration answers the same question with no allocation:

```ts
for (const anyCachedKey in bodyCache) {
  return (bodyCache[anyCachedKey as keyof Body] as Promise<BodyInit>).then((body) => {
```

Both forms visit own enumerable string keys in the same insertion order, so the key picked is identical. `for ... in` also walks the prototype chain, which is not a concern here: `bodyCache` is initialized as a plain `{}` object literal and only ever gets the five `Body` keys assigned, so `Object.prototype` contributes nothing enumerable.

The loop body always returns, so it is a probe rather than an iteration, and the fall-through to `return (bodyCache[key] = raw[key]())` is reached exactly when the cache is empty, as before.

`tsc -p tsconfig.json` and the full `vitest` main project (121 files, 3654 tests, including the body-cache suites that read the same request under multiple keys) pass unchanged.

### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
