### PR TITLE
fix(etag): skip unsafe methods or error responses on non-* case

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -273,13 +273,13 @@ describe('Etag Middleware', () => {
     expect(res.status).toBe(304)
   })
 
-  it('Should not return 304 for `If-None-Match: *` on unsafe methods or error responses', async () => {
+  it('Should not return 304 on unsafe methods or error responses', async () => {
     const app = new Hono()
     app.use('/etag/*', etag())
-    app.put('/etag/put', (c) => c.text('created', 201))
-    app.get('/etag/not-found', (c) => c.text('not found', 404))
+    app.put('/etag/put', (c) => c.text('created', 201, { ETag: '"etag-123"' }))
+    app.get('/etag/not-found', (c) => c.text('not found', 404, { ETag: '"etag-123"' }))
 
-    // `*` does not apply to unsafe methods:
+    // Unsafe methods:
     let res = await app.request('http://localhost/etag/put', {
       method: 'PUT',
       headers: {
@@ -289,10 +289,26 @@ describe('Etag Middleware', () => {
     expect(res.status).toBe(201)
     expect(await res.text()).toBe('created')
 
-    // `*` does not apply when there is no current representation:
+    res = await app.request('http://localhost/etag/put', {
+      method: 'PUT',
+      headers: {
+        'If-None-Match': '"etag-123"',
+      },
+    })
+    expect(res.status).toBe(201)
+    expect(await res.text()).toBe('created')
+
+    // Error responses:
     res = await app.request('http://localhost/etag/not-found', {
       headers: {
         'If-None-Match': '*',
+      },
+    })
+    expect(res.status).toBe(404)
+
+    res = await app.request('http://localhost/etag/not-found', {
+      headers: {
+        'If-None-Match': '"etag-123"',
       },
     })
     expect(res.status).toBe(404)

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -86,6 +86,13 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
 
     await next()
 
+    if (
+      !(c.req.method === 'GET' || c.req.method === 'HEAD' || c.req.method === 'QUERY') ||
+      !c.res.ok
+    ) {
+      return
+    }
+
     const res = c.res as Response
     let etag = res.headers.get('ETag')
 
@@ -104,10 +111,7 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
       etag = weak ? `W/"${hash}"` : `"${hash}"`
     }
 
-    const matched =
-      ifNoneMatch === '*'
-        ? (c.req.method === 'GET' || c.req.method === 'HEAD' || c.req.method === 'QUERY') && res.ok
-        : etagMatches(etag, ifNoneMatch)
+    const matched = ifNoneMatch === '*' || etagMatches(etag, ifNoneMatch)
 
     if (matched) {
       c.res = new Response(null, {


### PR DESCRIPTION
fix #5191

Previously, it checked request methods and response status only when if-none-match is `*`.
According to spec, it should not return 304 on unsafe methods or error response regardless of if-none-match value.
see https://github.com/honojs/hono/issues/5191#issuecomment-5205914907

If this gets merged, I think #5192 is not needed.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
