### PR TITLE
refactor: Reduce TrieRouter bundle size without a meaningful performance regression

### DIFF
--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -55,6 +55,13 @@ describe('Get with a suffix wildcard', () => {
     expect(node.search('get', '/file.+js')[0]).toEqual([['file', {}]])
     expect(node.search('get', '/fileZZjs')[0]).toEqual([])
   })
+
+  it('registers the pattern when its child already exists', () => {
+    const node = new Node()
+    node.insert('get', '/assets*/x', 'literal')
+    node.insert('get', '/assets*', 'assets')
+    expect(node.search('get', '/assets/app.js')[0]).toEqual([['assets', {}]])
+  })
 })
 
 describe('Basic Usage', () => {

--- a/src/router/trie-router/node.test.ts
+++ b/src/router/trie-router/node.test.ts
@@ -867,13 +867,3 @@ describe('Pattern spanning multiple parts', () => {
     })
   })
 })
-
-describe('Node with initial method and handler', () => {
-  it('should create a node with method and handler via constructor', () => {
-    const node = new Node('get', 'initial handler')
-    node.insert('get', '/hello', 'hello handler')
-    const [res] = node.search('get', '/hello')
-    expect(res.length).toBe(1)
-    expect(res[0][0]).toEqual('hello handler')
-  })
-})

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -14,36 +14,16 @@ type HandlerParamsSet<T> = HandlerSet<T> & {
 }
 
 const emptyParams = Object.create(null)
-
-const hasChildren = (children: Record<string, unknown>): boolean => {
-  for (const _ in children) {
-    return true
-  }
-  return false
-}
+let order = 0
 
 export class Node<T> {
-  #methods: Record<string, HandlerSet<T>>[]
+  #methods: Record<string, HandlerSet<T>>[] = []
 
-  #children: Record<string, Node<T>>
-  #patterns: (Pattern | string)[]
-  #order: number = 0
+  #children: Record<string, Node<T>> = Object.create(null)
+  #patterns: (Pattern | string)[] = []
   #params: Record<string, string> = emptyParams
 
-  constructor(method?: string, handler?: T, children?: Record<string, Node<T>>) {
-    this.#children = children || Object.create(null)
-    this.#methods = []
-    if (method && handler) {
-      const m: Record<string, HandlerSet<T>> = Object.create(null)
-      m[method] = { handler, possibleKeys: [], score: 0 }
-      this.#methods = [m]
-    }
-    this.#patterns = []
-  }
-
-  insert(method: string, path: string, handler: T): Node<T> {
-    this.#order = ++this.#order
-
+  insert(method: string, path: string, handler: T): void {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let curNode: Node<T> = this
     const parts = splitRoutingPath(path)
@@ -84,11 +64,9 @@ export class Node<T> {
       [method]: {
         handler,
         possibleKeys: possibleKeys.filter((v, i, a) => a.indexOf(v) === i),
-        score: this.#order,
+        score: ++order,
       },
     })
-
-    return curNode
   }
 
   #pushHandlerSets(
@@ -101,18 +79,13 @@ export class Node<T> {
     for (let i = 0, len = node.#methods.length; i < len; i++) {
       const m = node.#methods[i]
       const handlerSet = (m[method] || m[METHOD_NAME_ALL]) as HandlerParamsSet<T>
-      const processedSet: Record<number, boolean> = {}
-      if (handlerSet !== undefined) {
+      if (handlerSet) {
         handlerSet.params = Object.create(null)
         handlerSets.push(handlerSet)
-        if (nodeParams !== emptyParams || (params && params !== emptyParams)) {
-          for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
-            const key = handlerSet.possibleKeys[i]
-            const processed = processedSet[handlerSet.score]
-            handlerSet.params[key] =
-              params?.[key] && !processed ? params[key] : (nodeParams[key] ?? params?.[key])
-            processedSet[handlerSet.score] = true
-          }
+        for (let i = 0, len = handlerSet.possibleKeys.length; i < len; i++) {
+          const key = handlerSet.possibleKeys[i]
+          handlerSet.params[key] =
+            params?.[key] && !i ? params[key] : (nodeParams[key] ?? params?.[key])
         }
       }
     }
@@ -173,23 +146,23 @@ export class Node<T> {
 
           const [key, name, matcher] = pattern
 
-          if (!part && !(matcher instanceof RegExp)) {
+          if (!part && matcher === true) {
             continue
           }
 
           const child = node.#children[key]
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
-          if (matcher instanceof RegExp) {
-            if (partOffsets === null) {
-              partOffsets = new Array(len)
+          if (matcher !== true) {
+            if (!partOffsets) {
+              partOffsets = []
               let offset = path[0] === '/' ? 1 : 0
               for (let p = 0; p < len; p++) {
                 partOffsets[p] = offset
                 offset += parts[p].length + 1
               }
             }
-            const restPathString = path.substring(partOffsets[i])
+            const restPathString = path.slice(partOffsets[i])
 
             const m = matcher.exec(restPathString)
             if (m) {
@@ -207,11 +180,12 @@ export class Node<T> {
                 )
               }
 
-              if (hasChildren(child.#children)) {
+              for (const _ in child.#children) {
                 child.#params = params
                 const componentCount = m[0].match(/\//g)?.length ?? 0
                 const targetCurNodes = (curNodesQueue[componentCount] ||= [])
                 targetCurNodes.push(child)
+                break
               }
 
               continue
@@ -243,7 +217,7 @@ export class Node<T> {
       curNodes = shifted ? tempNodes.concat(shifted) : tempNodes
     }
 
-    if (handlerSets.length > 1) {
+    if (handlerSets[1]) {
       handlerSets.sort((a, b) => {
         return a.score - b.score
       })

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -59,6 +59,9 @@ export class Node<T> {
       const key = Array.isArray(pattern) ? pattern[0] : pattern || p
 
       if (key in curNode.#children) {
+        if (typeof pattern === 'string' && !curNode.#patterns.includes(pattern)) {
+          curNode.#patterns.push(pattern)
+        }
         curNode = curNode.#children[key]
         if (Array.isArray(pattern)) {
           possibleKeys.push(pattern[1])

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -20,7 +20,8 @@ export class Node<T> {
   #methods: Record<string, HandlerSet<T>>[] = []
 
   #children: Record<string, Node<T>> = Object.create(null)
-  #patterns: (Pattern | string)[] = []
+  #patterns: Node<T>[] = []
+  #pattern?: Pattern | string
   #params: Record<string, string> = emptyParams
 
   insert(method: string, path: string, handler: T): void {
@@ -28,42 +29,32 @@ export class Node<T> {
     let curNode: Node<T> = this
     const parts = splitRoutingPath(path)
 
-    const possibleKeys: string[] = []
+    const possibleKeys = new Set<string>()
 
-    for (let i = 0, len = parts.length; i < len; i++) {
-      const p: string = parts[i]
-      const nextP = parts[i + 1]
+    let i = 0
+    for (const p of parts) {
+      const nextP = parts[++i]
       const pattern =
         getPattern(p, nextP) ||
-        (i === len - 1 && p.length > 1 && p.indexOf('*') === p.length - 1 ? p : null)
-      const key = Array.isArray(pattern) ? pattern[0] : pattern || p
+        (nextP === undefined && p && p.indexOf('*') === p.length - 1 ? p : null)
+      const isParam = Array.isArray(pattern)
+      const key = isParam ? pattern[0] : pattern || p
 
-      if (key in curNode.#children) {
-        if (typeof pattern === 'string' && !curNode.#patterns.includes(pattern)) {
-          curNode.#patterns.push(pattern)
-        }
-        curNode = curNode.#children[key]
-        if (Array.isArray(pattern)) {
-          possibleKeys.push(pattern[1])
-        }
-        continue
+      const child = (curNode.#children[key] ||= new Node())
+      if (pattern && !child.#pattern) {
+        child.#pattern = pattern
+        curNode.#patterns.push(child)
       }
-
-      curNode.#children[key] = new Node()
-
-      if (pattern) {
-        curNode.#patterns.push(pattern)
-        if (Array.isArray(pattern)) {
-          possibleKeys.push(pattern[1])
-        }
+      curNode = child
+      if (isParam) {
+        possibleKeys.add(pattern[1])
       }
-      curNode = curNode.#children[key]
     }
 
     curNode.#methods.push({
       [method]: {
         handler,
-        possibleKeys: possibleKeys.filter((v, i, a) => a.indexOf(v) === i),
+        possibleKeys: [...possibleKeys],
         score: ++order,
       },
     })
@@ -126,14 +117,13 @@ export class Node<T> {
           }
         }
 
-        for (let k = 0, len3 = node.#patterns.length; k < len3; k++) {
-          const pattern = node.#patterns[k]
+        for (const child of node.#patterns) {
+          const pattern = child.#pattern!
           const params = node.#params === emptyParams ? {} : { ...node.#params }
 
           // Wildcard
           // '/hello/*/foo' => match /hello/bar/foo
           if (typeof pattern === 'string') {
-            const child = node.#children[pattern]
             if (pattern === '*' || part.startsWith(pattern.slice(0, -1))) {
               this.#pushHandlerSets(handlerSets, child, method, node.#params)
               if (pattern === '*') {
@@ -144,13 +134,11 @@ export class Node<T> {
             continue
           }
 
-          const [key, name, matcher] = pattern
+          const [, name, matcher] = pattern
 
           if (!part && matcher === true) {
             continue
           }
-
-          const child = node.#children[key]
 
           // `/js/:filename{[a-z]+.js}` => match /js/chunk/123.js
           if (matcher !== true) {

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -4,11 +4,7 @@ import { Node } from './node'
 
 export class TrieRouter<T> implements Router<T> {
   name: string = 'TrieRouter'
-  #node: Node<T>
-
-  constructor() {
-    this.#node = new Node()
-  }
+  #node: Node<T> = new Node()
 
   add(method: string, path: string, handler: T) {
     const results = checkOptionalParameter(path)

--- a/src/router/trie-router/router.ts
+++ b/src/router/trie-router/router.ts
@@ -7,15 +7,9 @@ export class TrieRouter<T> implements Router<T> {
   #node: Node<T> = new Node()
 
   add(method: string, path: string, handler: T) {
-    const results = checkOptionalParameter(path)
-    if (results) {
-      for (let i = 0, len = results.length; i < len; i++) {
-        this.#node.insert(method, results[i], handler)
-      }
-      return
+    for (const result of checkOptionalParameter(path) || [path]) {
+      this.#node.insert(method, result, handler)
     }
-
-    this.#node.insert(method, path, handler)
   }
 
   match(method: string, path: string): Result<T> {


### PR DESCRIPTION
This is a follow-up to the suffix wildcard fix (#5236).

This PR reduces TrieRouter's minified bundle size without a meaningful performance regression. It removes unused initialization paths and simplifies internal matching bookkeeping.

It also fixes an insertion-order edge case: when `/assets*/x` is registered before `/assets*`, the suffix wildcard pattern still needs to be registered on the existing child node.

| TrieRouter bundle | Before | After | Difference |
| --- | ---: | ---: | ---: |
| Minified | 3,340 B | 3,064 B | -276 B |
| Minified + gzip | 1,658 B | 1,533 B | -125 B |

Benchmarks showed no meaningful performance regression.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
