### PR TITLE
fix(cookie): allow parsing signed cookies with empty string values

### DIFF
--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -67,8 +67,8 @@ describe('Cookie Middleware', () => {
       const res = new Response('Signed fortune cookie')
       if (typeof fortuneCookie !== 'undefined' && typeof fruitCookie !== 'undefined') {
         // just examples for tests sake
-        res.headers.set('Fortune-Cookie', fortuneCookie || 'INVALID')
-        res.headers.set('Fruit-Cookie', fruitCookie || 'INVALID')
+        res.headers.set('Fortune-Cookie', fortuneCookie === false ? 'INVALID' : fortuneCookie)
+        res.headers.set('Fruit-Cookie', fruitCookie === false ? 'INVALID' : fruitCookie)
       }
       return res
     })
@@ -79,7 +79,7 @@ describe('Cookie Middleware', () => {
       const res = new Response('Signed fortune cookie')
       if (typeof fortuneCookie !== 'undefined') {
         // just an example for tests sake
-        res.headers.set('Fortune-Cookie', fortuneCookie || 'INVALID')
+        res.headers.set('Fortune-Cookie', fortuneCookie === false ? 'INVALID' : fortuneCookie)
       }
       return res
     })
@@ -122,6 +122,15 @@ describe('Cookie Middleware', () => {
       req.headers.set('Cookie', cookieString)
       const res = await app.request(req)
       expect(res.headers.get('Fortune-Cookie')).toBe('INVALID')
+    })
+
+    it('Get signed cookie with empty string value', async () => {
+      const secret = 'secret lucky charm'
+      const emptySignedCookie = await generateSignedCookie('fortune_cookie', '', secret)
+      const req = new Request('http://localhost/cookie-signed-get-one')
+      req.headers.set('Cookie', emptySignedCookie)
+      const res = await app.request(req)
+      expect(res.headers.get('Fortune-Cookie')).toBe('')
     })
 
     describe('get null if the value is undefined', () => {

--- a/src/utils/cookie.test.ts
+++ b/src/utils/cookie.test.ts
@@ -201,6 +201,13 @@ describe('Parse cookie', () => {
     expect(cookie['tasty_cookie']).toBe(false)
   })
 
+  it('Should parse signed cookie with empty string value', async () => {
+    const secret = 'secret ingredient'
+    const cookieString = await serializeSigned('empty_cookie', '', secret)
+    const cookie: SignedCookie = await parseSigned(cookieString, secret)
+    expect(cookie['empty_cookie']).toBe('')
+  })
+
   it('Should parse signed cookies and return "false" for corrupt signature', async () => {
     const secret = 'secret ingredient'
     // yummy_cookie has corrupt signature (i.e. invalid base64 encoding)

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -153,7 +153,7 @@ export const parseSigned = async (
 
   for (const [key, value] of Object.entries(parse(cookie, name))) {
     const signatureStartPos = value.lastIndexOf('.')
-    if (signatureStartPos < 1) {
+    if (signatureStartPos < 0) {
       continue
     }
 


### PR DESCRIPTION
 Fixes an issue in `parseSigned` where valid signed cookies with empty string values (`""`) were dropped during parsing.

### Problem

When serializing a signed cookie with an empty string value via `serializeSigned('key', '', secret)` (or `setSignedCookie(c, 'key', '', secret)`), the resulting cookie value is formatted as `.${signature}`.

In `src/utils/cookie.ts`:
```ts
    const signatureStartPos = value.lastIndexOf('.')
    if (signatureStartPos < 1) {
      continue
    }
```

When value is .${signature}, value.lastIndexOf('.') is 0. Because signatureStartPos < 1 evaluates to true, parseSigned assumes the cookie is malformed and drops it, returning an empty object (and causing getSignedCookie to return undefined).

### Solution

Change the condition from signatureStartPos < 1 to signatureStartPos < 0 so that signed cookies with a signature starting at index 0 (empty signed value "") are properly verified and parsed.

### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
