### PR TITLE
feat: introduce `handlerWrapper`

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,7 @@
 import type { Context } from './context'
-import type { Env, ErrorHandler, Next, NotFoundHandler } from './types'
+import type { Env, ErrorHandler, HandlerWrapper, Next, NotFoundHandler, RouterRoute } from './types'
+
+export const defaultHandlerWrapper: HandlerWrapper = (c, next, route) => route.handler(c, next)
 
 /**
  * Compose middleware functions into a single function based on `koa-compose` package.
@@ -15,7 +17,8 @@ import type { Env, ErrorHandler, Next, NotFoundHandler } from './types'
 export const compose = <E extends Env = Env>(
   middleware: [[Function, unknown], unknown][] | [[Function]][],
   onError?: ErrorHandler<E>,
-  onNotFound?: NotFoundHandler<E>
+  onNotFound?: NotFoundHandler<E>,
+  wrapper: HandlerWrapper = defaultHandlerWrapper
 ): ((context: Context, next?: Next) => Promise<Context>) => {
   return (context, next) => {
     let index = -1
@@ -47,8 +50,12 @@ export const compose = <E extends Env = Env>(
       }
 
       if (handler) {
+        // `route` is undefined for non-router executions, e.g., `hono/combine`
+        const route = (middleware[i]?.[0] as [unknown, RouterRoute?] | undefined)?.[1]
         try {
-          res = await handler(context, () => dispatch(i + 1))
+          res = route
+            ? await wrapper(context, (() => dispatch(i + 1)) as unknown as Next, route)
+            : await handler(context, () => dispatch(i + 1))
         } catch (err) {
           if (err instanceof Error && onError) {
             context.error = err

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { compose } from './compose'
+import { compose, defaultHandlerWrapper } from './compose'
 import { Context } from './context'
 import type { ExecutionContext } from './context'
 import type { Router } from './router'
@@ -15,6 +15,7 @@ import type {
   FetchEventLike,
   H,
   HandlerInterface,
+  HandlerWrapper,
   MergePath,
   MergeSchemaPath,
   MiddlewareHandler,
@@ -84,6 +85,25 @@ export type HonoOptions<E extends Env> = {
    * ```
    */
   getPath?: GetPath<E>
+  /**
+   * `handlerWrapper` intercepts every matched handler / middleware execution.
+   * The default wrapper just invokes the handler. Replace it for tracing, timing, etc.
+   *
+   * @example
+   * ```ts
+   * const app = new Hono({
+   *   handlerWrapper: async (c, next, route) => {
+   *     const start = performance.now()
+   *     try {
+   *       return await route.handler(c, next)
+   *     } finally {
+   *       console.log(`${route.path} ${route.handler.name}: ${performance.now() - start}ms`)
+   *     }
+   *   },
+   * })
+   * ```
+   */
+  handlerWrapper?: HandlerWrapper
 }
 
 type MountOptionHandler = (c: Context) => unknown
@@ -180,6 +200,7 @@ class Hono<
     })
     clone.errorHandler = this.errorHandler
     clone.#notFoundHandler = this.#notFoundHandler
+    clone.handlerWrapper = this.handlerWrapper
     clone.routes = this.routes
     return clone
   }
@@ -187,6 +208,8 @@ class Hono<
   #notFoundHandler: NotFoundHandler = notFoundHandler
   // Cannot use `#` because it requires visibility at JavaScript runtime.
   private errorHandler: ErrorHandler = errorHandler
+  // Cannot use `#` because it is set via `Object.assign` in the constructor.
+  private handlerWrapper: HandlerWrapper = defaultHandlerWrapper
 
   /**
    * `.route()` allows grouping other Hono instance in routes.
@@ -431,9 +454,13 @@ class Hono<
     if (matchResult[0].length === 1) {
       let res: ReturnType<H>
       try {
-        res = matchResult[0][0][0][0](c, async () => {
-          c.res = await this.#notFoundHandler(c)
-        })
+        res = this.handlerWrapper(
+          c,
+          async () => {
+            c.res = await this.#notFoundHandler(c)
+          },
+          matchResult[0][0][0][1]
+        ) as ReturnType<H>
       } catch (err) {
         return this.#handleError(err, c)
       }
@@ -448,7 +475,12 @@ class Hono<
         : (res ?? this.#notFoundHandler(c))
     }
 
-    const composed = compose(matchResult[0], this.errorHandler, this.#notFoundHandler)
+    const composed = compose(
+      matchResult[0],
+      this.errorHandler,
+      this.#notFoundHandler,
+      this.handlerWrapper
+    )
 
     return (async () => {
       try {

--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -208,8 +208,9 @@ class Hono<
   #notFoundHandler: NotFoundHandler = notFoundHandler
   // Cannot use `#` because it requires visibility at JavaScript runtime.
   private errorHandler: ErrorHandler = errorHandler
-  // Cannot use `#` because it is set via `Object.assign` in the constructor.
-  private handlerWrapper: HandlerWrapper = defaultHandlerWrapper
+  // Public and not `#` or `private`: it is set via `Object.assign` in the constructor,
+  // and a Hono instance must remain assignable to `HonoOptions` for extended classes
+  handlerWrapper: HandlerWrapper = defaultHandlerWrapper
 
   /**
    * `.route()` allows grouping other Hono instance in routes.

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,12 @@ export interface RouterRoute {
   handler: H
 }
 
+export type HandlerWrapper = (
+  c: Context,
+  next: Next,
+  route: RouterRoute
+) => Response | void | Promise<Response | void>
+
 ////////////////////////////////////////
 //////                            //////
 //////          Handlers          //////


### PR DESCRIPTION
To implement the function to measure the performance per handler, there is no good way to do it. So I think the demand, like the follow-up PR, is raised:

https://github.com/honojs/hono/issues/4842

To do it, I don't like to write a hard-coded `TracingChannels` function, but introducing a flexible general method is a great design.

`handlerWrapper` will enable them to inject their own method to wrap each handler execution. The example:

```ts
const app = new Hono({
  handlerWrapper: async (c, next, route) => {
    const start = performance.now()
    try {
      return await route.handler(c, next)
    } finally {
      console.log(`${route.path} ${route.handler.name}: ${performance.now() - start}ms`)
    }
  },
})
```

Tracing channel:

```ts
const dc = (globalThis as any).process?.getBuiltinModule?.('node:diagnostics_channel')
const tc = dc.tracingChannel('hono:request')

tc.subscribe({
  start(m: any) {
    m._start = performance.now()
    console.log(
      `  [start] ${m.route.method} ${m.route.path} :: ${m.route.handler.name || '(anonymous)'}`
    )
  },
  asyncEnd(m: any) {
    const ms = (performance.now() - m._start).toFixed(2)
    console.log(`  [end]   ${m.route.handler.name || '(anonymous)'} — ${ms}ms`)
  },
  error(m: any) {
    console.log(`  [error] ${m.route.handler.name || '(anonymous)'}: ${m.error.message}`)
  },
})

const app = new Hono({
  handlerWrapper: (c, next, route) => tc.tracePromise(() => route.handler(c, next), { route, c }),
})
```

And there are other use cases.

You can know which handler the error is thrown in. Currently, you can't know where the error comes from in `app.onError()`.

```ts
const app = new Hono({
  handlerWrapper: async (c, next, route) => {
    try {
      return await route.handler(c, next)
    } catch (err) {
      throw new Error(`Error in ${route.method} ${route.path}`)
    }
  },
})
```

And you can change the handler dynamically.

```ts
const app = new Hono({
  handlerWrapper: (c, next, route) => {
    const impl = registry.get(route.method + route.path) ?? route.handler
    return impl(c, next)
  },
})
```

### Pain points

The bundle size will be increased. But I think it's acceptable:

<img width="1030" height="264" alt="CleanShot 2026-08-07 at 17 45 19@2x" src="https://github.com/user-attachments/assets/97bc9149-e269-41b9-8a85-8bdf311abec7" />


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
