### PR TITLE
feat(bearer-auth): allow MessageFunction to return a Response

### DIFF
--- a/src/middleware/bearer-auth/index.test.ts
+++ b/src/middleware/bearer-auth/index.test.ts
@@ -197,6 +197,24 @@ describe('Bearer Auth by Middleware', () => {
     })
 
     app.use(
+      '/auth-custom-no-authentication-header-message-function-response/*',
+      bearerAuth({
+        token,
+        noAuthenticationHeader: {
+          message: () =>
+            new Response(JSON.stringify({ type: 'about:blank', title: 'Unauthorized', status: 401 }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/problem+json' },
+            }),
+        },
+      })
+    )
+    app.get('/auth-custom-no-authentication-header-message-function-response/*', (c) => {
+      handlerExecuted = true
+      return c.text('auth')
+    })
+
+    app.use(
       '/auth-custom-invalid-authentication-header-wwwAuthenticateHeader-string/*',
       bearerAuth({
         token: tokens,
@@ -912,6 +930,19 @@ describe('Bearer Auth by Middleware', () => {
     expect(res.status).toBe(401)
     expect(handlerExecuted).toBeFalsy()
     expect(await res.text()).toBe('Custom invalid token message as function string')
+  })
+
+  it('Should not authorize - custom no authorization header message as function Response (RFC 9457)', async () => {
+    const req = new Request(
+      'http://localhost/auth-custom-no-authentication-header-message-function-response'
+    )
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(res.headers.get('Content-Type')).toMatch('application/problem+json')
+    expect(res.headers.get('WWW-Authenticate')).toMatch(/Bearer/)
+    expect(handlerExecuted).toBeFalsy()
+    expect(await res.json()).toEqual({ type: 'about:blank', title: 'Unauthorized', status: 401 })
   })
 
   it('Should not authorize - custom invalid token message as function object', async () => {

--- a/src/middleware/bearer-auth/index.ts
+++ b/src/middleware/bearer-auth/index.ts
@@ -13,7 +13,8 @@ const TOKEN_STRINGS = '[A-Za-z0-9._~+/-]+=*'
 const PREFIX = 'Bearer'
 const HEADER = 'Authorization'
 
-type MessageFunction = (c: Context) => string | object | Promise<string | object>
+type MessageValue = string | object | Response
+type MessageFunction = (c: Context) => MessageValue | Promise<MessageValue>
 type CustomizedErrorResponseOptions = {
   wwwAuthenticateHeader?: string | object | MessageFunction
   message?: string | object | MessageFunction
@@ -140,6 +141,18 @@ export const bearerAuth = <E extends Env = Env>(
     }
     const responseMessage =
       typeof messageOption === 'function' ? await messageOption(c) : messageOption
+    if (responseMessage instanceof Response) {
+      const resHeaders = new Headers(responseMessage.headers)
+      if (!resHeaders.has('WWW-Authenticate')) {
+        resHeaders.set('WWW-Authenticate', headers['WWW-Authenticate'])
+      }
+      throw new HTTPException(status, {
+        res: new Response(responseMessage.body, {
+          status: responseMessage.status || status,
+          headers: resHeaders,
+        }),
+      })
+    }
     const res =
       typeof responseMessage === 'string'
         ? new Response(responseMessage, { status, headers })


### PR DESCRIPTION
Fixes https://github.com/honojs/hono/issues/5218

`message` / `MessageFunction` can now return a `Response` so error bodies can use any content type (e.g. RFC 9457 `application/problem+json`). Existing string/object messages are unchanged.

If the Response has no `WWW-Authenticate`, the middleware still sets it.

`yusukebe` said this is fine in a minor if it is not breaking.

Tests: `npx vitest --run src/middleware/bearer-auth/index.test.ts` — 51 passed.