### PR TITLE
feat(hono-base): support middleware handlers in notFound and onError

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -256,9 +256,12 @@ class Hono<
   /**
    * `.onError()` handles an error and returns a customized Response.
    *
+   * You can also pass middleware handlers before the error handler so that the
+   * middleware runs only for error responses without registering it globally.
+   *
    * @see {@link https://hono.dev/docs/api/hono#error-handling}
    *
-   * @param {ErrorHandler} handler - request Handler for error
+   * @param {...(MiddlewareHandler | ErrorHandler)} handlers - middleware handlers and an error handler
    * @returns {Hono} changed Hono instance
    *
    * @example
@@ -268,18 +271,49 @@ class Hono<
    *   return c.text('Custom Error Message', 500)
    * })
    * ```
+   *
+   * @example
+   * ```ts
+   * app.onError(
+   *   languageDetector(),
+   *   (err, c) => {
+   *     return c.html(renderErrorPage(c.get('language')))
+   *   }
+   * )
+   * ```
    */
-  onError = (handler: ErrorHandler<E>): Hono<E, S, BasePath, CurrentPath> => {
-    this.errorHandler = handler
+  onError: {
+    (handler: ErrorHandler<E>): Hono<E, S, BasePath, CurrentPath>
+    (
+      ...handlers: [MiddlewareHandler<E>, ...MiddlewareHandler<E>[], ErrorHandler<E>]
+    ): Hono<E, S, BasePath, CurrentPath>
+  } = (...handlers: unknown[]) => {
+    const handler = handlers[handlers.length - 1] as ErrorHandler<E>
+    const middlewares = handlers.slice(0, -1) as MiddlewareHandler<E>[]
+    if (middlewares.length === 0) {
+      this.errorHandler = handler
+    } else {
+      this.errorHandler = (err, c) => {
+        const composed = compose(
+          [...middlewares, (context: Context<E>, _next: Next) => handler(err, context)].map(
+            (middleware) => [[middleware, undefined], undefined]
+          ) as [[Function, unknown], unknown][]
+        )
+        return composed(c).then((context) => context.res)
+      }
+    }
     return this
   }
 
   /**
    * `.notFound()` allows you to customize a Not Found Response.
    *
+   * You can also pass middleware handlers before the not-found handler so that
+   * the middleware runs only for 404 responses without registering it globally.
+   *
    * @see {@link https://hono.dev/docs/api/hono#not-found}
    *
-   * @param {NotFoundHandler} handler - request handler for not-found
+   * @param {...(MiddlewareHandler | NotFoundHandler)} handlers - middleware handlers and a not-found handler
    * @returns {Hono} changed Hono instance
    *
    * @example
@@ -288,9 +322,36 @@ class Hono<
    *   return c.text('Custom 404 Message', 404)
    * })
    * ```
+   *
+   * @example
+   * ```ts
+   * app.notFound(
+   *   languageDetector(),
+   *   (c) => {
+   *     return c.html(render404Page(c.get('language')))
+   *   }
+   * )
+   * ```
    */
-  notFound = (handler: NotFoundHandler<E>): Hono<E, S, BasePath, CurrentPath> => {
-    this.#notFoundHandler = handler
+  notFound: {
+    (handler: NotFoundHandler<E>): Hono<E, S, BasePath, CurrentPath>
+    (
+      ...handlers: [MiddlewareHandler<E>, ...MiddlewareHandler<E>[], NotFoundHandler<E>]
+    ): Hono<E, S, BasePath, CurrentPath>
+  } = (...handlers: unknown[]) => {
+    const handler = handlers[handlers.length - 1] as NotFoundHandler<E>
+    const middlewares = handlers.slice(0, -1) as MiddlewareHandler<E>[]
+    if (middlewares.length === 0) {
+      this.#notFoundHandler = handler
+    } else {
+      const composed = compose(
+        [...middlewares, handler].map((middleware) => [[middleware, undefined], undefined]) as [
+          [Function, unknown],
+          unknown,
+        ][]
+      )
+      this.#notFoundHandler = (c) => composed(c).then((context) => context.res)
+    }
     return this
   }
 

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1638,6 +1638,116 @@ describe('Error handling in middleware', () => {
       expect(await res.text()).toBe('Error in Not Found')
     })
   })
+
+  describe('notFound with middleware handlers', () => {
+    const app = new Hono()
+
+    app.get('/', (c) => c.text('hello'))
+
+    app.get('/notfound', (c) => c.notFound())
+
+    app.notFound(
+      async (c, next) => {
+        c.header('x-not-found-middleware', 'true')
+        await next()
+      },
+      (c) => {
+        return c.text('Custom 404 from notFound middleware', 404)
+      }
+    )
+
+    it('Should run the middleware chain for a non-matching route', async () => {
+      const res = await app.request('http://localhost/foo')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe('Custom 404 from notFound middleware')
+      expect(res.headers.get('x-not-found-middleware')).toBe('true')
+    })
+
+    it('Should run the middleware chain for `c.notFound()`', async () => {
+      const res = await app.request('http://localhost/notfound')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe('Custom 404 from notFound middleware')
+      expect(res.headers.get('x-not-found-middleware')).toBe('true')
+    })
+  })
+
+  describe('notFound with multiple middleware handlers', () => {
+    const app = new Hono()
+
+    app.notFound(
+      async (c, next) => {
+        c.header('x-mw-1', '1')
+        await next()
+      },
+      async (c, next) => {
+        c.header('x-mw-2', '2')
+        await next()
+      },
+      (c) => {
+        return c.text('Custom 404 from notFound multi-middleware', 404)
+      }
+    )
+
+    it('Should run all the middleware handlers in order', async () => {
+      const res = await app.request('http://localhost/foo')
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe('Custom 404 from notFound multi-middleware')
+      expect(res.headers.get('x-mw-1')).toBe('1')
+      expect(res.headers.get('x-mw-2')).toBe('2')
+    })
+  })
+
+  describe('onError with middleware handlers', () => {
+    const app = new Hono()
+
+    app.get('/error', () => {
+      throw new Error('This is Error')
+    })
+
+    app.onError(
+      async (c, next) => {
+        c.header('x-error-middleware', 'true')
+        await next()
+      },
+      (err, c) => {
+        return c.text(`Custom Error: ${err.message}`, 500)
+      }
+    )
+
+    it('Should run the middleware chain before the error handler', async () => {
+      const res = await app.request('http://localhost/error')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toBe('Custom Error: This is Error')
+      expect(res.headers.get('x-error-middleware')).toBe('true')
+    })
+  })
+
+  describe('onError with middleware handlers for an error in a middleware', () => {
+    const app = new Hono()
+
+    app.use('/error', async () => {
+      throw new Error('This is Middleware Error')
+    })
+
+    app.get('/error', (c) => c.text('ok'))
+
+    app.onError(
+      async (c, next) => {
+        c.header('x-error-middleware', 'true')
+        await next()
+      },
+      (err, c) => {
+        return c.text(`Custom Error: ${err.message}`, 500)
+      }
+    )
+
+    it('Should run the middleware chain for an error thrown in a middleware', async () => {
+      const res = await app.request('http://localhost/error')
+      expect(res.status).toBe(500)
+      expect(await res.text()).toBe('Custom Error: This is Middleware Error')
+      expect(res.headers.get('x-error-middleware')).toBe('true')
+    })
+  })
 })
 
 describe('Request methods with custom middleware', () => {


### PR DESCRIPTION
This addresses #5193.

## Feature request (not a bug fix)

`app.notFound()` and `app.onError()` currently accept only a single handler. This PR lets them accept middleware handlers before the final handler, like route definitions do, so the middleware runs only for 404 / error responses without registering it globally.

```ts
const app = new Hono()

app.notFound(
  languageDetector(),
  (c) => c.html(render404Page(c.get('language')))
)

app.onError(
  languageDetector(),
  (err, c) => c.html(renderErrorPage(c.get('language')))
)
```

For example `languageDetector` may disable the edge cache (via `Set-Cookie`), so you do not want it registered globally — only when rendering 404 / error pages.

## Change

- `src/hono-base.ts`: `onError` and `notFound` now accept either a single handler (unchanged behavior) or one or more middleware handlers followed by the final handler. The middleware chain is composed with `compose()` and runs only when the error / not-found path is taken. Both methods keep their existing single-handler overload for full TypeScript back-compat.

## Test plan

- RED: `bunx vitest --run src/hono.test.ts -t 'middleware handlers'` fails on the current code — 5 new tests (`notFound`/`onError` with one or more middleware handlers, including an error thrown in a middleware).
- GREEN: `bunx vitest --run src/hono.test.ts` passes (215 tests, no regression).
- `tsc -p tsconfig.spec.json`, `eslint`, and `prettier --check` are clean on the touched files.