### PR TITLE
fix(router): support suffix wildcards in TrieRouter

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -106,6 +106,35 @@ export const runTest = ({
       })
     })
 
+    describe('Suffix wildcard', () => {
+      it('Matches the rest of the path', async () => {
+        router.add('GET', '/assets*', 'get assets')
+
+        for (const path of ['/assets', '/assets/app.js', '/assets/nested/app.js']) {
+          const res = match('GET', path)
+          expect(res.length).toBe(1)
+          expect(res[0].handler).toEqual('get assets')
+        }
+      })
+
+      it('Does not match another prefix', async () => {
+        router.add('GET', '/assets*', 'get assets')
+        expect(match('GET', '/static/app.js').length).toBe(0)
+      })
+
+      it('Matches below the root', async () => {
+        router.add('GET', '/a/b*', 'get b')
+
+        for (const path of ['/a/b', '/a/b/c']) {
+          const res = match('GET', path)
+          expect(res.length).toBe(1)
+          expect(res[0].handler).toEqual('get b')
+        }
+
+        expect(match('GET', '/a/c').length).toBe(0)
+      })
+    })
+
     describe('Complex', () => {
       it('Named Param', async () => {
         router.add('GET', '/entry/:id', 'get entry')

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -19,6 +19,11 @@ describe('LinearRouter', () => {
         reason: 'LinearRouter allows trailing slashes',
         tests: ['Trailing slash > GET /book/'],
       },
+      {
+        reason:
+          'Below the root, LinearRouter ignores the prefix of a suffix wildcard, so `/a/b*` also matches `/a/c`',
+        tests: ['Suffix wildcard > Matches below the root'],
+      },
     ],
     newRouter: () => new LinearRouter(),
   })

--- a/src/router/pattern-router/router.test.ts
+++ b/src/router/pattern-router/router.test.ts
@@ -13,6 +13,11 @@ describe('Pattern', () => {
         reason: 'PatternRouter allows trailing slashes',
         tests: ['Trailing slash > GET /book/'],
       },
+      {
+        reason:
+          'Below the root, PatternRouter ignores the prefix of a suffix wildcard, so `/a/b*` also matches `/a/c`',
+        tests: ['Suffix wildcard > Matches below the root'],
+      },
     ],
     newRouter: () => new PatternRouter(),
   })

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -15,6 +15,18 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
 
 const emptyParams = Object.create(null)
 
+// Byte offset of each part within the original path, so a match can look at the
+// rest of the path rather than a single part.
+const computePartOffsets = (path: string, parts: string[], len: number): number[] => {
+  const offsets = new Array(len)
+  let offset = path[0] === '/' ? 1 : 0
+  for (let i = 0; i < len; i++) {
+    offsets[i] = offset
+    offset += parts[i].length + 1
+  }
+  return offsets
+}
+
 const hasChildren = (children: Record<string, unknown>): boolean => {
   for (const _ in children) {
     return true
@@ -27,6 +39,8 @@ export class Node<T> {
 
   #children: Record<string, Node<T>>
   #patterns: Pattern[]
+  // '/assets*' => [['assets', node]]; the prefix matches the rest of the path
+  #suffixWildcards?: [string, Node<T>][]
   #order: number = 0
   #params: Record<string, string> = emptyParams
 
@@ -69,6 +83,9 @@ export class Node<T> {
       if (pattern) {
         curNode.#patterns.push(pattern)
         possibleKeys.push(pattern[1])
+      } else if (i === len - 1 && p.length > 1 && p.charCodeAt(p.length - 1) === 42 /* '*' */) {
+        // '/assets*' matches everything after the prefix, as the other routers do
+        ;(curNode.#suffixWildcards ??= []).push([p.slice(0, -1), curNode.#children[key]])
       }
       curNode = curNode.#children[key]
     }
@@ -146,6 +163,17 @@ export class Node<T> {
           }
         }
 
+        const suffixWildcards = node.#suffixWildcards
+        if (suffixWildcards !== undefined) {
+          partOffsets ??= computePartOffsets(path, parts, len)
+          const restPathString = path.substring(partOffsets[i])
+          for (let k = 0, len3 = suffixWildcards.length; k < len3; k++) {
+            if (restPathString.startsWith(suffixWildcards[k][0])) {
+              this.#pushHandlerSets(handlerSets, suffixWildcards[k][1], method, node.#params)
+            }
+          }
+        }
+
         for (let k = 0, len3 = node.#patterns.length; k < len3; k++) {
           const pattern = node.#patterns[k]
           const params = node.#params === emptyParams ? {} : { ...node.#params }
@@ -172,14 +200,7 @@ export class Node<T> {
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
           if (matcher instanceof RegExp) {
-            if (partOffsets === null) {
-              partOffsets = new Array(len)
-              let offset = path[0] === '/' ? 1 : 0
-              for (let p = 0; p < len; p++) {
-                partOffsets[p] = offset
-                offset += parts[p].length + 1
-              }
-            }
+            partOffsets ??= computePartOffsets(path, parts, len)
             const restPathString = path.substring(partOffsets[i])
 
             const m = matcher.exec(restPathString)


### PR DESCRIPTION
Closes #5219.

## What was happening

The sub-app in the report turns out to be a red herring. `TrieRouter` never supported suffix wildcards at all:

```ts
const app = new Hono({ router: new TrieRouter() })
app.get('/assets*', (c) => c.text('ok'))
await app.request('http://x/assets/app.js') // 404, no sub-app anywhere
```

`getPattern()` only treats `*` as a wildcard when the label is exactly `*`, so `/assets*` is stored as a literal child keyed `"assets*"`, which no request path can equal.

It's the only router with that gap:

| Router | `GET /assets*` → `/assets/app.js` |
| --- | --- |
| RegExpRouter | 200 |
| PatternRouter | 200 |
| LinearRouter | 200 |
| **TrieRouter** | **404** |

That explains the sub-app: `sub.post('/items')` alongside `sub.post('/:slug')` makes `RegExpRouter` throw `UnsupportedPathError`, so `SmartRouter` falls back to `TrieRouter` and the pre-existing gap surfaces. It also explains the three narrowing results in the issue — dropping either route, using different methods, or writing `{slug}` all keep `RegExpRouter` viable, and the wildcard keeps working. `/assets/*` is unaffected because that path ends in a bare `*`, which was already handled.

Worth noting the failure mode: an app silently changes routing behaviour based on which router `SmartRouter` settles on, and adding an unrelated route elsewhere can flip it.

## The change

The prefix is registered on the parent node when the route is inserted, and matched against the rest of the path at search time — a trailing `*` consumes everything after the prefix, which is what the other routers do. No params are captured, matching them.

The offset computation the regex branch already used is pulled into a small helper and shared, since both need the rest of the path rather than a single part. It stays lazy, so paths without either construct don't pay for it.

The new field is optional and only allocated for routes that actually use a suffix wildcard.

## Verification

`TrieRouter` now agrees with `RegExpRouter` on every case I probed — 2 routes × 9 paths, including `/assets` (empty remainder), `/assetsfoo` (partial segment) and `/assets/a/b` (crossing `/`):

```
RegExp  /a/b*     /a/b=1 /a/bc=1 /a/b/c=1 /a/c=0 /a/=0 /a/zzz=0 /assets=0 /assetsfoo=0 /xy=0
Trie    /a/b*     /a/b=1 /a/bc=1 /a/b/c=1 /a/c=0 /a/=0 /a/zzz=0 /assets=0 /assetsfoo=0 /xy=0
RegExp  /assets*  /a/b=0 /a/bc=0 /a/b/c=0 /a/c=0 /a/=0 /a/zzz=0 /assets=1 /assetsfoo=1 /xy=0
Trie    /assets*  /a/b=0 /a/bc=0 /a/b/c=0 /a/c=0 /a/=0 /a/zzz=0 /assets=1 /assetsfoo=1 /xy=0
```

Before the change, a cross-router comparison over that matrix showed 8 disagreements; afterwards 1, and that one is byte-identical before and after (see below). The reproduction from the issue passes, still resolving to `SmartRouter + TrieRouter`, and the sub-app's own routes still respond.

`pnpm vitest --project main`: 122 files, 3800 passed, 30 skipped, 0 failures — against 3784/28 on `main`. `tsc -p tsconfig.spec.json`, ESLint and Prettier are clean.

## Tests

Added to the shared router cases in `common.case.test.ts`, so every router is held to the same behaviour rather than only `TrieRouter`.

Two things that came up, both pre-existing and left alone:

- Below the root, `LinearRouter` and `PatternRouter` ignore the wildcard's prefix — `/a/b*` also matches `/a/c`, `/a/`, `/a/zzz`. `PatternRouter` goes further and matches `/assets` too. Rather than weaken the new case to accommodate that, I've added `skip` entries with the reason, which keeps the divergence visible. Happy to open a separate issue.
- `LinearRouter` matches `/assetsfoo` against `/assets/*`, where `RegExpRouter` and `TrieRouter` do not. Untouched by this change and identical before and after.

I have not touched non-trailing wildcards such as `/x*/y`. `RegExpRouter` supports those and `TrieRouter` still does not; it seemed better kept separate from the reported bug.
