### PR TITLE
perf(context): restore the `env` field initializer

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -312,7 +312,7 @@ export class Context<
    * })
    * ```
    */
-  env: E['Bindings']
+  env: E['Bindings'] = {}
   #var: Map<unknown, unknown> | undefined
   finalized: boolean = false
   /**
@@ -357,8 +357,6 @@ export class Context<
       this.#notFoundHandler = options.notFoundHandler
       this.#path = options.path
       this.#matchResult = options.matchResult
-    } else {
-      this.env = {}
     }
   }
 


### PR DESCRIPTION
Reverts #5174. Dropping the initializer looked like a harmless cleanup, but it makes ping ~2ns/req slower on JSC/Bun — measured with `benchmarks/fetch` (25 paired rounds). Curiously the fresh `{}` per request is what keeps the allocator path warm for the allocations that follow. Neutral on V8.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
