### PR TITLE
perf(jws): reuse imported CryptoKey for string secrets

### DIFF
--- a/src/utils/jwt/jws.ts
+++ b/src/utils/jwt/jws.ts
@@ -36,6 +36,12 @@ export async function signing(
   return await crypto.subtle.sign(algorithm, cryptoKey, data)
 }
 
+// String/PEM secrets are reused across requests; skip importKey after the first
+// call. Cap the map so Jwt.verify() cannot cache unbounded request-derived
+// material. JWK objects are not cached: mutation would keep the old CryptoKey.
+const MAX_CACHED_STRING_PUBLIC_KEYS = 16
+const cachedStringPublicKeys = new Map<string, CryptoKey>()
+
 export async function verifying(
   publicKey: SignatureKey,
   alg: SignatureAlgorithm,
@@ -43,7 +49,25 @@ export async function verifying(
   data: BufferSource
 ): Promise<boolean> {
   const algorithm = getKeyAlgorithm(alg)
-  const cryptoKey = await importPublicKey(publicKey, algorithm)
+  let cryptoKey: CryptoKey
+  if (typeof publicKey === 'string') {
+    const cacheKey = `${alg}\0${publicKey}`
+    const cached = cachedStringPublicKeys.get(cacheKey)
+    if (cached) {
+      cryptoKey = cached
+    } else {
+      cryptoKey = await importPublicKey(publicKey, algorithm)
+      if (cachedStringPublicKeys.size >= MAX_CACHED_STRING_PUBLIC_KEYS) {
+        const oldest = cachedStringPublicKeys.keys().next().value
+        if (oldest !== undefined) {
+          cachedStringPublicKeys.delete(oldest)
+        }
+      }
+      cachedStringPublicKeys.set(cacheKey, cryptoKey)
+    }
+  } else {
+    cryptoKey = await importPublicKey(publicKey, algorithm)
+  }
   return await crypto.subtle.verify(algorithm, cryptoKey, signature, data)
 }
 

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -1772,3 +1772,129 @@ describe('PEM parsing', async () => {
     expect(verified).toEqual(payload)
   })
 })
+
+describe('JWT public key import cache', () => {
+  const uniqueSecret = (label: string): string =>
+    `jwt-import-cache-${label}-${Math.random().toString(36).slice(2)}`
+
+  it('imports a string secret only once across verify() calls', async () => {
+    const secret = uniqueSecret('once')
+    const payload = { n: 1 }
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    const spy = vi.spyOn(crypto.subtle, 'importKey')
+    try {
+      await expect(JWT.verify(tok, secret, AlgorithmTypes.HS256)).resolves.toEqual(payload)
+      const afterFirst = spy.mock.calls.length
+      expect(afterFirst).toBeGreaterThan(0)
+      await expect(JWT.verify(tok, secret, AlgorithmTypes.HS256)).resolves.toEqual(payload)
+      expect(spy.mock.calls.length).toBe(afterFirst)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('imports again when the string secret changes', async () => {
+    const secretA = uniqueSecret('miss-a')
+    const secretB = uniqueSecret('miss-b')
+    const payload = { n: 1 }
+    const tokA = await JWT.sign(payload, secretA, AlgorithmTypes.HS256)
+    const tokB = await JWT.sign(payload, secretB, AlgorithmTypes.HS256)
+    const spy = vi.spyOn(crypto.subtle, 'importKey')
+    try {
+      await JWT.verify(tokA, secretA, AlgorithmTypes.HS256)
+      const afterFirst = spy.mock.calls.length
+      await JWT.verify(tokB, secretB, AlgorithmTypes.HS256)
+      expect(spy.mock.calls.length).toBeGreaterThan(afterFirst)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('does not re-import on signature mismatch', async () => {
+    const secret = uniqueSecret('mismatch')
+    const tok = await JWT.sign({ n: 1 }, secret, AlgorithmTypes.HS256)
+    const parts = tok.split('.')
+    const sig = parts[2]
+    const badTok = `${parts[0]}.${parts[1]}.${(sig[0] === 'A' ? 'B' : 'A') + sig.slice(1)}`
+    const spy = vi.spyOn(crypto.subtle, 'importKey')
+    try {
+      await expect(JWT.verify(badTok, secret, AlgorithmTypes.HS256)).rejects.toBeInstanceOf(
+        JwtTokenSignatureMismatched
+      )
+      const afterFirst = spy.mock.calls.length
+      expect(afterFirst).toBeGreaterThan(0)
+      await expect(JWT.verify(badTok, secret, AlgorithmTypes.HS256)).rejects.toBeInstanceOf(
+        JwtTokenSignatureMismatched
+      )
+      expect(spy.mock.calls.length).toBe(afterFirst)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('does not cache JWK objects', async () => {
+    const secret = uniqueSecret('jwk-obj')
+    const payload = { n: 1 }
+    const tok = await JWT.sign(payload, secret, AlgorithmTypes.HS256)
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      utf8Encoder.encode(secret),
+      { name: 'HMAC', hash: { name: 'SHA-256' } },
+      true,
+      ['sign', 'verify']
+    )
+    const jwk = (await crypto.subtle.exportKey('jwk', cryptoKey)) as HonoJsonWebKey
+    const spy = vi.spyOn(crypto.subtle, 'importKey')
+    try {
+      await expect(JWT.verify(tok, jwk, AlgorithmTypes.HS256)).resolves.toEqual(payload)
+      const afterFirst = spy.mock.calls.length
+      expect(afterFirst).toBeGreaterThan(0)
+      await expect(JWT.verify(tok, jwk, AlgorithmTypes.HS256)).resolves.toEqual(payload)
+      expect(spy.mock.calls.length).toBeGreaterThan(afterFirst)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('evicts the oldest string secret once 16 keys are cached', async () => {
+    const secrets = Array.from({ length: 17 }, (_, i) => uniqueSecret(`cap-${i}`))
+    const tokens = await Promise.all(
+      secrets.map((secret) => JWT.sign({ i: secret }, secret, AlgorithmTypes.HS256))
+    )
+    const spy = vi.spyOn(crypto.subtle, 'importKey')
+    try {
+      for (let i = 0; i < 17; i++) {
+        await JWT.verify(tokens[i], secrets[i], AlgorithmTypes.HS256)
+      }
+      const afterFill = spy.mock.calls.length
+      await JWT.verify(tokens[0], secrets[0], AlgorithmTypes.HS256)
+      expect(spy.mock.calls.length).toBeGreaterThan(afterFill)
+      const afterOldest = spy.mock.calls.length
+      await JWT.verify(tokens[16], secrets[16], AlgorithmTypes.HS256)
+      expect(spy.mock.calls.length).toBe(afterOldest)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('verifies concurrent distinct secrets without crossing keys', async () => {
+    const secretA = uniqueSecret('conc-a')
+    const secretB = uniqueSecret('conc-b')
+    const tokA = await JWT.sign({ s: 'a' }, secretA, AlgorithmTypes.HS256)
+    const tokB = await JWT.sign({ s: 'b' }, secretB, AlgorithmTypes.HS256)
+
+    const [payloadA, payloadB] = await Promise.all([
+      JWT.verify(tokA, secretA, AlgorithmTypes.HS256),
+      JWT.verify(tokB, secretB, AlgorithmTypes.HS256),
+    ])
+    expect(payloadA).toEqual({ s: 'a' })
+    expect(payloadB).toEqual({ s: 'b' })
+
+    await expect(JWT.verify(tokA, secretB, AlgorithmTypes.HS256)).rejects.toBeInstanceOf(
+      JwtTokenSignatureMismatched
+    )
+    await expect(JWT.verify(tokB, secretA, AlgorithmTypes.HS256)).rejects.toBeInstanceOf(
+      JwtTokenSignatureMismatched
+    )
+  })
+})


### PR DESCRIPTION
`jwt({ secret: '…', alg: 'HS256' })` and `Jwt.verify(token, secret, alg)` import the secret with `crypto.subtle.importKey` on every request. CryptoKey inputs already skip that. String secrets are the documented default.

On Node 22, `importKey` is about 30% of HMAC import+verify (14 µs vs 32 µs) and 42% of RSA SPKI import+verify (38 µs vs 53 µs). On Bun, HMAC `importKey` is cheaper; a full `app.fetch()` with `jwt()` + `c.json()` still spent about 7% of the authenticated request on it (84 µs vs 78 µs). JWT itself is ~90% of that request.

### What changed

`verifying()` caches the imported `CryptoKey` for `typeof publicKey === 'string'` (HMAC secrets and PEM). Keyed by `alg + secret`, cap 16, FIFO. The `CryptoKey` used for `subtle.verify` is a local binding, so eviction or a concurrent import cannot mix keys for an in-flight verify.

JWK objects are not cached. Mutating a JWK after the first verify would otherwise keep serving the old key. `signing()` is unchanged.

Factory-only cache inside `jwt()` would miss the documented Workers pattern that constructs the middleware per request from `c.env.JWT_SECRET`, and would miss standalone `Jwt.verify()`.

### Out of scope

- JWKS `fetch` on every `jwk({ jwks_uri })` request — users can already cache via `keys()`. That needs TTL and kid-miss refetch, which is a separate design.
- Signed cookies (`getCryptoKey`) — `parseSigned` already imports once per header.

### Testing

- `bunx vitest --run src/utils/jwt/jwt.test.ts src/middleware/jwt/index.test.ts` — 138 passed (6 new)
- `tsc -p tsconfig.spec.json` — OK
- New tests: same string is imported once; different string misses; signature mismatch still caches; JWK objects are not cached; two secrets in parallel do not cross; oldest of 16 is evicted

Not validated: Cloudflare Workers isolate (no local workerd run of this path).

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
