### PR TITLE
ci: introduce linters for GitHub Actions

### DIFF
--- a/.github/actions/perf-measures/action.yml
+++ b/.github/actions/perf-measures/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version-file: '.tool-versions'
     - run: |
@@ -44,7 +44,7 @@ runs:
 
     - name: Run octocov
       if: ${{ inputs.target-ref == 'auto' }}
-      uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
+      uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
       with:
         config: perf-measures/.octocov.consolidated.perf-measures.yml
       env:
@@ -54,7 +54,7 @@ runs:
 
     - name: Run octocov with custom target ref
       if: ${{ inputs.target-ref == 'main' }}
-      uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
+      uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
       with:
         config: perf-measures/.octocov.consolidated.perf-measures.main.yml
       env:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,14 +19,16 @@ jobs:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
       - run: bun run format:fix
       - run: bun run lint:fix
       - name: Apply fixes
-        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
         with:
           commit-message: 'ci: apply automated fixes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
       - bun
       - deno
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           pattern: coverage-*
           merge-multiple: true
@@ -38,11 +40,13 @@ jobs:
     name: 'Main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -51,7 +55,7 @@ jobs:
       - run: bun run editorconfig-checker -format github-actions
       - run: bun run build
       - run: bun run test
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: coverage-main
           path: coverage/
@@ -60,11 +64,13 @@ jobs:
     name: "Checking if it's valid for JSR"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: '.tool-versions'
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bunx jsr publish --dry-run
@@ -73,8 +79,10 @@ jobs:
     name: 'Deno'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: '.tool-versions'
       - run: env NAME=Deno deno test --coverage=coverage/raw/deno-runtime --allow-read --allow-env --allow-write --allow-net -c runtime-tests/deno/deno.json runtime-tests/deno
@@ -82,7 +90,7 @@ jobs:
       - run: deno test -c runtime-tests/deno-jsx/deno.react-jsx.json --coverage=coverage/raw/deno-react-jsx runtime-tests/deno-jsx
       - run: grep -R '"url":' coverage | grep -v runtime-tests | sed -e 's/.*file:..//;s/.,//' | xargs deno cache --unstable-sloppy-imports
       - run: deno coverage --lcov > coverage/deno-runtime-coverage-lcov.info
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: coverage-deno
           path: coverage/
@@ -91,13 +99,15 @@ jobs:
     name: 'Bun'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
       - run: bun run test:bun
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: coverage-bun
           path: coverage/
@@ -106,8 +116,10 @@ jobs:
     name: 'Bun - Windows'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun run test:bun
@@ -116,8 +128,10 @@ jobs:
     name: 'Fastly Compute'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -131,11 +145,13 @@ jobs:
       matrix:
         node: ['20.x', '22.x', '24.x']
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -146,11 +162,13 @@ jobs:
     name: 'workerd'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -161,8 +179,10 @@ jobs:
     name: 'AWS Lambda'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -173,8 +193,10 @@ jobs:
     name: 'Lambda@Edge'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -189,7 +211,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/perf-measures
         with:
           target-ref: 'auto'
@@ -202,8 +226,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
       - run: bun install --frozen-lockfile
@@ -217,7 +243,7 @@ jobs:
           cd benchmarks/http-server
           bun run benchmark.ts
       - name: Comment PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           script: |
@@ -264,7 +290,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/perf-measures
         with:
           target-ref: 'main'

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -23,17 +23,20 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
+          package-manager-cache: false
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
+          no-cache: true
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,46 @@
+name: lint-actions
+
+on:
+  push:
+    branches: [main, next]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: 'actionlint'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install actionlint
+        run: |
+          curl -sSfL -o actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz' | sha256sum -c -
+          tar xzf actionlint.tar.gz actionlint
+          sudo mv actionlint /usr/local/bin/
+      - name: Run actionlint
+        run: actionlint
+
+  zizmor:
+    name: 'zizmor'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          version: 1.29.0
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues with "not bug" label
-        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           days-before-stale: 7
           days-before-close: 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,19 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           registry-url: 'https://registry.npmjs.org'
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+          package-manager-cache: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: '.tool-versions'
-      - run: npm install -g npm@11.17.0
+          no-cache: true
+      - run: npm install -g npm@11.17.0 # zizmor: ignore[adhoc-packages] npm is pinned to an exact version for staged publishing
       - run: bun install --frozen-lockfile
       - run: bun run build
       - name: Publish to npm
@@ -41,9 +45,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: '.tool-versions'
       - run: deno install --no-lock --allow-scripts


### PR DESCRIPTION
Refs #4936

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

(Not applicable: this PR only touches `.github/**` workflow definitions — no TypeScript sources, so there are no tests/docs to add and no code paths that `bun run test`, `format`, or `lint` cover. `bun run editorconfig-checker`, which does cover YAML, passes.)

## What & why

Following up on #4932 (pin GitHub Actions to SHAs), #4936 proposes linting the workflows themselves. This PR adds a new `lint-actions` workflow running the two linters that came up in the issue discussion:

- [actionlint](https://github.com/rhysd/actionlint) v1.7.12 — workflow syntax/semantics lint. Installed from the official release tarball with SHA-256 checksum verification (same pattern as the existing `bombardier` install in `ci.yml`), so no new third-party action needs to be trusted.
- [zizmor](https://github.com/zizmorcore/zizmor) v1.29.0 — static security analysis for workflows, via the official SHA-pinned `zizmorcore/zizmor-action`, following the setup described for TanStack in the issue: separate workflow, read-only `contents: read` permission, `persist-credentials: false` on checkout, `advanced-security: false` + `annotations: true`. The zizmor version is pinned (`version: 1.29.0`) for reproducibility, mirroring how the repo pins everything else.

The workflow runs on pushes to `main`/`next` and on PRs that touch `.github/workflows/**` or `.github/actions/**`.

## Findings fixed in existing workflows

Running both linters against the current workflows (the "reproduction" step) surfaced the following, all fixed here so the new check is green from day one:

- `artipacked` (18 findings): every `actions/checkout` now sets `persist-credentials: false`. No job pushes over git — `autofix-ci/action` uploads the diff to the autofix.ci GitHub App instead of pushing, and npm/JSR publishing uses OIDC — so persisting credentials is unnecessary.
- `cache-poisoning` (4 findings): in the publish workflows (`release.yml`, `cr.yml`), `actions/setup-node`'s automatic package-manager cache is disabled via `package-manager-cache: false` and `oven-sh/setup-bun`'s cache via `no-cache: true`.
- `ref-version-mismatch` (28 findings, online audit): version comments on SHA-pinned actions now name the exact tag the pinned SHA points to (e.g. `# v6` → `# v6.0.2`, all verified against the upstream tag refs). I applied the same exact-tag style to the remaining, not-yet-flagged comments (`# v2` → `# v2.2.0`, etc.) for consistency — this also keeps the check deterministic, since a floating major tag moving upstream would otherwise flag the pin without any change in this repo. Happy to drop those if you prefer a smaller diff.
- `adhoc-packages` (1 finding): `npm install -g npm@11.17.0` in `release.yml` is kept with an inline `# zizmor: ignore[adhoc-packages]` justification — the npm version is exactly pinned and required for staged publishing.

actionlint itself was already clean; the new workflow file passes both linters (dogfooded).

## Verification

- `actionlint` v1.7.12 on the repo: exit 0. Run locally with shellcheck 0.9.0 on PATH, matching `ubuntu-latest`, so CI parity is confirmed (also verified clean with `-shellcheck=` disabled).
- `zizmor` v1.29.0 in online mode (same persona/audits as the CI job): `No findings to report. Good job! (1 ignored, 12 suppressed)`, exit 0.
- `bun install --frozen-lockfile` and `bun run editorconfig-checker`: pass.
- The full diff was reviewed with an AI code-review pass (kiro-cli, claude-opus-5); its findings were either verified against evidence (ignore-comment syntax, SHA↔tag matching — both enforced by zizmor's online audits) or addressed above.

### Testing limitations / notes

- The new workflow only executes on GitHub Actions after merge (or on this PR once it touches `.github/**`); I validated equivalent commands locally with the same pinned tool versions rather than via a live CI run.
- If these jobs ever become *required* status checks, the `paths` filter should be reconsidered, since skipped runs report no status.
- Disabling the default caches in `cr.yml`/`release.yml` makes those (infrequent) publish jobs slightly slower, which is the accepted trade-off for the cache-poisoning findings.
- Per the AI usage policy: this PR was prepared with AI assistance; every change was verified locally as described above.
