### PR TITLE
fix(cookie): return false for malformed or unsigned cookies when parsing signed cookie by name

### DIFF
--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -232,6 +232,20 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBe(false)
   })
 
+  it('Should parse one signed cookie specified by name and return "false" if cookie has no signature', async () => {
+    const secret = 'secret ingredient'
+    const cookieString = 'yummy_cookie=choco; tasty_cookie=strawberry'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret, 'tasty_cookie')
+    expect(cookie['tasty_cookie']).toBe(false)
+  })
+
+  it('Should parse one signed cookie specified by name and return "false" if cookie signature has invalid length', async () => {
+    const secret = 'secret ingredient'
+    const cookieString = 'tasty_cookie=strawberry.short'
+    const cookie: SignedCookie = await parseSigned(cookieString, secret, 'tasty_cookie')
+    expect(cookie['tasty_cookie']).toBe(false)
+  })
+
   it('Should parse signed cookies and ignore regular cookies', async () => {
     const secret = 'secret ingredient'
     // also contains another cookie with a '.' in its value to test it is not misinterpreted as signed cookie

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -154,12 +154,18 @@ export const parseSigned = async (
   for (const [key, value] of Object.entries(parse(cookie, name))) {
     const signatureStartPos = value.lastIndexOf('.')
     if (signatureStartPos < 1) {
+      if (name === key) {
+        parsedCookie[key] = false
+      }
       continue
     }
 
     const signedValue = value.substring(0, signatureStartPos)
     const signature = value.substring(signatureStartPos + 1)
     if (signature.length !== 44 || !signature.endsWith('=')) {
+      if (name === key) {
+        parsedCookie[key] = false
+      }
       continue
     }
 


### PR DESCRIPTION
When calling `getSignedCookie(c, secret, 'cookie_name')`, Hono is expected to return the verified cookie value, `undefined` if the cookie is not present, or `false` if verification fails.

However, if the cookie exists in the request but has a malformed signature (e.g., incorrect signature length or does not contain a signature dot delimiter), the helper silently skipped it and returned `undefined` instead of `false`. This allows clients to bypass verification logging or custom checks (which inspect for `=== false`) simply by sending a malformed signature length.

This PR updates `parseSigned` to ensure that when a specific cookie key is requested by name, any structural signature
  verification failure returns `false` explicitly instead of falling back to `undefined`.

### The author should do the following, if applicable

    - [x] Add tests
    - [x] Run tests
    - [x] `bun run format:fix && bun run lint:fix` to format the code
    - [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code