### PR TITLE
fix(jsx): report a clear error when a component returns an array

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -289,6 +289,12 @@ class JSXFunctionNode extends JSXNode {
         buffer.callbacks ||= []
         buffer.callbacks.push(...res.callbacks)
       }
+    } else if (Array.isArray(res)) {
+      // Reaching `escapeToBuffer()` with an array fails with an unrelated message,
+      // so report what the caller actually has to change.
+      throw new Error(
+        'A function component must not return an array. Wrap the elements in a Fragment: <>...</>'
+      )
     } else {
       escapeToBuffer(res, buffer)
     }

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -171,6 +171,16 @@ describe('render to string', () => {
     expect(template.toString()).toBe('<p><span>a</span><span>b</span></p>')
   })
 
+  it('Should throw when a component returns an array', () => {
+    const Item = ({ x }: { x: number }) => <span>{x}</span>
+    const Items = () => [0, 1].map((x) => <Item key={x} x={x} />)
+    // @ts-expect-error a component returning an array is not a valid JSX element
+    const template = <Items />
+    expect(() => template.toString()).toThrow(
+      'A function component must not return an array. Wrap the elements in a Fragment: <>...</>'
+    )
+  })
+
   it('Empty elements are rended without closing tag', () => {
     const template = <input />
     expect(template.toString()).toBe('<input/>')


### PR DESCRIPTION
Refs #5177.

This is direction 1 in the issue: returning an array stays unsupported, and the failure says so.

The alternative, supporting the array return, is #5179. **The two are alternatives, not a pair.** Only one should be merged, and I will close the other.

## Problem

A function component that returns an array reaches `escapeToBuffer()` in `src/utils/html.ts`, which starts with `str.search(escapeRe)`. The request responds 500 with `TypeError: str.search is not a function`, naming an internal helper rather than the code that has to change.

## Solution

`JSXFunctionNode.toStringToBuffer()` gets a branch for arrays, which throws instead:

```
A function component must not return an array. Wrap the elements in a Fragment: <>...</>
```

No type changes are needed. The type layer already rejects the code with `TS2786`, so this only makes the runtime agree with what the types already say.

`hono/jsx/dom` renders an array-returning component correctly, and this PR leaves that difference in place. Removing it is what the other direction does.

## Tests

`src/jsx/index.test.tsx` asserts the thrown message. The test needs `@ts-expect-error` on the JSX expression, which doubles as a check that the type layer still rejects it.
