### PR TITLE
fix(jsx/dom): run previous ref cleanup when the ref changes

### DIFF
--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -346,6 +346,30 @@ describe('DOM', () => {
       expect(ref).toBeCalledTimes(1)
       expect(cleanup).toBeCalledTimes(1)
     })
+
+    it('ref cleanup function on ref change', async () => {
+      const cleanup1 = vi.fn()
+      const ref1 = vi.fn().mockReturnValue(cleanup1)
+      const ref2 = vi.fn()
+      const App = () => {
+        const [swapped, setSwapped] = useState(false)
+        return (
+          <>
+            <div ref={swapped ? ref2 : ref1} />
+            <button onClick={() => setSwapped(true)}>switch</button>
+          </>
+        )
+      }
+      render(<App />, root)
+      expect(root.innerHTML).toBe('<div></div><button>switch</button>')
+      expect(ref1).toHaveBeenLastCalledWith(expect.any(dom.window.HTMLDivElement))
+      expect(cleanup1).not.toHaveBeenCalled()
+      root.querySelector('button')?.click()
+      await Promise.resolve()
+      expect(root.innerHTML).toBe('<div></div><button>switch</button>')
+      expect(cleanup1).toBeCalledTimes(1)
+      expect(ref2).toHaveBeenLastCalledWith(expect.any(dom.window.HTMLDivElement))
+    })
   })
 
   describe('child component', () => {

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -187,6 +187,7 @@ const applyProps = (
       } else if (key === 'dangerouslySetInnerHTML' && value) {
         container.innerHTML = value.__html
       } else if (key === 'ref') {
+        refCleanupMap.get(container)?.()
         let cleanup
         if (typeof value === 'function') {
           cleanup = value(container) || (() => value(null))
@@ -257,6 +258,7 @@ const applyProps = (
           container.removeEventListener(eventSpec[0], value, eventSpec[1])
         } else if (key === 'ref') {
           refCleanupMap.get(container)?.()
+          refCleanupMap.delete(container)
         } else {
           try {
             container.removeAttribute(toAttributeName(container, key))


### PR DESCRIPTION
Fixes #5262

When a `ref` prop changes identity across a re-render, `applyProps` registers the new ref and overwrites `refCleanupMap`, so the cleanup returned by the previous ref (or the `ref(null)` call for a plain callback ref) never runs. The cleanup currently fires only when the `ref` key disappears from the props entirely, or when the node is removed.

The fix invokes the stored cleanup before the new ref is attached, matching how the event listener branch above already removes the old listener when the handler changes.

The removal branch now also drops the entry from `refCleanupMap` after running it. That element stays in the tree with only its `ref` gone, so without the delete a later re-added `ref` would run the stale cleanup a second time.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
