### PR TITLE
fix(utils/ipaddr): avoid truncation on embedded IPv4 addresses in expand IPv6

### DIFF
--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -27,6 +27,9 @@ describe('expandIPv6', () => {
     expect(expandIPv6('2001:2::')).toBe('2001:0002:0000:0000:0000:0000:0000:0000')
     expect(expandIPv6('2001:0:0:db8::1')).toBe('2001:0000:0000:0db8:0000:0000:0000:0001')
     expect(expandIPv6('::ffff:127.0.0.1')).toBe('0000:0000:0000:0000:0000:ffff:7f00:0001')
+    expect(expandIPv6('::ffff:0.0.0.1')).toBe('0000:0000:0000:0000:0000:ffff:0000:0001')
+    expect(expandIPv6('2001:db8:1:2:3:4:0.0.0.1')).toBe('2001:0db8:0001:0002:0003:0004:0000:0001')
+    expect(expandIPv6('::0.0.0.0')).toBe('0000:0000:0000:0000:0000:0000:0000:0000')
   })
 
   it('Should expand the unspecified address "::" to eight zero groups', () => {

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -12,13 +12,14 @@ import type { AddressType } from '../helper/conninfo'
  */
 export const expandIPv6 = (ipV6: string): string => {
   const sections = ipV6.split(':')
-  if (IPV4_REGEX.test(sections.at(-1) as string)) {
+  const lastSection = sections.at(-1) as string
+  if (IPV4_REGEX.test(lastSection)) {
+    const octets = lastSection.split('.').map(Number)
     sections.splice(
       -1,
       1,
-      ...convertIPv6BinaryToString(convertIPv4ToBinary(sections.at(-1) as string)) // => ::7f00:0001
-        .substring(2) // => 7f00:0001
-        .split(':') // => ['7f00', '0001']
+      ((octets[0] << 8) | octets[1]).toString(16),
+      ((octets[2] << 8) | octets[3]).toString(16)
     )
   }
   for (let i = 0; i < sections.length; i++) {


### PR DESCRIPTION
## Problem

Fixes an issue in `expandIPv6` where IPv6 addresses with embedded IPv4 addresses in the `0.0.x.x` range (where the first two octets are `0`) were truncated into invalid 7-group IPv6 strings.

In `src/utils/ipaddr.ts`, the IPv4 segment was expanded via:

```ts
convertIPv6BinaryToString(convertIPv4ToBinary(sections.at(-1) as string))
  .substring(2)
  .split(':')
```

For IPv4 addresses such as `0.0.0.1`, `convertIPv6BinaryToString(1n)` compresses the leading zero groups to `::1`. Applying `.substring(2)` and splitting the result produces only a single group:

```ts
['1']
```

instead of the required two 16-bit groups:

```ts
['0', '1']
```

As a result, `sections.splice()` inserts only one group instead of two, producing an invalid 7-group IPv6 string.

For example:

```text
2001:db8:1:2:3:4:0.0.0.1
```

was incorrectly expanded to:

```text
2001:0db8:0001:0002:0003:0004:0001
```

## Solution

Directly convert the four IPv4 octets `a.b.c.d` into two 16-bit hexadecimal groups:

```ts
((a << 8) | b).toString(16)
((c << 8) | d).toString(16)
```

This guarantees that exactly two IPv6 groups are inserted, regardless of leading zeros in the IPv4 address.

## Verification

* [x] Add tests
* [x] Run tests
* [x] Run `bun run format:fix && bun run lint:fix` to format and lint the code
* [ ] Add [[TSDoc](https://tsdoc.org/)](https://tsdoc.org/)/[[JSDoc](https://jsdoc.app/about-getting-started)](https://jsdoc.app/about-getting-started) to document the code