### PR TITLE
fix(cloudflare-workers): close server WebSocket on client disconnect

### DIFF
--- a/src/adapter/cloudflare-workers/websocket.test.ts
+++ b/src/adapter/cloudflare-workers/websocket.test.ts
@@ -27,6 +27,15 @@ describe('upgradeWebSocket middleware', () => {
       }))
     )
   )
+
+  app.get(
+    '/ws-auto-close',
+    upgradeWebSocket(() => ({
+      onMessage(_evt, _ws) {
+        // no user onClose
+      },
+    }))
+  )
   it('Should receive message and readyState is valid', async () => {
     const sendingData = Math.random().toString()
     await app.request('/ws', {
@@ -158,5 +167,30 @@ describe('upgradeWebSocket middleware', () => {
 
     // @ts-expect-error mock method
     expect(server.close).toHaveBeenCalledWith(1000, 'done')
+  })
+
+  it('Should close the server WebSocket when the client closes and no onClose is provided', async () => {
+    // @ts-expect-error adding mock state/methods for the test
+    server.readyState = WebSocket.OPEN
+    // @ts-expect-error adding a mock method for the test
+    server.close = vi.fn()
+
+    await app.request('/ws-auto-close', {
+      headers: {
+        Upgrade: 'websocket',
+      },
+    })
+
+    server.dispatchEvent(
+      Object.assign(new Event('close'), { code: 1000, reason: 'Normal Closure' })
+    )
+
+    // @ts-expect-error mock method
+    expect(server.close).toHaveBeenCalledWith(1000, 'Normal Closure')
+
+    // @ts-expect-error clean up mock state
+    delete server.readyState
+    // @ts-expect-error clean up mock method
+    delete server.close
   })
 })

--- a/src/adapter/cloudflare-workers/websocket.ts
+++ b/src/adapter/cloudflare-workers/websocket.ts
@@ -33,9 +33,19 @@ export const upgradeWebSocket: UpgradeWebSocket<
 
   // note: cloudflare workers doesn't support 'open' event
 
-  if (events.onClose) {
-    server.addEventListener('close', (evt: CloseEvent) => events.onClose?.(evt, wsContext))
-  }
+  // Always attach a close listener. If a user onClose is provided we call it
+  // first, then close the server side of the WebSocketPair when it is still
+  // open. Without this, the Workers runtime keeps the request alive and reports
+  // that the Worker "will never generate a response" after the client
+  // disconnects (honojs/hono#4603). On runtimes with the
+  // `web_socket_auto_reply_to_close` compatibility flag, readyState is already
+  // CLOSED, so server.close() is a no-op.
+  server.addEventListener('close', (evt: CloseEvent) => {
+    events.onClose?.(evt, wsContext)
+    if (server.readyState === WebSocket.OPEN && typeof server.close === 'function') {
+      server.close(evt.code, evt.reason)
+    }
+  })
   if (events.onMessage) {
     server.addEventListener('message', (evt: MessageEvent) => events.onMessage?.(evt, wsContext))
   }


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

## Summary

Cloudflare Workers reports `The Workers runtime canceled this request because it detected that your Worker’s code had hung and would never generate a response` when a WebSocket client sends a message and then disconnects (honojs/hono#4603).

`src/adapter/cloudflare-workers/websocket.ts` only attached a `close` listener when the user provided an `onClose` callback, and it never explicitly closed the server-side `WebSocket` when the client disconnected. The Workers runtime keeps the request alive until the server socket is closed, so the lack of explicit cleanup caused the hang.

## Fix

Always attach a `close` listener. After firing any user-provided `onClose` handler, the adapter now calls `server.close()` with the close event's code and reason when `readyState === OPEN` (and `close` exists). On runtimes with the `web_socket_auto_reply_to_close` compatibility flag, `readyState` is already `CLOSED`, so the call is a no-op and avoids the double-hang reported in the issue.

## Testing

- `bun test src/adapter/cloudflare-workers/websocket.test.ts` passes.
- `bun run test` passes for all touched areas; the only failing test is a pre-existing unrelated snapshot mismatch in `src/client/utils.test.ts` (`parseResponse > should throw error matching snapshots`) caused by the local Vitest environment's fetch error string, and it is not affected by this change.

Fixes #4603
