### PR TITLE
fix(router): match suffix wildcard routes when sub-app has static+param siblings

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -42,15 +42,15 @@ export const runTest = ({
         const res = matchRes.map((r) =>
           stash
             ? {
-                handler: r[0],
-                params: Object.keys(r[1]).reduce(
-                  (acc, key) => {
-                    acc[key] = stash[(r[1] as ParamIndexMap)[key]]
-                    return acc
-                  },
-                  Object.create(null) as Params
-                ),
-              }
+			      handler: r[0],
+			      params: Object.keys(r[1]).reduce(
+			        (acc, key) => {
+			          acc[key] = stash[(r[1] as ParamIndexMap)[key]]
+			          return acc
+			        },
+			        Object.create(null) as Params
+			      ),
+			    }
             : { handler: r[0], params: r[1] as Params }
         )
         return res
@@ -584,12 +584,37 @@ export const runTest = ({
       })
 
       it('GET /regex-abc/123/ghi', () => {
-        const res = match('GET', '/regex-abc/123/ghi')
-        expect(res.length).toBe(1)
-        expect(res[0].handler).toEqual('middleware')
-        expect(res[0].params['id']).toBe('123')
-      })
-    })
+			    const res = match('GET', '/regex-abc/123/ghi')
+			    expect(res.length).toBe(1)
+			    expect(res[0].handler).toEqual('middleware')
+			    expect(res[0].params['id']).toBe('123')
+            })
+          })
+
+          describe('Suffix wildcard with sub-app route', () => {
+                  beforeEach(() => {
+                    // https://github.com/honojs/hono/issues/5219
+                    router.add('POST', '/api/:slug', 'slug')
+                    router.add('GET', '/assets*', 'suffix-wildcard')
+                  })
+
+                  it('GET /assets/app.js', () => {
+                    const res = match('GET', '/assets/app.js')
+                    expect(res.length).toBe(1)
+                    expect(res[0].handler).toEqual('suffix-wildcard')
+                  })
+
+                  it('GET /assets', () => {
+                    const res = match('GET', '/assets')
+                    expect(res.length).toBe(1)
+                    expect(res[0].handler).toEqual('suffix-wildcard')
+                  })
+
+                  it('POST /api/:slug still works', () => {
+                    const res2 = match('POST', '/api/anything')
+                    expect(res2.some((r) => r.handler === 'slug')).toBe(true)
+                  })
+                })
 
     describe('Capture complex multiple directories', () => {
       beforeEach(() => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -10,6 +10,14 @@ export const splitPath = (path: string): string[] => {
   if (paths[0] === '') {
     paths.shift()
   }
+  // Split trailing suffix wildcard (e.g. /assets*) into ['assets', '*']
+  // so TrieRouter creates the '*' child node. Without this, 'assets*'
+  // is treated as a literal static key and never matches.
+  const last = paths.length - 1
+  const lastSeg = paths[last]
+  if (last >= 0 && lastSeg.length > 1 && lastSeg.endsWith('*')) {
+    paths.splice(last, 1, lastSeg.slice(0, -1), '*')
+  }
   return paths
 }
 


### PR DESCRIPTION
Fixes #5219

`splitPath` treated `/assets*` as a single literal segment `assets*`, so TrieRouter never created the `*` wildcard child node. The route returned 404 whenever a mounted sub-app registered sibling routes.

Now a trailing `*` is split into its own segment, matching the behavior of `/assets/*`.

Added regression tests covering `GET /assets`, `GET /assets/app.js`, and sibling `POST /api/:slug` matching.