### PR TITLE
fix(client): send falsy JSON bodies

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -885,6 +885,20 @@ describe('Use custom fetch (app.request) method', () => {
     const res = await client.search.$get()
     expect(res.ok).toBe(true)
   })
+
+  it.each([false, 0, '', null])('Should send falsy JSON value: %j', async (json) => {
+    const app = new Hono().post(
+      '/json',
+      validator('json', (value) => value as boolean | number | string | null),
+      (c) => c.json(c.req.valid('json'))
+    )
+    const client = hc<typeof app>('', { fetch: app.request })
+
+    const res = await client.json.$post({ json })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBe(json)
+  })
 })
 
 describe('Optional parameters in JSON response', () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -78,7 +78,7 @@ class ClientRequestImpl {
         this.rBody = form
       }
 
-      if (args.json) {
+      if (args.json !== undefined) {
         this.rBody = JSON.stringify(args.json)
         this.cType = 'application/json'
       }


### PR DESCRIPTION
## Summary

- serialize falsy root JSON inputs (`false`, `0`, `""`, and `null`) instead of treating them as absent
- keep `undefined` as the signal for an omitted JSON body
- add regression coverage through the complete `hc` → `app.request` path

## Impact

Before this change, RPC endpoints accepting a JSON primitive silently received `{}` for these four inputs because the client omitted the body and JSON content type. This can change application behavior—for example, `false` may fail to disable a flag, while `0`, `""`, or `null` may fail to clear a setting. Object and array bodies are unaffected.

## Regression proof

```sh
vitest --run src/client/client.test.ts -t "Should send falsy JSON value"
```

- with `main`'s truthiness condition: **4 failed** (each expected primitive was received as `{}`)
- with this PR: **4 passed**

## Testing

- `vitest --run src/client/client.test.ts` — 108 tests passed
- `tsc -p tsconfig.spec.json --noEmit`
- `eslint src/client/client.ts src/client/client.test.ts`
- `prettier --check src/client/client.ts src/client/client.test.ts`

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] Format and lint changed files
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) — not applicable; no public API was added or changed