### PR TITLE
feat(types): add Cloudflare Access context

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,3 +1,5 @@
+import { expectTypeOf } from 'vitest'
+import type { CloudflareAccessContext, CloudflareAccessIdentity, ExecutionContext } from './context'
 import { Context } from './context'
 import { setCookie } from './helper/cookie'
 
@@ -36,6 +38,16 @@ const makeResponseHeaderImmutable = (res: Response) => {
   })
   return res
 }
+
+describe('ExecutionContext', () => {
+  it('types Cloudflare Access authentication information', () => {
+    expectTypeOf<ExecutionContext['access']>().toEqualTypeOf<CloudflareAccessContext | undefined>()
+    expectTypeOf<Awaited<ReturnType<CloudflareAccessContext['getIdentity']>>>().toEqualTypeOf<
+      CloudflareAccessIdentity | undefined
+    >()
+    expectTypeOf<CloudflareAccessIdentity['email']>().toEqualTypeOf<string | undefined>()
+  })
+})
 
 describe('Context', () => {
   const req = new Request('http://localhost/')

--- a/src/context.ts
+++ b/src/context.ts
@@ -26,6 +26,42 @@ type HeaderRecord =
 export type Data = string | ArrayBuffer | ReadableStream | Uint8Array<ArrayBuffer>
 
 /**
+ * Identity information for a user authenticated by Cloudflare Access.
+ */
+export interface CloudflareAccessIdentity extends Record<string, unknown> {
+  email?: string
+  name?: string
+  user_uuid?: string
+  account_id?: string
+  iat?: number
+  ip?: string
+  amr?: string[]
+  idp?: {
+    id: string
+    type: string
+  }
+  geo?: {
+    country: string
+  }
+  groups?: Array<{
+    id: string
+    name: string
+    email?: string
+  }>
+  devicePosture?: Record<string, unknown>
+  is_warp?: boolean
+  is_gateway?: boolean
+}
+
+/**
+ * Cloudflare Access authentication information for the current request.
+ */
+export interface CloudflareAccessContext {
+  readonly aud: string
+  getIdentity(): Promise<CloudflareAccessIdentity | undefined>
+}
+
+/**
  * Interface for the execution context in a web worker or similar environment.
  */
 export interface ExecutionContext {
@@ -49,6 +85,10 @@ export interface ExecutionContext {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   exports?: any
+  /**
+   * Cloudflare Access authentication information, when available.
+   */
+  readonly access?: CloudflareAccessContext
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,13 @@ export type {
  * Types for context, context variable map, context renderer, and execution context.
  */
 export { Context } from './context'
-export type { ContextVariableMap, ContextRenderer, ExecutionContext } from './context'
+export type {
+  CloudflareAccessContext,
+  CloudflareAccessIdentity,
+  ContextVariableMap,
+  ContextRenderer,
+  ExecutionContext,
+} from './context'
 /**
  * Type for HonoRequest.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,7 @@ export type {
  * Types for context, context variable map, context renderer, and execution context.
  */
 export { Context } from './context'
-export type {
-  CloudflareAccessContext,
-  CloudflareAccessIdentity,
-  ContextVariableMap,
-  ContextRenderer,
-  ExecutionContext,
-} from './context'
+export type { ContextVariableMap, ContextRenderer, ExecutionContext } from './context'
 /**
  * Type for HonoRequest.
  */


### PR DESCRIPTION
## Summary

- add the optional Cloudflare Access context to Hono's `ExecutionContext`
- mirror Cloudflare's structural Access context and identity types without adding a runtime-specific dependency

## Problem

Cloudflare Workers now exposes an optional, readonly `access` property on the execution context for requests authenticated by Cloudflare Access. Hono's local `ExecutionContext` interface predates that property, so applications cannot access `c.executionCtx.access` without a cast or module augmentation even when the runtime provides it.

The Access context is not application-defined: Cloudflare specifies its audience value and `getIdentity()` result. Typing it as `any` would discard useful platform guarantees, while directly referencing Cloudflare's ambient generated types would make Hono's core declarations depend on those types being installed.

## Implementation

This change mirrors Cloudflare's canonical structural definitions as `CloudflareAccessContext` and `CloudflareAccessIdentity`. The identity includes the documented common fields and extends `Record<string, unknown>` for identity-provider-specific data. `ExecutionContext.access` is optional because the runtime only supplies it for applicable requests. The supporting types are not re-exported from the main `hono` entry point.

Canonical definitions: https://github.com/cloudflare/workerd/blob/main/types/defines/access.d.ts

## Validation

- `bun run test`
- `bun run lint`
- `bun run format`
- `bun run build`
