### PR TITLE
fix(serve-static): do not serve content for non-GET/HEAD requests

### DIFF
--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -243,6 +243,36 @@ describe('Serve Static Middleware', () => {
     expect(res.body).toBe(body)
   })
 
+  describe('Request methods', () => {
+    const app = new Hono()
+    app.use('/static/*', baseServeStatic({ getContent }))
+
+    it.each(['POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])(
+      'Should not serve the content for %s',
+      async (method) => {
+        const res = await app.request('/static/hello.html', { method })
+        expect(res.status).toBe(404)
+        expect(getContent).not.toHaveBeenCalled()
+      }
+    )
+
+    it('Should serve the content for HEAD', async () => {
+      const res = await app.request('/static/hello.html', { method: 'HEAD' })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
+    })
+
+    it('Should let a later handler take over the request', async () => {
+      const app = new Hono()
+      app.use('/*', baseServeStatic({ getContent }))
+      app.post('/hello.html', (c) => c.text('posted'))
+
+      const res = await app.request('/hello.html', { method: 'POST' })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('posted')
+    })
+  })
+
   describe('Changing root path', () => {
     it('Should return the content with absolute root path', async () => {
       const app = new Hono()

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -57,6 +57,12 @@ export const serveStatic = <E extends Env = Env>(
       return next()
     }
 
+    // Static files can only be retrieved. Other methods are passed through so that
+    // subsequent handlers, `notFound()`, or `methodNotAllowed()` can handle them.
+    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+      return next()
+    }
+
     let filename: string
 
     if (options.path) {


### PR DESCRIPTION
Closes #5223

## Problem

`serveStatic` never looks at the request method. When it is registered with `app.use()` — which is what the docs show, and what #5223 reports — it serves the file body for *any* method:

```ts
const app = new Hono()
app.use('/*', serveStatic({ root: './static' }))
```

| Request | Before |
| --- | --- |
| `GET /hello.txt` | 200 + body |
| `POST /hello.txt` | **200 + body** |
| `PUT /hello.txt` | **200 + body** |
| `DELETE /hello.txt` | **200 + body** |
| `OPTIONS /hello.txt` | **200 + body** |

Two consequences beyond the odd status codes:

- A `POST`/`PUT`/`DELETE` route registered *after* `serveStatic` is shadowed whenever the path happens to match a file, so the request never reaches it.
- `methodNotAllowed()` can never see those requests, because `serveStatic` has already finalized a 200.

## Change

Pass non-`GET`/`HEAD` requests through to the next handler:

```ts
if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
  return next()
}
```

`HEAD` is kept because `Hono#dispatch` re-dispatches `HEAD` as `GET` while `c.req.method` still reads `HEAD`, so an early return would break `HEAD` on static files.

Falling through rather than returning 405 keeps `serveStatic` a plain pass-through middleware and leaves the response to whatever comes next — a later route, `notFound()`, or `methodNotAllowed()`. It also matches how the other method-sensitive middleware in the repo already behave (`etag`, `cache`, `compress`, `trailingSlash` all gate on `c.req.method`).

With the `use()` setup from #5223 this now gives:

- `200` on `GET /api` and on `GET` of an existing file
- `404` on `GET` of a missing file
- `405` on `POST /api`
- `404` on `POST` of an existing or missing file — the issue notes 404 is acceptable here

## Tests

Added a `Request methods` block to `src/middleware/serve-static/index.test.ts` covering: `POST`/`PUT`/`DELETE`/`PATCH`/`OPTIONS` are not served (and `getContent` is never called), `HEAD` still is, and a later `app.post()` handler now receives the request.

`bun run test` passes (4931 tests), as do the Bun runtime tests. `bun run lint` reports no new problems.
