### PR TITLE
fix(cors): append Origin to Vary header on OPTIONS preflight

### DIFF
--- a/src/middleware/cors/index.test.ts
+++ b/src/middleware/cors/index.test.ts
@@ -277,6 +277,34 @@ describe('CORS by Middleware', () => {
     expect(res.headers.get('Vary')).toBe('X-Custom-Vary-Value, Origin')
   })
 
+  it('Append "Origin" to Vary header on OPTIONS preflight, if response has some Vary header', async () => {
+    const testApp = new Hono()
+    testApp.use('/api/*', async (c, next) => {
+      c.header('Vary', 'Accept-Encoding', { append: true })
+      await next()
+    })
+    testApp.use(
+      '/api/*',
+      cors({
+        origin: 'http://example.com',
+        allowHeaders: ['X-Custom-Header'],
+      })
+    )
+    testApp.all('/api/test', (c) => c.text('ok'))
+
+    const res = await testApp.request('http://localhost/api/test', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://example.com',
+        'Access-Control-Request-Headers': 'X-Custom-Header',
+      },
+    })
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com')
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding, Origin, Access-Control-Request-Headers')
+  })
+
   it('Allow origins by function', async () => {
     let req = new Request('http://localhost/api4/abc', {
       headers: {

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -117,7 +117,7 @@ export const cors = (options?: CORSOptions): MiddlewareHandler => {
 
     if (c.req.method === 'OPTIONS') {
       if (opts.origin !== '*') {
-        set('Vary', 'Origin')
+        c.res.headers.append('Vary', 'Origin')
       }
 
       if (opts.maxAge != null) {


### PR DESCRIPTION
Ensures that `Vary: Origin` is appended rather than set on `OPTIONS` preflight requests, preserving any preexisting `Vary` headers (such as `Accept-Encoding`) set by upstream middleware.

### Problem

In `src/middleware/cors/index.ts`, the `OPTIONS` preflight handler called `set('Vary', 'Origin')`, which executes `c.res.headers.set('Vary', 'Origin')`. This inadvertently overwrites any preexisting `Vary` header values set by earlier middleware (e.g. `Vary: Accept-Encoding`).

In contrast, lines 144 (`c.res.headers.append('Vary', 'Access-Control-Request-Headers')`) and 161 (`c.header('Vary', 'Origin', { append: true })`) already use `.append()` to preserve existing directives.

### Solution

Use `c.res.headers.append('Vary', 'Origin')` in the `OPTIONS` handler to align with lines 144 and 161, ensuring all `Vary` directives are retained.

### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
