### PR TITLE
fix(method-not-allowed, serve-static): ignore wildcards and skip non-GET/HEAD

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -289,4 +289,42 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
     expect(await res.text()).toBe('Missing')
   })
+
+  it('ignores trailing wildcard routes when inferring allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('api'))
+    app.get('/*', (c) => c.text('fallback'))
+
+    expect((await app.request('/api')).status).toBe(200)
+
+    const postApi = await app.request('/api', { method: 'POST' })
+    expect(postApi.status).toBe(405)
+    expect(postApi.headers.get('Allow')).toBe('GET, HEAD')
+
+    // Wildcard must not convert an unmatched path into 405.
+    const postMissing = await app.request('/missing', { method: 'POST' })
+    expect(postMissing.status).toBe(404)
+    expect(postMissing.headers.has('Allow')).toBe(false)
+
+    // GET still reaches the wildcard handler.
+    expect((await app.request('/missing')).status).toBe(200)
+  })
+
+  it('ignores suffix wildcard routes when inferring allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('api'))
+    app.get('/assets*', (c) => c.text('static'))
+
+    expect((await app.request('/assets/app.js')).status).toBe(200)
+
+    const postApi = await app.request('/api', { method: 'POST' })
+    expect(postApi.status).toBe(405)
+    expect(postApi.headers.get('Allow')).toBe('GET, HEAD')
+
+    const postAssets = await app.request('/assets/app.js', { method: 'POST' })
+    expect(postAssets.status).toBe(404)
+    expect(postAssets.headers.has('Allow')).toBe(false)
+  })
 })

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -83,6 +83,13 @@ export const methodNotAllowed = <E extends Env = Env>(
           continue
         }
 
+        // Trailing-wildcard routes (e.g. `GET /*` or `GET /assets*`) match an arbitrary
+        // path remainder, so they do not prove that a particular resource exists.
+        // Including them would turn every otherwise-unhandled request into 405.
+        if (route.path.endsWith('*')) {
+          continue
+        }
+
         const methods = methodsByPath.get(route.path) ?? new Set<string>()
         methods.add(route.method)
 

--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from '../../hono'
+import { methodNotAllowed } from '../method-not-allowed'
 import { serveStatic as baseServeStatic } from '.'
 
 describe('Serve Static Middleware', () => {
@@ -241,6 +242,31 @@ describe('Serve Static Middleware', () => {
     } as Request)
     expect(res.status).toBe(200)
     expect(res.body).toBe(body)
+  })
+
+  it('Should skip non-GET/HEAD requests and call next()', async () => {
+    const localApp = new Hono().use('/*', serveStatic)
+
+    const res = await localApp.request('/static/hello.html', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('404 Not Found')
+    expect(getContent).not.toBeCalled()
+  })
+
+  it('Should not serve static files for POST when used with methodNotAllowed', async () => {
+    const localApp = new Hono()
+    localApp.use(methodNotAllowed({ app: localApp }))
+    localApp.get('/api', (c) => c.text('ok'))
+    localApp.use('/*', serveStatic)
+
+    const postStatic = await localApp.request('/static/hello.html', { method: 'POST' })
+    expect(postStatic.status).toBe(404)
+    expect(getContent).not.toBeCalled()
+
+    const postApi = await localApp.request('/api', { method: 'POST' })
+    expect(postApi.status).toBe(405)
+    expect(postApi.headers.get('Allow')).toBe('GET, HEAD')
   })
 
   describe('Changing root path', () => {

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -57,6 +57,12 @@ export const serveStatic = <E extends Env = Env>(
       return next()
     }
 
+    // Only GET and HEAD serve files. Other methods fall through so callers can
+    // return 405 (e.g. via methodNotAllowed) without a file-existence check.
+    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+      return next()
+    }
+
     let filename: string
 
     if (options.path) {


### PR DESCRIPTION
## Summary

Fixes #5223.

Two related refinements from the discussion on that issue:

1. **`methodNotAllowed`** — skip routes whose path ends with `*` when building the Allow map. A trailing wildcard matches an arbitrary remainder of the path, so it should not turn unmatched requests into 405.
2. **`serveStatic`** — only serve GET/HEAD. For other methods, call `next()` before touching the filesystem so a POST cannot return 200 for an existing file.

## Test plan

- [x] `bunx vitest --run src/middleware/method-not-allowed/index.test.ts src/middleware/serve-static/index.test.ts` (44 passed)
- [x] Regression: `GET /*` / `/assets*` no longer makes `POST /missing` return 405
- [x] Regression: `use('/*', serveStatic)` no longer serves on POST