### PR TITLE
perf(context): merge headers in place when replacing the response

### DIFF
--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -15,9 +15,9 @@
 // Runs on both Bun and Node.
 import './ts-resolve.mjs'
 import { run, bench } from 'mitata'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const src = process.env.HONO_SRC ?? new URL('../../src', import.meta.url).pathname
+const src = process.env.HONO_SRC ?? fileURLToPath(new URL('../../src', import.meta.url))
 const label = process.env.HONO_LABEL ?? 'hono'
 const asJson = process.env.HONO_JSON === '1'
 
@@ -37,6 +37,11 @@ const makeApp = async (src: string): Promise<any> => {
       c.header('x-powered-by', 'benchmark')
       return c.text(`${id} ${name}`)
     })
+    .get('/user', (c: any) => c.json({ id: 123, name: 'Alice', roles: ['admin', 'editor'] }))
+    .use('/mw/*', async (_c: any, next: any) => {
+      await next()
+    })
+    .get('/mw/hello', (c: any) => c.text('mw'))
   return app
 }
 
@@ -44,6 +49,8 @@ const app = await makeApp(src)
 
 const ping = new Request('http://localhost/')
 const query = new Request('http://localhost/id/1?name=bun')
+const user = new Request('http://localhost/user')
+const mw = new Request('http://localhost/mw/hello')
 
 let sink: unknown
 
@@ -51,6 +58,8 @@ let sink: unknown
 const cases: [string, (app: any) => Promise<unknown>][] = [
   ['ping GET /', (app) => app.fetch(ping)],
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],
+  ['json GET /user', (app) => app.fetch(user)],
+  ['middleware GET /mw/hello', (app) => app.fetch(mw)],
   [
     'body POST /json',
     (app) =>

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -11,10 +11,11 @@
 //   HONO_SRC    ... path to the hono `src` directory to benchmark (default: ../../src)
 //   HONO_LABEL  ... label used in the output (default: hono)
 //   HONO_JSON=1 ... suppress mitata output and print a single JSON line instead
+//   HONO_CASE   ... run only cases whose name starts with this prefix (e.g. "ping")
 //
 // Runs on both Bun and Node.
 import './ts-resolve.mjs'
-import { run, bench } from 'mitata'
+import { run, bench, measure } from 'mitata'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const src = process.env.HONO_SRC ?? fileURLToPath(new URL('../../src', import.meta.url))
@@ -54,8 +55,9 @@ const mw = new Request('http://localhost/mw/hello')
 
 let sink: unknown
 
- 
-const cases: [string, (app: any) => Promise<unknown>][] = [
+const caseFilter = process.env.HONO_CASE
+
+const allCases: [string, (app: any) => Promise<unknown>][] = [
   ['ping GET /', (app) => app.fetch(ping)],
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],
   ['json GET /user', (app) => app.fetch(user)],
@@ -73,6 +75,17 @@ const cases: [string, (app: any) => Promise<unknown>][] = [
   ],
 ]
 
+const cases = caseFilter ? allCases.filter(([name]) => name.startsWith(caseFilter)) : allCases
+if (cases.length === 0) {
+  throw new Error(`no cases match HONO_CASE=${caseFilter}`)
+}
+
+// Warm up before registering benches: the first fetch builds the router
+// lazily (>500µs), which makes mitata skip batching for the first bench.
+for (const [, fn] of allCases) {
+  sink = await fn(app)
+}
+
 for (const [name, fn] of cases) {
   bench(name, async () => {
     sink = await fn(app)
@@ -80,14 +93,21 @@ for (const [name, fn] of cases) {
 }
 
 if (asJson) {
-  const { benchmarks } = await run({ format: 'quiet' })
+  // Force batching on: without it, each iteration is timed individually at
+  // timer granularity (~41ns on Apple Silicon), which is too coarse here.
   const results: Record<string, { avg: number; min: number; p75: number }> = {}
-  for (const b of benchmarks) {
-    const { stats, error } = b.runs[0]
-    if (error || !stats) {
-      throw error ?? new Error(`no stats for ${b.alias}`)
-    }
-    results[b.alias] = { avg: stats.avg, min: stats.min, p75: stats.p75 }
+  for (const [name, fn] of cases) {
+    const stats = await measure(
+      async () => {
+        sink = await fn(app)
+      },
+      {
+        warmup_threshold: Number.MAX_SAFE_INTEGER,
+        batch_threshold: Number.MAX_SAFE_INTEGER,
+      }
+    )
+    // p50 rather than avg: insensitive to the slow JIT tier-up windows
+    results[name] = { avg: stats.p50, min: stats.min, p75: stats.p75 }
   }
   console.log(JSON.stringify({ label, cases: results }))
   console.error(typeof sink)

--- a/benchmarks/fetch/bench.mts
+++ b/benchmarks/fetch/bench.mts
@@ -43,6 +43,12 @@ const makeApp = async (src: string): Promise<any> => {
       await next()
     })
     .get('/mw/hello', (c: any) => c.text('mw'))
+    .use('/replace/*', async (c: any, next: any) => {
+      await next()
+      // the shape of compress/cache-style middleware
+      c.res = new Response(c.res.body, c.res)
+    })
+    .get('/replace/hello', (c: any) => c.text('replace'))
   return app
 }
 
@@ -52,6 +58,7 @@ const ping = new Request('http://localhost/')
 const query = new Request('http://localhost/id/1?name=bun')
 const user = new Request('http://localhost/user')
 const mw = new Request('http://localhost/mw/hello')
+const replace = new Request('http://localhost/replace/hello')
 
 let sink: unknown
 
@@ -62,6 +69,7 @@ const allCases: [string, (app: any) => Promise<unknown>][] = [
   ['query GET /id/1?name=bun', (app) => app.fetch(query)],
   ['json GET /user', (app) => app.fetch(user)],
   ['middleware GET /mw/hello', (app) => app.fetch(mw)],
+  ['replace-res GET /replace/hello', (app) => app.fetch(replace)],
   [
     'body POST /json',
     (app) =>

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -266,6 +266,16 @@ describe('Context', () => {
     expect(await res.text()).toBe('this is body')
   })
 
+  it('Can replace the response with one that has immutable headers', async () => {
+    c.res = new Response('first', { headers: { 'X-Custom1': 'Message1' } })
+    // Response.redirect() returns a response whose headers are immutable,
+    // like a response returned by fetch()
+    c.res = Response.redirect('https://example.com/', 301)
+    expect(c.res.status).toBe(301)
+    expect(c.res.headers.get('Location')).toBe('https://example.com/')
+    expect(c.res.headers.get('X-Custom1')).toBe('Message1')
+  })
+
   it('Inherit current status if not specified', async () => {
     c.status(201)
     const res = c.newResponse('this is body', {

--- a/src/context.ts
+++ b/src/context.ts
@@ -622,7 +622,8 @@ export class Context<
     }
 
     if (headers) {
-      for (const [k, v] of Object.entries(headers)) {
+      for (const k in headers) {
+        const v = headers[k as keyof HeaderRecord]
         if (typeof v === 'string') {
           responseHeaders.set(k, v)
         } else {

--- a/src/context.ts
+++ b/src/context.ts
@@ -606,14 +606,12 @@ export class Context<
     arg?: StatusCode | ResponseOrInit,
     headers?: HeaderRecord
   ): Response {
-    const responseHeaders = this.#res
-      ? new Headers(this.#res.headers)
-      : (this.#preparedHeaders ?? new Headers())
+    let responseHeaders = this.#res ? new Headers(this.#res.headers) : this.#preparedHeaders
 
-    if (typeof arg === 'object' && 'headers' in arg) {
-      const argHeaders = arg.headers instanceof Headers ? arg.headers : new Headers(arg.headers)
-      for (const [key, value] of argHeaders) {
-        if (key.toLowerCase() === 'set-cookie') {
+    if (typeof arg === 'object' && arg.headers) {
+      responseHeaders ??= new Headers()
+      for (const [key, value] of new Headers(arg.headers)) {
+        if (key === 'set-cookie') {
           responseHeaders.append(key, value)
         } else {
           responseHeaders.set(key, value)
@@ -622,21 +620,35 @@ export class Context<
     }
 
     if (headers) {
-      for (const k in headers) {
-        const v = headers[k as keyof HeaderRecord]
-        if (typeof v === 'string') {
-          responseHeaders.set(k, v)
-        } else {
-          responseHeaders.delete(k)
-          for (const v2 of v) {
-            responseHeaders.append(k, v2)
+      if (!responseHeaders) {
+        let count = 0
+        for (const k in headers) {
+          if (++count > 1 || typeof headers[k as keyof HeaderRecord] !== 'string') {
+            responseHeaders = new Headers()
+            break
+          }
+        }
+      }
+      if (responseHeaders) {
+        for (const k in headers) {
+          const v = headers[k as keyof HeaderRecord]
+          if (typeof v === 'string') {
+            responseHeaders.set(k, v)
+          } else {
+            responseHeaders.delete(k)
+            for (const v2 of v) {
+              responseHeaders.append(k, v2)
+            }
           }
         }
       }
     }
 
     const status = typeof arg === 'number' ? arg : (arg?.status ?? this.#status)
-    return createResponseInstance(data, { status, headers: responseHeaders })
+    return createResponseInstance(data, {
+      status,
+      headers: responseHeaders ?? (headers as Record<string, string> | undefined),
+    })
   }
 
   newResponse: NewResponse = (...args) => this.#newResponse(...(args as Parameters<NewResponse>))

--- a/src/context.ts
+++ b/src/context.ts
@@ -290,6 +290,23 @@ const createResponseInstance = (
   init?: globalThis.ResponseInit
 ): Response => new Response(body, init)
 
+const copyHeadersOnto = (source: Headers, target: Response): void => {
+  for (const [k, v] of source.entries()) {
+    if (k === 'content-type') {
+      continue
+    }
+    if (k === 'set-cookie') {
+      const cookies = source.getSetCookie()
+      target.headers.delete('set-cookie')
+      for (const cookie of cookies) {
+        target.headers.append('set-cookie', cookie)
+      }
+    } else {
+      target.headers.set(k, v)
+    }
+  }
+}
+
 export class Context<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Env = any,
@@ -415,20 +432,14 @@ export class Context<
    */
   set res(_res: Response | undefined) {
     if (this.#res && _res) {
-      _res = createResponseInstance(_res.body, _res)
-      for (const [k, v] of this.#res.headers.entries()) {
-        if (k === 'content-type') {
-          continue
-        }
-        if (k === 'set-cookie') {
-          const cookies = this.#res.headers.getSetCookie()
-          _res.headers.delete('set-cookie')
-          for (const cookie of cookies) {
-            _res.headers.append('set-cookie', cookie)
-          }
-        } else {
-          _res.headers.set(k, v)
-        }
+      // Merge the previous response's headers into the new response in place. Recreating
+      // the Response is expensive, so do it only when its headers are immutable (e.g. a
+      // response obtained with `fetch()`) and mutating them throws.
+      try {
+        copyHeadersOnto(this.#res.headers, _res)
+      } catch {
+        _res = createResponseInstance(_res.body, _res)
+        copyHeadersOnto(this.#res.headers, _res)
       }
     }
     this.#res = _res

--- a/src/context.ts
+++ b/src/context.ts
@@ -312,7 +312,7 @@ export class Context<
    * })
    * ```
    */
-  env: E['Bindings'] = {}
+  env: E['Bindings']
   #var: Map<unknown, unknown> | undefined
   finalized: boolean = false
   /**
@@ -357,6 +357,8 @@ export class Context<
       this.#notFoundHandler = options.notFoundHandler
       this.#path = options.path
       this.#matchResult = options.matchResult
+    } else {
+      this.env = {}
     }
   }
 

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -471,17 +471,17 @@ class Hono<
    * @see {@link https://hono.dev/docs/api/hono#fetch}
    *
    * @param {Request} request - request Object of request
-   * @param {Env} Env - env Object
-   * @param {ExecutionContext} - context of execution
+   * @param {Env} env - env Object
+   * @param {ExecutionContext} executionCtx - context of execution
    * @returns {Response | Promise<Response>} response of request
    *
    */
   fetch: (
     request: Request,
-    Env?: E['Bindings'] | {},
+    env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => Response | Promise<Response> = (request, ...rest) => {
-    return this.#dispatch(request, rest[1], rest[0], request.method)
+  ) => Response | Promise<Response> = (request, env, executionCtx) => {
+    return this.#dispatch(request, executionCtx, env, request.method)
   }
 
   /**

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -480,8 +480,8 @@ class Hono<
     request: Request,
     env?: E['Bindings'] | {},
     executionCtx?: ExecutionContext
-  ) => Response | Promise<Response> = (request, env, executionCtx) => {
-    return this.#dispatch(request, executionCtx, env, request.method)
+  ) => Response | Promise<Response> = (request, ...rest) => {
+    return this.#dispatch(request, rest[1], rest[0], request.method)
   }
 
   /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -106,7 +106,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   #getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
     const param = this.#getParamValue(paramKey)
-    return param && /\%/.test(param) ? tryDecodeURIComponent(param) : param
+    return param && param.indexOf('%') !== -1 ? tryDecodeURIComponent(param) : param
   }
 
   #getAllDecodedParams(): Record<string, string> {
@@ -116,7 +116,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     for (const key of keys) {
       const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value !== undefined) {
-        decoded[key] = /\%/.test(value) ? tryDecodeURIComponent(value) : value
+        decoded[key] = value.indexOf('%') !== -1 ? tryDecodeURIComponent(value) : value
       }
     }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -15,7 +15,7 @@ import { parseBody } from './utils/body'
 import type { BodyData, ParseBodyOptions } from './utils/body'
 import type { CustomHeader, RequestHeader } from './utils/headers'
 import type { Simplify, UnionToIntersection } from './utils/types'
-import { decodeURIComponent_, getQueryParam, getQueryParams, tryDecode } from './utils/url'
+import { getQueryParam, getQueryParams, tryDecodeURIComponent } from './utils/url'
 
 type Body = {
   json: any
@@ -30,8 +30,6 @@ type OptionalRequestInitProperties = 'window' | 'priority'
 type RequiredRequestInit = Required<Omit<RequestInit, OptionalRequestInitProperties>> & {
   [Key in OptionalRequestInitProperties]?: RequestInit[Key]
 }
-
-const tryDecodeURIComponent = (str: string) => tryDecode(str, decodeURIComponent_)
 
 export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   /**
@@ -106,7 +104,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   #getDecodedParam(key: string): string | undefined {
     const paramKey = this.#matchResult[0][this.routeIndex][1][key]
     const param = this.#getParamValue(paramKey)
-    return param && param.indexOf('%') !== -1 ? tryDecodeURIComponent(param) : param
+    return param && tryDecodeURIComponent(param)
   }
 
   #getAllDecodedParams(): Record<string, string> {
@@ -116,7 +114,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     for (const key of keys) {
       const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value !== undefined) {
-        decoded[key] = value.indexOf('%') !== -1 ? tryDecodeURIComponent(value) : value
+        decoded[key] = tryDecodeURIComponent(value)
       }
     }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -48,7 +48,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   raw: Request
 
-  #validatedData: { [K in keyof ValidationTargets]?: {} } // Short name of validatedData
+  #validatedData: { [K in keyof ValidationTargets]?: {} } | undefined // Short name of validatedData
   #matchResult: Result<[unknown, RouterRoute]>
   routeIndex: number = 0
   /**
@@ -74,7 +74,6 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
     this.raw = request
     this.path = path
     this.#matchResult = matchResult
-    this.#validatedData = {}
   }
 
   /**
@@ -335,7 +334,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    * @param data - The validated data to add.
    */
   addValidatedData(target: keyof ValidationTargets, data: {}) {
-    this.#validatedData[target] = data
+    ;(this.#validatedData ??= {})[target] = data
   }
 
   /**
@@ -348,7 +347,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
    */
   valid<T extends keyof I & keyof ValidationTargets>(target: T): InputToDataByTarget<I, T>
   valid(target: keyof ValidationTargets) {
-    return this.#validatedData[target] as unknown
+    return this.#validatedData?.[target] as unknown
   }
 
   /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -222,8 +222,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
       return cachedBody
     }
 
-    const anyCachedKey = Object.keys(bodyCache)[0]
-    if (anyCachedKey) {
+    for (const anyCachedKey in bodyCache) {
       return (bodyCache[anyCachedKey as keyof Body] as Promise<BodyInit>).then((body) => {
         if (anyCachedKey === 'json') {
           body = JSON.stringify(body)

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -3,7 +3,7 @@
  * Cookie utility.
  */
 
-import { decodeURIComponent_, tryDecode } from './url'
+import { tryDecodeURIComponent } from './url'
 
 export type Cookie = Record<string, string>
 export type SignedCookie = Record<string, string | false>
@@ -126,8 +126,7 @@ export const parse = (cookie: string, name?: string): Cookie => {
       cookieValue = cookieValue.slice(1, -1)
     }
     if (validCookieValueRegEx.test(cookieValue)) {
-      parsedCookie[cookieName] =
-        cookieValue.indexOf('%') !== -1 ? tryDecode(cookieValue, decodeURIComponent_) : cookieValue
+      parsedCookie[cookieName] = tryDecodeURIComponent(cookieValue)
       if (name) {
         // Fast-path: return only the demanded-key immediately. Other keys are not needed.
         break

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -207,9 +207,6 @@ export const checkOptionalParameter = (path: string): string[] | null => {
 
 // Optimized
 const _decodeURI = (value: string) => {
-  if (!/[%+]/.test(value)) {
-    return value
-  }
   if (value.indexOf('+') !== -1) {
     value = value.replace(/\+/g, ' ')
   }
@@ -223,7 +220,7 @@ const _getQueryParam = (
 ): string | undefined | Record<string, string> | string[] | Record<string, string[]> => {
   let encoded
 
-  if (!multiple && key && !/[%+]/.test(key)) {
+  if (!multiple && key && key.indexOf('%') === -1 && key.indexOf('+') === -1) {
     // optimized for unencoded key
 
     let keyIndex = url.indexOf('?', 8)

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -205,12 +205,15 @@ export const checkOptionalParameter = (path: string): string[] | null => {
   return results.filter((v, i, a) => a.indexOf(v) === i)
 }
 
+export const tryDecodeURIComponent = (str: string): string =>
+  str.indexOf('%') !== -1 ? tryDecode(str, decodeURIComponent_) : str
+
 // Optimized
-const _decodeURI = (value: string) => {
+const _decodeURI = (value: string): string => {
   if (value.indexOf('+') !== -1) {
     value = value.replace(/\+/g, ' ')
   }
-  return value.indexOf('%') !== -1 ? tryDecode(value, decodeURIComponent_) : value
+  return tryDecodeURIComponent(value)
 }
 
 const _getQueryParam = (


### PR DESCRIPTION
The `res` setter recreated the assigned Response whenever a previous response existed, purely so that merging the old headers into it could not hit immutable headers. That is the exact shape of compress/cache-style middleware (`c.res = new Response(body, c.res)` after `await next()`), so those flows paid a second, redundant Response construction per request. CPU profiling on Node shows `new Response()` is the most expensive operation in the request path.

This change merges the previous response's headers into the assigned response in place and recreates the Response only when the mutation throws (e.g. a response obtained with `fetch()`, whose headers are immutable). Same approach as #5185, which targets `c.header()` on a finalized response; the two changes are independent.

Measured with a new `replace-res GET /replace/hello` case added to `benchmarks/fetch`, two independent 5-round `compare.sh` runs on Node:

- 4.68 µs -> 4.14 µs (1.13x faster)
- 4.69 µs -> 4.26 µs (1.10x faster)

The win is smaller than #5185 because this flow still legitimately constructs two Responses (the handler's and the middleware's own); only the third, redundant one is removed. All other cases stayed within the noise band.

Notes on behavior:

- When the assigned response's headers are mutable, `c.res` now keeps the assigned object's identity (previously it was always replaced with a copy), and the merged headers are visible through the caller's reference to it.
- Edge case: assigning a response whose status cannot be passed to the Response constructor (e.g. `Response.error()` with status 0) previously threw during the unconditional recreation even when there was nothing to merge; it now succeeds unless a header merge actually requires recreation.
- A regression test covers the immutable-headers fallback using `Response.redirect()`, which carries the same immutable-headers guard as a `fetch()` response without needing a network.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
