### PR TITLE
feat(etag): add cacheableStatusCodes option

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -394,4 +394,36 @@ describe('Etag Middleware', () => {
       expect(res.headers.get('ETag')).toBeNull()
     })
   })
+
+  it('Should only generate ETag and return 304 for specified cacheable status codes', async () => {
+    const app = new Hono()
+    app.use(
+      '/etag/*',
+      etag({
+        cacheableStatusCodes: [200],
+      })
+    )
+    app.get('/etag/200', (c) => c.text('OK', 200))
+    app.get('/etag/201', (c) => c.text('OK', 201))
+
+    let res = await app.request('http://localhost/etag/200')
+    expect(res.status).toBe(200)
+    const etagOK = res.headers.get('ETag')
+    expect(etagOK).not.toBeNull()
+
+    res = await app.request('http://localhost/etag/200', {
+      headers: { 'If-None-Match': etagOK! },
+    })
+    expect(res.status).toBe(304)
+
+    res = await app.request('http://localhost/etag/201')
+    expect(res.status).toBe(201)
+    expect(res.headers.get('ETag')).toBeNull()
+
+    res = await app.request('http://localhost/etag/201', {
+      headers: { 'If-None-Match': etagOK! },
+    })
+    expect(res.status).toBe(201)
+    expect(res.headers.get('ETag')).toBeNull()
+  })
 })

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -4,12 +4,14 @@
  */
 
 import type { MiddlewareHandler } from '../../types'
+import type { StatusCode } from '../../utils/http-status'
 import { generateDigest } from './digest'
 
 type ETagOptions = {
   retainedHeaders?: string[]
   weak?: boolean
   generateDigest?: (body: Uint8Array<ArrayBuffer>) => ArrayBuffer | Promise<ArrayBuffer>
+  cacheableStatusCodes?: StatusCode[] | undefined
 }
 
 /**
@@ -64,6 +66,7 @@ function initializeGenerator(
  * @param {function(Uint8Array): ArrayBuffer | Promise<ArrayBuffer>} [options.generateDigest] -
  * A custom digest generation function. By default, it uses 'SHA-1'
  * This function is called with the response body as a `Uint8Array` and should return a hash as an `ArrayBuffer` or a Promise of one.
+ * @param {number[] | undefined} [options.cacheableStatusCodes] - An array of status codes for which an ETag can be generated and a 304 response returned. By default, all responses are included.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -80,11 +83,17 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false
   const generator = initializeGenerator(options?.generateDigest)
+  const cacheableStatusCodes = options?.cacheableStatusCodes
+    ? new Set<number>(options.cacheableStatusCodes)
+    : undefined
 
   return async function etag(c, next) {
     const ifNoneMatch = c.req.header('If-None-Match') ?? null
 
     await next()
+    if (cacheableStatusCodes && !cacheableStatusCodes.has(c.res.status)) {
+      return
+    }
 
     const res = c.res as Response
     let etag = res.headers.get('ETag')


### PR DESCRIPTION
close #5191

I copied the snippet from the cache middleware.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
