### PR TITLE
fix(trie-router): match suffix wildcard routes

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -473,6 +473,20 @@ describe('Routing', () => {
     expect(await res.text()).toBe('get /add-path-after-route-call')
   })
 
+  it('Should match a suffix wildcard after falling back to TrieRouter', async () => {
+    const app = new Hono()
+    const sub = new Hono()
+    sub.post('/items', (c) => c.text('items'))
+    sub.post('/:slug', (c) => c.text('slug'))
+    app.route('/api', sub)
+    app.get('/assets*', (c) => c.text('asset'))
+
+    const res = await app.request('http://localhost/assets/app.js')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('asset')
+    expect(app.router.name).toBe('SmartRouter + TrieRouter')
+  })
+
   it('Nested route - subApp with basePath', async () => {
     const app = new Hono()
     const book = new Hono().basePath('/book')

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -55,6 +55,13 @@ describe('Get with a suffix wildcard', () => {
     expect(node.search('get', '/file.+js')[0]).toEqual([['file', {}]])
     expect(node.search('get', '/fileZZjs')[0]).toEqual([])
   })
+
+  it('registers the pattern when its child already exists', () => {
+    const node = new Node()
+    node.insert('get', '/assets*/x', 'literal')
+    node.insert('get', '/assets*', 'assets')
+    expect(node.search('get', '/assets/app.js')[0]).toEqual([['assets', {}]])
+  })
 })
 
 describe('Basic Usage', () => {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -867,13 +867,3 @@ describe('Pattern spanning multiple parts', () => {
     })
   })
 })
-
-describe('Node with initial method and handler', () => {
-  it('should create a node with method and handler via constructor', () => {
-    const node = new Node('get', 'initial handler')
-    node.insert('get', '/hello', 'hello handler')
-    const [res] = node.search('get', '/hello')
-    expect(res.length).toBe(1)
-    expect(res[0][0]).toEqual('hello handler')
-  })
-})

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -37,6 +37,26 @@ describe('Get with * including JS reserved words', () => {
   })
 })
 
+describe('Get with a suffix wildcard', () => {
+  const node = new Node()
+  node.insert('get', '/assets*', 'assets')
+
+  it.each(['/assets', '/assets-v2', '/assets/app.js'])('matches %s', (path) => {
+    expect(node.search('get', path)[0]).toEqual([['assets', {}]])
+  })
+
+  it('does not match a shorter prefix', () => {
+    expect(node.search('get', '/asset')[0]).toEqual([])
+  })
+
+  it('treats regular expression characters in the prefix literally', () => {
+    const node = new Node()
+    node.insert('get', '/file.+*', 'file')
+    expect(node.search('get', '/file.+js')[0]).toEqual([['file', {}]])
+    expect(node.search('get', '/fileZZjs')[0]).toEqual([])
+  })
+})
+
 describe('Basic Usage', () => {
   const node = new Node()
   node.insert('get', '/hello', 'get hello')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -14,36 +14,16 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
 }
 
 const emptyParams = Object.create(null)
-
-const hasChildren = (children: Record<string, unknown>): boolean => {
-  for (const _ in children) {
-    return true
-  }
-  return false
-}
+let order = 0
 
 export class Node<T> {
-  #methods: Record<string, HandlerSet<T>>[]
+  #methods: Record<string, HandlerSet<T>>[] = []
 
-  #children: Record<string, Node<T>>
-  #patterns: (Pattern | string)[]
-  #order: number = 0
+  #children: Record<string, Node<T>> = Object.create(null)
+  #patterns: (Pattern | string)[] = []
   #params: Record<string, string> = emptyParams
 
-  constructor(method?: string, handler?: T, children?: Record<string, Node<T>>) {
-    this.#children = children || Object.create(null)
-    this.#methods = []
-    if (method && handler) {
-      const m: Record<string, HandlerSet<T>> = Object.create(null)
-      m[method] = { handler, possibleKeys: [], score: 0 }
-      this.#methods = [m]
-    }
-    this.#patterns = []
-  }
-
-  insert(method: string, path: string, handler: T): Node<T> {
-    this.#order = ++this.#order
-
+  insert(method: string, path: string, handler: T): void {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let curNode: Node<T> = this
     const parts = splitRoutingPath(path)
@@ -84,11 +64,9 @@ export class Node<T> {
       [method]: {
         handler,
         possibleKeys: possibleKeys.filter((v, i, a) => a.indexOf(v) === i),
-        score: this.#order,
+        score: ++order,
       },
     })
-
-    return curNode
   }
 
   #pushHandlerSets(
@@ -101,18 +79,13 @@ export class Node<T> {
     for (let i = 0, len = node.#methods.length; i < len; i++) {
       const m = node.#methods[i]
       const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T>
-      const processedSet: Record<number, boolean> = {}
-      if (handlerSet !== undefined) {
+      if (handlerSet) {
         handlerSet.params = Object.create(null)
         handlerSets.push(handlerSet)
-        if (nodeParams !== emptyParams || (params && params !== emptyParams)) {
-          for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
-            const key = handlerSet.possibleKeys[i]
-            const processed = processedSet[handlerSet.score]
-            handlerSet.params[key] =
-              params?.[key] && !processed ? params[key] : (nodeParams[key] ?? params?.[key])
-            processedSet[handlerSet.score] = true
-          }
+        for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
+          const key = handlerSet.possibleKeys[i]
+          handlerSet.params[key] =
+            params?.[key] && !i ? params[key] : (nodeParams[key] ?? params?.[key])
         }
       }
     }
@@ -173,23 +146,23 @@ export class Node<T> {
 
           const [key, name, matcher] = pattern
 
-          if (!part && !(matcher instanceof RegExp)) {
+          if (!part && matcher === true) {
             continue
           }
 
           const child = node.#children[key]
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
-          if (matcher instanceof RegExp) {
-            if (partOffsets === null) {
-              partOffsets = new Array(len)
+          if (matcher !== true) {
+            if (!partOffsets) {
+              partOffsets = []
               let offset = path[0] === '/' ? 1 : 0
               for (let p = 0; p < len; p++) {
                 partOffsets[p] = offset
                 offset += parts[p].length + 1
               }
             }
-            const restPathString = path.substring(partOffsets[i])
+            const restPathString = path.slice(partOffsets[i])
 
             const m = matcher.exec(restPathString)
             if (m) {
@@ -207,11 +180,12 @@ export class Node<T> {
                 )
               }
 
-              if (hasChildren(child.#children)) {
+              for (const _ in child.#children) {
                 child.#params = params
                 const componentCount = m[0].match(/\//g)?.length ?? 0
                 const targetCurNodes = (curNodesQueue[componentCount] ||= [])
                 targetCurNodes.push(child)
+                break
               }
 
               continue
@@ -243,7 +217,7 @@ export class Node<T> {
       curNodes = shifted ? tempNodes.concat(shifted) : tempNodes
     }
 
-    if (handlerSets.length > 1) {
+    if (handlerSets[1]) {
       handlerSets.sort((a, b) => {
         return a.score - b.score
       })

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -59,6 +59,9 @@ export class Node<T> {
       const key = Array.isArray(pattern) ? pattern[0] : pattern || p
 
       if (key in curNode.#children) {
+        if (typeof pattern === 'string' && !curNode.#patterns.includes(pattern)) {
+          curNode.#patterns.push(pattern)
+        }
         curNode = curNode.#children[key]
         if (Array.isArray(pattern)) {
           possibleKeys.push(pattern[1])

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -20,7 +20,8 @@ export class Node<T> {
   #methods: Record<string, HandlerSet<T>>[] = []
 
   #children: Record<string, Node<T>> = Object.create(null)
-  #patterns: (Pattern | string)[] = []
+  #patterns: Node<T>[] = []
+  #pattern?: Pattern | string
   #params: Record<string, string> = emptyParams
 
   insert(method: string, path: string, handler: T): void {
@@ -28,42 +29,32 @@ export class Node<T> {
     let curNode: Node<T> = this
     const parts = splitRoutingPath(path)
 
-    const possibleKeys: string[] = []
+    const possibleKeys = new Set<string>()
 
-    for (let i = 0, len = parts.length; i < len; i++) {
-      const p: string = parts[i]
-      const nextP = parts[i + 1]
+    let i = 0
+    for (const p of parts) {
+      const nextP = parts[++i]
       const pattern =
         getPattern(p, nextP) ||
-        (i === len - 1 && p.length > 1 && p.indexOf('*') === p.length - 1 ? p : null)
-      const key = Array.isArray(pattern) ? pattern[0] : pattern || p
+        (nextP === undefined && p && p.indexOf('*') === p.length - 1 ? p : null)
+      const isParam = Array.isArray(pattern)
+      const key = isParam ? pattern[0] : pattern || p
 
-      if (key in curNode.#children) {
-        if (typeof pattern === 'string' && !curNode.#patterns.includes(pattern)) {
-          curNode.#patterns.push(pattern)
-        }
-        curNode = curNode.#children[key]
-        if (Array.isArray(pattern)) {
-          possibleKeys.push(pattern[1])
-        }
-        continue
+      const child = (curNode.#children[key] ||= new Node())
+      if (pattern && !child.#pattern) {
+        child.#pattern = pattern
+        curNode.#patterns.push(child)
       }
-
-      curNode.#children[key] = new Node()
-
-      if (pattern) {
-        curNode.#patterns.push(pattern)
-        if (Array.isArray(pattern)) {
-          possibleKeys.push(pattern[1])
-        }
+      curNode = child
+      if (isParam) {
+        possibleKeys.add(pattern[1])
       }
-      curNode = curNode.#children[key]
     }
 
     curNode.#methods.push({
       [method]: {
         handler,
-        possibleKeys: possibleKeys.filter((v, i, a) => a.indexOf(v) === i),
+        possibleKeys: [...possibleKeys],
         score: ++order,
       },
     })
@@ -126,14 +117,13 @@ export class Node<T> {
           }
         }
 
-        for (let k = 0, len3 = node.#patterns.length; k < len3; k++) {
-          const pattern = node.#patterns[k]
+        for (const child of node.#patterns) {
+          const pattern = child.#pattern!
           const params = node.#params === emptyParams ? {} : { ...node.#params }
 
           // Wildcard
           // '/hello/*/foo' => match /hello/bar/foo
           if (typeof pattern === 'string') {
-            const child = node.#children[pattern]
             if (pattern === '*' || part.startsWith(pattern.slice(0, -1))) {
               this.#pushHandlerSets(handlerSets, child, method, node.#params)
               if (pattern === '*') {
@@ -144,13 +134,11 @@ export class Node<T> {
             continue
           }
 
-          const [key, name, matcher] = pattern
+          const [, name, matcher] = pattern
 
           if (!part && matcher === true) {
             continue
           }
-
-          const child = node.#children[key]
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
           if (matcher !== true) {

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -26,7 +26,7 @@ export class Node<T> {
   #methods: Record<string, HandlerSet<T>>[]
 
   #children: Record<string, Node<T>>
-  #patterns: Pattern[]
+  #patterns: (Pattern | string)[]
   #order: number = 0
   #params: Record<string, string> = emptyParams
 
@@ -53,12 +53,14 @@ export class Node<T> {
     for (let i = 0, len = parts.length; i < len; i++) {
       const p: string = parts[i]
       const nextP = parts[i + 1]
-      const pattern = getPattern(p, nextP)
-      const key = Array.isArray(pattern) ? pattern[0] : p
+      const pattern =
+        getPattern(p, nextP) ||
+        (i === len - 1 && p.length > 1 && p.indexOf('*') === p.length - 1 ? p : null)
+      const key = Array.isArray(pattern) ? pattern[0] : pattern || p
 
       if (key in curNode.#children) {
         curNode = curNode.#children[key]
-        if (pattern) {
+        if (Array.isArray(pattern)) {
           possibleKeys.push(pattern[1])
         }
         continue
@@ -68,7 +70,9 @@ export class Node<T> {
 
       if (pattern) {
         curNode.#patterns.push(pattern)
-        possibleKeys.push(pattern[1])
+        if (Array.isArray(pattern)) {
+          possibleKeys.push(pattern[1])
+        }
       }
       curNode = curNode.#children[key]
     }
@@ -152,12 +156,14 @@ export class Node<T> {
 
           // Wildcard
           // '/hello/*/foo' => match /hello/bar/foo
-          if (pattern === '*') {
-            const astNode = node.#children['*']
-            if (astNode) {
-              this.#pushHandlerSets(handlerSets, astNode, method, node.#params)
-              astNode.#params = params
-              tempNodes.push(astNode)
+          if (typeof pattern === 'string') {
+            const child = node.#children[pattern]
+            if (pattern === '*' || part.startsWith(pattern.slice(0, -1))) {
+              this.#pushHandlerSets(handlerSets, child, method, node.#params)
+              if (pattern === '*') {
+                child.#params = params
+                tempNodes.push(child)
+              }
             }
             continue
           }

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -4,11 +4,7 @@ import { Node } from './node'
 
 export class TrieRouter<T> implements Router<T> {
   name: string = 'TrieRouter'
-  #node: Node<T>
-
-  constructor() {
-    this.#node = new Node()
-  }
+  #node: Node<T> = new Node()
 
   add(method: string, path: string, handler: T) {
     const results = checkOptionalParameter(path)

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -7,15 +7,9 @@ export class TrieRouter<T> implements Router<T> {
   #node: Node<T> = new Node()
 
   add(method: string, path: string, handler: T) {
-    const results = checkOptionalParameter(path)
-    if (results) {
-      for (let i = 0, len = results.length; i < len; i++) {
-        this.#node.insert(method, results[i], handler)
-      }
-      return
+    for (const result of checkOptionalParameter(path) || [path]) {
+      this.#node.insert(method, result, handler)
     }
-
-    this.#node.insert(method, path, handler)
   }
 
   match(method: string, path: string): Result<T> {


### PR DESCRIPTION
Fixes #5219

This PR makes TrieRouter recognize a terminal segment ending in `*` as a suffix wildcard. The prefix is matched literally, so regular expression characters have no special meaning.

There are already two PRs addressing this issue (#5220 and #5230), but they either have a larger implementation footprint or do not cover all relevant cases. This approach is more compact and keeps the fix narrowly scoped to TrieRouter.

It slightly increases the bundle size, but planned follow-up PRs should more than offset that increase.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
