### PR TITLE
fix(client): omit empty query delimiter

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1841,6 +1841,66 @@ describe('Query arrays containing undefined', () => {
   })
 })
 
+describe('Empty serialized query', () => {
+  const app = new Hono().get(
+    '/search',
+    validator('query', () => ({}) as { q?: string }),
+    (c) => c.json({ ok: true })
+  )
+  const input = { query: { q: undefined } }
+
+  it('Should omit the query delimiter when no query values are serialized', async () => {
+    let requestedUrl = ''
+    const client = hc<typeof app>('http://localhost', {
+      fetch: (input: RequestInfo | URL) => {
+        requestedUrl = input.toString()
+        return Promise.resolve(new Response('{}'))
+      },
+    })
+
+    await client.search.$get(input)
+
+    expect(requestedUrl).toBe('http://localhost/search')
+    expect(client.search.$url(input).href).toBe('http://localhost/search')
+    expect(client.search.$path(input)).toBe('/search')
+  })
+
+  it('Should omit the query delimiter when a custom serializer returns no values', async () => {
+    let requestedUrl = ''
+    const client = hc<typeof app>('http://localhost', {
+      buildSearchParams: () => new URLSearchParams(),
+      fetch: (input: RequestInfo | URL) => {
+        requestedUrl = input.toString()
+        return Promise.resolve(new Response('{}'))
+      },
+    })
+    const customInput = { query: { q: 'ignored' } }
+
+    await client.search.$get(customInput)
+
+    expect(requestedUrl).toBe('http://localhost/search')
+    expect(client.search.$url(customInput).href).toBe('http://localhost/search')
+    expect(client.search.$path(customInput)).toBe('/search')
+  })
+
+  it('Should preserve empty-string query values', async () => {
+    let requestedUrl = ''
+    const client = hc<typeof app>('http://localhost', {
+      fetch: (input: RequestInfo | URL) => {
+        requestedUrl = input.toString()
+        return Promise.resolve(new Response('{}'))
+      },
+    })
+    const emptyStringInput = { query: { q: '' } }
+
+    await client.search.$get(emptyStringInput)
+
+    expect(requestedUrl).toBe('http://localhost/search?q=')
+    expect(client.search.$url(emptyStringInput).href).toBe('http://localhost/search?q=')
+    expect(client.search.$path(emptyStringInput)).toBe('/search?q=')
+  })
+})
+
 describe('Custom buildSearchParams', () => {
   const app = new Hono()
   const route = app.get(

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -30,6 +30,11 @@ const createProxy = (callback: Callback, path: string[]) => {
   return proxy
 }
 
+const appendQueryParams = (url: string, searchParams: URLSearchParams): string => {
+  const queryString = searchParams.toString()
+  return queryString ? `${url}?${queryString}` : url
+}
+
 class ClientRequestImpl {
   private url: string
   private method: string
@@ -127,7 +132,7 @@ class ClientRequestImpl {
     url = replaceUrlParam(url, this.pathParams)
 
     if (this.queryParams) {
-      url = url + '?' + this.queryParams.toString()
+      url = appendQueryParams(url, this.queryParams)
     }
     methodUpperCase = this.method.toUpperCase()
     const setBody = !(methodUpperCase === 'GET' || methodUpperCase === 'HEAD')
@@ -188,7 +193,7 @@ export const hc = <T extends Hono<any, any, any>, Prefix extends string = string
           result = replaceUrlParam(url, opts.args[0].param)
         }
         if (opts.args[0].query) {
-          result = result + '?' + buildSearchParamsOption(opts.args[0].query).toString()
+          result = appendQueryParams(result, buildSearchParamsOption(opts.args[0].query))
         }
       }
       result = removeIndexString(result)


### PR DESCRIPTION
## Summary

`hc` currently appends `?` whenever query input is present, even when the configured serializer emits no query pairs. This makes an omitted optional query structurally different from an absent query.

This change centralizes query attachment so the delimiter is added only when the serialized query string is non-empty. It applies to request methods, `$url()`, and `$path()`; non-empty queries (including `q=`) are preserved.

## Before / after

For typed input `{ query: { q: undefined } }`:

| API | Before | After |
| --- | --- | --- |
| `$get()` request | `http://localhost/search?` | `http://localhost/search` |
| `$url().href` | `http://localhost/search?` | `http://localhost/search` |
| `$path()` | `/search?` | `/search` |

The same result is verified when a custom `buildSearchParams` returns an empty `URLSearchParams`.

## Impact

The URL Standard distinguishes an absent query from an empty query. Avoiding the dangling delimiter keeps generated client URLs canonical for exact comparisons, cache/signature keys, redirects, and logs, without changing queries that serialize at least one pair.

`$ws()` is unchanged because it already omits the delimiter when no pairs are appended. No public API or type changes are included.

## Verification

- `npx vitest --run src/client/client.test.ts` — 118 passed
- `npx tsc -p tsconfig.spec.json --pretty false`
- `npx prettier --check src/client/client.ts src/client/client.test.ts`
- `npx eslint src/client/client.ts src/client/client.test.ts` — no errors (one pre-existing warning elsewhere in the test file)
- Full `npm test` was attempted; Vitest aborted before assertions completed because its coverage temp directory was removed during the run. CI remains the authoritative full-suite check.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] Format and lint the changed files
- [ ] Add TSDoc/JSDoc — not applicable; no public API added