### PR TITLE
fix(reg-exp-router): apply middleware registered with a tail wildcard that has no preceding slash

### DIFF
--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -158,6 +158,36 @@ describe('RegExpRouter', () => {
       expect(res[1][0]).toBe('wildcard')
     })
 
+    it('Should apply middleware registered with a tail wildcard that has no preceding slash', () => {
+      // https://github.com/honojs/hono/issues/5258
+      // `/assets*` is a valid route pattern, but `findMiddleware` used to escape the
+      // `*` literally, so middleware registered this way never matched any request.
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/assets*', 'middleware')
+      router.add('GET', '/assets/app.js', 'handler')
+
+      const [res] = router.match('GET', '/assets/app.js')
+      expect(res.map(([handler]) => handler)).toEqual(['middleware', 'handler'])
+    })
+
+    it('Should match a tail wildcard without a preceding slash as a prefix', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/assets*', 'middleware')
+      router.add('GET', '/assets-v2/app.js', 'handler')
+
+      const [res] = router.match('GET', '/assets-v2/app.js')
+      expect(res.map(([handler]) => handler)).toEqual(['middleware', 'handler'])
+    })
+
+    it('Should not let a tail wildcard with a preceding slash match a sibling prefix', () => {
+      const router = new RegExpRouter<string>()
+      router.add('ALL', '/assets/*', 'middleware')
+      router.add('GET', '/assets-v2/app.js', 'handler')
+
+      const [res] = router.match('GET', '/assets-v2/app.js')
+      expect(res.map(([handler]) => handler)).toEqual(['handler'])
+    })
+
     it('Should prioritize the only wildcard over the tail wildcard regardless of the order', () => {
       for (const paths of [
         ['/a*', '/a/*'],

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -17,8 +17,8 @@ function buildWildcardRegExp(path: string): RegExp {
   return (wildcardRegExpCache[path] ??= new RegExp(
     path === '*'
       ? ''
-      : `^${path.replace(/\/\*$|([.\\+*[^\]$()])/g, (_, metaChar) =>
-          metaChar ? `\\${metaChar}` : '(?:|/.*)'
+      : `^${path.replace(/\/\*$|\*$|([.\\+*[^\]$()])/g, (match, metaChar) =>
+          metaChar ? `\\${metaChar}` : match === '/*' ? '(?:|/.*)' : '.*'
         )}$`
   ))
 }


### PR DESCRIPTION
Closes #5258.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `format:fix` / `lint:fix` (verified clean with `prettier --check` and `eslint`)
- [ ] Add TSDoc/JSDoc — not applicable, internal helper

---

### Problem

`findMiddleware` matches already-registered middleware against a path using `buildWildcardRegExp`, whose only wildcard branch is `\/\*$` — it requires a slash before the `*`. For a pattern like `/assets*` the `*` falls through to the metacharacter class and is escaped literally:

```
/assets*   ->  ^\/assets\*$          matches only the literal string "/assets*"
/assets/*  ->  ^\/assets(?:|\/.*)$
```

So `app.use('/assets*', mw)` never runs, while `app.get('/assets*', handler)` matches the same requests — route matching goes through a different code path. Since `RegExpRouter` is the default via `SmartRouter`, a common pattern like `app.use('/api*', authMiddleware)` silently applies no middleware, with no error or warning.

### Fix

Add a branch for a trailing `*` with no preceding slash and emit a prefix match:

```js
path.replace(/\/\*$|\*$|([.\\+*[^\]$()])/g, (match, metaChar) =>
  metaChar ? `\\${metaChar}` : match === '/*' ? '(?:|/.*)' : '.*'
)
```

Alternation order matters here: `\/\*$` is tried first, so `/foo/*` keeps its existing `(?:|/.*)` expansion and still does not match a sibling prefix like `/foo-v2`. A non-trailing `*` (e.g. `/a*b`) keeps being escaped as a literal, as before.

Prefix semantics for the no-slash form matches what the other routers already do for the same pattern as a route — `LinearRouter`, `PatternRouter` and `RegExpRouter`'s own route matching all treat `/assets*` as matching `/assets`, `/assets/app.js`, `/assets-v2` and `/assetsX`.

### Tests

Three cases added to `router.test.ts`:

- middleware registered as `/assets*` is applied to `/assets/app.js`
- the no-slash form matches a sibling prefix (`/assets*` against `/assets-v2/app.js`)
- regression guard: `/assets/*` still does **not** match `/assets-v2/app.js`

The first two fail on `main` and pass with this change; the third passes both ways and exists to pin the `/foo/*` semantics.

Full suite is green — 3861 passed, 28 skipped across 123 files — plus `tsc -p tsconfig.spec.json`, `prettier --check` and `eslint` clean.

### Scope

This only covers `RegExpRouter`'s middleware path. As noted in #5258, `TrieRouter` also does not match `/assets*` as a plain route while the other three routers do; that is a separate behaviour change and I left it out of this PR deliberately. Happy to follow up on it if you want it aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Smwb1MRyiGRRMEEDVioV88
