### PR TITLE
 fix(secure-headers): output standard empty parentheses () instead of none for disabled Permissions-Policy directives

### DIFF
--- a/src/middleware/secure-headers/index.test.ts
+++ b/src/middleware/secure-headers/index.test.ts
@@ -187,7 +187,7 @@ describe('Secure Headers Middleware', () => {
 
     const res = await app.request('/test')
     expect(res.headers.get('Permissions-Policy')).toEqual(
-      'fullscreen=(self), bluetooth=none, payment=(self "example.com"), sync-xhr=(), camera=none, microphone=*, ' +
+      'fullscreen=(self), bluetooth=(), payment=(self "example.com"), sync-xhr=(), camera=(), microphone=*, ' +
         'geolocation=*, usb=(self "https://a.example.com" "https://b.example.com"), ' +
         'accelerometer=("https://*.example.com"), gyroscope=(src), ' +
         'magnetometer=("https://a.example.com" "https://b.example.com")'

--- a/src/middleware/secure-headers/secure-headers.ts
+++ b/src/middleware/secure-headers/secure-headers.ts
@@ -297,15 +297,18 @@ function getPermissionsPolicyDirectives(policy: PermissionsPolicyOptions): strin
       const kebabDirective = camelToKebab(directive)
 
       if (typeof value === 'boolean') {
-        return `${kebabDirective}=${value ? '*' : 'none'}`
+        return `${kebabDirective}=${value ? '*' : '()'}`
       }
 
       if (Array.isArray(value)) {
         if (value.length === 0) {
           return `${kebabDirective}=()`
         }
-        if (value.length === 1 && (value[0] === '*' || value[0] === 'none')) {
-          return `${kebabDirective}=${value[0]}`
+        if (value.length === 1 && value[0] === '*') {
+          return `${kebabDirective}=*`
+        }
+        if (value.length === 1 && value[0] === 'none') {
+          return `${kebabDirective}=()`
         }
         const allowlist = value.map((item) => (['self', 'src'].includes(item) ? item : `"${item}"`))
         return `${kebabDirective}=(${allowlist.join(' ')})`


### PR DESCRIPTION
Historically, Hono's `secureHeaders` middleware serialized disabled or `none` value Permissions-Policy directives as `none` (e.g.,
  `camera=none`). However, according to the modern W3C Structured Fields specification for the `Permissions-Policy` header, the
  keyword `none` is not a valid value. Instead, the correct syntax to disable a feature for all origins is an empty structured list
  represented by empty parentheses `()`.

This PR updates the serialization in `getPermissionsPolicyDirectives` to correctly output `()` instead of `none` when a directive
  value is `false` or `['none']`, ensuring strict compliance with the standard and preventing modern browsers from failing to parse
  the header.

### The author should do the following, if applicable

    - [x] Add tests
    - [x] Run tests
    - [x] `bun run format:fix && bun run lint:fix` to format the code
    - [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
