### PR TITLE
fix(client): serialize multiple cookies correctly

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -274,6 +274,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
       validator('cookie', () => {
         return {
           hello: 'world',
+          goodbye: 'moon',
         }
       }),
       (c) => {
@@ -312,9 +313,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
       return HttpResponse.json({ 'x-message-id': message })
     }),
     http.get('http://localhost/api/cookie', async ({ request }) => {
-      const obj = parse(request.headers.get('cookie') || '')
-      const value = obj['hello']
-      return HttpResponse.json({ hello: value })
+      return HttpResponse.json(parse(request.headers.get('cookie') || ''))
     })
   )
 
@@ -373,6 +372,7 @@ describe('Basic - query, queries, form, path params, header and cookie', () => {
   it('Should get 200 response - cookie', async () => {
     const cookie = {
       hello: 'world',
+      goodbye: 'moon',
     }
     const res = await client.cookie.$get({
       cookie,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -98,9 +98,9 @@ class ClientRequestImpl {
     if (args?.cookie) {
       const cookies: string[] = []
       for (const [key, value] of Object.entries(args.cookie)) {
-        cookies.push(serialize(key, value, { path: '/' }))
+        cookies.push(serialize(key, value))
       }
-      headerValues['Cookie'] = cookies.join(',')
+      headerValues['Cookie'] = cookies.join('; ')
     }
 
     if (this.cType) {


### PR DESCRIPTION
## Summary

- serialize RPC request cookies without response-only `Path` attributes
- separate multiple cookie pairs with `; ` so every value reaches the server
- extend the client regression test to cover multiple cookies and detect leaked attributes

Before this change, two cookies were sent as:

```text
hello=world; Path=/,goodbye=moon; Path=/
```

Hono's cookie parser consequently interpreted the second pair as part of the `Path` attribute. The client now sends:

```text
hello=world; goodbye=moon
```

## Testing

- `bun run test` (146 files passed; 4760 tests passed, 35 skipped)
- `bun run test:bun` (26 tests passed)
- `bun run build` (including publint)
- `tsc -p tsconfig.spec.json --noEmit`
- `eslint src/client/client.ts src/client/client.test.ts`
- `prettier --check src/client/client.ts src/client/client.test.ts`

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc — not applicable; no public API was added or changed
