### PR TITLE
fix(reg-exp-router): match tail wildcard without a leading slash befo…

### DIFF
--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -171,6 +171,24 @@ describe('RegExpRouter', () => {
         expect(res[0][0]).toBe('/a*')
       }
     })
+
+    it('Should apply a tail wildcard registered without a leading slash before the *', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/api*', 'wildcard')
+      router.add('GET', '/api/foo', 'foo')
+
+      const [res] = router.match('GET', '/api/foo')
+      expect(res.map((r) => r[0])).toEqual(['wildcard', 'foo'])
+    })
+
+    it('Should apply a tail wildcard registered after the concrete path, without a leading slash before the *', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/api/foo', 'foo')
+      router.add('GET', '/api*', 'wildcard')
+
+      const [res] = router.match('GET', '/api/foo')
+      expect(res.map((r) => r[0])).toEqual(['foo', 'wildcard'])
+    })
   })
 
   describe('Single character regexp pattern', () => {

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -17,8 +17,8 @@ function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
     path === '*'
       ? ''
-      : `^${path.replace(/\/\*$|([.\\+*[^\]$()])/g, (_, metaChar) =>
-          metaChar ? `\\${metaChar}` : '(?:|/.*)'
+      : `^${path.replace(/\/\*$|\*$|([.\\+*[^\]$()])/g, (match, metaChar) =>
+          metaChar ? `\\${metaChar}` : match === '/*' ? '(?:|/.*)' : '.*'
         )}$`
   ))
 }


### PR DESCRIPTION
…re *

buildWildcardRegExp() only recognized a wildcard suffix when it was preceded by a slash (e.g. "/assets/*"). A pattern like "/assets*" fell through to the generic metacharacter-escaping branch instead, so the "*" was escaped literally and the compiled regex became "^/assets\*$" — which only matches the literal string "/assets*" and never a real path such as "/assets/foo.js".

That regex is used by add() to associate an already-registered wildcard route/middleware with sibling paths added before or after it (via findMiddleware() and the re.test(p) cross-association loops). Because it never matched, middleware registered as app.use('/assets*', mw) silently never attached to routes added around it, even though a plain app.get('/assets*', handler) still dispatched correctly on its own (that path goes through the trie, not this regex).

Fix: treat a bare trailing "*" the same as the "/*" case, only without forcing a leading slash — replace it with ".*" instead of escaping it, while leaving the existing "/*" -> "(?:|/.*)" behavior untouched.

Adds regression tests covering both registration orders (wildcard added before and after the concrete path) for a pattern without a leading slash.

Fixes #5258

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

