### PR TITLE
perf(hono-base): restore the rest parameter in `fetch`

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -480,8 +480,8 @@ class Hono<
     request: Request,
     env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => Response | Promise<Response> = (request, env, executionCtx) => {
-    return this.#dispatch(request, executionCtx, env, request.method)
+  ) => Response | Promise<Response> = (request, ...rest) => {
+    return this.#dispatch(request, rest[1], rest[0], request.method)
   }
 
   /**


### PR DESCRIPTION
Reverts the runtime part of #5113. Calling `app.fetch(request)` with fewer args than the three declared parameters triggers an arity fixup on JSC (~2ns/req on the ping benchmark). The rest parameter form avoids it and is neutral on V8.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
