### PR TITLE
fix(request): prevent TypeError when calling param() on unmatched request

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -72,6 +72,12 @@ describe('Param', () => {
     expect(req.param('name')).toBe('key')
   })
 
+  test('param() on un-matched HonoRequest', () => {
+    const req = new HonoRequest(new Request('http://localhost/'))
+    expect(req.param('id')).toBeUndefined()
+    expect(req.param()).toEqual({})
+  })
+
   test('req.param() without ParamStash', () => {
     const rawRequest = new Request('http://localhost?page=2&tag=A&tag=B')
     const req = new HonoRequest<'/:id/:name'>(rawRequest, '/123/key', [

--- a/src/request.ts
+++ b/src/request.ts
@@ -101,7 +101,11 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   #getDecodedParam(key: string): string | undefined {
-    const paramKey = this.#matchResult[0][this.routeIndex][1][key]
+    const routeMatch = this.#matchResult[0][this.routeIndex]
+    if (!routeMatch) {
+      return undefined
+    }
+    const paramKey = routeMatch[1][key]
     const param = this.#getParamValue(paramKey)
     return param && tryDecodeURIComponent(param)
   }
@@ -109,9 +113,14 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   #getAllDecodedParams(): Record<string, string> {
     const decoded: Record<string, string> = {}
 
-    const keys = Object.keys(this.#matchResult[0][this.routeIndex][1])
+    const routeMatch = this.#matchResult[0][this.routeIndex]
+    if (!routeMatch) {
+      return decoded
+    }
+
+    const keys = Object.keys(routeMatch[1])
     for (const key of keys) {
-      const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
+      const value = this.#getParamValue(routeMatch[1][key])
       if (value !== undefined) {
         decoded[key] = tryDecodeURIComponent(value)
       }


### PR DESCRIPTION
### Summary
Fixes an unhandled `TypeError: Cannot read properties of undefined (reading '1')` when calling `c.req.param(key)` or `c.req.param()` on a `HonoRequest` instance that has not matched a route (such as standalone request handlers, custom middlewares, testing environments, or error handlers).

### Details & Root Cause
When a `HonoRequest` instance is initialized without a route match result (using the default constructor argument `matchResult = [[]]`), `this.#matchResult[0]` is an empty array `[]`.

In `#getDecodedParam` and `#getAllDecodedParams`:
- `#getDecodedParam` evaluated `this.#matchResult[0][this.routeIndex][1][key]`. Because `this.#matchResult[0][0]` is `undefined`, attempting to index `[1]` threw a `TypeError`.
- `#getAllDecodedParams` evaluated `Object.keys(this.#matchResult[0][this.routeIndex][1])`, throwing the same `TypeError`.

### Solution
- Added a single guard check `const routeMatch = this.#matchResult[0][this.routeIndex]` before property access in both `#getDecodedParam` and `#getAllDecodedParams`.
- If `routeMatch` is not present, `#getDecodedParam` returns `undefined` and `#getAllDecodedParams` returns `{}` as expected by the API contract.
- Zero performance impact on the hot path for matched routes.

### Test Coverage
Added unit test `param() on un-matched HonoRequest` in `src/request.test.ts`. All existing unit tests pass cleanly.
