### PR TITLE
fix(reg-exp-router): apply middleware for a trailing wildcard not preceded by a slash

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -3798,3 +3798,29 @@ describe('Catch-all route with empty segment', () => {
     expect(json).toEqual({ type: 'string', value: '' })
   })
 })
+
+describe('Middleware with a wildcard not preceded by a slash', () => {
+  const app = new Hono()
+
+  app.use('/assets*', async (c, next) => {
+    await next()
+    c.res.headers.append('x-mw', 'hit')
+  })
+
+  app.get('/assets/app.js', (c) => c.text('app.js'))
+  app.get('/assets-v2', (c) => c.text('v2'))
+
+  it('Should run the middleware for a sub path', async () => {
+    const res = await app.request('http://localhost/assets/app.js')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('app.js')
+    expect(res.headers.get('x-mw')).toBe('hit')
+  })
+
+  it('Should run the middleware for a suffix in the same segment, like a route does', async () => {
+    const res = await app.request('http://localhost/assets-v2')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('v2')
+    expect(res.headers.get('x-mw')).toBe('hit')
+  })
+})

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -262,4 +262,61 @@ describe('RegExpRouter', () => {
       }
     })
   })
+
+  describe('Middleware with a trailing wildcard without a slash', () => {
+    it('Should be applied to a route registered afterwards', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/a*', 'middleware')
+      router.add('GET', '/a/b', 'handler')
+
+      const [res] = router.match('GET', '/a/b')
+      expect(res.map(([h]) => h)).toEqual(['middleware', 'handler'])
+    })
+
+    it('Should be applied to a route registered beforehand', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/a/b', 'handler')
+      router.add('ALL', '/a*', 'middleware')
+
+      const [res] = router.match('GET', '/a/b')
+      // handlers run in registration order, as with a slash-prefixed wildcard
+      expect(res.map(([h]) => h)).toEqual(['handler', 'middleware'])
+    })
+
+    it('Should match a suffix in the same segment as a route does', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/a*', 'route')
+      router.add('ALL', '/a*', 'middleware')
+
+      const [res] = router.match('GET', '/a-v2')
+      expect(res.map(([h]) => h)).toEqual(['route', 'middleware'])
+    })
+
+    it('Should match the path without the suffix like a route does', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/a*', 'middleware')
+      router.add('GET', '/a', 'handler')
+
+      const [res] = router.match('GET', '/a')
+      expect(res.map(([h]) => h)).toEqual(['middleware', 'handler'])
+    })
+
+    it('Should not match a path that only differs before the suffix', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/a*', 'middleware')
+      router.add('GET', '/b/a', 'handler')
+
+      const [res] = router.match('GET', '/b/a')
+      expect(res.map(([h]) => h)).toEqual(['handler'])
+    })
+
+    it('Should keep the tail wildcard behavior for a slash-prefixed star', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/a/*', 'middleware')
+      router.add('GET', '/a-v2', 'handler')
+
+      const [res] = router.match('GET', '/a-v2')
+      expect(res.map(([h]) => h)).toEqual(['handler'])
+    })
+  })
 })

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -13,12 +13,15 @@ import { Trie } from './trie'
 type HandlerWithMetadata<T> = [T, number] // [handler, paramCount]
 
 let wildcardRegExpCache: Record<string, RegExp> = Object.create(null)
+// A wildcard not preceded by a slash (e.g. `/path*`) matches any trailing
+// characters, like a route with the same pattern does. A slash-prefixed
+// wildcard (e.g. `/path/*`) matches the path itself or any sub path.
 function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
     path === '*'
       ? ''
-      : `^${path.replace(/\/\*$|([.\\+*[^\]$()])/g, (_, metaChar) =>
-          metaChar ? `\\${metaChar}` : '(?:|/.*)'
+      : `^${path.replace(/\/\*$|\*$|([.\\+*[^\]$()])/g, (match, metaChar) =>
+          metaChar ? `\\${metaChar}` : match === '/*' ? '(?:|/.*)' : '.*'
         )}$`
   ))
 }


### PR DESCRIPTION
Fixes #5258

## What this does

A middleware registered with a wildcard not preceded by a slash, such as `app.use('/assets*', mw)`, was never applied, while a route with the same pattern (`app.get('/assets*')`) matched the same paths.

Root cause: `buildWildcardRegExp` in `src/router/reg-exp-router/router.ts` only recognized a slash-prefixed star (`/path/*`). For a bare trailing star (`/path*`) the star fell into the meta-character class and was escaped as a literal, producing `^/assets\\*$`, which only matches the literal string `/assets*`. So `findMiddleware` never associated the middleware with any route path.

The fix adds a second anchored alternative for a bare trailing star and compiles it to `.*` — the same semantics the route side of this router already gives a `*` token (`ONLY_WILDCARD_REG_EXP_STR` in `node.ts`), and the same semantics `LinearRouter`/`PatternRouter` already have for this pattern:

```ts
path.replace(/\\/\\*$|\\*$|([.\\\\+*[^\\]$()])/g, (match, metaChar) =>
  metaChar ? `\\\\${metaChar}` : match === '/*' ? '(?:|/.*)' : '.*'
)
```

`/assets/*` keeps its previous tail-wildcard meaning (`^/assets(?:|/.*)$`); only paths ending in a star without a preceding slash change behavior — from "matches the literal string containing a star" (a path that can never be requested) to "matches any trailing characters", like the equivalent route.

## Verification

`app.use('/assets*', mw)` + `app.get('/assets/app.js')` + `app.get('/assets-v2')` against the default router, before vs after:

| request | before | after |
| --- | --- | --- |
| `/assets/app.js` | `x-mw: null` | `x-mw: hit` |
| `/assets-v2` | `x-mw: null` | `x-mw: hit` |

`app.use('/assets/*')` (control) hit in both.

Note: `TrieRouter` does not support a bare-star pattern at all (neither for routes nor middleware — it only special-cases a whole `*` segment), so this PR restores parity with `LinearRouter`/`PatternRouter`; the `TrieRouter` gap is pre-existing and unchanged.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code