### PR TITLE
fix(reg-exp-router): apply a trailing wildcard to paths using a different label name

### DIFF
--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -487,6 +487,21 @@ describe('Routing', () => {
     expect(app.router.name).toBe('SmartRouter + TrieRouter')
   })
 
+  it('Should apply a wildcard middleware to a route using a different label name', async () => {
+    const app = new Hono()
+    app.use('/:name/*', async (c, next) => {
+      c.header('X-Name', c.req.param('name'))
+      await next()
+    })
+    app.get('/:id', (c) => c.text(`id=${c.req.param('id')}`))
+
+    const res = await app.request('http://localhost/abc')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Name')).toBe('abc')
+    expect(await res.text()).toBe('id=abc')
+    expect(app.router.name).toBe('SmartRouter + RegExpRouter')
+  })
+
   it('Nested route - subApp with basePath', async () => {
     const app = new Hono()
     const book = new Hono().basePath('/book')

--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -422,6 +422,29 @@ export const runTest = ({
       })
     })
 
+    describe('Trailing wildcard after a label', () => {
+      beforeEach(() => {
+        router.add('GET', '/:name/*', 'middleware')
+        router.add('GET', '/:id', 'handler')
+      })
+
+      it('GET /abc', async () => {
+        const res = match('GET', '/abc')
+        expect(res.length).toBe(2)
+        expect(res[0].handler).toEqual('middleware')
+        expect(res[0].params).toEqual({ name: 'abc' })
+        expect(res[1].handler).toEqual('handler')
+        expect(res[1].params).toEqual({ id: 'abc' })
+      })
+
+      it('GET /abc/sub', async () => {
+        const res = match('GET', '/abc/sub')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('middleware')
+        expect(res[0].params).toEqual({ name: 'abc' })
+      })
+    })
+
     describe('Trailing wildcard after a middle wildcard', () => {
       beforeEach(() => {
         router.add('GET', '/a/*/b/*', 'b')

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -12,6 +12,8 @@ describe('LinearRouter', () => {
           'Capture regex pattern has trailing wildcard > GET /foo/bar/file.html',
           'Capture regex param with trailing wildcard on empty remainder > GET /123',
           'Capture regex param with trailing wildcard and sibling route > GET /regex-abc/123/ghi',
+          'Trailing wildcard after a label > GET /abc',
+          'Trailing wildcard after a label > GET /abc/sub',
           'Complex > Parameter with {.*} regexp',
         ],
       },

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -10,15 +10,19 @@ import { match, emptyParam } from './matcher'
 import { PATH_ERROR } from './node'
 import { Trie } from './trie'
 
-type HandlerWithMetadata<T> = [T, number] // [handler, paramCount]
+type HandlerWithMetadata<T> = [T, number, string[]?] // [handler, paramCount, paramNames]
 
 let wildcardRegExpCache: Record<string, RegExp> = Object.create(null)
+
+// a plain :label matches any segment, so its name does not affect what a wildcard covers;
+// :label{[0-9]+} stays a literal because it matches a narrower set
+const PLAIN_LABEL_REG_EXP_STR = '/:[^/]+'
 function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
     path === '*'
       ? ''
-      : `^${path.replace(/\/\*$|([.\\+*[^\]$()])/g, (_, metaChar) =>
-          metaChar ? `\\${metaChar}` : '(?:|/.*)'
+      : `^${path.replace(/\/:[^/{}]+(?=\/|$)|\/\*$|([.\\+*[^\]$()])/g, (match, metaChar) =>
+          metaChar ? `\\${metaChar}` : match === '/*' ? '(?:|/.*)' : PLAIN_LABEL_REG_EXP_STR
         )}$`
   ))
 }
@@ -91,6 +95,9 @@ export class RegExpRouter<T> implements Router<T> {
 
     if (/\*$/.test(path)) {
       const re = buildWildcardRegExp(path)
+      // The path this handler is registered for may use different label names than the
+      // paths it is associated with, so carry its own names to build the param map.
+      const paramNames = path.match(/\/:[^/{}]+/g)?.map((label) => label.slice(2))
       Object.keys(middleware).forEach((m) => {
         if ((method === METHOD_NAME_ALL || method === m) && !middleware[m][path]) {
           this.#insertPath(m, path)
@@ -103,7 +110,7 @@ export class RegExpRouter<T> implements Router<T> {
       Object.keys(middleware).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
           Object.keys(middleware[m]).forEach((p) => {
-            re.test(p) && middleware[m][p].push([handler, paramCount])
+            re.test(p) && middleware[m][p].push([handler, paramCount, paramNames])
           })
         }
       })
@@ -111,7 +118,7 @@ export class RegExpRouter<T> implements Router<T> {
       Object.keys(routes).forEach((m) => {
         if (method === METHOD_NAME_ALL || method === m) {
           Object.keys(routes[m]).forEach(
-            (p) => re.test(p) && routes[m][p].push([handler, paramCount])
+            (p) => re.test(p) && routes[m][p].push([handler, paramCount, paramNames])
           )
         }
       })
@@ -174,12 +181,12 @@ export class RegExpRouter<T> implements Router<T> {
           continue
         }
         const paramAssoc = pathData[1]
-        handlerData[pathData[0]] = handlers.map(([h, paramCount]) => {
+        handlerData[pathData[0]] = handlers.map(([h, paramCount, paramNames]) => {
           const paramIndexMap: ParamIndexMap = Object.create(null)
           paramCount -= 1
           for (; paramCount >= 0; paramCount--) {
             const [key, value] = paramAssoc[paramCount]
-            paramIndexMap[key] = value
+            paramIndexMap[paramNames?.[paramCount] ?? key] = value
           }
           return [h, paramIndexMap]
         })


### PR DESCRIPTION
## What this fixes

A middleware registered with a label before a trailing wildcard is silently skipped by
`RegExpRouter` whenever a route uses a **different label name** for the same segment.

```ts
const app = new Hono()

app.use('/:name/*', async (c, next) => {
  c.header('X-Name', c.req.param('name'))
  await next()
})
app.get('/:id', (c) => c.text('handler'))

const res = await app.request('/abc')
res.headers.get('X-Name') // null  -- expected 'abc'
```

This happens on the default router (`SmartRouter + RegExpRouter`), so it affects apps
out of the box. `TrieRouter` and `PatternRouter` both run the middleware here.

The behaviour depends only on the label *name*, which makes it easy to hit by accident:

| routes | `RegExpRouter` before | `TrieRouter` / `PatternRouter` |
| --- | --- | --- |
| `/:a/*` + `/:a` (same name) | middleware runs | middleware runs |
| `/:a/*` + `/:b` (different name) | **middleware skipped** | middleware runs |
| `/a/*` + `/a` (static) | middleware runs | middleware runs |

## Cause

`RegExpRouter` decides which registered paths a trailing wildcard is associated with by
testing the wildcard against the registered path *strings*, not against request paths.
`buildWildcardRegExp('/:name/*')` produces `^/:name(?:|/.*)$`, which is then tested
against the literal string `/:id` and does not match.

## The change

A plain `:label` matches any single path segment, so its name does not affect which paths
a wildcard covers. The association regexp now replaces plain labels with a pattern that
matches any label. Patterns with a regexp (`:label{[0-9]+}`) are kept as literals, because
they match a narrower set of segments and must not be broadened.

Because an associated path may now use different label names, the wildcard path's own
label names are carried alongside the handler and used to build the param map. This keeps
`c.req.param()` inside the middleware reporting the names it was registered with, matching
`TrieRouter` exactly.

Everything changed runs at registration and build time, so there is **no per-request cost**.

## Tests

- `src/router/common.case.test.ts` — a shared case, so it runs against every router.
  `LinearRouter` is skipped, as it already raises `UnsupportedPathError` for a label
  followed by a wildcard.
- `src/hono.test.ts` — an app-level case covering the reported symptom.

Without the source change these fail in three places: `RegExpRouter`,
`PreparedRegExpRouter` and the app-level test.

## Verification

I checked this with a differential test that registers the same routes in all four routers
and compares both the matched handlers and the resulting params.

- Across ~5,200 generated wildcard/label cases: **55 distinct divergences before, 2 after**.
- The 2 remaining divergences are the pre-existing duplicate-label-name limitation
  (`/:id/:id{[0-9]+}`), which is unrelated to this change and already documented in the
  routers' test skip lists.
- A separate order-sensitive sweep over 60,000 route/path combinations reports 0
  divergences after the change.

Full suite passes: 147 files, 4851 tests.

Note: this touches `buildWildcardRegExp`, which #5259 and #5260 also modify for a different
case (a trailing wildcard with no slash before it). Happy to rebase if either lands first.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
