### PR TITLE
fix(body-limit): enforce the limit when Content-Length is not a number

### DIFF
--- a/src/middleware/body-limit/index.test.ts
+++ b/src/middleware/body-limit/index.test.ts
@@ -176,6 +176,30 @@ describe('Body Limit Middleware', () => {
       expect(await res.text()).toBe(smallContent)
     })
 
+    it('should not bypass the limit when Content-Length is not a number', async () => {
+      // A non-numeric Content-Length makes parseInt return NaN, and `NaN > maxSize`
+      // is false, which previously skipped the check and let an oversized body
+      // through. The limit must still be enforced against the actual bytes.
+      const largeContent = 'this is a large content that exceeds 10 bytes'
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(largeContent))
+          controller.close()
+        },
+      })
+
+      const res = await app.request('/test', {
+        method: 'POST',
+        headers: {
+          'Content-Length': 'not-a-number',
+        },
+        body: stream,
+        duplex: 'half',
+      } as RequestInit)
+
+      expect(res.status).toBe(413)
+    })
+
     it('should handle only Transfer-Encoding header correctly', async () => {
       const content = 'test'
       const stream = new ReadableStream({

--- a/src/middleware/body-limit/index.ts
+++ b/src/middleware/body-limit/index.ts
@@ -68,9 +68,16 @@ export const bodyLimit = (options: BodyLimitOptions): MiddlewareHandler => {
     const hasContentLength = c.req.raw.headers.has('content-length')
 
     if (hasContentLength && !hasTransferEncoding) {
-      // Only Content-Length present - we can trust it
+      // Only Content-Length present - we can trust it when it is a valid number.
+      // A non-numeric Content-Length (e.g. "abc") makes parseInt return NaN, and
+      // `NaN > maxSize` is false, which would silently skip the limit and let the
+      // handler read an unbounded body. Fall through to the streaming check, which
+      // enforces the limit against the actual bytes, whenever the header is not a
+      // usable number.
       const contentLength = parseInt(c.req.raw.headers.get('content-length') || '0', 10)
-      return contentLength > maxSize ? onError(c) : next()
+      if (!Number.isNaN(contentLength)) {
+        return contentLength > maxSize ? onError(c) : next()
+      }
     }
 
     // Transfer-Encoding present (chunked) or no length headers.


### PR DESCRIPTION
## Problem

In the `body-limit` middleware, the Content-Length-only fast path trusts `parseInt` without checking for `NaN`:

```ts
const contentLength = parseInt(c.req.raw.headers.get('content-length') || '0', 10)
return contentLength > maxSize ? onError(c) : next()
```

A non-numeric `Content-Length` (e.g. `Content-Length: abc`) makes `parseInt` return `NaN`, and `NaN > maxSize` is `false`, so the middleware calls `next()` and the handler reads the body with **no size limit** — the protection is silently bypassed. This only affects the branch where `Content-Length` is present and `Transfer-Encoding` is not (the streaming branch already checks the real byte count).

## Fix

When the parsed `Content-Length` is not a usable number, fall through to the existing streaming check, which enforces the limit against the actual bytes. Numeric Content-Length behavior is unchanged.

## Test

Adds a regression test that sends `Content-Length: not-a-number` with an oversized body and asserts `413`. Verified **red→green**: it fails on `main` (the body is accepted) and passes with the fix; the existing `body-limit` tests stay green (13/13).

AI was used to help find and verify this; the fix and test were reproduced end-to-end before opening.