### PR TITLE
feat: introduce `TransformRouter`

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -62,6 +62,7 @@
     "./router/trie-router": "./src/router/trie-router/index.ts",
     "./router/pattern-router": "./src/router/pattern-router/index.ts",
     "./router/linear-router": "./src/router/linear-router/index.ts",
+    "./router/transform-router": "./src/router/transform-router/index.ts",
     "./client": "./src/client/index.ts",
     "./adapter": "./src/helper/adapter/index.ts",
     "./factory": "./src/helper/factory/index.ts",

--- a/package.json
+++ b/package.json
@@ -316,6 +316,11 @@
       "import": "./dist/router/linear-router/index.js",
       "require": "./dist/cjs/router/linear-router/index.js"
     },
+    "./router/transform-router": {
+      "types": "./dist/types/router/transform-router/index.d.ts",
+      "import": "./dist/router/transform-router/index.js",
+      "require": "./dist/cjs/router/transform-router/index.js"
+    },
     "./utils/jwt": {
       "types": "./dist/types/utils/jwt/index.d.ts",
       "import": "./dist/utils/jwt/index.js",
@@ -583,6 +588,9 @@
       ],
       "router/linear-router": [
         "./dist/types/router/linear-router"
+      ],
+      "router/transform-router": [
+        "./dist/types/router/transform-router"
       ],
       "utils/jwt": [
         "./dist/types/utils/jwt/index.d.ts"

--- a/src/router/transform-router/index.ts
+++ b/src/router/transform-router/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { TransformRouter } from './router'
-export type { RouterTransform, TransformRouterOptions } from './router'
+export type { HandlerTransform, TransformRouterOptions } from './router'

--- a/src/router/transform-router/index.ts
+++ b/src/router/transform-router/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @module
+ * TransformRouter for Hono.
+ */
+
+export { TransformRouter } from './router'
+export type { RouterTransform, TransformRouterOptions } from './router'

--- a/src/router/transform-router/router.test.ts
+++ b/src/router/transform-router/router.test.ts
@@ -2,23 +2,24 @@ import { matchedRoutes } from '../../helper/route'
 import { Hono } from '../../hono'
 import type { Result, Router } from '../../router'
 import type { H, Handler, MiddlewareHandler, RouterRoute } from '../../types'
-import { runTest } from '../common.case.test'
 import { RegExpRouter } from '../reg-exp-router'
 import { TransformRouter } from './router'
 
 describe('TransformRouter', () => {
-  runTest({
-    newRouter: <T>() =>
-      new TransformRouter<T>({
-        transform: (handler) => handler,
-      }),
-  })
-
   it('transforms registrations and delegates matching', () => {
-    const matchResult: Result<string> = [[['matched', {}]]]
-    const added: [string, string, string][] = []
+    const routeHandler: H = vi.fn()
+    const currentHandler: H = vi.fn()
+    const transformedHandler: H = vi.fn()
+    const route: RouterRoute = {
+      basePath: '/',
+      method: 'GET',
+      path: '/posts',
+      handler: routeHandler,
+    }
+    const matchResult: Result<[H, RouterRoute]> = [[[[transformedHandler, route], {}]]]
+    const added: [string, string, [H, RouterRoute]][] = []
     const matched: [string, string][] = []
-    const delegateRouter: Router<string> = {
+    const delegateRouter: Router<[H, RouterRoute]> = {
       name: 'DelegateRouter',
       add(method, path, handler) {
         added.push([method, path, handler])
@@ -28,16 +29,15 @@ describe('TransformRouter', () => {
         return matchResult
       },
     }
-    const transform = vi.fn((handler: string, method: string, path: string) => {
-      return `${method} ${path}: ${handler}`
-    })
+    const transform = vi.fn((_route: Readonly<RouterRoute>) => transformedHandler)
     const router = new TransformRouter({ delegateRouter, transform })
 
-    router.add('GET', '/posts', 'handler')
+    router.add('GET', '/posts', [currentHandler, route])
     const result = router.match('POST', '/comments')
 
-    expect(transform).toHaveBeenCalledWith('handler', 'GET', '/posts')
-    expect(added).toEqual([['GET', '/posts', 'GET /posts: handler']])
+    expect(transform).toHaveBeenCalledWith({ ...route, handler: currentHandler })
+    expect(added).toEqual([['GET', '/posts', [transformedHandler, route]]])
+    expect(route.handler).toBe(routeHandler)
     expect(matched).toEqual([['POST', '/comments']])
     expect(result).toBe(matchResult)
     expect(router.name).toBe('TransformRouter + DelegateRouter')
@@ -48,17 +48,17 @@ describe('TransformRouter', () => {
     const registrations: string[] = []
     const app = new Hono({
       router: new TransformRouter({
-        transform: ([handler, route], method, path) => {
+        delegateRouter: new RegExpRouter(),
+        transform: ({ handler, method, path }) => {
           registrations.push(`${method} ${path}`)
-          const wrapped: H = async (c, next) => {
-            events.push(`start:${route.handler.name}`)
+          return async (c, next) => {
+            events.push(`start:${handler.name}`)
             try {
               return await handler(c, next)
             } finally {
-              events.push(`end:${route.handler.name}`)
+              events.push(`end:${handler.name}`)
             }
           }
-          return [wrapped, route]
         },
       }),
     })
@@ -83,7 +83,7 @@ describe('TransformRouter', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('ok')
     expect(registrations).toEqual(['ALL /posts/*', 'GET /posts/:id'])
-    expect(app.router.name).toBe('TransformRouter + SmartRouter + RegExpRouter')
+    expect(app.router.name).toBe('TransformRouter + RegExpRouter')
     expect(app.routes.map((route) => route.handler)).toEqual([middleware, handler])
     expect(events).toEqual([
       'start:middleware',
@@ -98,18 +98,17 @@ describe('TransformRouter', () => {
 
   it('observes errors before Hono handles them', async () => {
     const errors: string[] = []
-    const router = new TransformRouter<[H, RouterRoute]>({
+    const router = new TransformRouter({
       delegateRouter: new RegExpRouter(),
-      transform: ([handler, route]) => {
-        const wrapped: H = async (c, next) => {
+      transform: ({ handler, path }) => {
+        return async (c, next) => {
           try {
             return await handler(c, next)
           } catch (error) {
-            errors.push(`${route.path}: ${(error as Error).message}`)
+            errors.push(`${path}: ${(error as Error).message}`)
             throw error
           }
         }
-        return [wrapped, route]
       },
     })
     const app = new Hono({ router })

--- a/src/router/transform-router/router.test.ts
+++ b/src/router/transform-router/router.test.ts
@@ -1,0 +1,128 @@
+import { matchedRoutes } from '../../helper/route'
+import { Hono } from '../../hono'
+import type { Result, Router } from '../../router'
+import type { H, Handler, MiddlewareHandler, RouterRoute } from '../../types'
+import { runTest } from '../common.case.test'
+import { RegExpRouter } from '../reg-exp-router'
+import { TransformRouter } from './router'
+
+describe('TransformRouter', () => {
+  runTest({
+    newRouter: <T>() =>
+      new TransformRouter<T>({
+        transform: (handler) => handler,
+      }),
+  })
+
+  it('transforms registrations and delegates matching', () => {
+    const matchResult: Result<string> = [[['matched', {}]]]
+    const added: [string, string, string][] = []
+    const matched: [string, string][] = []
+    const delegateRouter: Router<string> = {
+      name: 'DelegateRouter',
+      add(method, path, handler) {
+        added.push([method, path, handler])
+      },
+      match(method, path) {
+        matched.push([method, path])
+        return matchResult
+      },
+    }
+    const transform = vi.fn((handler: string, method: string, path: string) => {
+      return `${method} ${path}: ${handler}`
+    })
+    const router = new TransformRouter({ delegateRouter, transform })
+
+    router.add('GET', '/posts', 'handler')
+    const result = router.match('POST', '/comments')
+
+    expect(transform).toHaveBeenCalledWith('handler', 'GET', '/posts')
+    expect(added).toEqual([['GET', '/posts', 'GET /posts: handler']])
+    expect(matched).toEqual([['POST', '/comments']])
+    expect(result).toBe(matchResult)
+    expect(router.name).toBe('TransformRouter + DelegateRouter')
+  })
+
+  it('wraps Hono handlers without changing route metadata', async () => {
+    const events: string[] = []
+    const registrations: string[] = []
+    const app = new Hono({
+      router: new TransformRouter({
+        transform: ([handler, route], method, path) => {
+          registrations.push(`${method} ${path}`)
+          const wrapped: H = async (c, next) => {
+            events.push(`start:${route.handler.name}`)
+            try {
+              return await handler(c, next)
+            } finally {
+              events.push(`end:${route.handler.name}`)
+            }
+          }
+          return [wrapped, route]
+        },
+      }),
+    })
+
+    const middleware: MiddlewareHandler = async function middleware(_c, next) {
+      events.push('middleware:before')
+      await next()
+      events.push('middleware:after')
+    }
+
+    const handler: Handler = function handler(c) {
+      events.push('handler')
+      expect(matchedRoutes(c).map((route) => route.handler)).toEqual([middleware, handler])
+      return c.text('ok')
+    }
+
+    app.use('/posts/*', middleware)
+    app.get('/posts/:id', handler)
+
+    const res = await app.request('/posts/123')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('ok')
+    expect(registrations).toEqual(['ALL /posts/*', 'GET /posts/:id'])
+    expect(app.router.name).toBe('TransformRouter + SmartRouter + RegExpRouter')
+    expect(app.routes.map((route) => route.handler)).toEqual([middleware, handler])
+    expect(events).toEqual([
+      'start:middleware',
+      'middleware:before',
+      'start:handler',
+      'handler',
+      'end:handler',
+      'middleware:after',
+      'end:middleware',
+    ])
+  })
+
+  it('observes errors before Hono handles them', async () => {
+    const errors: string[] = []
+    const router = new TransformRouter<[H, RouterRoute]>({
+      delegateRouter: new RegExpRouter(),
+      transform: ([handler, route]) => {
+        const wrapped: H = async (c, next) => {
+          try {
+            return await handler(c, next)
+          } catch (error) {
+            errors.push(`${route.path}: ${(error as Error).message}`)
+            throw error
+          }
+        }
+        return [wrapped, route]
+      },
+    })
+    const app = new Hono({ router })
+
+    app.get('/error', () => {
+      throw new Error('boom')
+    })
+    app.onError((error, c) => c.text(error.message, 500))
+
+    const res = await app.request('/error')
+
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('boom')
+    expect(errors).toEqual(['/error: boom'])
+  })
+})

--- a/src/router/transform-router/router.ts
+++ b/src/router/transform-router/router.ts
@@ -1,54 +1,48 @@
 import type { Result, Router } from '../../router'
-import { RegExpRouter } from '../reg-exp-router'
-import { SmartRouter } from '../smart-router'
-import { TrieRouter } from '../trie-router'
+import type { H, RouterRoute } from '../../types'
 
-export type RouterTransform<T> = (handler: T, method: string, path: string) => T
+export type HandlerTransform = (route: Readonly<RouterRoute>) => H
 
-export type TransformRouterOptions<T> = {
+export type TransformRouterOptions = {
   /**
    * The router to which transformed registrations and matching are delegated.
    */
-  delegateRouter?: Router<T>
-  transform: RouterTransform<T>
+  delegateRouter: Router<[H, RouterRoute]>
+  transform: HandlerTransform
 }
 
 /**
- * A router decorator that transforms handlers when they are registered and delegates matching to
- * another router.
+ * A router decorator that transforms Hono handlers when they are registered and delegates matching
+ * to another router.
  *
  * @example
  * ```ts
  * import { Hono } from 'hono'
+ * import { RegExpRouter } from 'hono/router/reg-exp-router'
  * import { TransformRouter } from 'hono/router/transform-router'
  *
  * const app = new Hono({
  *   router: new TransformRouter({
- *     transform: ([handler, route]) => [
- *       async (c, next) => {
- *         console.time(route.path)
- *         try {
- *           return await handler(c, next)
- *         } finally {
- *           console.timeEnd(route.path)
- *         }
- *       },
- *       route,
- *     ],
+ *     delegateRouter: new RegExpRouter(),
+ *     transform: ({ handler, method, path }) => async (c, next) => {
+ *       const label = `${method} ${path}`
+ *       console.time(label)
+ *       try {
+ *         return await handler(c, next)
+ *       } finally {
+ *         console.timeEnd(label)
+ *       }
+ *     },
  *   }),
  * })
  * ```
  */
-export class TransformRouter<T> implements Router<T> {
-  #delegateRouter: Router<T>
-  #transform: RouterTransform<T>
+export class TransformRouter implements Router<[H, RouterRoute]> {
+  #delegateRouter: Router<[H, RouterRoute]>
+  #transform: HandlerTransform
 
-  constructor(init: TransformRouterOptions<T>) {
-    this.#delegateRouter =
-      init.delegateRouter ??
-      new SmartRouter({
-        routers: [new RegExpRouter(), new TrieRouter()],
-      })
+  constructor(init: TransformRouterOptions) {
+    this.#delegateRouter = init.delegateRouter
     this.#transform = init.transform
   }
 
@@ -56,11 +50,11 @@ export class TransformRouter<T> implements Router<T> {
     return `TransformRouter + ${this.#delegateRouter.name}`
   }
 
-  add(method: string, path: string, handler: T): void {
-    this.#delegateRouter.add(method, path, this.#transform(handler, method, path))
+  add(method: string, path: string, [handler, route]: [H, RouterRoute]): void {
+    this.#delegateRouter.add(method, path, [this.#transform({ ...route, handler }), route])
   }
 
-  match(method: string, path: string): Result<T> {
+  match(method: string, path: string): Result<[H, RouterRoute]> {
     return this.#delegateRouter.match(method, path)
   }
 }

--- a/src/router/transform-router/router.ts
+++ b/src/router/transform-router/router.ts
@@ -1,0 +1,66 @@
+import type { Result, Router } from '../../router'
+import { RegExpRouter } from '../reg-exp-router'
+import { SmartRouter } from '../smart-router'
+import { TrieRouter } from '../trie-router'
+
+export type RouterTransform<T> = (handler: T, method: string, path: string) => T
+
+export type TransformRouterOptions<T> = {
+  /**
+   * The router to which transformed registrations and matching are delegated.
+   */
+  delegateRouter?: Router<T>
+  transform: RouterTransform<T>
+}
+
+/**
+ * A router decorator that transforms handlers when they are registered and delegates matching to
+ * another router.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono'
+ * import { TransformRouter } from 'hono/router/transform-router'
+ *
+ * const app = new Hono({
+ *   router: new TransformRouter({
+ *     transform: ([handler, route]) => [
+ *       async (c, next) => {
+ *         console.time(route.path)
+ *         try {
+ *           return await handler(c, next)
+ *         } finally {
+ *           console.timeEnd(route.path)
+ *         }
+ *       },
+ *       route,
+ *     ],
+ *   }),
+ * })
+ * ```
+ */
+export class TransformRouter<T> implements Router<T> {
+  #delegateRouter: Router<T>
+  #transform: RouterTransform<T>
+
+  constructor(init: TransformRouterOptions<T>) {
+    this.#delegateRouter =
+      init.delegateRouter ??
+      new SmartRouter({
+        routers: [new RegExpRouter(), new TrieRouter()],
+      })
+    this.#transform = init.transform
+  }
+
+  get name(): string {
+    return `TransformRouter + ${this.#delegateRouter.name}`
+  }
+
+  add(method: string, path: string, handler: T): void {
+    this.#delegateRouter.add(method, path, this.#transform(handler, method, path))
+  }
+
+  match(method: string, path: string): Result<T> {
+    return this.#delegateRouter.match(method, path)
+  }
+}


### PR DESCRIPTION
This is an alternative approach to #5200.

This PR introduces `TransformRouter`, a generic router decorator. It transforms registered handlers once in `add()` and delegates matching to another router without changing Hono's handler execution path.

For Hono, the registered value is `[handler, route]`, so each handler can be wrapped like this:

```ts
import { Hono } from 'hono'
import { TransformRouter } from 'hono/router/transform-router'

const app = new Hono({
  router: new TransformRouter({
    transform: ([handler, route]) => [
      async (c, next) => {
        const start = performance.now()
        try {
          return await handler(c, next)
        } finally {
          console.log(
            `${route.path} ${route.handler.name}: ${performance.now() - start}ms`
          )
        }
      },
      route,
    ],
  }),
})
```

### Tracing channel

```ts
const dc = (globalThis as any).process?.getBuiltinModule?.(
  'node:diagnostics_channel'
)
const tc = dc.tracingChannel('hono:request')

tc.subscribe({
  start(m: any) {
    m._start = performance.now()
    console.log(
      `  [start] ${m.route.method} ${m.route.path} :: ${
        m.route.handler.name || '(anonymous)'
      }`
    )
  },
  asyncEnd(m: any) {
    const ms = (performance.now() - m._start).toFixed(2)
    console.log(`  [end]   ${m.route.handler.name || '(anonymous)'} — ${ms}ms`)
  },
  error(m: any) {
    console.log(
      `  [error] ${m.route.handler.name || '(anonymous)'}: ${m.error.message}`
    )
  },
})

const app = new Hono({
  router: new TransformRouter({
    transform: ([handler, route]) => [
      (c, next) =>
        tc.tracePromise(() => handler(c, next), {
          route,
          c,
        }),
      route,
    ],
  }),
})
```

### Other use cases

You can identify which handler threw an error before `app.onError()` handles it:

```ts
const app = new Hono({
  router: new TransformRouter({
    transform: ([handler, route]) => [
      async (c, next) => {
        try {
          return await handler(c, next)
        } catch (err) {
          throw new Error(`Error in ${route.method} ${route.path}`)
        }
      },
      route,
    ],
  }),
})
```

Handlers can also be selected dynamically:

```ts
const app = new Hono({
  router: new TransformRouter({
    transform: ([handler, route]) => [
      (c, next) => {
        const impl = registry.get(route.method + route.path) ?? handler
        return impl(c, next)
      },
      route,
    ],
  }),
})
```

### Why a router decorator?

- It uses the existing `Router<T>` extension point.
- It does not change `HonoBase`, the single-handler fast path, or `compose()`.
- Applications that do not opt in have no additional handler dispatch work.
- Transformation happens once when a route is registered.
- Matching is still handled entirely by the delegated router.
- The original `RouterRoute` metadata and `app.routes` handlers can be preserved.

### Pain points

The API is lower-level than `handlerWrapper`. Hono users need to transform the internal `[handler, route]` value and return the route metadata together with the wrapped handler.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
