### PR TITLE
fix(method-not-allowed): ignore trailing wildcard routes when inferring Allow

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -277,6 +277,64 @@ describe('Method Not Allowed Middleware', () => {
     })
   })
 
+  it('ignores trailing wildcard routes (path ending with *) when inferring allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('api'))
+    app.get('/*', (c) => c.text('fallback'))
+
+    // GET /api should be 200
+    const getRes = await app.request('/api')
+    expect(getRes.status).toBe(200)
+
+    // POST /api should be 405 (concrete route)
+    const postRes = await app.request('/api', { method: 'POST' })
+    expect(postRes.status).toBe(405)
+    expect(postRes.headers.get('Allow')).toBe('GET, HEAD')
+
+    // POST /missing should stay 404 (wildcard should not convert it to 405)
+    const postMissingRes = await app.request('/missing', { method: 'POST' })
+    expect(postMissingRes.status).toBe(404)
+    expect(postMissingRes.headers.has('Allow')).toBe(false)
+  })
+
+  it('ignores suffix wildcard routes (e.g. /assets*) when inferring allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('api'))
+    app.get('/assets*', (c) => c.text('static'))
+
+    // GET /assets/app.js should be 200 (wildcard serves it)
+    const getRes = await app.request('/assets/app.js')
+    expect(getRes.status).toBe(200)
+
+    // POST /api should be 405 (concrete route)
+    const postRes = await app.request('/api', { method: 'POST' })
+    expect(postRes.status).toBe(405)
+
+    // POST /assets/app.js should stay 404 (suffix wildcard should not convert it to 405)
+    const postAssetsRes = await app.request('/assets/app.js', { method: 'POST' })
+    expect(postAssetsRes.status).toBe(404)
+    expect(postAssetsRes.headers.has('Allow')).toBe(false)
+  })
+
+  it('still returns 405 for concrete routes alongside ignored wildcards', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.post('/resource', (c) => c.text('POST'))
+    app.get('/files/*', (c) => c.text('file'))
+
+    // DELETE /resource should be 405 (concrete routes)
+    const deleteRes = await app.request('/resource', { method: 'DELETE' })
+    expect(deleteRes.status).toBe(405)
+    expect(deleteRes.headers.get('Allow')).toBe('GET, HEAD, POST')
+
+    // DELETE /files/readme should stay 404 (trailing wildcard ignored)
+    const deleteFilesRes = await app.request('/files/readme', { method: 'DELETE' })
+    expect(deleteFilesRes.status).toBe(404)
+  })
+
   it('leaves a non-404 custom not-found response unchanged', async () => {
     const app = new Hono()
     app.use(methodNotAllowed({ app }))

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -83,6 +83,14 @@ export const methodNotAllowed = <E extends Env = Env>(
           continue
         }
 
+        // Trailing-wildcard routes (e.g. `GET /assets*` or `GET /*`) match an
+        // arbitrary remainder of the path, so they do not prove that a particular
+        // target resource exists.  Including them in the Allow map would convert
+        // every otherwise-unhandled request in that namespace from 404 to 405.
+        if (route.path.endsWith('*')) {
+          continue
+        }
+
         const methods = methodsByPath.get(route.path) ?? new Set<string>()
         methods.add(route.method)
 


### PR DESCRIPTION
## Problem

Fixes #5223

When `methodNotAllowed` collects allowed methods from registered routes, it treats trailing-wildcard routes (e.g. `GET /*` or `GET /assets*`) as evidence that **every** path exists. This converts otherwise-unhandled requests in that namespace from 404 to 405.

For example, with:
```ts
app.use(methodNotAllowed({ app }))
app.get('/api', (c) => c.text('api'))
app.get('/*', serveStatic())
```

A `POST /missing` request incorrectly returns **405** instead of **404**, because the `/*` wildcard contributes `GET` to the Allow map for every path.

## Root cause

The `methodNotAllowed` middleware builds a `methodsByPath` map from all registered routes without filtering out trailing-wildcard paths. A trailing wildcard matches an arbitrary path suffix — it does not prove that a particular target resource exists.

## Fix

Skip routes whose path ends with `*` when building the Allow map.

```diff
+ // Trailing-wildcard routes (e.g. GET /assets* or GET /*) match an
+ // arbitrary remainder of the path, so they do not prove that a particular
+ // target resource exists. Including them in the Allow map would convert
+ // every otherwise-unhandled request in that namespace from 404 to 405.
+ if (route.path.endsWith('*')) {
+   continue
+ }
```

Concrete routes (e.g. `GET /api`) still produce 405 for other methods. GET/HEAD still reach the wildcard handler itself.

This follows the direction discussed in #5223: "routes whose paths end in `*` should be ignored when inferring allowed methods".

## Verification

- `npx vitest --run src/middleware/method-not-allowed/index.test.ts` — **23 passed** (3 new regression tests)
- New tests cover:
  - Slash-star wildcards (`/*`) alongside concrete routes
  - Suffix wildcards (`/assets*`) alongside concrete routes
  - Mixed concrete + wildcard routes in a single app
- `eslint` and `prettier --check` clean