### PR TITLE
fix(jsx): normalize SVG camelCase attribute keys to hyphenated names

### DIFF
--- a/src/jsx/utils.test.ts
+++ b/src/jsx/utils.test.ts
@@ -7,16 +7,29 @@ import {
 
 describe('normalizeIntrinsicElementKey', () => {
   test.each`
-    key                | expected
-    ${'className'}     | ${'class'}
-    ${'htmlFor'}       | ${'for'}
-    ${'crossOrigin'}   | ${'crossorigin'}
-    ${'httpEquiv'}     | ${'http-equiv'}
-    ${'itemProp'}      | ${'itemprop'}
-    ${'fetchPriority'} | ${'fetchpriority'}
-    ${'noModule'}      | ${'nomodule'}
-    ${'formAction'}    | ${'formaction'}
-    ${'href'}          | ${'href'}
+    key                  | expected
+    ${'className'}       | ${'class'}
+    ${'htmlFor'}         | ${'for'}
+    ${'crossOrigin'}     | ${'crossorigin'}
+    ${'httpEquiv'}       | ${'http-equiv'}
+    ${'itemProp'}        | ${'itemprop'}
+    ${'fetchPriority'}   | ${'fetchpriority'}
+    ${'noModule'}        | ${'nomodule'}
+    ${'formAction'}      | ${'formaction'}
+    ${'strokeWidth'}     | ${'stroke-width'}
+    ${'strokeLinecap'}   | ${'stroke-linecap'}
+    ${'strokeLinejoin'}  | ${'stroke-linejoin'}
+    ${'strokeDasharray'} | ${'stroke-dasharray'}
+    ${'strokeDashoffset'}| ${'stroke-dashoffset'}
+    ${'strokeMiterlimit'}| ${'stroke-miterlimit'}
+    ${'strokeOpacity'}   | ${'stroke-opacity'}
+    ${'fillRule'}        | ${'fill-rule'}
+    ${'fillOpacity'}     | ${'fill-opacity'}
+    ${'clipPath'}        | ${'clip-path'}
+    ${'clipRule'}        | ${'clip-rule'}
+    ${'stopColor'}       | ${'stop-color'}
+    ${'stopOpacity'}     | ${'stop-opacity'}
+    ${'href'}            | ${'href'}
   `('should convert $key to $expected', ({ key, expected }) => {
     expect(normalizeIntrinsicElementKey(key)).toBe(expected)
   })

--- a/src/jsx/utils.ts
+++ b/src/jsx/utils.ts
@@ -7,6 +7,19 @@ const normalizeElementKeyMap: Map<string, string> = new Map([
   ['fetchPriority', 'fetchpriority'],
   ['noModule', 'nomodule'],
   ['formAction', 'formaction'],
+  ['strokeWidth', 'stroke-width'],
+  ['strokeLinecap', 'stroke-linecap'],
+  ['strokeLinejoin', 'stroke-linejoin'],
+  ['strokeDasharray', 'stroke-dasharray'],
+  ['strokeDashoffset', 'stroke-dashoffset'],
+  ['strokeMiterlimit', 'stroke-miterlimit'],
+  ['strokeOpacity', 'stroke-opacity'],
+  ['fillRule', 'fill-rule'],
+  ['fillOpacity', 'fill-opacity'],
+  ['clipPath', 'clip-path'],
+  ['clipRule', 'clip-rule'],
+  ['stopColor', 'stop-color'],
+  ['stopOpacity', 'stop-opacity'],
 ])
 export const normalizeIntrinsicElementKey = (key: string): string =>
   normalizeElementKeyMap.get(key) || key


### PR DESCRIPTION
## Description

Fixes an issue in Hono JSX where SVG camelCase attribute keys (e.g., `strokeWidth`, `fillRule`, `strokeLinecap`) were not normalized to valid hyphenated HTML/SVG attribute names during rendering.

### Problem
`normalizeElementKeyMap` previously only mapped a few HTML attributes (`className`, `htmlFor`, etc.). When rendering SVG icon sets (such as Lucide or Heroicons React components) via Hono JSX / SSR, camelCase SVG attributes were preserved as-is (e.g. `strokeWidth="2"`), causing browsers to ignore the attributes and render icons incorrectly.

### Solution
Extended `normalizeElementKeyMap` in `src/jsx/utils.ts` to include standard SVG camelCase attribute mappings:
- `strokeWidth` -> `stroke-width`
- `strokeLinecap` -> `stroke-linecap`
- `strokeLinejoin` -> `stroke-linejoin`
- `strokeDasharray` -> `stroke-dasharray`
- `strokeDashoffset` -> `stroke-dashoffset`
- `strokeMiterlimit` -> `stroke-miterlimit`
- `strokeOpacity` -> `stroke-opacity`
- `fillRule` -> `fill-rule`
- `fillOpacity` -> `fill-opacity`
- `clipPath` -> `clip-path`
- `clipRule` -> `clip-rule`
- `stopColor` -> `stop-color`
- `stopOpacity` -> `stop-opacity`

## Checklist
- [x] Added unit tests in `src/jsx/utils.test.ts` for SVG camelCase attribute key normalization.
- [x] All JSX unit tests pass (`npx vitest run src/jsx/`).
- [x] Type checking passes clean (`npx tsc --noEmit`).
