### PR TITLE
fix(method-not-allowed): ignore trailing wildcard routes when inferring Allow

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -197,6 +197,30 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
   })
 
+  it('ignores trailing wildcard routes when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('ok'))
+    app.get('/*', (c) => c.text('file'))
+    app.get('/files*', (c) => c.text('prefix'))
+
+    const postApi = await app.request('/api', { method: 'POST' })
+    expect(postApi.status).toBe(405)
+    expect(postApi.headers.get('Allow')).toBe('GET, HEAD')
+
+    const postMissing = await app.request('/missing', { method: 'POST' })
+    expect(postMissing.status).toBe(404)
+    expect(postMissing.headers.has('Allow')).toBe(false)
+
+    const postPrefixed = await app.request('/files/readme', { method: 'POST' })
+    expect(postPrefixed.status).toBe(404)
+    expect(postPrefixed.headers.has('Allow')).toBe(false)
+
+    const getWildcard = await app.request('/missing')
+    expect(getWildcard.status).toBe(200)
+    expect(await getWildcard.text()).toBe('file')
+  })
+
   it('does not invoke the error handler for a 405 response', async () => {
     const app = new Hono()
     const onError = vi.fn(() => new Response('error', { status: 500 }))

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -83,6 +83,13 @@ export const methodNotAllowed = <E extends Env = Env>(
           continue
         }
 
+        // A trailing wildcard matches an arbitrary remainder of the path, so it is not
+        // evidence that a particular target resource exists. Including it would turn
+        // otherwise-unhandled requests in that namespace into 405s.
+        if (route.path.endsWith('*')) {
+          continue
+        }
+
         const methods = methodsByPath.get(route.path) ?? new Set<string>()
         methods.add(route.method)
 


### PR DESCRIPTION
## Summary

Fixes #5223.

`methodNotAllowed` currently treats a trailing-wildcard route such as `GET /*` as evidence that every path exists. That turns `POST /missing` into 405 instead of 404, which is the `serveStatic` + `methodNotAllowed` case reported in the issue.

A maintainer asked to ignore routes whose paths end in `*` when inferring allowed methods: a trailing wildcard matches an arbitrary remainder, so it does not show that a particular resource exists.

This change skips those routes when building the Allow map. Concrete paths such as `GET /api` still produce 405 for other methods. GET/HEAD still reach the wildcard handler itself.

## Test plan

- [x] Added a regression test for `GET /api` + `GET /*` + `GET /files*`: POST `/api` is 405, POST `/missing` and POST `/files/readme` stay 404, GET `/missing` still hits the wildcard.
- [x] `bunx vitest --run src/middleware/method-not-allowed/index.test.ts` — 21 passed