### PR TITLE
fix(method-not-allowed): ignore trailing wildcard routes when inferring allowed methods

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -197,6 +197,31 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
   })
 
+  it('ignores trailing wildcard routes when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('ok'))
+    // Catch-all GET routes, e.g. those registered by `app.get('/*', serveStatic())`
+    // or `app.get('/assets/*', serveStatic({ root: './public' }))`.
+    app.get('/*', (_c, next) => next())
+    app.get('/assets/*', (_c, next) => next())
+
+    // A root-level wildcard must not make an unhandled path report 405 instead of 404.
+    const missing = await app.request('/missing', { method: 'POST' })
+    expect(missing.status).toBe(404)
+    expect(missing.headers.has('Allow')).toBe(false)
+
+    // A prefixed wildcard must be ignored just the same.
+    const missingAsset = await app.request('/assets/missing.js', { method: 'POST' })
+    expect(missingAsset.status).toBe(404)
+    expect(missingAsset.headers.has('Allow')).toBe(false)
+
+    // A concrete route still advertises its allowed methods.
+    const real = await app.request('/api', { method: 'POST' })
+    expect(real.status).toBe(405)
+    expect(real.headers.get('Allow')).toBe('GET, HEAD')
+  })
+
   it('does not invoke the error handler for a 405 response', async () => {
     const app = new Hono()
     const onError = vi.fn(() => new Response('error', { status: 500 }))

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -83,6 +83,14 @@ export const methodNotAllowed = <E extends Env = Env>(
           continue
         }
 
+        // A trailing wildcard (e.g. `app.get('/*', serveStatic())`) matches an arbitrary
+        // remainder of the path, so it does not prove that a specific target resource
+        // exists. Letting it contribute would turn every otherwise-unhandled request in
+        // that namespace from a 404 into a 405.
+        if (route.path.endsWith('*')) {
+          continue
+        }
+
         const methods = methodsByPath.get(route.path) ?? new Set<string>()
         methods.add(route.method)
 


### PR DESCRIPTION
When a catch-all route like `app.get('/*', serveStatic())` is registered, `methodNotAllowed`
treats GET as allowed for every path, since the wildcard matches everything. A non-GET request
to a path that doesn't exist then returns 405 instead of 404 (#5223).

Skip routes whose path ends in `*` when collecting allowed methods, the same way `ALL` routes
are already skipped. A trailing wildcard isn't evidence that a specific resource exists. Middle
wildcards (`/a/*/b`) and regex catch-alls are left alone, matching the direction discussed in the
issue. The `serveStatic` part of the report is separate (#5224) and left untouched.

One side effect: when a wildcard GET also covers a path that has a concrete non-GET route, `Allow`
no longer lists GET. That is the intended trade-off, since a 404 on an otherwise-unhandled path is
better than a misleading 405.

Closes #5223

## Testing

- `vitest --run --project main`: 3920 passed, including the new method-not-allowed cases
- `tsc -p tsconfig.spec.json`, `eslint`, and `prettier --check` on the changed files

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
