### PR TITLE
fix(jsx): allow a function component to return an array

### DIFF
--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -26,7 +26,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Props = Record<string, any>
 export type FC<P = Props> = {
-  (props: P): HtmlEscapedString | Promise<HtmlEscapedString> | Child[] | null
+  (props: P): HtmlEscapedString | Child[] | Promise<HtmlEscapedString | Child[]> | null
   defaultProps?: Partial<P> | undefined
   displayName?: string | undefined
 }
@@ -39,7 +39,7 @@ export namespace JSX {
   // returning an array is accepted as a tag.
   export type ElementType =
     | string
-    | ((props: never) => HtmlEscapedString | Promise<HtmlEscapedString> | Child[] | null)
+    | ((props: never) => HtmlEscapedString | Child[] | Promise<HtmlEscapedString | Child[]> | null)
   export interface ElementChildrenAttribute {
     children: Child
   }
@@ -110,6 +110,23 @@ export const booleanAttributes = [
   'selected',
 ]
 
+// An array cannot be resolved into the string buffer as-is, so wrap it in a fragment.
+// When a context is given, it is attached to the resolved node so that the suspended
+// subtree resumes with the same context state.
+const resolveArrayToFragment = (
+  child: Promise<string | Child[]>,
+  suspendedContext?: <T>(callback: () => T) => T
+): Promise<string> =>
+  child.then((resolved) => {
+    const node = Array.isArray(resolved) ? new JSXFragmentNode('', {}, resolved) : resolved
+    if (suspendedContext && node instanceof JSXNode) {
+      node.suspendedContext = suspendedContext
+    }
+    // The buffer is typed as strings, but it also holds resolved nodes, which
+    // `stringBufferToString()` stringifies.
+    return node as unknown as string
+  })
+
 const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCallbacks): void => {
   for (let i = 0, len = children.length; i < len; i++) {
     const child = children[i]
@@ -125,7 +142,7 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCal
     ) {
       ;(buffer[0] as string) += child
     } else if (child instanceof Promise) {
-      buffer.unshift('', child)
+      buffer.unshift('', resolveArrayToFragment(child))
     } else {
       // `child` type is `Child[]`, so stringify recursively
       childrenToStringToBuffer(child, buffer)
@@ -135,7 +152,7 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCal
 
 export type Child =
   | string
-  | Promise<string>
+  | Promise<string | Child[]>
   | number
   | JSXNode
   | null
@@ -272,19 +289,10 @@ class JSXFunctionNode extends JSXNode {
       return
     } else if (res instanceof Promise) {
       if (globalContexts.length === 0) {
-        buffer.unshift('', res)
+        buffer.unshift('', resolveArrayToFragment(res))
       } else {
         // save the current context state for resuming the suspended subtree
-        const suspendedContext = captureRenderContext()
-        buffer.unshift(
-          '',
-          res.then((childRes) => {
-            if (childRes instanceof JSXNode) {
-              childRes.suspendedContext = suspendedContext
-            }
-            return childRes
-          })
-        )
+        buffer.unshift('', resolveArrayToFragment(res, captureRenderContext()))
       }
     } else if (res instanceof JSXNode) {
       res.toStringToBuffer(buffer)

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -35,6 +35,9 @@ export type DOMAttributes = HonoJSX.HTMLAttributes
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {
   export type Element = HtmlEscapedString | Promise<HtmlEscapedString>
+  // A function component may return anything renderable, not just a single element.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type ElementType = string | ((props: any) => Child)
   export interface ElementChildrenAttribute {
     children: Child
   }
@@ -283,6 +286,8 @@ class JSXFunctionNode extends JSXNode {
       }
     } else if (res instanceof JSXNode) {
       res.toStringToBuffer(buffer)
+    } else if (Array.isArray(res)) {
+      childrenToStringToBuffer(res, buffer)
     } else if (typeof res === 'number' || (res as HtmlEscaped).isEscaped) {
       buffer[0] += res
       if (res.callbacks) {

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -26,7 +26,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Props = Record<string, any>
 export type FC<P = Props> = {
-  (props: P): HtmlEscapedString | Promise<HtmlEscapedString> | null
+  (props: P): HtmlEscapedString | Promise<HtmlEscapedString> | Child[] | null
   defaultProps?: Partial<P> | undefined
   displayName?: string | undefined
 }
@@ -35,9 +35,11 @@ export type DOMAttributes = HonoJSX.HTMLAttributes
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {
   export type Element = HtmlEscapedString | Promise<HtmlEscapedString>
-  // A function component may return anything renderable, not just a single element.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  export type ElementType = string | ((props: any) => Child)
+  // Kept in sync with the call signature of `FC`, so that a function component
+  // returning an array is accepted as a tag.
+  export type ElementType =
+    | string
+    | ((props: never) => HtmlEscapedString | Promise<HtmlEscapedString> | Child[] | null)
   export interface ElementChildrenAttribute {
     children: Child
   }

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -122,10 +122,14 @@ const resolveFunctionComponentResult = (
       return resolved
     }
     const children = Array.isArray(resolved) ? resolved : [resolved]
-    const render = () => new JSXFragmentNode('', {}, children).toString()
-    return Promise.resolve(suspendedContext ? suspendedContext(render) : render()).then((value) =>
-      raw(value, (value as HtmlEscapedString).callbacks)
-    )
+    const render = () => {
+      const buffer: StringBufferWithCallbacks = [''] as StringBufferWithCallbacks
+      childrenToStringToBuffer(children, buffer)
+      return buffer.length === 1
+        ? raw(buffer[0], buffer.callbacks)
+        : stringBufferToString(buffer, buffer.callbacks)
+    }
+    return suspendedContext ? suspendedContext(render) : runWithRenderContext(render)
   })
 
 const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCallbacks): void => {
@@ -137,11 +141,15 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCal
       continue
     } else if (child instanceof JSXNode) {
       child.toStringToBuffer(buffer)
-    } else if (
-      typeof child === 'number' ||
-      (child as unknown as { isEscaped: boolean }).isEscaped
-    ) {
+    } else if (typeof child === 'number') {
       ;(buffer[0] as string) += child
+    } else if ((child as unknown as HtmlEscaped).isEscaped) {
+      ;(buffer[0] as string) += child
+      const callbacks = (child as unknown as HtmlEscapedString).callbacks
+      if (callbacks) {
+        buffer.callbacks ||= []
+        buffer.callbacks.push(...callbacks)
+      }
     } else if (child instanceof Promise) {
       buffer.unshift('', child)
     } else {

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -25,8 +25,13 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Props = Record<string, any>
+type FunctionComponentResult =
+  | HtmlEscapedString
+  | Child[]
+  | Promise<HtmlEscapedString | Child[]>
+  | null
 export type FC<P = Props> = {
-  (props: P): HtmlEscapedString | Child[] | Promise<HtmlEscapedString | Child[]> | null
+  (props: P): FunctionComponentResult
   defaultProps?: Partial<P> | undefined
   displayName?: string | undefined
 }
@@ -35,11 +40,7 @@ export type DOMAttributes = HonoJSX.HTMLAttributes
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {
   export type Element = HtmlEscapedString | Promise<HtmlEscapedString>
-  // Kept in sync with the call signature of `FC`, so that a function component
-  // returning an array is accepted as a tag.
-  export type ElementType =
-    | string
-    | ((props: never) => HtmlEscapedString | Child[] | Promise<HtmlEscapedString | Child[]> | null)
+  export type ElementType = string | ((props: never) => FunctionComponentResult)
   export interface ElementChildrenAttribute {
     children: Child
   }
@@ -110,21 +111,21 @@ export const booleanAttributes = [
   'selected',
 ]
 
-// An array cannot be resolved into the string buffer as-is, so wrap it in a fragment.
-// When a context is given, it is attached to the resolved node so that the suspended
-// subtree resumes with the same context state.
-const resolveArrayToFragment = (
-  child: Promise<string | Child[]>,
-  suspendedContext?: <T>(callback: () => T) => T
+type SuspendedContext = <T>(callback: () => T) => T
+
+const resolveFunctionComponentResult = (
+  result: Promise<string | JSXNode | Child[]>,
+  suspendedContext?: SuspendedContext
 ): Promise<string> =>
-  child.then((resolved) => {
-    const node = Array.isArray(resolved) ? new JSXFragmentNode('', {}, resolved) : resolved
-    if (suspendedContext && node instanceof JSXNode) {
-      node.suspendedContext = suspendedContext
+  result.then((resolved) => {
+    if (!Array.isArray(resolved) && !(resolved instanceof JSXNode)) {
+      return resolved
     }
-    // The buffer is typed as strings, but it also holds resolved nodes, which
-    // `stringBufferToString()` stringifies.
-    return node as unknown as string
+    const children = Array.isArray(resolved) ? resolved : [resolved]
+    const render = () => new JSXFragmentNode('', {}, children).toString()
+    return Promise.resolve(suspendedContext ? suspendedContext(render) : render()).then((value) =>
+      raw(value, (value as HtmlEscapedString).callbacks)
+    )
   })
 
 const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCallbacks): void => {
@@ -142,7 +143,7 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCal
     ) {
       ;(buffer[0] as string) += child
     } else if (child instanceof Promise) {
-      buffer.unshift('', resolveArrayToFragment(child))
+      buffer.unshift('', child)
     } else {
       // `child` type is `Child[]`, so stringify recursively
       childrenToStringToBuffer(child, buffer)
@@ -152,7 +153,7 @@ const childrenToStringToBuffer = (children: Child[], buffer: StringBufferWithCal
 
 export type Child =
   | string
-  | Promise<string | Child[]>
+  | Promise<string>
   | number
   | JSXNode
   | null
@@ -289,10 +290,10 @@ class JSXFunctionNode extends JSXNode {
       return
     } else if (res instanceof Promise) {
       if (globalContexts.length === 0) {
-        buffer.unshift('', resolveArrayToFragment(res))
+        buffer.unshift('', resolveFunctionComponentResult(res))
       } else {
         // save the current context state for resuming the suspended subtree
-        buffer.unshift('', resolveArrayToFragment(res, captureRenderContext()))
+        buffer.unshift('', resolveFunctionComponentResult(res, captureRenderContext()))
       }
     } else if (res instanceof JSXNode) {
       res.toStringToBuffer(buffer)

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -174,7 +174,6 @@ export class JSXNode implements HtmlEscaped {
   key?: string
   children: Child[]
   isEscaped: true = true as const
-  suspendedContext?: <T>(callback: () => T) => T
   constructor(tag: string | Function, props: Props, children: Child[]) {
     if (typeof tag !== 'function' && !isValidTagName(tag)) {
       throw new Error(`Invalid JSX tag name: ${tag}`)
@@ -204,7 +203,7 @@ export class JSXNode implements HtmlEscaped {
           : buffer[0]
         : stringBufferToString(buffer, buffer.callbacks)
     }
-    return this.suspendedContext ? this.suspendedContext(render) : runWithRenderContext(render)
+    return runWithRenderContext(render)
   }
 
   toStringToBuffer(buffer: StringBufferWithCallbacks): void {

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -374,6 +374,18 @@ describe('DOM', () => {
       expect(Child).toBeCalledTimes(3)
     })
 
+    it('returning an array', async () => {
+      const App = () => {
+        const [count, setCount] = useState(0)
+        return [<div>{count}</div>, <button onClick={() => setCount(count + 1)}>+</button>]
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<div>0</div><button>+</button>')
+      root.querySelector('button')?.click()
+      await Promise.resolve()
+      expect(root.innerHTML).toBe('<div>1</div><button>+</button>')
+    })
+
     it('multiple children', async () => {
       const Child = ({ name }: { name: string }) => {
         const [count, setCount] = useState(0)

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -386,6 +386,18 @@ describe('DOM', () => {
       expect(root.innerHTML).toBe('<div>1</div><button>+</button>')
     })
 
+    it('typed as FC returning an array', async () => {
+      const App: FC = () => {
+        const [count, setCount] = useState(0)
+        return [<div>{count}</div>, <button onClick={() => setCount(count + 1)}>+</button>]
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<div>0</div><button>+</button>')
+      root.querySelector('button')?.click()
+      await Promise.resolve()
+      expect(root.innerHTML).toBe('<div>1</div><button>+</button>')
+    })
+
     it('multiple children', async () => {
       const Child = ({ name }: { name: string }) => {
         const [count, setCount] = useState(0)

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -284,7 +284,7 @@ const invokeTag = (context: Context, node: NodeObject): Child[] => {
       }
     : node.props
   try {
-    return [func.call(null, props)]
+    return [func.call(null, props) as Child]
   } finally {
     buildDataStack.pop()
   }

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -171,6 +171,26 @@ describe('render to string', () => {
     expect(template.toString()).toBe('<p><span>a</span><span>b</span></p>')
   })
 
+  it('Component returning an array', () => {
+    const Item = ({ x }: { x: number }) => <span>{x}</span>
+    const Items = () => [0, 1].map((x) => <Item key={x} x={x} />)
+    const template = <Items />
+    expect(template.toString()).toBe('<span>0</span><span>1</span>')
+  })
+
+  it('Component returning a nested array', () => {
+    const Items = () => [['a', 'b'], [<span>c</span>], null]
+    const template = <Items />
+    expect(template.toString()).toBe('ab<span>c</span>')
+  })
+
+  it('Component returning an array including async components', async () => {
+    const AsyncItem = async ({ x }: { x: number }) => <span>{x}</span>
+    const Items = () => [0, 1].map((x) => <AsyncItem key={x} x={x} />)
+    const template = <Items />
+    expect((await template.toString()).toString()).toBe('<span>0</span><span>1</span>')
+  })
+
   it('Empty elements are rended without closing tag', () => {
     const template = <input />
     expect(template.toString()).toBe('<input/>')

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -198,6 +198,19 @@ describe('render to string', () => {
     expect(template.toString()).toBe('<span>0</span><span>1</span>')
   })
 
+  it('Async component returning an array', async () => {
+    const AsyncItems = async () => [<span>a</span>, <span>b</span>]
+    const template = <AsyncItems />
+    expect((await template.toString()).toString()).toBe('<span>a</span><span>b</span>')
+  })
+
+  it('Async component returning an array of async components', async () => {
+    const AsyncItem = async ({ x }: { x: number }) => <span>{x}</span>
+    const AsyncItems = async () => [<AsyncItem key={0} x={0} />, <AsyncItem key={1} x={1} />]
+    const template = <AsyncItems />
+    expect((await template.toString()).toString()).toBe('<span>0</span><span>1</span>')
+  })
+
   it('Empty elements are rended without closing tag', () => {
     const template = <input />
     expect(template.toString()).toBe('<input/>')
@@ -1267,6 +1280,19 @@ d.replaceWith(c.content)
         </ThemeContext.Provider>
       )
       expect((await template.toString()).toString()).toBe('<span>dark</span>')
+    })
+
+    it('returning an array', async () => {
+      const ArrayConsumer = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return [<span>{useContext(ThemeContext)}</span>, <span>x</span>]
+      }
+      const template = (
+        <ThemeContext.Provider value='dark'>
+          <ArrayConsumer />
+        </ThemeContext.Provider>
+      )
+      expect((await template.toString()).toString()).toBe('<span>dark</span><span>x</span>')
     })
 
     it('nested', async () => {

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource ./ */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { html } from '../helper/html'
+import { html, raw } from '../helper/html'
 import { Hono } from '../hono'
 import { captureRenderContext } from './context'
 import { Suspense, renderToReadableStream } from './streaming'
@@ -182,6 +182,28 @@ describe('render to string', () => {
     const Items = () => [['a', 'b'], [<span>c</span>], null]
     const template = <Items />
     expect(template.toString()).toBe('ab<span>c</span>')
+  })
+
+  it('Component returning an array preserves escaped string callbacks', () => {
+    const Items = () => [
+      raw('a', [
+        ({ buffer }) => {
+          if (buffer) {
+            buffer[0] += 'b'
+          }
+        },
+      ]),
+    ]
+    expect((<Items />).toString()).toBe('ab')
+  })
+
+  it('Component returning an array escapes strings', async () => {
+    const SyncItems = () => ['<script>alert(1)</script>']
+    const AsyncItems = async () => ['<script>alert(1)</script>']
+    const expected = '&lt;script&gt;alert(1)&lt;/script&gt;'
+
+    expect((<SyncItems />).toString()).toBe(expected)
+    expect((await (<AsyncItems />).toString()).toString()).toBe(expected)
   })
 
   it('Component returning an array including async components', async () => {

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -1295,6 +1295,25 @@ d.replaceWith(c.content)
       expect((await template.toString()).toString()).toBe('<span>dark</span><span>x</span>')
     })
 
+    it('isolates a shared async result between providers', async () => {
+      const sharedResult = Promise.resolve(<Consumer />)
+      const SharedConsumer = () => sharedResult
+      const [dark, black] = await Promise.all([
+        (
+          <ThemeContext.Provider value='dark'>
+            <SharedConsumer />
+          </ThemeContext.Provider>
+        ).toString(),
+        (
+          <ThemeContext.Provider value='black'>
+            <SharedConsumer />
+          </ThemeContext.Provider>
+        ).toString(),
+      ])
+      expect(dark.toString()).toBe('<span>dark</span>')
+      expect(black.toString()).toBe('<span>black</span>')
+    })
+
     it('nested', async () => {
       const template = (
         <ThemeContext.Provider value='dark'>

--- a/src/jsx/index.test.tsx
+++ b/src/jsx/index.test.tsx
@@ -191,6 +191,13 @@ describe('render to string', () => {
     expect((await template.toString()).toString()).toBe('<span>0</span><span>1</span>')
   })
 
+  it('Component typed as FC returning an array', () => {
+    const Item: FC<{ x: number }> = ({ x }) => <span>{x}</span>
+    const Items: FC = () => [0, 1].map((x) => <Item key={x} x={x} />)
+    const template = <Items />
+    expect(template.toString()).toBe('<span>0</span><span>1</span>')
+  })
+
   it('Empty elements are rended without closing tag', () => {
     const template = <input />
     expect(template.toString()).toBe('<input/>')

--- a/src/jsx/intrinsic-element/components.test.tsx
+++ b/src/jsx/intrinsic-element/components.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource ../ */
 import { useActionState } from '../'
+import { HtmlEscapedCallbackPhase, resolveCallback } from '../../utils/html'
 
 describe('intrinsic element', () => {
   describe('document metadata', () => {
@@ -15,6 +16,23 @@ describe('intrinsic element', () => {
           </html>
         )
         expect(template.toString()).toBe(
+          '<html><head><title>Hello</title></head><body><h1>World</h1></body></html>'
+        )
+      })
+
+      it('should hoist a title from an async component array', async () => {
+        const Metadata = async () => [<title>Hello</title>]
+        const template = (
+          <html>
+            <head></head>
+            <body>
+              <Metadata />
+              <h1>World</h1>
+            </body>
+          </html>
+        )
+        const rendered = await template.toString()
+        expect(await resolveCallback(rendered, HtmlEscapedCallbackPhase.Stringify, false, {})).toBe(
           '<html><head><title>Hello</title></head><body><h1>World</h1></body></html>'
         )
       })

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -56,6 +56,20 @@ describe('Streaming', () => {
     )
   })
 
+  it('preserves callbacks in a streamed async component array', async () => {
+    const phases: number[] = []
+    const Content = async () => [
+      raw('Hello', [({ phase }) => void phases.push(phase)]),
+      <span>World</span>,
+    ]
+
+    const html = await drainStream(renderToReadableStream(<Content />))
+
+    expect(html).toBe('Hello<span>World</span>')
+    expect(phases).toEqual([HtmlEscapedCallbackPhase.BeforeStream, HtmlEscapedCallbackPhase.Stream])
+    suspenseCounter--
+  })
+
   it('Suspense / renderToReadableStream', async () => {
     let contentEvaluatedCount = 0
     const Content = () => {

--- a/src/jsx/streaming.test.tsx
+++ b/src/jsx/streaming.test.tsx
@@ -30,6 +30,32 @@ describe('Streaming', () => {
     suspenseCounter++
   })
 
+  it('Suspense / async component returning an array', async () => {
+    const Content = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return [<h1>Hello</h1>, <h2>World</h2>]
+    }
+
+    const stream = renderToReadableStream(
+      <Suspense fallback={<p>Loading...</p>}>
+        <Content />
+      </Suspense>
+    )
+
+    const chunks = []
+    const textDecoder = new TextDecoder()
+    for await (const chunk of stream as any) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+
+    expect(chunks[0]).toBe(
+      `<template id="H:${suspenseCounter}"></template><p>Loading...</p><!--/$-->`
+    )
+    expect(chunks[1]).toContain(
+      `<template data-hono-target="H:${suspenseCounter}"><h1>Hello</h1><h2>World</h2></template>`
+    )
+  })
+
   it('Suspense / renderToReadableStream', async () => {
     let contentEvaluatedCount = 0
     const Content = () => {

--- a/src/middleware/jsx-renderer/index.test.tsx
+++ b/src/middleware/jsx-renderer/index.test.tsx
@@ -55,6 +55,22 @@ describe('JSX renderer', () => {
     )
   })
 
+  it('accepts an array result', async () => {
+    const app = new Hono()
+    app.use(jsxRenderer(({ children }) => [<header>Header</header>, <main>{children}</main>]))
+    app.get('/', (c) => c.render(<h1>Hello</h1>, { title: 'Hello' }))
+
+    const res = await app.request('/')
+    expect(await res.text()).toBe(
+      '<!DOCTYPE html><header>Header</header><main><h1>Hello</h1></main>'
+    )
+  })
+
+  it('does not accept a null result', () => {
+    // @ts-expect-error A JSX renderer component must produce renderable content.
+    jsxRenderer(() => null)
+  })
+
   it('Should get the context object as a 2nd arg', async () => {
     const app = new Hono()
     app.use(

--- a/src/middleware/jsx-renderer/index.ts
+++ b/src/middleware/jsx-renderer/index.ts
@@ -10,7 +10,6 @@ import { Fragment, createContext, jsx, useContext } from '../../jsx'
 import type { FC, Context as JSXContext, JSXNode, PropsWithChildren } from '../../jsx'
 import { renderToReadableStream } from '../../jsx/streaming'
 import type { Env, Input, MiddlewareHandler } from '../../types'
-import type { HtmlEscapedString } from '../../utils/html'
 
 export const RequestContext: JSXContext<Context<any, any, {}> | null> =
   createContext<Context | null>(null)
@@ -20,15 +19,14 @@ type RendererOptions = {
   stream?: boolean | Record<string, string>
 }
 
-type Component = (
-  props: PropsForRenderer & { Layout: FC },
-  c: Context
-) => HtmlEscapedString | Promise<HtmlEscapedString>
+type ComponentResult = Exclude<ReturnType<FC>, null>
+
+type Component = (props: PropsForRenderer & { Layout: FC }, c: Context) => ComponentResult
 
 type ComponentWithChildren = (
   props: PropsWithChildren<PropsForRenderer & { Layout: FC }>,
   c: Context
-) => HtmlEscapedString | Promise<HtmlEscapedString>
+) => ComponentResult
 
 const createRenderer =
   (


### PR DESCRIPTION
Refs #5177.

This is direction 2 in the issue: a function component may return an array, as `hono/jsx/dom` already allows.

The alternative, keeping it unsupported behind an explicit error, is #5178. **The two are alternatives, not a pair.** Only one should be merged, and I will close the other.

## Solution

**1. `fix(jsx): allow a function component to return an array`**

Handle arrays in `JSXFunctionNode.toStringToBuffer()` with `childrenToStringToBuffer()`, the path already used for array children.

**2. `fix(jsx): accept an array return in the type layer`**

The runtime fix alone is unreachable from TypeScript, which reports `TS2786: ... Its return type 'Element[]' is not a valid JSX element`. `Child[]` is added to the call signature of `FC`, and `JSX.ElementType` is defined with the same return type. Without `JSX.ElementType`, TypeScript checks the return type against `JSX.Element`; with it, it checks the tag instead.

Both types are given the same return type, so nothing beyond arrays becomes newly valid:

| | before | after |
| --- | --- | --- |
| `() => [<a />, <b />]` | error | **ok** |
| `() => 42`, `() => 'x'`, `() => undefined` | error | error |

**3. `fix(jsx): render an array resolved from a promise`**

A component may be async, so the array can arrive through a promise. Without this the feature would only be half there, since `async () => [<li>a</li>]` would still be rejected. It renders through `toString()` and through `Suspense` / `renderToReadableStream()` alike.

`Child` therefore carries `Promise<string \| Child[]>`, and a resolved array is wrapped in a fragment so it renders like any other node. Widening `Child` surfaced the same path for children, so both call sites share `resolveArrayToFragment()`. The helper also attaches the suspended context, which let the promise branch drop its own `then()` chain.

## A note on the cast in `resolveArrayToFragment()`

The helper returns `Promise<string>` but resolves to a node, so it ends with `as unknown as string`. The buffer already held nodes before this PR:

```ts
res.then((childRes) => {
  if (childRes instanceof JSXNode) { // the buffer already received nodes here
    childRes.suspendedContext = suspendedContext
  }
  return childRes
})
```

That branch type-checked only because `res` was `any`, and `stringBufferToString()` is written for it too, calling `toString()` on an object entry. What is inaccurate is the declaration, `StringBuffer = (string | Promise<string>)[]`.

Typing it honestly is a separate change. It needs `stringBufferToString()` to settle how it treats `String` objects versus primitives, and it exports a new type from `hono/utils/html`, which is used outside JSX. It is left out here on purpose, and the cast is kept in one place with a comment instead of spread across the three call sites.

