### PR TITLE
feat(etag): optional cacheableStatusCodes for non-2xx safety

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -394,4 +394,40 @@ describe('Etag Middleware', () => {
       expect(res.headers.get('ETag')).toBeNull()
     })
   })
+
+  describe('cacheableStatusCodes option', () => {
+    it('Should skip ETag generation for non-listed status codes', async () => {
+      const app = new Hono()
+      app.use(
+        '/etag/*',
+        etag({
+          cacheableStatusCodes: [200],
+        })
+      )
+      app.get('/etag/ok', (c) => c.text('{}'))
+      app.get('/etag/bad', (c) => c.json({}, 400))
+      app.get('/etag/err', (c) => c.json({}, 500))
+
+      const ok = await app.request('http://localhost/etag/ok')
+      expect(ok.status).toBe(200)
+      expect(ok.headers.get('ETag')).not.toBeNull()
+
+      const bad = await app.request('http://localhost/etag/bad')
+      expect(bad.status).toBe(400)
+      expect(bad.headers.get('ETag')).toBeNull()
+
+      const err = await app.request('http://localhost/etag/err')
+      expect(err.status).toBe(500)
+      expect(err.headers.get('ETag')).toBeNull()
+    })
+
+    it('Should still generate ETags for error statuses when not restricted (default)', async () => {
+      const app = new Hono()
+      app.use('/etag/*', etag())
+      app.get('/etag/bad', (c) => c.json({}, 400))
+      const res = await app.request('http://localhost/etag/bad')
+      expect(res.status).toBe(400)
+      expect(res.headers.get('ETag')).not.toBeNull()
+    })
+  })
 })

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -10,6 +10,12 @@ type ETagOptions = {
   retainedHeaders?: string[]
   weak?: boolean
   generateDigest?: (body: Uint8Array<ArrayBuffer>) => ArrayBuffer | Promise<ArrayBuffer>
+  /**
+   * Status codes for which an ETag may be generated / used for 304 negotiation.
+   * When omitted, all status codes remain eligible (backward compatible).
+   * Common choice for safer caching: `[200]`.
+   */
+  cacheableStatusCodes?: number[]
 }
 
 /**
@@ -64,6 +70,10 @@ function initializeGenerator(
  * @param {function(Uint8Array): ArrayBuffer | Promise<ArrayBuffer>} [options.generateDigest] -
  * A custom digest generation function. By default, it uses 'SHA-1'
  * This function is called with the response body as a `Uint8Array` and should return a hash as an `ArrayBuffer` or a Promise of one.
+ * @param {number[]} [options.cacheableStatusCodes] - Status codes allowed for
+ * ETag generation and 304 negotiation. When omitted, all statuses are eligible
+ * (backward compatible). Prefer `[200]` (or other cacheable 2xx) so identical
+ * error bodies cannot collapse to 304 across different status codes.
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -74,12 +84,18 @@ function initializeGenerator(
  * app.get('/etag/abc', (c) => {
  *   return c.text('Hono is hot')
  * })
+ *
+ * // Only attach / negotiate ETags for successful responses
+ * app.use('/cache/*', etag({ cacheableStatusCodes: [200] }))
  * ```
  */
 export const etag = (options?: ETagOptions): MiddlewareHandler => {
   const retainedHeaders = options?.retainedHeaders ?? RETAINED_304_HEADERS
   const weak = options?.weak ?? false
   const generator = initializeGenerator(options?.generateDigest)
+  const cacheableStatusCodes = options?.cacheableStatusCodes
+  const isCacheableStatus = (status: number) =>
+    cacheableStatusCodes == null || cacheableStatusCodes.includes(status)
 
   return async function etag(c, next) {
     const ifNoneMatch = c.req.header('If-None-Match') ?? null
@@ -87,6 +103,10 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
     await next()
 
     const res = c.res as Response
+    if (!isCacheableStatus(res.status)) {
+      return
+    }
+
     let etag = res.headers.get('ETag')
 
     if (!etag) {


### PR DESCRIPTION
## Summary
- Adds `cacheableStatusCodes?: number[]` to the ETag middleware options.
- When set (e.g. `[200]`), ETags are only generated / used for 304 negotiation for those statuses — fixing cases where identical `{}` bodies on 200 vs 4xx/5xx confuses clients.
- Default behavior is unchanged (all statuses remain eligible).

Closes #5191

## Test plan
- [x] `vitest --run src/middleware/etag/index.test.ts` (19 passed)
- [x] With `cacheableStatusCodes: [200]`, 400/500 JSON `{}` responses have no ETag; 200 still does
- [x] Default middleware still attaches ETag on 400 for compatibility


Made with [Cursor](https://cursor.com)