### PR TITLE
fix(etag): compute correct digest for bodies >= CHUNK_SIZE (streaming SHA-1, not hash-of-hash)

### DIFF
--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -1,95 +1,104 @@
-const mergeBuffers = (
-  buffer1: ArrayBuffer | undefined,
-  buffer2: Uint8Array<ArrayBuffer>
-): Uint8Array<ArrayBuffer> => {
-  if (!buffer1) {
-    return buffer2
-  }
-  const merged = new Uint8Array<ArrayBuffer>(
-    new ArrayBuffer(buffer1.byteLength + buffer2.byteLength)
-  )
-  merged.set(new Uint8Array(buffer1), 0)
-  merged.set(buffer2, buffer1.byteLength)
-  return merged
+/**
+ * An incremental SHA-1 hasher.
+ * `crypto.subtle.digest` is one-shot (there is no streaming Web Crypto API),
+ * so this is only available on runtimes that expose a streaming primitive.
+ */
+type IncrementalSha1 = {
+  update: (chunk: Uint8Array<ArrayBuffer>) => void
+  digestHex: () => string
 }
 
-const CHUNK_SIZE = 256 * 1024
+/**
+ * Returns an incremental SHA-1 hasher when the runtime exposes one.
+ *
+ * - Bun: `Bun.CryptoHasher`
+ * - Node.js: `node:crypto.createHash`, reached through
+ *   `process.getBuiltinModule` instead of a static `node:` import so edge
+ *   bundlers (e.g. Cloudflare Workers) can still skip it.
+ *
+ * Returns `null` on runtimes where Web Crypto is the only option (Cloudflare
+ * Workers, older Node.js, Deno), in which case the caller falls back to
+ * buffering the full body and hashing it once.
+ */
+const getIncrementalSha1 = (): IncrementalSha1 | null => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const global = globalThis as any
+
+  if (typeof global.Bun !== 'undefined' && global.Bun.CryptoHasher) {
+    const hasher = new global.Bun.CryptoHasher('sha1')
+    return {
+      update: (chunk) => hasher.update(chunk),
+      digestHex: () => hasher.digest('hex') as string,
+    }
+  }
+
+  const nodeCrypto = global?.process?.getBuiltinModule?.('node:crypto')
+  if (nodeCrypto?.createHash) {
+    const hasher = nodeCrypto.createHash('sha1')
+    return {
+      update: (chunk) => hasher.update(chunk),
+      digestHex: () => hasher.digest('hex') as string,
+    }
+  }
+
+  return null
+}
+
+const toHex = (buffer: ArrayBuffer) =>
+  Array.prototype.map.call(new Uint8Array(buffer), (x) => x.toString(16).padStart(2, '0')).join('')
 
 export const generateDigest = async (
   stream: ReadableStream<Uint8Array<ArrayBuffer>> | null,
-  generator: (body: Uint8Array<ArrayBuffer>) => ArrayBuffer | Promise<ArrayBuffer>
+  generator: (body: Uint8Array<ArrayBuffer>) => ArrayBuffer | Promise<ArrayBuffer>,
+  useIncrementalSha1 = false
 ): Promise<string | null> => {
   if (!stream) {
     return null
   }
 
-  let result: ArrayBuffer | undefined = undefined
-  let chunk: Uint8Array<ArrayBuffer> | undefined
-  let chunkLength = 0
+  const reader = stream.getReader()
+  const sha1 = useIncrementalSha1 ? getIncrementalSha1() : null
 
-  const digest = async (body: Uint8Array<ArrayBuffer>) => {
-    result = await generator(mergeBuffers(result, body))
+  if (sha1) {
+    let totalLength = 0
+    for (;;) {
+      const { value, done } = await reader.read()
+      if (done) {
+        break
+      }
+      totalLength += value.byteLength
+      sha1.update(value)
+    }
+    if (totalLength === 0) {
+      return null
+    }
+    return sha1.digestHex()
   }
 
-  const reader = stream.getReader()
+  // No incremental primitive is available (e.g. Web Crypto only on Workers) or
+  // a custom one-shot `generator` was provided: accumulate the full body and
+  // hash it once, so the digest always matches a real hash of the content.
+  const chunks: Uint8Array<ArrayBuffer>[] = []
+  let totalLength = 0
   for (;;) {
     const { value, done } = await reader.read()
     if (done) {
       break
     }
-
-    let offset = 0
-    while (offset < value.byteLength) {
-      const remaining = value.byteLength - offset
-
-      if (chunkLength === 0 && remaining >= CHUNK_SIZE) {
-        await digest(value.subarray(offset, offset + CHUNK_SIZE))
-        offset += CHUNK_SIZE
-        continue
-      }
-
-      const requiredLength = chunkLength + remaining
-      if (requiredLength < CHUNK_SIZE) {
-        if (!chunk) {
-          chunk = value.subarray(offset)
-        } else {
-          if (chunk.byteLength < requiredLength) {
-            const nextChunk = new Uint8Array<ArrayBuffer>(
-              new ArrayBuffer(Math.min(CHUNK_SIZE, Math.max(requiredLength, chunk.byteLength * 2)))
-            )
-            nextChunk.set(chunk.subarray(0, chunkLength))
-            chunk = nextChunk
-          }
-          chunk.set(value.subarray(offset), chunkLength)
-        }
-        chunkLength = requiredLength
-        break
-      }
-
-      const length = CHUNK_SIZE - chunkLength
-      if (chunk?.byteLength !== CHUNK_SIZE) {
-        const nextChunk = new Uint8Array<ArrayBuffer>(new ArrayBuffer(CHUNK_SIZE))
-        if (chunk) {
-          nextChunk.set(chunk.subarray(0, chunkLength))
-        }
-        chunk = nextChunk
-      }
-      chunk.set(value.subarray(offset, offset + length), chunkLength)
-      await digest(chunk)
-      chunkLength = 0
-      offset += length
-    }
+    chunks.push(value)
+    totalLength += value.byteLength
   }
-
-  if (chunk && chunkLength > 0) {
-    await digest(chunk.subarray(0, chunkLength))
-  }
-
-  if (!result) {
+  if (totalLength === 0) {
     return null
   }
 
-  return Array.prototype.map
-    .call(new Uint8Array(result), (x) => x.toString(16).padStart(2, '0'))
-    .join('')
+  const fullBody = new Uint8Array<ArrayBuffer>(new ArrayBuffer(totalLength))
+  let offset = 0
+  for (const chunk of chunks) {
+    fullBody.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  const result = await generator(fullBody)
+  return toHex(result)
 }

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -161,6 +161,61 @@ describe('Etag Middleware', () => {
     expect(res2.headers.get('ETag')).toBe(res1.headers.get('ETag'))
   })
 
+  it('Should return an etag equal to the real SHA-1 of a body >= CHUNK_SIZE', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    // 300 KiB exceeds the 256 KiB digest chunk boundary.
+    const size = 300 * 1024
+    const body = new Uint8Array(size)
+    for (let i = 0; i < size; i++) {
+      body[i] = i % 256
+    }
+    app.get('/etag/large', (c) => c.body(body))
+
+    const res = await app.request('http://localhost/etag/large')
+    const etagHeader = res.headers.get('ETag')
+    expect(etagHeader).not.toBeFalsy()
+
+    const expected = await crypto.subtle.digest({ name: 'SHA-1' }, body)
+    const expectedHex = Array.prototype.map
+      .call(new Uint8Array(expected), (x) => x.toString(16).padStart(2, '0'))
+      .join('')
+    expect(etagHeader).toBe(`"${expectedHex}"`)
+  })
+
+  it('Should return an etag equal to the real digest for a custom generator and a body >= CHUNK_SIZE', async () => {
+    const app = new Hono()
+    app.use(
+      '/etag/*',
+      etag({
+        generateDigest: (body) =>
+          crypto.subtle.digest(
+            {
+              name: 'SHA-256',
+            },
+            body
+          ),
+      })
+    )
+    // 300 KiB exceeds the 256 KiB digest chunk boundary.
+    const size = 300 * 1024
+    const body = new Uint8Array(size)
+    for (let i = 0; i < size; i++) {
+      body[i] = i % 256
+    }
+    app.get('/etag/large-sha256', (c) => c.body(body))
+
+    const res = await app.request('http://localhost/etag/large-sha256')
+    const etagHeader = res.headers.get('ETag')
+    expect(etagHeader).not.toBeFalsy()
+
+    const expected = await crypto.subtle.digest({ name: 'SHA-256' }, body)
+    const expectedHex = Array.prototype.map
+      .call(new Uint8Array(expected), (x) => x.toString(16).padStart(2, '0'))
+      .join('')
+    expect(etagHeader).toBe(`"${expectedHex}"`)
+  })
+
   it('Should not return etag header when the stream is empty', async () => {
     const app = new Hono()
     app.use('/etag/*', etag())

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -35,18 +35,20 @@ function etagMatches(etag: string, ifNoneMatch: string | null) {
   )
 }
 
+const defaultDigest = (body: Uint8Array<ArrayBuffer>) =>
+  crypto.subtle.digest(
+    {
+      name: 'SHA-1',
+    },
+    body
+  )
+
 function initializeGenerator(
   generator?: ETagOptions['generateDigest']
 ): ETagOptions['generateDigest'] | undefined {
   if (!generator) {
     if (crypto && crypto.subtle) {
-      generator = (body: Uint8Array<ArrayBuffer>) =>
-        crypto.subtle.digest(
-          {
-            name: 'SHA-1',
-          },
-          body
-        )
+      generator = defaultDigest
     }
   }
 
@@ -103,7 +105,10 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
       const hash = await generateDigest(
         // This type casing avoids the type error for `deno publish`
         res.clone().body as ReadableStream<Uint8Array<ArrayBuffer>>,
-        generator
+        generator,
+        // The built-in SHA-1 digest can be computed incrementally (bounded
+        // memory) when the runtime exposes a streaming primitive.
+        generator === defaultDigest
       )
       if (hash === null) {
         return


### PR DESCRIPTION
Closes #5212.

## Root cause

PR #5205 replaced the buffer-and-hash-once logic from #5199 with a chunked accumulator to bound memory, but the chunked path recomputes the digest as `hash(hash(chunk1) + chunk2)`. Since the default generator (`crypto.subtle.digest({ name: 'SHA-1' })`) is a one-shot, stateless hash, re-hashing a digest concatenated with the next 256 KiB chunk does **not** reconstruct `SHA-1(full body)`. For any response body >= 256 KiB (CHUNK_SIZE), the emitted ETag no longer matches the real SHA-1 of the body.

#5205 fixed the *determinism* symptom of #5199 (same content -> same ETag regardless of network chunking) but silently dropped *mathematical correctness* for large bodies.

## Fix

Compute a real streaming digest instead of re-hashing digests:

- The built-in SHA-1 path now uses an **incremental** hasher when the runtime exposes one:
  - Bun: `Bun.CryptoHasher`
  - Node.js: `node:crypto.createHash`, reached via `process.getBuiltinModule` (no static `node:` import, so edge bundlers such as Cloudflare Workers can still skip it)
- Each stream chunk is fed to the hasher and discarded, so memory stays bounded.
- On runtimes without an incremental primitive (Cloudflare Workers: Web Crypto is one-shot; also Deno and older Node.js) and for user-supplied one-shot `generateDigest` functions, the middleware buffers the full body and hashes it once (the #5199 approach). This is the only correct option there and matches the documented `generateDigest` contract.

## Tests

- RED (fails before this change): a 300 KiB body must produce an ETag equal to the real SHA-1 of the full body; the same holds for a custom SHA-256 `generateDigest`.
- The existing determinism test (same 1 MiB content delivered with different stream chunk boundaries -> same ETag) still passes.
- Full etag test scope: 20 tests pass under both Bun and Node; the full hono suite (4765 tests) passes.

## Notes

- Determinism is preserved: the digest depends only on the byte sequence, not on stream chunk boundaries, on both the incremental and buffered paths.
- The >= 256 KiB case is where #5205's value was wrong; this restores correctness there without reintroducing unbounded buffering on runtimes that support streaming hashes.