### PR TITLE
fix(etag): match If-None-Match tags with optional whitespace before the comma

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -248,6 +248,14 @@ describe('Etag Middleware', () => {
     })
     expect(res.status).toBe(304)
 
+    // conditional GET with matching ETag among list, OWS before the comma (RFC 9110):
+    res = await app.request('http://localhost/etag/ghi', {
+      headers: {
+        'If-None-Match': `"mismatch 1", ${etagHeaderValue} , "mismatch 2"`,
+      },
+    })
+    expect(res.status).toBe(304)
+
     // conditional GET with `*` wildcard:
     res = await app.request('http://localhost/etag/ghi', {
       headers: {

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -32,10 +32,7 @@ const stripWeak = (tag: string) => tag.replace(/^W\//, '')
 function etagMatches(etag: string, ifNoneMatch: string | null) {
   return (
     ifNoneMatch != null &&
-    ifNoneMatch
-      .trim()
-      .split(/\s*,\s*/)
-      .some((t) => stripWeak(t) === stripWeak(etag))
+    ifNoneMatch.split(',').some((t) => stripWeak(t.trim()) === stripWeak(etag))
   )
 }
 

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -31,7 +31,11 @@ const stripWeak = (tag: string) => tag.replace(/^W\//, '')
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {
   return (
-    ifNoneMatch != null && ifNoneMatch.split(/,\s*/).some((t) => stripWeak(t) === stripWeak(etag))
+    ifNoneMatch != null &&
+    ifNoneMatch
+      .trim()
+      .split(/\s*,\s*/)
+      .some((t) => stripWeak(t) === stripWeak(etag))
   )
 }
 


### PR DESCRIPTION
Fixes the ETag middleware so `If-None-Match` matches when optional whitespace precedes the comma in the tag list.

## What

The ETag middleware returned `200` with the full body instead of `304 Not Modified` when a conditional request's `If-None-Match` header placed whitespace before a delimiting comma (e.g. `"a" , "b"`), even though the current ETag was present in the list.

## Why

`etagMatches` split the header with `/,\s*/`, which only consumes whitespace *after* each comma. RFC 9110 defines `If-None-Match` as a `1#entity-tag` list, and the `#` list rule permits optional whitespace (OWS) on **both** sides of the delimiter. When OWS preceded a comma, the preceding tag kept a trailing space, so `stripWeak('"abc" ') !== stripWeak('"abc"')` and the match silently failed. Any tag not in the last list position was affected, causing an unnecessary full-body transfer instead of a cheap `304`.

The fix trims the header and splits on `/\s*,\s*/`, so OWS on either side of the comma is consumed. A regression test covers a matching tag with a space before the following comma.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `format:fix && lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code
