### PR TITLE
docs(context): add custom headers append option example to Context JSDoc

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -508,6 +508,10 @@ export class Context<
    *   c.header('X-Message', 'Hello!')
    *   c.header('Content-Type', 'text/plain')
    *
+   *   // Append multiple headers using the append option (e.g. Vary)
+   *   c.header('Vary', 'Accept-Encoding', { append: true })
+   *   c.header('Vary', 'User-Agent', { append: true })
+   *
    *   return c.body('Thank you for coming')
    * })
    * ```


### PR DESCRIPTION
 ### What this PR does                                                                    
    This PR adds a practical example to the `c.header` JSDoc in `Context`, showing how to use
  the `{ append: true }` option for setting headers like `Vary`. 