### PR TITLE
fix(types): infer handler response from last handler in path[] overload

### DIFF
--- a/.changeset/fix-path-array-overload.md
+++ b/.changeset/fix-path-array-overload.md
@@ -1,0 +1,5 @@
+---
+'hono': patch
+---
+
+Fixed `app.on()` type inference when multiple paths are combined with middleware: an inline middleware whose inferred return type is `Promise<void>` (e.g. an `async` function returning `next()`) made the `path[]` overload infer `R = Promise<void>` for **every** handler, so the final handler returning a JSON response was rejected with "No overload matches this call". The `path[]` overload now mirrors the single-path and `method[]` overloads: only the last handler carries the response type, and preceding handlers are treated as middleware.

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -2,6 +2,7 @@
 import { expectTypeOf } from 'vitest'
 import { hc } from './client'
 import { Context } from './context'
+import type { Next } from './types'
 import { createMiddleware } from './helper/factory'
 import { testClient } from './helper/testing'
 import { Hono } from './hono'
@@ -354,6 +355,19 @@ describe('OnHandlerInterface', () => {
     app.on('GET', ['/a', '/b'], middleware, (c) => {
       expectTypeOf(c.var.foo).toEqualTypeOf<string>()
       return c.json({})
+    })
+  })
+
+  // Regression for https://github.com/honojs/hono/issues/5144
+  // An inline middleware whose inferred return type is Promise<void> (async fn
+  // returning next()) used to make the path[] overload infer R = Promise<void>
+  // for every handler, rejecting the final JSON-returning handler.
+  test('app.on(method, path[], inline middleware returning next(), handler) should infer handler response', () => {
+    const middleware = async (_c: Context, next: Next) => {
+      return next()
+    }
+    app.on('POST', ['/route1', '/route2'], middleware, (c) => {
+      return c.json({ message: 'Hello from route1 or route2' })
     })
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2459,16 +2459,18 @@ export interface OnHandlerInterface<
   <
     M extends string,
     const Ps extends string[],
-    I extends Input = BlankInput,
     R extends HandlerResponse<any> = any,
+    I extends Input = BlankInput,
+    I2 extends Input = I,
     E2 extends Env = E,
+    E3 extends Env = IntersectNonAnyTypes<[E, E2]>,
   >(
     methods: M | M[],
     paths: Ps,
-    ...handlers: H<E2, MergePath<BasePath, Ps[number]>, I, R>[]
+    ...handlers: [...H<E2, MergePath<BasePath, Ps[number]>, I>[], H<E3, MergePath<BasePath, Ps[number]>, I2, R>]
   ): HonoBase<
-    E,
-    S & ToSchema<M, MergePath<BasePath, Ps[number]>, I, MergeTypedResponse<R>>,
+    IntersectNonAnyTypes<[E, E2, E3]>,
+    S & ToSchema<M, MergePath<BasePath, Ps[number]>, I2, MergeTypedResponse<R>>,
     BasePath,
     Ps extends [...string[], infer LastPath extends string] ? MergePath<BasePath, LastPath> : never
   >


### PR DESCRIPTION
Fixes #5144

## Problem

`app.on('POST', ['/route1', '/route2'], middleware, handler)` failed to compile with:

```
No overload matches this call.
  Argument of type '(c: Context<any, "/route1" | "/route2", {}>) => JSONRespondReturn<...>' is not assignable to parameter of type 'H<any, "/route1" | "/route2", {}, Promise<void>>'.
```

## Root cause

The `app.on(method | method[], path[], ...handlers[])` overload typed **every** handler as `H<..., I, R>[]`, so TypeScript inferred `R` from the first handler. An inline middleware `async (c, next) => { return next() }` has inferred return type `Promise<void>` (from `next()`), which forced `R = Promise<void>` — and then the final handler returning `c.json(...)` no longer matched.

The single-path and `method[]` overloads already handle this correctly by only giving the **last** handler the response type (`[...middleware, handler]`); the `path[]` overload was the odd one out.

## Fix

Rework the `path[]` overload to the same shape:

```ts
...handlers: [...H<E2, MergedPath, I>[], H<E3, MergedPath, I2, R>]
```

Only the last handler carries `R`; preceding handlers are middleware. Input/env types are still accumulated across all handlers.

## Testing

- New regression test reproducing the exact issue (inline middleware returning `next()`, multiple paths, JSON handler) — verified it **fails without the fix** (1 TS error) and **passes with it**.
- Full `types.test.ts` suite: 121/121 passing.
- `tsc -p tsconfig.spec.json` clean.