### PR TITLE
fix(streaming): expose Last-Event-ID and make write-after-abort a no-op

### DIFF
--- a/runtime-tests/node/index.test.ts
+++ b/runtime-tests/node/index.test.ts
@@ -213,8 +213,8 @@ describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
   let handlerDone = false
   let writesAfterAbort = 0
 
-  // Resume-capable feed: replays only the events after the Last-Event-ID cursor,
-  // exactly like an EventSource reconnect would expect.
+  // Replays only the events after the Last-Event-ID cursor, as an EventSource
+  // reconnect would expect.
   app.get('/feed', (c) =>
     streamSSE(c, async (stream) => {
       const cursor = Number(stream.lastEventId ?? 0)
@@ -224,13 +224,10 @@ describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
     })
   )
 
-  app.get('/abrupt', (c) => {
-    handlerDone = false
-    writesAfterAbort = 0
-    return streamSSE(c, async (stream) => {
+  app.get('/abrupt', (c) =>
+    streamSSE(c, async (stream) => {
       await stream.writeSSE({ data: 'one', id: '1' })
-      // The client disconnects during this window; keep producing —
-      // writes after the disconnect must be safe no-ops.
+      // The client disconnects during this window; keep producing.
       await stream.sleep(20)
       for (let i = 2; i <= 4; i++) {
         await stream.writeSSE({ data: `dropped-${i}`, id: String(i) })
@@ -238,9 +235,14 @@ describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
       }
       handlerDone = true
     })
-  })
+  )
 
   const agent = createAgent(app)
+
+  beforeEach(() => {
+    handlerDone = false
+    writesAfterAbort = 0
+  })
 
   const readEvents = async (res: Response, count: number): Promise<string[]> => {
     const reader = res.body!.getReader()
@@ -256,9 +258,9 @@ describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
       const frames = buffer.split('\n\n')
       buffer = frames.pop() ?? ''
       for (const frame of frames) {
-        const data = /^data: (.*)$/m.exec(frame)
-        if (data) {
-          out.push(data[1])
+        const data = /^data: (.*)$/m.exec(frame)?.[1]
+        if (data !== undefined) {
+          out.push(data)
         }
       }
     }
@@ -272,8 +274,7 @@ describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
     expect(await readEvents(first, 2)).toEqual(['alpha', 'beta'])
     await first.body!.cancel()
 
-    // Reconnect with Last-Event-ID: 2 (the id of the last event received):
-    // only the events after the cursor are replayed.
+    // Reconnect with the id of the last received event: only later events replay.
     const second = await agent.get('/feed', { headers: { 'Last-Event-ID': '2' } })
     expect(await readEvents(second, 2)).toEqual(['gamma', 'delta'])
     await second.body!.cancel()
@@ -292,8 +293,7 @@ describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
     controller.abort()
     await res.body!.cancel().catch(() => {})
 
-    // The handler keeps writing after the disconnect: those writes are no-ops
-    // and the handler must complete instead of hanging or crashing.
+    // Writes after the disconnect are no-ops; the handler must still complete.
     const deadline = Date.now() + 2000
     while (!handlerDone && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 10))

--- a/runtime-tests/node/index.test.ts
+++ b/runtime-tests/node/index.test.ts
@@ -206,6 +206,103 @@ describe('streamSSE', () => {
   })
 })
 
+describe('streamSSE lifecycle (Last-Event-ID + write-after-abort)', () => {
+  const events = ['alpha', 'beta', 'gamma', 'delta']
+  const app = new Hono()
+
+  let handlerDone = false
+  let writesAfterAbort = 0
+
+  // Resume-capable feed: replays only the events after the Last-Event-ID cursor,
+  // exactly like an EventSource reconnect would expect.
+  app.get('/feed', (c) =>
+    streamSSE(c, async (stream) => {
+      const cursor = Number(stream.lastEventId ?? 0)
+      for (let i = cursor; i < events.length; i++) {
+        await stream.writeSSE({ data: events[i], id: String(i + 1) })
+      }
+    })
+  )
+
+  app.get('/abrupt', (c) => {
+    handlerDone = false
+    writesAfterAbort = 0
+    return streamSSE(c, async (stream) => {
+      await stream.writeSSE({ data: 'one', id: '1' })
+      // The client disconnects during this window; keep producing —
+      // writes after the disconnect must be safe no-ops.
+      await stream.sleep(20)
+      for (let i = 2; i <= 4; i++) {
+        await stream.writeSSE({ data: `dropped-${i}`, id: String(i) })
+        writesAfterAbort++
+      }
+      handlerDone = true
+    })
+  })
+
+  const agent = createAgent(app)
+
+  const readEvents = async (res: Response, count: number): Promise<string[]> => {
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    const out: string[] = []
+    let buffer = ''
+    while (out.length < count) {
+      const { value, done } = await reader.read()
+      if (done) {
+        break
+      }
+      buffer += decoder.decode(value, { stream: true })
+      const frames = buffer.split('\n\n')
+      buffer = frames.pop() ?? ''
+      for (const frame of frames) {
+        const data = /^data: (.*)$/m.exec(frame)
+        if (data) {
+          out.push(data[1])
+        }
+      }
+    }
+    reader.releaseLock()
+    return out
+  }
+
+  it('Should resume from the Last-Event-ID header after a reconnect', async () => {
+    // First connection: the client reads two events, then drops.
+    const first = await agent.get('/feed')
+    expect(await readEvents(first, 2)).toEqual(['alpha', 'beta'])
+    await first.body!.cancel()
+
+    // Reconnect with Last-Event-ID: 2 (the id of the last event received):
+    // only the events after the cursor are replayed.
+    const second = await agent.get('/feed', { headers: { 'Last-Event-ID': '2' } })
+    expect(await readEvents(second, 2)).toEqual(['gamma', 'delta'])
+    await second.body!.cancel()
+  })
+
+  it('Should resume from the beginning without a Last-Event-ID header', async () => {
+    const res = await agent.get('/feed')
+    expect(await readEvents(res, 4)).toEqual(['alpha', 'beta', 'gamma', 'delta'])
+    await res.body!.cancel()
+  })
+
+  it('Should let the handler finish cleanly when the client disconnects mid-stream', async () => {
+    const controller = new AbortController()
+    const res = await agent.get('/abrupt', { signal: controller.signal })
+    expect(await readEvents(res, 1)).toEqual(['one'])
+    controller.abort()
+    await res.body!.cancel().catch(() => {})
+
+    // The handler keeps writing after the disconnect: those writes are no-ops
+    // and the handler must complete instead of hanging or crashing.
+    const deadline = Date.now() + 2000
+    while (!handlerDone && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(handlerDone).toBe(true)
+    expect(writesAfterAbort).toBe(3)
+  })
+})
+
 describe('compress', async () => {
   const cssContent = Array.from({ length: 60 }, () => 'body { color: red; }').join('\n')
   const [externalServer, serverInfo] = await new Promise<[Server, AddressInfo]>((resolve) => {

--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -428,4 +428,47 @@ describe('SSE Streaming helper', () => {
     // Two \r should produce an empty line in between
     expect(decodedValue).toBe('event: test-double-cr\ndata: Left\ndata: \ndata: Right\n\n')
   })
+
+  it('Exposes the Last-Event-ID request header as stream.lastEventId', async () => {
+    const req = new Request('http://localhost/', { headers: { 'Last-Event-ID': '41' } })
+    const c = new Context(req)
+    const res = streamSSE(c, async (stream) => {
+      await stream.writeSSE({ data: `resumed from ${stream.lastEventId}` })
+    })
+    expect(await res.text()).toBe('data: resumed from 41\n\n')
+  })
+
+  it('stream.lastEventId is undefined when the header is not sent', async () => {
+    const req = new Request('http://localhost/')
+    const c = new Context(req)
+    const res = streamSSE(c, async (stream) => {
+      await stream.writeSSE({ data: `lastEventId=${String(stream.lastEventId)}` })
+    })
+    expect(await res.text()).toBe('data: lastEventId=undefined\n\n')
+  })
+
+  it('writeSSE() after the client disconnects resolves as a no-op', async () => {
+    let handlerDone = false
+    const wroteWhileAborted: boolean[] = []
+    const res = streamSSE(c, async (stream) => {
+      await stream.writeSSE({ data: 'one', id: '1' })
+      await stream.sleep(10) // the test cancels the reader during this window
+      for (let i = 2; i <= 4; i++) {
+        // Must neither throw nor hang even though the client is gone.
+        await stream.writeSSE({ data: `after-abort-${i}`, id: String(i) })
+        wroteWhileAborted.push(stream.aborted)
+      }
+      handlerDone = true
+    })
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const { value } = await reader.read()
+    expect(new TextDecoder().decode(value)).toBe('data: one\nid: 1\n\n')
+    await reader.cancel()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(handlerDone).toBe(true)
+    expect(wroteWhileAborted).toEqual([true, true, true])
+  })
 })

--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -442,7 +442,7 @@ describe('SSE Streaming helper', () => {
     const req = new Request('http://localhost/')
     const c = new Context(req)
     const res = streamSSE(c, async (stream) => {
-      await stream.writeSSE({ data: `lastEventId=${String(stream.lastEventId)}` })
+      await stream.writeSSE({ data: `lastEventId=${stream.lastEventId}` })
     })
     expect(await res.text()).toBe('data: lastEventId=undefined\n\n')
   })

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -12,11 +12,8 @@ export interface SSEMessage {
 
 export class SSEStreamingApi extends StreamingApi {
   /**
-   * The value of the `Last-Event-ID` request header sent by the client, or
-   * `undefined` when it was not sent. When an `EventSource` reconnects, the
-   * browser sends this header automatically with the `id` of the last event
-   * it received, so a handler can use it to resume the event stream instead
-   * of replaying everything.
+   * The `Last-Event-ID` request header sent by an `EventSource` on reconnect
+   * (the id of the last event it received), or `undefined` when absent.
    */
   lastEventId?: string
 

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -11,8 +11,18 @@ export interface SSEMessage {
 }
 
 export class SSEStreamingApi extends StreamingApi {
-  constructor(writable: WritableStream, readable: ReadableStream) {
+  /**
+   * The value of the `Last-Event-ID` request header sent by the client, or
+   * `undefined` when it was not sent. When an `EventSource` reconnects, the
+   * browser sends this header automatically with the `id` of the last event
+   * it received, so a handler can use it to resume the event stream instead
+   * of replaying everything.
+   */
+  lastEventId?: string
+
+  constructor(writable: WritableStream, readable: ReadableStream, lastEventId?: string) {
     super(writable, readable)
+    this.lastEventId = lastEventId
   }
 
   async writeSSE(message: SSEMessage) {
@@ -76,7 +86,7 @@ export const streamSSE = (
   onError?: (e: Error, stream: SSEStreamingApi) => Promise<void>
 ): Response => {
   const { readable, writable } = new TransformStream()
-  const stream = new SSEStreamingApi(writable, readable)
+  const stream = new SSEStreamingApi(writable, readable, c.req.header('Last-Event-ID'))
 
   // Until Bun v1.1.27, Bun didn't call cancel() on the ReadableStream for Response objects from Bun.serve()
   if (isOldBunVersion()) {

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -220,7 +220,7 @@ describe('StreamingApi', () => {
     api.abort()
     expect(api.aborted).toBe(true)
 
-    // Must resolve immediately without enqueuing anything nor throwing.
+    // Must resolve immediately without enqueuing anything or throwing.
     await expect(api.write('after')).resolves.toBe(api)
     await expect(api.writeln('after')).resolves.toBe(api)
     const { value, done } = await Promise.race([
@@ -240,7 +240,7 @@ describe('StreamingApi', () => {
     api.write('first')
     await reader.read()
 
-    await reader.cancel() // client disconnect -> abort()
+    await reader.cancel()
     expect(api.aborted).toBe(true)
 
     // Writing after the disconnect neither throws nor hangs.

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -209,4 +209,52 @@ describe('StreamingApi', () => {
       process.off('unhandledRejection', unhandled)
     }
   })
+
+  it('write() is a no-op after abort() and does not touch the writer', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+    const reader = api.responseReadable.getReader()
+    api.write('before')
+    expect((await reader.read()).value).toEqual(new TextEncoder().encode('before'))
+
+    api.abort()
+    expect(api.aborted).toBe(true)
+
+    // Must resolve immediately without enqueuing anything nor throwing.
+    await expect(api.write('after')).resolves.toBe(api)
+    await expect(api.writeln('after')).resolves.toBe(api)
+    const { value, done } = await Promise.race([
+      reader.read(),
+      new Promise<{ value: undefined; done: true }>((resolve) =>
+        setTimeout(() => resolve({ value: undefined, done: true }), 100)
+      ),
+    ])
+    expect(done).toBe(true)
+    expect(value).toBeUndefined()
+  })
+
+  it('write() is a no-op after the client cancels the response stream', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+    const reader = api.responseReadable.getReader()
+    api.write('first')
+    await reader.read()
+
+    await reader.cancel() // client disconnect -> abort()
+    expect(api.aborted).toBe(true)
+
+    // Writing after the disconnect neither throws nor hangs.
+    const write = api.write('after-abort')
+    await expect(
+      Promise.race([write, new Promise((resolve) => setTimeout(() => resolve('hung'), 500))])
+    ).resolves.not.toBe('hung')
+  })
+
+  it('close() after abort() is a no-op and does not throw', async () => {
+    const { readable, writable } = new TransformStream()
+    const api = new StreamingApi(writable, readable)
+    api.abort()
+    await expect(api.close()).resolves.toBeUndefined()
+    expect(api.closed).toBe(true)
+  })
 })

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -46,6 +46,13 @@ export class StreamingApi {
   }
 
   async write(input: Uint8Array | string): Promise<StreamingApi> {
+    if (this.aborted) {
+      // Once the stream is aborted, the client is gone and the writable may
+      // already be errored or about to be. Writing is defined as a no-op:
+      // it never touches the writer, so it can neither throw nor hang,
+      // regardless of how the runtime propagates the cancellation.
+      return this
+    }
     try {
       if (typeof input === 'string') {
         input = this.encoder.encode(input)
@@ -68,6 +75,10 @@ export class StreamingApi {
 
   async close() {
     this.closed = true
+    if (this.aborted) {
+      // The writable was torn down by abort(); there is nothing to close.
+      return
+    }
     try {
       await this.writer.close()
     } catch {

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -47,10 +47,8 @@ export class StreamingApi {
 
   async write(input: Uint8Array | string): Promise<StreamingApi> {
     if (this.aborted) {
-      // Once the stream is aborted, the client is gone and the writable may
-      // already be errored or about to be. Writing is defined as a no-op:
-      // it never touches the writer, so it can neither throw nor hang,
-      // regardless of how the runtime propagates the cancellation.
+      // The client is gone and the writable may be errored; depending on the
+      // runtime, writing can throw or hang, so writes after abort are no-ops.
       return this
     }
     try {


### PR DESCRIPTION
Fixes #3765

## What

Two fixes to the SSE streaming lifecycle:

1. **`streamSSE` now exposes the `Last-Event-ID` request header as `stream.lastEventId`.** When an `EventSource` reconnects, the browser re-sends the `id` of the last event it received in this header, so handlers can resume the event stream instead of replaying everything. It is `undefined` when the header is absent.

2. **`StreamingApi.write()` and `close()` are no-ops after `abort()`.** Once the client is gone the writable may be errored, and touching the writer can throw or hang depending on the runtime. Both methods now return early when `aborted` is set, so a handler that keeps producing after a disconnect completes cleanly instead of hanging or crashing.

## Testing

- `src/utils/stream.test.ts`: `write()`/`close()` after `abort()` and after the client cancels the response stream resolve as no-ops without touching the writer.
- `src/helper/streaming/sse.test.tsx`: `lastEventId` is exposed from the header and `undefined` when absent; `writeSSE()` after a client disconnect resolves as a no-op and the handler finishes.
- `runtime-tests/node/index.test.ts`: end-to-end over a real Node server — resume from `Last-Event-ID` on reconnect, full replay without the header, and a handler finishing cleanly after a mid-stream disconnect.