### PR TITLE
fix(client): skip an undefined entry inside a query array

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1715,6 +1715,31 @@ describe('WebSocket Provider Integration', () => {
   })
 })
 
+describe('Query arrays containing undefined', () => {
+  // A validator whose query field is an optional union gives the client an input
+  // type of `(string | undefined)[] | undefined`, so this compiles with no cast.
+  const app = new Hono().get(
+    '/search',
+    validator('query', () => ({}) as { tag: (string | undefined)[] | undefined }),
+    (c) => c.json({ ok: true })
+  )
+  type AppType = typeof app
+
+  it('Should not send the literal string "undefined" for an absent entry', async () => {
+    let requestedUrl = ''
+    const client = hc<AppType>('http://localhost', {
+      fetch: (input: RequestInfo | URL) => {
+        requestedUrl = input.toString()
+        return Promise.resolve(new Response('{}'))
+      },
+    })
+
+    await client.search.$get({ query: { tag: ['a', undefined, 'b'] } })
+
+    expect(requestedUrl).toBe('http://localhost/search?tag=a&tag=b')
+  })
+})
+
 describe('Custom buildSearchParams', () => {
   const app = new Hono()
   const route = app.get(

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -101,6 +101,27 @@ describe('buildSearchParams', () => {
     const searchParams = buildSearchParams(query)
     expect(searchParams.toString()).toBe('id=123&type=test&tag=a&tag=b')
   })
+
+  it('Should skip an undefined entry inside an array, as it does for a top-level value', () => {
+    // `['a', undefined, 'b']` used to serialise as `tag=a&tag=undefined&tag=b`,
+    // sending the literal string "undefined" to the server.
+    const searchParams = buildSearchParams({
+      tag: ['a', undefined as unknown as string, 'b'],
+    })
+    expect(searchParams.toString()).toBe('tag=a&tag=b')
+  })
+
+  it('Should keep an empty string in an array', () => {
+    const searchParams = buildSearchParams({ tag: ['a', '', 'b'] })
+    expect(searchParams.toString()).toBe('tag=a&tag=&tag=b')
+  })
+
+  it('Should drop an array whose entries are all undefined', () => {
+    const searchParams = buildSearchParams({
+      tag: [undefined, undefined] as unknown as string[],
+    })
+    expect(searchParams.toString()).toBe('')
+  })
 })
 
 describe('replaceUrlProtocol', () => {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -33,6 +33,9 @@ export const buildSearchParams = (query: Record<string, string | string[]>) => {
 
     if (Array.isArray(v)) {
       for (const v2 of v) {
+        if (v2 === undefined) {
+          continue
+        }
         searchParams.append(k, v2)
       }
     } else {


### PR DESCRIPTION
`buildSearchParams` skips a top-level `undefined` value, but the array branch
appended every entry unconditionally. `URLSearchParams` stringifies, so the
literal string `"undefined"` went out on the wire:

```ts
buildSearchParams({ tag: ['a', undefined, 'b'] }).toString()
// main:  "tag=a&tag=undefined&tag=b"
// here:  "tag=a&tag=b"
```

### It is reachable without a cast

`InferInputInner` (`src/validator/utils.ts:31-33`) passes the schema type through
verbatim when the field is an optional union, so a route validated with the
equivalent of `z.array(z.string().optional()).optional()` gives the client an
input type of `(string | undefined)[] | undefined`. This type checks today:

```ts
await client.search.$get({ query: { tag: ['a', undefined, 'b'] } })
// GET /search?tag=a&tag=undefined&tag=b
```

That is the case in the added `client.test.ts` test — no cast on the call.

### Scope

An `undefined` array entry is now skipped, matching the guard three lines above
it. An empty string is still sent (`tag=a&tag=&tag=b`), so this is deliberately
`=== undefined` rather than falsy.

`null` is untouched and still serialises as the string `"null"`. That is
pre-existing and symmetric with the top-level branch, which does the same;
dropping it would be a behaviour change nobody asked for.

### Two related things I did not fold in

- **`$ws`** had the same problem and is already being fixed in #5256, which
  routes it through `buildSearchParams`. That PR does not change the array
  branch, so `$ws` will still emit `tag=undefined` for an array entry until this
  one lands — the two are complementary, and I have deliberately left
  `client.ts` alone here to avoid conflicting with it.
- **`form`** (`src/client/client.ts:70-73`) has the identical asymmetry: the
  top-level `undefined` guard is there, the array entries are appended
  unguarded, so `{ form: { tag: ['a', undefined, 'b'] } }` sends `"undefined"`
  as a value. That is the other half of #4731: #4732 added the top-level guard
  and left the array loop below it untouched. Happy to follow up with it
  separately if you want it fixed the same way.

4 tests added, 3 of which fail without the change. The fourth
(`Should keep an empty string in an array`) passes on `main` already — it is a
guard so that this never gets narrowed to a falsy check, which would start
dropping empty values.

Full suite passes locally. A couple of unrelated tests time out under full-suite
load on my machine and pass in isolation - none of them import `src/client`.
