### PR TITLE
fix(types): support middleware with multiple paths

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -15,6 +15,7 @@ import type {
   MergePath,
   MergeSchemaPath,
   MiddlewareHandler,
+  Next,
   ParamKeyToRecord,
   ParamKeys,
   RemoveQuestion,
@@ -355,6 +356,38 @@ describe('OnHandlerInterface', () => {
       expectTypeOf(c.var.foo).toEqualTypeOf<string>()
       return c.json({})
     })
+  })
+
+  test('app.on(method, path[], explicitly typed middleware, handler)', () => {
+    const app = new Hono<{ Bindings: { value: string } }>()
+    const middleware = async (_c: Context, next: Next) => {
+      await next()
+    }
+    const route = app.on('POST', ['/route1', '/route2'], middleware, (c) => {
+      expectTypeOf(c.env.value).toEqualTypeOf<string>()
+      return c.json({ message: 'Hello from route1 or route2' })
+    })
+    type Actual = ExtractSchema<typeof route>
+    type ExpectedPaths = '/route1' | '/route2'
+    type verifyPaths = Expect<Equal<ExpectedPaths, keyof Actual>>
+    type ExpectedOutput = { message: string }
+    type verifyOutput = Expect<Equal<ExpectedOutput, Actual['/route1']['$post']['output']>>
+  })
+
+  test('app.on(method[], path[], middleware response)', async () => {
+    const badRequest = createMiddleware(async (c) => c.json({ badRequest: true }, 400))
+    const route = new Hono().on(['GET', 'POST'], ['/test', '/test2'], badRequest, (c) =>
+      c.json({ success: true }, 200)
+    )
+    const client = hc<typeof route>('http://localhost', { fetch: route.request })
+    const res = await client.test.$get()
+
+    if (res.status === 200) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ success: true }>()
+    }
+    if (res.status === 400) {
+      expectTypeOf(await res.json()).toEqualTypeOf<{ badRequest: true }>()
+    }
   })
 
   test('app.on(method, path[], handler).get(pathless handler) - pathless handler should use last path', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2455,6 +2455,41 @@ export interface OnHandlerInterface<
     MergePath<BasePath, P>
   >
 
+  // app.on(method | method[], path[], handler x2)
+  <
+    M extends string,
+    const Ps extends string[],
+    R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
+    E2 extends Env = E,
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
+    // Middleware
+    M1 extends H<E2, MergePath<BasePath, Ps[number]>, I> = H<
+      E2,
+      MergePath<BasePath, Ps[number]>,
+      I
+    >,
+  >(
+    methods: M | M[],
+    paths: Ps,
+    ...handlers: [
+      H<E2, MergePath<BasePath, Ps[number]>, I> & M1,
+      H<E3, MergePath<BasePath, Ps[number]>, I2, R>,
+    ]
+  ): HonoBase<
+    IntersectNonAnyTypes<[E, E2, E3]>,
+    S &
+      ToSchema<
+        M,
+        MergePath<BasePath, Ps[number]>,
+        I2,
+        MergeTypedResponse<R> | MergeMiddlewareResponse<M1>
+      >,
+    BasePath,
+    Ps extends [...string[], infer LastPath extends string] ? MergePath<BasePath, LastPath> : never
+  >
+
   // app.on(method | method[], path[], ...handlers[])
   <
     M extends string,


### PR DESCRIPTION
### Summary

- add a dedicated two-handler overload for `app.on()` with one or more methods and multiple paths
- infer the final handler response independently from explicitly typed middleware
- preserve environment, input, middleware-response, method, and path schema inference
- add regression coverage for the TypeScript 7 reproduction and middleware response unions

Fixes #5144

### Testing

- `tsc -p tsconfig.spec.json --noEmit`
- TypeScript 7.0.2 isolated type-check for `src/types.test.ts`
- `vitest run src/types.test.ts --coverage.enabled=false` (122 tests passed)
- `eslint src/types.ts src/types.test.ts`
- `prettier --check src/types.ts src/types.test.ts`

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] Format and lint changed files
- [ ] Add TSDoc/JSDoc — not applicable; this mirrors the neighboring overload declarations