### PR TITLE
fix(csrf): exempt OPTIONS request from CSRF validation

### DIFF
--- a/src/middleware/csrf/index.test.ts
+++ b/src/middleware/csrf/index.test.ts
@@ -1,5 +1,6 @@
 import type { Context } from '../../context'
 import { Hono } from '../../hono'
+import { cors } from '../../middleware/cors'
 import { csrf } from '../../middleware/csrf'
 
 const simplePostHandler = vi.fn(async (c: Context) => {
@@ -232,6 +233,27 @@ describe('CSRF by Middleware', () => {
       })
       expect(res.status).toBe(403)
       expect(simplePostHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with CORS middleware', () => {
+    it('should allow a cross-site preflight when CSRF middleware is registered first', async () => {
+      const app = new Hono()
+
+      app.use('*', csrf())
+      app.use('*', cors())
+
+      const res = await app.request('http://localhost/form', {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'http://example.com',
+          'access-control-request-method': 'POST',
+          'sec-fetch-site': 'cross-site',
+        },
+      })
+
+      expect(res.status).toBe(204)
+      expect(res.headers.get('access-control-allow-origin')).toBe('*')
     })
   })
 

--- a/src/middleware/csrf/index.test.ts
+++ b/src/middleware/csrf/index.test.ts
@@ -1,6 +1,5 @@
 import type { Context } from '../../context'
 import { Hono } from '../../hono'
-import { cors } from '../../middleware/cors'
 import { csrf } from '../../middleware/csrf'
 
 const simplePostHandler = vi.fn(async (c: Context) => {
@@ -226,27 +225,6 @@ describe('CSRF by Middleware', () => {
       })
       expect(res.status).toBe(403)
       expect(simplePostHandler).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('with CORS middleware', () => {
-    it('should not block a cross-site preflight request when CSRF is registered before CORS', async () => {
-      const app = new Hono()
-
-      app.use('*', csrf())
-      app.use('*', cors())
-
-      const res = await app.request('http://localhost/form', {
-        method: 'OPTIONS',
-        headers: {
-          origin: 'http://example.com',
-          'access-control-request-method': 'POST',
-          'sec-fetch-site': 'cross-site',
-        },
-      })
-
-      expect(res.status).toBe(204)
-      expect(res.headers.get('access-control-allow-origin')).toBe('*')
     })
   })
 

--- a/src/middleware/csrf/index.test.ts
+++ b/src/middleware/csrf/index.test.ts
@@ -58,15 +58,8 @@ describe('CSRF by Middleware', () => {
     })
 
     describe('OPTIONS /form', async () => {
-      it('should be 200 for a cross-site preflight request', async () => {
-        const res = await app.request('http://localhost/form', {
-          method: 'OPTIONS',
-          headers: {
-            origin: 'http://example.com',
-            'access-control-request-method': 'POST',
-            'sec-fetch-site': 'cross-site',
-          },
-        })
+      it('should be 200 for any request', async () => {
+        const res = await app.request('http://localhost/form', { method: 'OPTIONS' })
 
         expect(res.status).toBe(200)
         expect(await res.text()).toBe('OK')
@@ -237,7 +230,7 @@ describe('CSRF by Middleware', () => {
   })
 
   describe('with CORS middleware', () => {
-    it('should allow a cross-site preflight when CSRF middleware is registered first', async () => {
+    it('should not block a cross-site preflight request when CSRF is registered before CORS', async () => {
       const app = new Hono()
 
       app.use('*', csrf())

--- a/src/middleware/csrf/index.test.ts
+++ b/src/middleware/csrf/index.test.ts
@@ -33,6 +33,7 @@ describe('CSRF by Middleware', () => {
 
     app.use('*', csrf())
     app.get('/form', (c) => c.html('<form></form>'))
+    app.options('/form', (c) => c.text('OK'))
     app.post('/form', simplePostHandler)
     app.put('/form', (c) => c.text('OK'))
     app.delete('/form', (c) => c.text('OK'))
@@ -52,6 +53,22 @@ describe('CSRF by Middleware', () => {
         const res = await app.request('http://localhost/form', { method: 'HEAD' })
 
         expect(res.status).toBe(200)
+      })
+    })
+
+    describe('OPTIONS /form', async () => {
+      it('should be 200 for a cross-site preflight request', async () => {
+        const res = await app.request('http://localhost/form', {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://example.com',
+            'access-control-request-method': 'POST',
+            'sec-fetch-site': 'cross-site',
+          },
+        })
+
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe('OK')
       })
     })
 

--- a/src/middleware/csrf/index.ts
+++ b/src/middleware/csrf/index.ts
@@ -25,7 +25,7 @@ interface CSRFOptions {
   secFetchSite?: SecFetchSite | SecFetchSite[] | IsAllowedSecFetchSiteHandler
 }
 
-const isSafeMethodRe = /^(GET|HEAD)$/
+const isSafeMethodRe = /^(GET|HEAD|OPTIONS)$/
 const isRequestedByFormElementRe =
   /^\b(application\/x-www-form-urlencoded|multipart\/form-data|text\/plain)\b/i
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#safe.methods) defines `OPTIONS` as a safe method, and CORS uses it for preflight requests.
> Of the request methods defined by this specification, the [GET](https://www.rfc-editor.org/rfc/rfc9110.html#GET), [HEAD](https://www.rfc-editor.org/rfc/rfc9110.html#HEAD), [OPTIONS](https://www.rfc-editor.org/rfc/rfc9110.html#OPTIONS), and [TRACE](https://www.rfc-editor.org/rfc/rfc9110.html#TRACE) methods are defined to be safe.