### PR TITLE
fix(trie-router): count every slash a pattern consumes

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -535,6 +535,20 @@ export const runTest = ({
         expect(res[0].handler).toEqual('file.html')
         expect(res[0].params['dirs']).toEqual('foo/bar')
       })
+
+      it('GET /foo/bar/baz/file.html', () => {
+        const res = match('GET', '/foo/bar/baz/file.html')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('file.html')
+        expect(res[0].params['dirs']).toEqual('foo/bar/baz')
+      })
+
+      it('GET /a/b/c/d/file.html', () => {
+        const res = match('GET', '/a/b/c/d/file.html')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('file.html')
+        expect(res[0].params['dirs']).toEqual('a/b/c/d')
+      })
     })
 
     describe('Capture regex pattern has trailing wildcard', () => {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -812,6 +812,35 @@ describe('The same name is used for path params', () => {
   })
 })
 
+describe('Pattern spanning multiple parts', () => {
+  describe('followed by a wildcard', () => {
+    const node = new Node()
+    node.insert('get', '/:file{.*}/*', 'file')
+
+    it('should return the handler once per matching part count', () => {
+      for (const path of ['/a', '/a/b', '/a/b/c', '/a/b/c/d']) {
+        const [res] = node.search('get', path)
+        expect(res.length).toBe(1)
+        expect(res[0][0]).toEqual('file')
+      }
+    })
+  })
+
+  describe('followed by a static part', () => {
+    const node = new Node()
+    node.insert('get', '/:dirs{.+}/file.html', 'file.html')
+
+    it('should match however many parts the pattern spans', () => {
+      for (const dirs of ['foo', 'foo/bar', 'foo/bar/baz', 'a/b/c/d']) {
+        const [res] = node.search('get', `/${dirs}/file.html`)
+        expect(res.length).toBe(1)
+        expect(res[0][0]).toEqual('file.html')
+        expect(res[0][1]).toEqual({ dirs })
+      }
+    })
+  })
+})
+
 describe('Node with initial method and handler', () => {
   it('should create a node with method and handler via constructor', () => {
     const node = new Node('get', 'initial handler')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -200,7 +200,11 @@ export class Node<T> {
 
               if (hasChildren(child.#children)) {
                 child.#params = params
-                const componentCount = m[0].match(/\//)?.length ?? 0
+                // Count every slash the pattern consumed, so the node resumes at the
+                // part after the match. A non-global regexp would report 1 for any
+                // number of slashes and resume one part too early, matching a part
+                // the pattern had already consumed.
+                const componentCount = m[0].match(/\//g)?.length ?? 0
                 const targetCurNodes = (curNodesQueue[componentCount] ||= [])
                 targetCurNodes.push(child)
               }

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -200,10 +200,6 @@ export class Node<T> {
 
               if (hasChildren(child.#children)) {
                 child.#params = params
-                // Count every slash the pattern consumed, so the node resumes at the
-                // part after the match. A non-global regexp would report 1 for any
-                // number of slashes and resume one part too early, matching a part
-                // the pattern had already consumed.
                 const componentCount = m[0].match(/\//g)?.length ?? 0
                 const targetCurNodes = (curNodesQueue[componentCount] ||= [])
                 targetCurNodes.push(child)


### PR DESCRIPTION
When a `:param{regexp}` match spans several path parts, `Node#search` requeues the child into `curNodesQueue[componentCount]` so it resumes at the part *after* the match. `componentCount` came from:

```js
const componentCount = m[0].match(/\//)?.length ?? 0
```

Without the `g` flag, `String.prototype.match` returns a single-match array, so `.length` is `1` for **any** number of slashes. A pattern spanning three or more parts resumed one part too early and matched a part it had already consumed.

Two parts happen to give the right answer (one slash → `1`), which is why the existing `/foo/bar/file.html` case passes and this went unnoticed.

## Symptoms

Both reproduce on a plain `new Hono()` — `RegExpRouter` reports `UnsupportedPathError` for these routes, so `SmartRouter` falls through to `TrieRouter`.

**A route stops matching once the pattern spans 3+ parts.** `/:dirs{.+}/file.html` is the repo's own `Capture simple multiple directories` route:

| path | before | after |
| --- | --- | --- |
| `/foo/file.html` | 200 | 200 |
| `/foo/bar/file.html` | 200 | 200 |
| `/foo/bar/baz/file.html` | **404** | 200 |
| `/a/b/c/d/file.html` | **404** | 200 |

**A handler is returned twice, so middleware runs twice per request:**

```ts
const app = new Hono()
let runs = 0
app.use('/:path{.*}/*', async (c, next) => { runs++; await next() })
app.get('/a/b/c', (c) => c.text('ok'))

await app.request('/a/b/c')
// before: runs === 2
// after:  runs === 1
```

At the raw router level:

```ts
const r = new TrieRouter()
r.add('GET', '/:file{.*}/*', 'handler')
r.match('GET', '/a/b/c')
// before: [[['handler', {file:'a/b/c'}], ['handler', {file:'a/b/c'}]]]
// after:  [[['handler', {file:'a/b/c'}]]]
```

`RegExpRouter` and `PatternRouter` already return the correct result in every case above; this brings `TrieRouter` in line.

## Fix

Count with a global regexp so the offset reflects every slash the pattern consumed.

## Tests

- `common.case.test.ts` — extended `Capture simple multiple directories` with 3- and 4-directory paths. It runs for every router, so it pins the behaviour across all of them; all pass unchanged, no new skip entries needed.
- `trie-router/node.test.ts` — added `Pattern spanning multiple parts`, covering both the duplicate handler and the missed match at increasing depth.

Without the one-line change these fail with `expected 2 to be 1` and `expected +0 to be 1`.

I also fuzzed ~197k random route sets across all four routers looking for any handler returned twice from a single `match()`: 16 distinct reproductions before, 0 after.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests — `bun run test`: 146 files, 4758 passed / 35 skipped
- [x] `bun run format:fix && bun run lint:fix` to format the code — prettier clean, 0 lint errors
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code — n/a, internal branch in `Node#search`; left an inline comment on the counting logic instead