### PR TITLE
fix(client): support custom buildSearchParams and filter undefined query in $ws()

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1787,6 +1787,13 @@ describe('Custom buildSearchParams', () => {
     expect(url.href).toBe('http://localhost/search?q=test&tags%5B%5D=tag1&tags%5B%5D=tag2')
   })
 
+  it('Should use default buildSearchParams in $url() when custom one is not provided', () => {
+    const client = hc<AppType>('http://localhost')
+    const url = client.search.$url({ query: { q: 'test', tags: ['tag1', 'tag2'] } })
+
+    expect(url.href).toBe('http://localhost/search?q=test&tags=tag1&tags=tag2')
+  })
+
   it('Should use custom buildSearchParams in $ws() method', () => {
     const webSocketMock = vi.fn()
     const client = hc<AppType>('http://localhost', {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1787,11 +1787,34 @@ describe('Custom buildSearchParams', () => {
     expect(url.href).toBe('http://localhost/search?q=test&tags%5B%5D=tag1&tags%5B%5D=tag2')
   })
 
-  it('Should use default buildSearchParams in $url() when custom one is not provided', () => {
-    const client = hc<AppType>('http://localhost')
-    const url = client.search.$url({ query: { q: 'test', tags: ['tag1', 'tag2'] } })
+  it('Should use custom buildSearchParams in $ws() method', () => {
+    const webSocketMock = vi.fn()
+    const client = hc<AppType>('http://localhost', {
+      buildSearchParams: customBuildSearchParams,
+      webSocket(url, options) {
+        return webSocketMock(url, options)
+      },
+    })
+    // @ts-expect-error search route does not explicitly define $ws in mock AppType
+    client.search.$ws({ query: { q: 'test', tags: ['tag1', 'tag2'] } })
 
-    expect(url.href).toBe('http://localhost/search?q=test&tags=tag1&tags=tag2')
+    expect(webSocketMock).toHaveBeenCalledWith(
+      'ws://localhost/search?q=test&tags%5B%5D=tag1&tags%5B%5D=tag2',
+      undefined
+    )
+  })
+
+  it('Should filter out undefined query parameters in $ws()', () => {
+    const webSocketMock = vi.fn()
+    const client = hc<AppType>('http://localhost', {
+      webSocket(url, options) {
+        return webSocketMock(url, options)
+      },
+    })
+    // @ts-expect-error search route does not explicitly define $ws in mock AppType
+    client.search.$ws({ query: { q: 'test', tags: undefined as any } })
+
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/search?q=test', undefined)
   })
 })
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -186,19 +186,16 @@ export const hc = <T extends Hono<any, any, any>, Prefix extends string = string
     }
     if (method === 'ws') {
       const webSocketUrl = replaceUrlProtocol(
-        opts.args[0] && opts.args[0].param ? replaceUrlParam(url, opts.args[0].param) : url,
+        opts.args[0]?.param ? replaceUrlParam(url, opts.args[0].param) : url,
         'ws'
       )
       const targetUrl = new URL(webSocketUrl)
 
       const queryParams: Record<string, string | string[]> | undefined = opts.args[0]?.query
       if (queryParams) {
-        Object.entries(queryParams).forEach(([key, value]) => {
-          if (Array.isArray(value)) {
-            value.forEach((item) => targetUrl.searchParams.append(key, item))
-          } else {
-            targetUrl.searchParams.set(key, value)
-          }
+        const searchParams = buildSearchParamsOption(queryParams)
+        searchParams.forEach((value, key) => {
+          targetUrl.searchParams.append(key, value)
         })
       }
       const establishWebSocket = (...args: ConstructorParameters<typeof WebSocket>) => {


### PR DESCRIPTION
## Description

Fixes query parameter processing in `hc().$ws()` so that custom `buildSearchParams` functions are respected and `undefined` query parameter values are omitted.

### Problem
When calling `$ws()` on an `hc` client:
1. Any custom `buildSearchParams` function passed in `options.buildSearchParams` was ignored because `$ws()` manually iterated over `opts.args[0].query` using standard `URLSearchParams.set/append`.
2. `undefined` query parameter values were serialized as literal `"undefined"` strings (e.g., `?foo=undefined`), whereas `buildSearchParams` filters out `undefined` keys for HTTP endpoints.

### Solution
1. Updated `hc()`'s `proxyCallback` for `method === 'ws'` to route `opts.args[0].query` through `buildSearchParamsOption`.
2. Appended search parameter entries generated by `buildSearchParamsOption` to the WebSocket target URL, preserving custom search parameter encoders and filtering out `undefined` keys.

## Checklist
- [x] Added unit tests for `$ws()` with custom `buildSearchParams` and `undefined` query stripping in `src/client/client.test.ts`.
- [x] All unit tests pass (`npx vitest run src/client/client.test.ts`).
- [x] Type checking passes clean (`npx tsc --noEmit`).
