### PR TITLE
fix(etag): copy pending stream bytes

### DIFF
--- a/src/middleware/etag/digest.test.ts
+++ b/src/middleware/etag/digest.test.ts
@@ -1,0 +1,21 @@
+import { generateDigest } from './digest'
+
+describe('generateDigest', () => {
+  it('Should copy pending bytes from a stream that reuses its buffer', async () => {
+    const scratch = new Uint8Array(4)
+    let pullCount = 0
+    const stream = new ReadableStream({
+      pull(controller) {
+        scratch.fill(pullCount === 0 ? 0x41 : 0x42)
+        controller.enqueue(scratch)
+        if (++pullCount === 2) {
+          controller.close()
+        }
+      },
+    })
+
+    const digest = await generateDigest(stream, (body) => crypto.subtle.digest('SHA-1', body))
+
+    expect(digest).toBe('7cd188ef3a9ea7fa0ee9c62c168709695460f5c0')
+  })
+})

--- a/src/middleware/etag/digest.ts
+++ b/src/middleware/etag/digest.ts
@@ -51,7 +51,7 @@ export const generateDigest = async (
       const requiredLength = chunkLength + remaining
       if (requiredLength < CHUNK_SIZE) {
         if (!chunk) {
-          chunk = value.subarray(offset)
+          chunk = value.slice(offset)
         } else {
           if (chunk.byteLength < requiredLength) {
             const nextChunk = new Uint8Array<ArrayBuffer>(

--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -1,6 +1,14 @@
 import { Hono } from '../../hono'
 import { RETAINED_304_HEADERS, etag } from '.'
 
+const createPatternedBody = (length: number) => {
+  const body = new Uint8Array(length)
+  for (let i = 0; i < body.byteLength; i++) {
+    body[i] = i % 256
+  }
+  return body
+}
+
 describe('Etag Middleware', () => {
   it('Should return etag header', async () => {
     const app = new Hono()
@@ -133,11 +141,12 @@ describe('Etag Middleware', () => {
   it('Should return the same etag regardless of ReadableStream chunk boundaries', async () => {
     const app = new Hono()
     app.use('/etag/*', etag())
+    const body = createPatternedBody(1_000_000)
     app.get('/etag/rs1', (c) => {
       return c.body(
         new ReadableStream({
           start(controller) {
-            controller.enqueue(new Uint8Array(1_000_000))
+            controller.enqueue(body)
             controller.close()
           },
         })
@@ -147,9 +156,9 @@ describe('Etag Middleware', () => {
       return c.body(
         new ReadableStream({
           start(controller) {
-            controller.enqueue(new Uint8Array(1))
-            controller.enqueue(new Uint8Array(32_768))
-            controller.enqueue(new Uint8Array(967_231))
+            controller.enqueue(body.slice(0, 1))
+            controller.enqueue(body.slice(1, 32_769))
+            controller.enqueue(body.slice(32_769))
             controller.close()
           },
         })
@@ -158,7 +167,18 @@ describe('Etag Middleware', () => {
 
     const res1 = await app.request('http://localhost/etag/rs1')
     const res2 = await app.request('http://localhost/etag/rs2')
-    expect(res2.headers.get('ETag')).toBe(res1.headers.get('ETag'))
+    const expected = '"550563e0460b33a3540278a8446a70bb96eb5172"'
+    expect(res1.headers.get('ETag')).toBe(expected)
+    expect(res2.headers.get('ETag')).toBe(expected)
+  })
+
+  it('Should preserve the SHA-1 digest for bodies up to 256 KiB', async () => {
+    const app = new Hono()
+    app.use('/etag/*', etag())
+    app.get('/etag', (c) => c.body(createPatternedBody(256 * 1024)))
+
+    const res = await app.request('http://localhost/etag')
+    expect(res.headers.get('ETag')).toBe('"37ef77696fc255bf53b4cdd014b223676f2dc8bb"')
   })
 
   it('Should not return etag header when the stream is empty', async () => {


### PR DESCRIPTION
Fix ETag digest corruption when a `ReadableStream` producer reuses its backing buffer.

`generateDigest()` retained a `subarray()` across `reader.read()` calls. Because `subarray()` shares the producer-owned backing buffer, a subsequent pull could overwrite bytes that had not yet been digested. For example, a stream producing `[A, B]` with one reusable buffer could be hashed as `[B, B]`.

This regression was introduced in https://github.com/honojs/hono/pull/5205.

Pending bytes are now copied with `slice()` before the next read. This adds a small, bounded overhead—at most one additional allocation and a copy of less than 256 KiB per stream—but its impact should be negligible in practice. Regression coverage also verifies reusable buffers, patterned bodies across different chunk boundaries, and regular SHA-1 digests for bodies up to 256 KiB.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code