### PR TITLE
fix(request): handle params on unmatched requests

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -39,6 +39,13 @@ describe('Query', () => {
 })
 
 describe('Param', () => {
+  test('req.param() on an unmatched request', () => {
+    const req = new HonoRequest(new Request('http://localhost/'))
+
+    expect(req.param('id')).toBeUndefined()
+    expect(req.param()).toEqual({})
+  })
+
   test('req.param() should return empty string for zero-length match', () => {
     // Simulate a route like '/:remaining{.*}' matching '/'
     const rawRequest = new Request('http://localhost/')

--- a/src/request.ts
+++ b/src/request.ts
@@ -101,7 +101,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   }
 
   #getDecodedParam(key: string): string | undefined {
-    const paramKey = this.#matchResult[0][this.routeIndex][1][key]
+    const paramKey = this.#matchResult[0][this.routeIndex]?.[1][key]
     const param = this.#getParamValue(paramKey)
     return param && tryDecodeURIComponent(param)
   }
@@ -109,7 +109,7 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
   #getAllDecodedParams(): Record<string, string> {
     const decoded: Record<string, string> = {}
 
-    const keys = Object.keys(this.#matchResult[0][this.routeIndex][1])
+    const keys = Object.keys(this.#matchResult[0][this.routeIndex]?.[1] ?? {})
     for (const key of keys) {
       const value = this.#getParamValue(this.#matchResult[0][this.routeIndex][1][key])
       if (value !== undefined) {


### PR DESCRIPTION
Prevents `req.param()` from throwing when the request has no matched route.

Keyed access returns `undefined`, while `req.param()` returns an empty object. Includes a regression test.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code

