### PR TITLE
fix(etag): avoid skipping headers when filtering 304 response headers

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -441,4 +441,33 @@ describe('Etag Middleware', () => {
       expect(res.headers.get('ETag')).toBeNull()
     })
   })
+
+  it('Should remove all non-retained headers on 304 without skipping any', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    app.get('/etag/multi-headers', (c) => {
+      c.header('X-Custom-1', 'val1')
+      c.header('X-Custom-2', 'val2')
+      c.header('X-Custom-3', 'val3')
+      c.header('X-Custom-4', 'val4')
+      c.header('Cache-Control', 'max-age=3600')
+      return c.text('Hono is hot')
+    })
+    const res1 = await app.request('http://localhost/etag/multi-headers')
+    const etagHeader = res1.headers.get('ETag')!
+    expect(res1.status).toBe(200)
+
+    const res2 = await app.request('http://localhost/etag/multi-headers', {
+      headers: {
+        'If-None-Match': etagHeader,
+      },
+    })
+    expect(res2.status).toBe(304)
+    expect(res2.headers.get('ETag')).toBe(etagHeader)
+    expect(res2.headers.get('Cache-Control')).toBe('max-age=3600')
+    expect(res2.headers.get('X-Custom-1')).toBeNull()
+    expect(res2.headers.get('X-Custom-2')).toBeNull()
+    expect(res2.headers.get('X-Custom-3')).toBeNull()
+    expect(res2.headers.get('X-Custom-4')).toBeNull()
+  })
 })

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -121,11 +121,15 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
           ETag: etag,
         },
       })
+      const headersToDelete: string[] = []
       c.res.headers.forEach((_, key) => {
         if (retainedHeaders.indexOf(key.toLowerCase()) === -1) {
-          c.res.headers.delete(key)
+          headersToDelete.push(key)
         }
       })
+      for (let i = 0; i < headersToDelete.length; i++) {
+        c.res.headers.delete(headersToDelete[i])
+      }
     } else {
       c.res.headers.set('ETag', etag)
     }

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -121,14 +121,10 @@ export const etag = (options?: ETagOptions): MiddlewareHandler => {
           ETag: etag,
         },
       })
-      const headersToDelete: string[] = []
-      c.res.headers.forEach((_, key) => {
+      for (const key of Array.from(c.res.headers.keys())) {
         if (retainedHeaders.indexOf(key.toLowerCase()) === -1) {
-          headersToDelete.push(key)
+          c.res.headers.delete(key)
         }
-      })
-      for (let i = 0; i < headersToDelete.length; i++) {
-        c.res.headers.delete(headersToDelete[i])
       }
     } else {
       c.res.headers.set('ETag', etag)


### PR DESCRIPTION
 Fixes an issue in the `etag` middleware where non-retained headers could be skipped during 304 response filtering due to mutating the `Headers` instance during `forEach` iteration.

 ### Problem
In `src/middleware/etag/index.ts`, non-retained headers are deleted inside `c.res.headers.forEach`:

```ts
    c.res.headers.forEach((_, key) => {
      if (retainedHeaders.indexOf(key.toLowerCase()) === -1) {
        c.res.headers.delete(key)
      }
    })
```

Under standard Headers (and Map) iterator semantics, calling .delete() on the underlying collection during .forEach() shifts internal iterator indices, causing the iterator to skip subsequent header entries.

### Solution

Collect the keys to delete in a temporary array first, and then delete them in a separate loop so the collection being iterated is not mutated in-flight.

### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
