### PR TITLE
fix(jsx/dom): run cleanups when replacing rendered roots

### DIFF
--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -114,6 +114,25 @@ describe('DOM', () => {
     expect(root.innerHTML).toBe('<h1>Hello</h1>')
   })
 
+  it('runs effect cleanup when rendering null', async () => {
+    const cleanup = vi.fn()
+    const App = () => {
+      useEffect(() => cleanup, [])
+      return <div>Hello</div>
+    }
+
+    render(<App />, root)
+    await new Promise((resolve) => setTimeout(resolve))
+    expect(root.innerHTML).toBe('<div>Hello</div>')
+    expect(cleanup).not.toHaveBeenCalled()
+
+    render(null, root)
+    await Promise.resolve()
+
+    expect(root.innerHTML).toBe('')
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
   it('render text directly', () => {
     const App = () => <>{'Hello'}</>
     render(<App />, root)

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -795,9 +795,18 @@ export const renderNode = (node: NodeObject, container: Container): void => {
   container.replaceChildren(fragment)
 }
 
+const renderedRoots: WeakMap<Container, NodeObject> = new WeakMap()
+
 export const render = (jsxNode: Child, container: Container): void => {
+  const previousRoot = renderedRoots.get(container)
+  if (previousRoot) {
+    removeNode(previousRoot)
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  renderNode(buildNode({ tag: '', props: { children: jsxNode } } as any) as NodeObject, container)
+  const root = buildNode({ tag: '', props: { children: jsxNode } } as any) as NodeObject
+  renderNode(root, container)
+  renderedRoots.set(container, root)
 }
 
 export const flushSync = (callback: () => void): void => {


### PR DESCRIPTION
Fixes #5277.

The standalone render function replaced container contents without unmounting the previous virtual tree, so effect cleanups did not run. Track the previous root per container and remove it before rendering the replacement.

Tests:
- JSX DOM default runtime suite: 432 passed, 3 skipped
- JSX DOM runtime suite: 432 passed, 3 skipped
- TypeScript, Prettier, ESLint, and diff checks passed