### PR TITLE
fix(method-not-allowed): ignore routes ending in a wildcard

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -197,6 +197,30 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
   })
 
+  it('ignores routes ending in a wildcard when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('api'))
+    app.get('/*', (c) => c.text('static'))
+
+    // the wildcard says nothing about whether a resource exists there
+    expect((await app.request('/missing', { method: 'POST' })).status).toBe(404)
+    expect((await app.request('/anything', { method: 'PUT' })).status).toBe(404)
+
+    // a route registered for the path still reports its methods
+    const res = await app.request('/api', { method: 'POST' })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD')
+  })
+
+  it('ignores a suffix wildcard route', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/assets*', (c) => c.text('assets'))
+
+    expect((await app.request('/assets/app.js', { method: 'POST' })).status).toBe(404)
+  })
+
   it('does not invoke the error handler for a 405 response', async () => {
     const app = new Hono()
     const onError = vi.fn(() => new Response('error', { status: 500 }))

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -83,6 +83,12 @@ export const methodNotAllowed = <E extends Env = Env>(
           continue
         }
 
+        // A trailing wildcard matches any remainder of the path, so it is not
+        // evidence that the requested resource exists.
+        if (route.path.endsWith('*')) {
+          continue
+        }
+
         const methods = methodsByPath.get(route.path) ?? new Set<string>()
         methods.add(route.method)
 


### PR DESCRIPTION
Implements the `methodNotAllowed` half of #5223, following @usualoma's direction in [that thread](https://github.com/honojs/hono/issues/5223#issuecomment-3527062584): routes whose paths end in `*` are ignored when inferring allowed methods.

I have deliberately left the `serveStatic` half alone, since the comment suggests it belongs in its own issue. Happy to hold this until @yusukebe has weighed in on the direction — I would rather have it ready than have it merged before it is agreed.

## Behaviour

With a wildcard route registered, every unhandled request in that namespace was being converted from 404 to 405:

```ts
app.use(methodNotAllowed({ app }))
app.get('/api', (c) => c.text('ok'))
app.get('/*', (c) => c.text('static'))
```

| request | before | after |
| --- | --- | --- |
| `GET /api` | 200 | 200 |
| `POST /api` | 405 `Allow: GET, HEAD` | 405 `Allow: GET, HEAD` |
| `GET /exists` | 200 | 200 |
| `POST /exists` | 405 | 404 |
| `POST /nope` | **405** | 404 |
| `PUT /anything` | **405** | 404 |

A trailing wildcard matches an arbitrary remainder, so it is not evidence that the requested resource exists. Routes registered for the path itself still report their methods, so `POST /api` is unaffected.

`POST /exists` becoming 404 is the trade-off named in the issue. The remaining piece — `serveStatic` passing non-GET/HEAD requests to `next()` rather than serving them — is what would make that case behave fully, and is out of scope here.

## Change

Six lines in the loop that builds the method map, alongside the existing `ALL` and `HEAD` skips:

```ts
if (route.path.endsWith('*')) {
  continue
}
```

This covers both `/*` and the suffix form `/assets*`.

## Tests

Two cases added to `src/middleware/method-not-allowed/index.test.ts`: a `/*` route no longer turning misses into 405 while a real route still reports its methods, and the same for a suffix wildcard. Both fail without the change.

`pnpm vitest --project main`: 123 files, 3858 passed, 28 skipped, 0 failed. The 20 existing `methodNotAllowed` tests pass unchanged — none of them relied on wildcard routes contributing. `tsc -p tsconfig.spec.json`, ESLint and Prettier clean.
