### PR TITLE
feat(bearer-auth): support Response as custom error message

### DIFF
--- a/src/middleware/bearer-auth/index.test.ts
+++ b/src/middleware/bearer-auth/index.test.ts
@@ -197,6 +197,45 @@ describe('Bearer Auth by Middleware', () => {
     })
 
     app.use(
+      '/auth-custom-no-authentication-header-message-response/*',
+      bearerAuth({
+        token,
+        noAuthenticationHeader: {
+          message: () =>
+            new Response('Custom no authentication header message as response', {
+              status: 401,
+              headers: { 'content-type': 'text/plain' },
+            }),
+        },
+      })
+    )
+    app.get('/auth-custom-no-authentication-header-message-response/*', (c) => {
+      handlerExecuted = true
+      return c.text('auth')
+    })
+
+    app.use(
+      '/auth-custom-no-authentication-header-message-response-with-www-authenticate/*',
+      bearerAuth({
+        token,
+        noAuthenticationHeader: {
+          message: () =>
+            new Response('Custom no authentication header message as response', {
+              status: 401,
+              headers: { 'WWW-Authenticate': 'Bearer error="custom"' },
+            }),
+        },
+      })
+    )
+    app.get(
+      '/auth-custom-no-authentication-header-message-response-with-www-authenticate/*',
+      (c) => {
+        handlerExecuted = true
+        return c.text('auth')
+      }
+    )
+
+    app.use(
       '/auth-custom-invalid-authentication-header-wwwAuthenticateHeader-string/*',
       bearerAuth({
         token: tokens,
@@ -326,6 +365,24 @@ describe('Bearer Auth by Middleware', () => {
     })
 
     app.use(
+      '/auth-custom-invalid-authentication-header-message-response/*',
+      bearerAuth({
+        token,
+        invalidAuthenticationHeader: {
+          message: () =>
+            new Response(JSON.stringify({ error: 'invalid_request' }), {
+              status: 400,
+              headers: { 'content-type': 'application/problem+json' },
+            }),
+        },
+      })
+    )
+    app.get('/auth-custom-invalid-authentication-header-message-response/*', (c) => {
+      handlerExecuted = true
+      return c.text('auth')
+    })
+
+    app.use(
       '/auth-custom-invalid-token-wwwAuthenticateHeader-string/*',
       bearerAuth({
         token: tokens,
@@ -436,6 +493,24 @@ describe('Bearer Auth by Middleware', () => {
       })
     )
     app.get('/auth-custom-invalid-token-message-function-object/*', (c) => {
+      handlerExecuted = true
+      return c.text('auth')
+    })
+
+    app.use(
+      '/auth-custom-invalid-token-message-response/*',
+      bearerAuth({
+        token,
+        invalidToken: {
+          message: () =>
+            new Response(JSON.stringify({ error: 'invalid_token' }), {
+              status: 401,
+              headers: { 'content-type': 'application/problem+json' },
+            }),
+        },
+      })
+    )
+    app.get('/auth-custom-invalid-token-message-response/*', (c) => {
       handlerExecuted = true
       return c.text('auth')
     })
@@ -717,6 +792,31 @@ describe('Bearer Auth by Middleware', () => {
     )
   })
 
+  it('Should not authorize - custom no authorization header message as Response', async () => {
+    const req = new Request(
+      'http://localhost/auth-custom-no-authentication-header-message-response'
+    )
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(res.headers.get('Content-Type')).toMatch('text/plain')
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm=""')
+    expect(handlerExecuted).toBeFalsy()
+    expect(await res.text()).toBe('Custom no authentication header message as response')
+  })
+
+  it('Should not authorize - custom no authorization header message as Response with existing WWW-Authenticate header', async () => {
+    const req = new Request(
+      'http://localhost/auth-custom-no-authentication-header-message-response-with-www-authenticate'
+    )
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="custom"')
+    expect(handlerExecuted).toBeFalsy()
+    expect(await res.text()).toBe('Custom no authentication header message as response')
+  })
+
   it('Should not authorize - custom invalid authentication header wwwAuthenticateHeader as string', async () => {
     const req = new Request(
       'http://localhost/auth-custom-invalid-authentication-header-wwwAuthenticateHeader-string'
@@ -923,6 +1023,18 @@ describe('Bearer Auth by Middleware', () => {
     expect(res.headers.get('Content-Type')).toMatch('application/json')
     expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('{"message":"Custom invalid token message as function object"}')
+  })
+
+  it('Should not authorize - custom invalid token message as Response', async () => {
+    const req = new Request('http://localhost/auth-custom-invalid-token-message-response')
+    req.headers.set('Authorization', 'Bearer invalid-token')
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(res.headers.get('Content-Type')).toMatch('application/problem+json')
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer error="invalid_token"')
+    expect(handlerExecuted).toBeFalsy()
+    expect(await res.text()).toBe('{"error":"invalid_token"}')
   })
 })
 

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -14,9 +14,12 @@ const PREFIX = 'Bearer'
 const HEADER = 'Authorization'
 
 type MessageFunction = (c: Context) => string | object | Promise<string | object>
+type ResponseMessageFunction = (
+  c: Context
+) => string | object | Response | Promise<string | object | Response>
 type CustomizedErrorResponseOptions = {
   wwwAuthenticateHeader?: string | object | MessageFunction
-  message?: string | object | MessageFunction
+  message?: string | object | Response | ResponseMessageFunction
 }
 
 type BearerAuthOptions<E extends Env = Env> =
@@ -29,17 +32,17 @@ type BearerAuthOptions<E extends Env = Env> =
       /**
        * @deprecated Use noAuthenticationHeader.message instead
        */
-      noAuthenticationHeaderMessage?: string | object | MessageFunction
+      noAuthenticationHeaderMessage?: string | object | Response | ResponseMessageFunction
       noAuthenticationHeader?: CustomizedErrorResponseOptions
       /**
        * @deprecated Use invalidAuthenticationHeader.message instead
        */
-      invalidAuthenticationHeaderMessage?: string | object | MessageFunction
+      invalidAuthenticationHeaderMessage?: string | object | Response | ResponseMessageFunction
       invalidAuthenticationHeader?: CustomizedErrorResponseOptions
       /**
        * @deprecated Use invalidToken.message instead
        */
-      invalidTokenMessage?: string | object | MessageFunction
+      invalidTokenMessage?: string | object | Response | ResponseMessageFunction
       invalidToken?: CustomizedErrorResponseOptions
     }
   | {
@@ -51,17 +54,17 @@ type BearerAuthOptions<E extends Env = Env> =
       /**
        * @deprecated Use noAuthenticationHeader.message instead
        */
-      noAuthenticationHeaderMessage?: string | object | MessageFunction
+      noAuthenticationHeaderMessage?: string | object | Response | ResponseMessageFunction
       noAuthenticationHeader?: CustomizedErrorResponseOptions
       /**
        * @deprecated Use invalidAuthenticationHeader.message instead
        */
-      invalidAuthenticationHeaderMessage?: string | object | MessageFunction
+      invalidAuthenticationHeaderMessage?: string | object | Response | ResponseMessageFunction
       invalidAuthenticationHeader?: CustomizedErrorResponseOptions
       /**
        * @deprecated Use invalidToken.message instead
        */
-      invalidTokenMessage?: string | object | MessageFunction
+      invalidTokenMessage?: string | object | Response | ResponseMessageFunction
       invalidToken?: CustomizedErrorResponseOptions
     }
 
@@ -78,11 +81,11 @@ type BearerAuthOptions<E extends Env = Env> =
  * @param {string} [options.prefix="Bearer"] - The prefix (or known as `schema`) for the Authorization header value. If set to the empty string, no prefix is expected.
  * @param {string} [options.headerName=Authorization] - The header name.
  * @param {Function} [options.hashFunction] - A function to handle hashing for safe comparison of authentication tokens.
- * @param {string | object | MessageFunction} [options.noAuthenticationHeader.message="Unauthorized"] - The no authentication header message.
+ * @param {string | object | Response | ResponseMessageFunction} [options.noAuthenticationHeader.message] - The no authentication header message. When a `Response` or a function returning a `Response` is provided, it is used as-is (the `WWW-Authenticate` header is added if missing).
  * @param {string | object | MessageFunction} [options.noAuthenticationHeader.wwwAuthenticateHeader="Bearer realm=\"\""] - The response header value for the WWW-Authenticate header when no authentication header is provided.
- * @param {string | object | MessageFunction} [options.invalidAuthenticationHeader.message="Bad Request"] - The invalid authentication header message.
+ * @param {string | object | Response | ResponseMessageFunction} [options.invalidAuthenticationHeader.message] - The invalid authentication header message. When a `Response` or a function returning a `Response` is provided, it is used as-is (the `WWW-Authenticate` header is added if missing).
  * @param {string | object | MessageFunction} [options.invalidAuthenticationHeader.wwwAuthenticateHeader="Bearer error=\"invalid_request\""] - The response header value for the WWW-Authenticate header when authentication header is invalid.
- * @param {string | object | MessageFunction} [options.invalidToken.message="Unauthorized"] - The invalid token message.
+ * @param {string | object | Response | ResponseMessageFunction} [options.invalidToken.message] - The invalid token message. When a `Response` or a function returning a `Response` is provided, it is used as-is (the `WWW-Authenticate` header is added if missing).
  * @param {string | object | MessageFunction} [options.invalidToken.wwwAuthenticateHeader="Bearer error=\"invalid_token\""] - The response header value for the WWW-Authenticate header when token is invalid.
  * @returns {MiddlewareHandler<E>} The middleware handler function.
  * @throws {Error} If neither "token" nor "verifyToken" options are provided.
@@ -123,7 +126,7 @@ export const bearerAuth = <E extends Env = Env>(
     c: Context,
     status: ContentfulStatusCode,
     wwwAuthenticateHeader: string | object | MessageFunction,
-    messageOption: string | object | MessageFunction
+    messageOption: string | object | Response | ResponseMessageFunction
   ): Promise<Response> => {
     const wwwAuthenticateHeaderValue: string | object =
       typeof wwwAuthenticateHeader === 'function'
@@ -140,6 +143,16 @@ export const bearerAuth = <E extends Env = Env>(
     }
     const responseMessage =
       typeof messageOption === 'function' ? await messageOption(c) : messageOption
+
+    if (responseMessage instanceof Response) {
+      if (!responseMessage.headers.has('WWW-Authenticate')) {
+        responseMessage.headers.set('WWW-Authenticate', headers['WWW-Authenticate'])
+      }
+      throw new HTTPException(responseMessage.status as ContentfulStatusCode, {
+        res: responseMessage,
+      })
+    }
+
     const res =
       typeof responseMessage === 'string'
         ? new Response(responseMessage, { status, headers })


### PR DESCRIPTION
### What
Allow custom error messages in bearer-auth to be a `Response` object (or a
function that returns one), in addition to the existing `string` / `object`
/ `MessageFunction` types.

This applies to the three failure cases:
- `noAuthenticationHeader.message`
- `invalidAuthenticationHeader.message`
- `invalidToken.message`

### Why
Users need full control over the error response (status code, headers,
custom body such as `application/problem+json`). A plain `string` or
`object` message is not enough when the response must be a complete,
custom `Response`.

### How
When the resolved message is a `Response`, it is used as-is. If it does
not already include a `WWW-Authenticate` header, the middleware adds the
computed one (from `wwwAuthenticateHeader` or the default), so the
behavior stays consistent with the existing flow.

### Tests
Added test coverage for `Response` messages in all three cases, including
the `WWW-Authenticate` auto-injection and preservation of an existing
header.

- `bearer-auth` tests: 53 passed
- Full suite: 4771 passed