### PR TITLE
fix(request): drop stale content length for cloned FormData

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -593,6 +593,34 @@ describe('cloneRawRequest', () => {
     expect(formData.get('file')).toBeInstanceOf(File)
   })
 
+  test('drops stale content length when cloning consumed multipart request', async () => {
+    const boundary = 'boundary'
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="foo"',
+      '',
+      'bar',
+      `--${boundary}--`,
+      '',
+    ].join('\r\n')
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          'Content-Length': new TextEncoder().encode(body).byteLength.toString(),
+        },
+        body,
+      })
+    )
+    await req.formData()
+
+    const clonedReq = await cloneRawRequest(req)
+
+    expect(clonedReq.headers.has('Content-Length')).toBe(false)
+    expect((await clonedReq.formData()).get('foo')).toBe('bar')
+  })
+
   test('clones GET request without body', async () => {
     const req = new HonoRequest(
       new Request('http://localhost', {

--- a/src/request.ts
+++ b/src/request.ts
@@ -485,9 +485,10 @@ export const cloneRawRequest = async (req: HonoRequest): Promise<Request> => {
   const body = await req[cacheKey]()
   const headers = req.header()
   if (body instanceof FormData) {
-    // The FormData is re-serialized with a fresh multipart boundary, so the original
-    // Content-Type header no longer matches. Let the Request constructor generate it.
+    // The FormData is re-serialized, so the original content headers no longer
+    // describe the body. Let the runtime generate them for the new representation.
     delete headers['content-type']
+    delete headers['content-length']
   }
 
   const requestInit: RequiredRequestInit = {


### PR DESCRIPTION
## Summary

- remove the inherited `Content-Length` when `cloneRawRequest()` reserializes consumed `FormData`
- let the runtime determine representation headers for the newly encoded multipart body
- add a regression test using a valid multipart request with an explicit original length

## Impact

`cloneRawRequest()` supports forwarding requests after validation or body parsing. Multipart reserialization changes the boundary and can change the encoded size, so retaining the original `Content-Length` can leave downstream transports with invalid framing metadata.

## Regression proof

On the Node 22 runtime used for the regression test, the valid multipart fixture is 77 bytes. Before this fix, reserialization produced a 125-byte body while the clone still declared `Content-Length: 77`.

After this fix, the stale header is absent and the cloned form remains parseable, allowing the transport to determine the new length. This completes the representation-header handling introduced in #5133.

## Testing

- `vitest --run src/request.test.ts`: 43 passed
- `tsc -p tsconfig.spec.json --pretty false`
- `eslint src/request.ts src/request.test.ts`: 0 errors
- `prettier --check src/request.ts src/request.test.ts`
- Full `npm test`: 4,910 passed; local Windows `workerd` startup/WebSocket timed out. The `NO_COLOR`-dependent files passed 26/26 after unsetting the inherited variable.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code