### PR TITLE
fix(client): skip undefined header and cookie values

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -521,6 +521,53 @@ describe('Form - Undefined Values', () => {
   })
 })
 
+describe('Optional header and cookie values', () => {
+  const app = new Hono().get(
+    '/',
+    validator('header', () => {
+      return {} as {
+        'x-required': string
+        'x-optional'?: string
+      }
+    }),
+    validator('cookie', () => {
+      return {} as {
+        required: string
+        optional?: string
+      }
+    }),
+    (c) =>
+      c.json({
+        requiredHeader: c.req.header('x-required'),
+        optionalHeader: c.req.header('x-optional') ?? null,
+        cookies: parse(c.req.header('cookie') ?? ''),
+      })
+  )
+  const client = hc<typeof app>('', { fetch: app.request })
+
+  it('Should skip undefined header and cookie values', async () => {
+    const res = await client.index.$get({
+      header: {
+        'x-required': 'header-value',
+        'x-optional': undefined,
+      },
+      cookie: {
+        required: 'cookie-value',
+        optional: undefined,
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      requiredHeader: 'header-value',
+      optionalHeader: null,
+      cookies: {
+        required: 'cookie-value',
+      },
+    })
+  })
+})
+
 describe('Infer the response/request type', () => {
   const app = new Hono()
   const route = app.get(

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -566,6 +566,28 @@ describe('Optional header and cookie values', () => {
       },
     })
   })
+
+  it('Should not send a Cookie header if all cookie values are undefined', async () => {
+    const app = new Hono().get(
+      '/',
+      validator('cookie', () => {
+        return {} as {
+          optional?: string
+        }
+      }),
+      (c) => c.json({ cookieHeader: c.req.header('cookie') ?? null })
+    )
+    const client = hc<typeof app>('', { fetch: app.request })
+
+    const res = await client.index.$get({
+      cookie: {
+        optional: undefined,
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ cookieHeader: null })
+  })
 })
 
 describe('Infer the response/request type', () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -90,7 +90,7 @@ class ClientRequestImpl {
 
     let methodUpperCase = this.method.toUpperCase()
 
-    const headerValues: Record<string, string> = {
+    const headerValues: Record<string, string | undefined> = {
       ...args?.header,
       ...(typeof opt?.headers === 'function' ? await opt.headers() : opt?.headers),
     }
@@ -98,16 +98,26 @@ class ClientRequestImpl {
     if (args?.cookie) {
       const cookies: string[] = []
       for (const [key, value] of Object.entries(args.cookie)) {
+        if (value === undefined) {
+          continue
+        }
         cookies.push(serialize(key, value))
       }
-      headerValues['Cookie'] = cookies.join('; ')
+      if (cookies.length > 0) {
+        headerValues['Cookie'] = cookies.join('; ')
+      }
     }
 
     if (this.cType) {
       headerValues['Content-Type'] = this.cType
     }
 
-    const headers = new Headers(headerValues ?? undefined)
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(headerValues)) {
+      if (value !== undefined) {
+        headers.set(key, value)
+      }
+    }
     let url = this.url
 
     url = removeIndexString(url)


### PR DESCRIPTION
## Summary

- skip `undefined` values when building RPC client headers and cookies
- avoid sending an empty `Cookie` header when every cookie value is omitted
- add a typed end-to-end regression test for both paths

## Impact

Optional header and cookie fields accepted by Hono's inferred RPC types no longer arrive as the literal string `"undefined"`. Omitted values now remain absent, preventing request logic from mistaking them for values supplied by the caller.

## Regression proof

Before this fix, the new test received:

- `x-optional: undefined` as the header value `"undefined"`
- `optional: undefined` as the cookie `optional=undefined`

After this fix, the optional header is absent and only `required=cookie-value` is serialized. Required values remain unchanged.

## Testing

- `vitest --run src/client/client.test.ts`: 109 passed
- `tsc -p tsconfig.spec.json --pretty false`
- `eslint src/client/client.ts src/client/client.test.ts`
- `prettier --check src/client/client.ts src/client/client.test.ts`
- Full `npm test`: 4,766 passed; the unrelated local `workerd` startup hook timed out on Windows

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code