### PR TITLE
fix(trie-router): match suffix wildcard routes

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -126,6 +126,19 @@ export const runTest = ({
         expect(res[0].handler).toEqual('get wildcard')
       })
 
+      it('Suffix wildcard', async () => {
+        router.add('GET', '/assets*', 'get assets')
+        let res = match('GET', '/assets')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('get assets')
+        res = match('GET', '/assets-v2')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('get assets')
+        res = match('GET', '/assets/app.js')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('get assets')
+      })
+
       it('Default', async () => {
         router.add('GET', '/api/abc', 'get api')
         router.add('GET', '/api/*', 'fallback')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -27,6 +27,7 @@ export class Node<T> {
 
   #children: Record<string, Node<T>>
   #patterns: Pattern[]
+  #suffixWildcards: [string, Node<T>][] = []
   #order: number = 0
   #params: Record<string, string> = emptyParams
 
@@ -69,6 +70,8 @@ export class Node<T> {
       if (pattern) {
         curNode.#patterns.push(pattern)
         possibleKeys.push(pattern[1])
+      } else if (p.length > 1 && p.at(-1) === '*') {
+        curNode.#suffixWildcards.push([p.slice(0, -1), curNode.#children[key]])
       }
       curNode = curNode.#children[key]
     }
@@ -143,6 +146,13 @@ export class Node<T> {
             this.#pushHandlerSets(handlerSets, nextNode, method, node.#params)
           } else {
             tempNodes.push(nextNode)
+          }
+        }
+
+        for (let k = 0, len3 = node.#suffixWildcards.length; k < len3; k++) {
+          const [prefix, child] = node.#suffixWildcards[k]
+          if (part.startsWith(prefix)) {
+            this.#pushHandlerSets(handlerSets, child, method, node.#params)
           }
         }
 


### PR DESCRIPTION
`TrieRouter` stores a label like `assets*` as a plain literal child, so `/assets*` never matched anything. `RegExpRouter`, `LinearRouter` and `PatternRouter` all handle it. The gap only shows up once `RegExpRouter` throws `UnsupportedPathError` and `SmartRouter` falls back to the trie, which is what the report in the issue hits.

`Node#insert` now records a label ending in `*` as a prefix on the parent node, and `Node#search` pushes that node's handlers when the current path part starts with the prefix.

Fixes #5219

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code