### PR TITLE
fix(pattern-router/linear-router): prevent prefix overmatch on wildcard routes

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -370,6 +370,58 @@ export const runTest = ({
       })
     })
 
+    describe('Suffix wildcard', () => {
+      beforeEach(() => {
+        router.add('GET', '/assets*', 'assets')
+      })
+
+      it('GET /assets', async () => {
+        const res = match('GET', '/assets')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('assets')
+      })
+
+      it('GET /assets-v2', async () => {
+        const res = match('GET', '/assets-v2')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('assets')
+      })
+
+      it('GET /assets/app.js', async () => {
+        const res = match('GET', '/assets/app.js')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('assets')
+      })
+
+      it('GET /asset', async () => {
+        const res = match('GET', '/asset')
+        expect(res.length).toBe(0)
+      })
+    })
+
+    describe('Trailing wildcard', () => {
+      beforeEach(() => {
+        router.add('GET', '/path/*', 'path')
+      })
+
+      it('GET /path', async () => {
+        const res = match('GET', '/path')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('path')
+      })
+
+      it('GET /path/to/file', async () => {
+        const res = match('GET', '/path/to/file')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('path')
+      })
+
+      it('GET /pathfoo', async () => {
+        const res = match('GET', '/pathfoo')
+        expect(res.length).toBe(0)
+      })
+    })
+
     describe('Optional route', () => {
       beforeEach(() => {
         router.add('GET', '/api/animals/:type?', 'animals')

--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -422,6 +422,29 @@ export const runTest = ({
       })
     })
 
+    describe('Trailing wildcard after a middle wildcard', () => {
+      beforeEach(() => {
+        router.add('GET', '/a/*/b/*', 'b')
+      })
+
+      it('GET /a/x/b', async () => {
+        const res = match('GET', '/a/x/b')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('b')
+      })
+
+      it('GET /a/x/b/c', async () => {
+        const res = match('GET', '/a/x/b/c')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('b')
+      })
+
+      it('GET /a/x/bz', async () => {
+        const res = match('GET', '/a/x/bz')
+        expect(res.length).toBe(0)
+      })
+    })
+
     describe('Optional route', () => {
       beforeEach(() => {
         router.add('GET', '/api/animals/:type?', 'animals')

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -40,14 +40,10 @@ export class LinearRouter<T> implements Router<T> {
           }
         } else if (hasStar && !hasLabel) {
           const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
-          const prefixPath = endsWithStar ? routePath.slice(0, -1) : routePath
-
-          if (routePath.endsWith('/*') && path + '/' === prefixPath) {
-            handlers.push([handler, emptyParams])
-            continue
-          }
-
-          const parts = prefixPath.split(splitByStarRe)
+          const endsWithSlashStar = routePath.endsWith('/*')
+          const parts = (
+            endsWithStar ? routePath.slice(0, endsWithSlashStar ? -2 : -1) : routePath
+          ).split(splitByStarRe)
 
           const lastIndex = parts.length - 1
           for (let j = 0, pos = 0, len = parts.length; j < len; j++) {
@@ -58,7 +54,11 @@ export class LinearRouter<T> implements Router<T> {
             }
             pos += part.length
             if (j === lastIndex) {
-              if (
+              if (endsWithSlashStar) {
+                if (pos !== path.length && path.charCodeAt(pos) !== 47) {
+                  continue ROUTES_LOOP
+                }
+              } else if (
                 !endsWithStar &&
                 pos !== path.length &&
                 !(pos === path.length - 1 && path.charCodeAt(pos) === 47)

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -42,11 +42,7 @@ export class LinearRouter<T> implements Router<T> {
           const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
           const prefixPath = endsWithStar ? routePath.slice(0, -1) : routePath
 
-          if (
-            endsWithStar &&
-            prefixPath.charCodeAt(prefixPath.length - 1) === 47 &&
-            path + '/' === prefixPath
-          ) {
+          if (routePath.endsWith('/*') && path + '/' === prefixPath) {
             handlers.push([handler, emptyParams])
             continue
           }

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -40,7 +40,18 @@ export class LinearRouter<T> implements Router<T> {
           }
         } else if (hasStar && !hasLabel) {
           const endsWithStar = routePath.charCodeAt(routePath.length - 1) === 42
-          const parts = (endsWithStar ? routePath.slice(0, -2) : routePath).split(splitByStarRe)
+          const prefixPath = endsWithStar ? routePath.slice(0, -1) : routePath
+
+          if (
+            endsWithStar &&
+            prefixPath.charCodeAt(prefixPath.length - 1) === 47 &&
+            path + '/' === prefixPath
+          ) {
+            handlers.push([handler, emptyParams])
+            continue
+          }
+
+          const parts = prefixPath.split(splitByStarRe)
 
           const lastIndex = parts.length - 1
           for (let j = 0, pos = 0, len = parts.length; j < len; j++) {

--- a/src/router/pattern-router/router.test.ts
+++ b/src/router/pattern-router/router.test.ts
@@ -25,6 +25,50 @@ describe('Pattern', () => {
       }).toThrowError(UnsupportedPathError)
     })
   })
+  describe('Suffix wildcard', () => {
+    const router = new PatternRouter<string>()
+    router.add('GET', '/assets*', 'assets')
+
+    it('GET /assets/app.js', () => {
+      const [res] = router.match('GET', '/assets/app.js')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('assets')
+    })
+
+    it('GET /assets', () => {
+      const [res] = router.match('GET', '/assets')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('assets')
+    })
+
+    it('GET /asset', () => {
+      const [res] = router.match('GET', '/asset')
+      expect(res.length).toBe(0)
+    })
+  })
+
+  describe('Trailing wildcard', () => {
+    const router = new PatternRouter<string>()
+    router.add('GET', '/path/*', 'path')
+
+    it('GET /path', () => {
+      const [res] = router.match('GET', '/path')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('path')
+    })
+
+    it('GET /path/to/file', () => {
+      const [res] = router.match('GET', '/path/to/file')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('path')
+    })
+
+    it('GET /pathfoo', () => {
+      const [res] = router.match('GET', '/pathfoo')
+      expect(res.length).toBe(0)
+    })
+  })
+
   describe('Trailing slash', () => {
     const router = new PatternRouter<string>()
 

--- a/src/router/pattern-router/router.test.ts
+++ b/src/router/pattern-router/router.test.ts
@@ -25,50 +25,6 @@ describe('Pattern', () => {
       }).toThrowError(UnsupportedPathError)
     })
   })
-  describe('Suffix wildcard', () => {
-    const router = new PatternRouter<string>()
-    router.add('GET', '/assets*', 'assets')
-
-    it('GET /assets/app.js', () => {
-      const [res] = router.match('GET', '/assets/app.js')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('assets')
-    })
-
-    it('GET /assets', () => {
-      const [res] = router.match('GET', '/assets')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('assets')
-    })
-
-    it('GET /asset', () => {
-      const [res] = router.match('GET', '/asset')
-      expect(res.length).toBe(0)
-    })
-  })
-
-  describe('Trailing wildcard', () => {
-    const router = new PatternRouter<string>()
-    router.add('GET', '/path/*', 'path')
-
-    it('GET /path', () => {
-      const [res] = router.match('GET', '/path')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('path')
-    })
-
-    it('GET /path/to/file', () => {
-      const [res] = router.match('GET', '/path/to/file')
-      expect(res.length).toBe(1)
-      expect(res[0][0]).toBe('path')
-    })
-
-    it('GET /pathfoo', () => {
-      const [res] = router.match('GET', '/pathfoo')
-      expect(res.length).toBe(0)
-    })
-  })
-
   describe('Trailing slash', () => {
     const router = new PatternRouter<string>()
 

--- a/src/router/pattern-router/router.ts
+++ b/src/router/pattern-router/router.ts
@@ -10,10 +10,8 @@ export class PatternRouter<T> implements Router<T> {
   #routes: Route<T>[] = []
 
   add(method: string, path: string, handler: T) {
-    const endsWithWildcard = path.at(-1) === '*'
-    if (endsWithWildcard) {
-      path = path.slice(0, -2)
-    }
+    const suffix = path.endsWith('/*') ? '(?:$|/)' : path.endsWith('*') ? '' : '/?$'
+    path = path.replace(/\*$/, '')
     if (path.at(-1) === '?') {
       path = path.slice(0, -1)
       this.add(method, path.replace(/\/[^/]+$/, ''), handler)
@@ -31,11 +29,7 @@ export class PatternRouter<T> implements Router<T> {
     )
 
     try {
-      this.#routes.push([
-        new RegExp(`^${parts.join('')}${endsWithWildcard ? '' : '/?$'}`),
-        method,
-        handler,
-      ])
+      this.#routes.push([new RegExp(`^${parts.join('')}${suffix}`), method, handler])
     } catch {
       throw new UnsupportedPathError()
     }


### PR DESCRIPTION
I found that `/assets*` matches `/asset` and `/path/*` matches `/pathfoo` in PatternRouter. LinearRouter has the same bug. This PR will fix both.

The tests are added to `common.case.test.ts`, so all routers are now verified to behave the same for suffix and trailing wildcards.

Related to #5219

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
