### PR TITLE
fix(serve-static): vary precompressed identity responses

### DIFF
--- a/src/middleware/compress/index.ts
+++ b/src/middleware/compress/index.ts
@@ -6,6 +6,7 @@
 import type { MiddlewareHandler } from '../../types'
 import { parseAccept } from '../../utils/accept'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
+import { addAcceptEncodingToVary } from '../vary'
 
 export { COMPRESSIBLE_CONTENT_TYPE_REGEX }
 
@@ -42,8 +43,6 @@ const selectEncoding = (
   }
   return best?.encoding
 }
-
-const varyAcceptEncodingRegExp = /(?:^|,)\s*accept-encoding\s*(?:,|$)/i
 
 /**
  * Compress Middleware for Hono.
@@ -110,9 +109,10 @@ export const compress = (options?: CompressionOptions): MiddlewareHandler => {
     // Accept-Encoding "or lack thereof" as a determining factor. Without this, a shared
     // cache could reuse the identity response for a client that does accept gzip.
     // https://www.rfc-editor.org/rfc/rfc9110#field.vary
-    const current = ctx.res.headers.get('Vary')
-    if (current !== '*' && !(current && varyAcceptEncodingRegExp.test(current))) {
-      ctx.header('Vary', current ? `${current}, Accept-Encoding` : 'Accept-Encoding')
+    const currentVary = ctx.res.headers.get('Vary')
+    const nextVary = addAcceptEncodingToVary(currentVary)
+    if (nextVary !== currentVary) {
+      ctx.header('Vary', nextVary)
     }
 
     const accepted = ctx.req.header('Accept-Encoding')

--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -183,7 +183,7 @@ describe('Serve Static Middleware', () => {
     expect(await res.text()).toBe('404 Not Found')
   })
 
-  it('Should not return a pre-compressed response - /static/hello.html', async () => {
+  it('Should vary an identity response for an unsupported encoding', async () => {
     const app = new Hono().use(
       '*',
       baseServeStatic({
@@ -198,9 +198,49 @@ describe('Serve Static Middleware', () => {
 
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Encoding')).toBeNull()
-    expect(res.headers.get('Vary')).toBeNull()
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding')
     expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
     expect(await res.text()).toBe('Hello in static/hello.html')
+  })
+
+  it('Should vary an identity response when Accept-Encoding is absent', async () => {
+    const app = new Hono().use(
+      '*',
+      baseServeStatic({
+        getContent,
+        precompressed: true,
+      })
+    )
+
+    const res = await app.request('/static/hello.html')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Encoding')).toBeNull()
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding')
+    expect(await res.text()).toBe('Hello in static/hello.html')
+  })
+
+  test.each([
+    ['Cookie', 'Cookie, Accept-Encoding'],
+    ['aCcEpT-eNcOdInG', 'aCcEpT-eNcOdInG'],
+    ['*', '*'],
+  ])('Should merge Accept-Encoding with Vary: %s', async (vary, expected) => {
+    const app = new Hono()
+    app.use('*', async (c, next) => {
+      c.header('Vary', vary)
+      await next()
+    })
+    app.use(
+      '*',
+      baseServeStatic({
+        getContent,
+        precompressed: true,
+      })
+    )
+
+    const res = await app.request('/static/hello.html')
+
+    expect(res.headers.get('Vary')).toBe(expected)
   })
 
   it('Should not find pre-compressed files - /static/hello.jpg', async () => {

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -8,6 +8,7 @@ import type { Env, MiddlewareHandler } from '../../types'
 import { COMPRESSIBLE_CONTENT_TYPE_REGEX } from '../../utils/compress'
 import { getMimeType } from '../../utils/mime'
 import { tryDecodeURI } from '../../utils/url'
+import { addAcceptEncodingToVary } from '../vary'
 import { defaultJoin } from './path'
 
 export type ServeStaticOptions<E extends Env = Env> = {
@@ -94,6 +95,12 @@ export const serveStatic = <E extends Env = Env>(
       c.header('Content-Type', mimeType || 'application/octet-stream')
 
       if (options.precompressed && (!mimeType || COMPRESSIBLE_CONTENT_TYPE_REGEX.test(mimeType))) {
+        const currentVary = c.res.headers.get('Vary')
+        const nextVary = addAcceptEncodingToVary(currentVary)
+        if (nextVary !== currentVary) {
+          c.header('Vary', nextVary)
+        }
+
         const acceptEncodingSet = new Set(
           c.req
             .header('Accept-Encoding')
@@ -110,7 +117,6 @@ export const serveStatic = <E extends Env = Env>(
           if (compressedContent) {
             content = compressedContent
             c.header('Content-Encoding', encoding)
-            c.header('Vary', 'Accept-Encoding', { append: true })
             break
           }
         }

--- a/src/middleware/vary.ts
+++ b/src/middleware/vary.ts
@@ -1,0 +1,11 @@
+const varyAcceptEncodingRegExp = /(?:^|,)\s*accept-encoding\s*(?:,|$)/i
+
+export const addAcceptEncodingToVary = (vary: string | null): string => {
+  if (!vary) {
+    return 'Accept-Encoding'
+  }
+  if (vary === '*' || varyAcceptEncodingRegExp.test(vary)) {
+    return vary
+  }
+  return `${vary}, Accept-Encoding`
+}


### PR DESCRIPTION
## Summary

- mark every eligible `precompressed` response as varying on `Accept-Encoding`, including identity fallbacks
- preserve existing `Vary` values, `Vary: *`, and case-insensitive `Accept-Encoding` entries through one internal helper shared with `compress`
- add regression coverage for absent/unsupported encodings and existing `Vary` values

## Before / after

| Request | Before | After |
| --- | --- | --- |
| no `Accept-Encoding` | identity, no `Vary` | identity, `Vary: Accept-Encoding` |
| unsupported encoding | identity, no `Vary` | identity, `Vary: Accept-Encoding` |
| supported encoding | compressed + `Vary` | unchanged |

## Impact

`serveStatic({ precompressed: true })` selects a representation using `Accept-Encoding`, including when it falls back to identity. Without `Vary` on that fallback, a shared cache can store the identity response under a non-varying key and reuse it for a later client that accepts an available precompressed representation. This makes the cache key match the negotiation input, as required by [RFC 9110 §12.5.5](https://www.rfc-editor.org/rfc/rfc9110#section-12.5.5).

The change remains limited to compressible static responses with `precompressed` enabled. Missing files, non-compressible content, returned `Response` objects, and `precompressed: false` are unchanged.

## Verification

- `npx vitest --run src/middleware/serve-static/index.test.ts` — 24 passed
- `npx vitest --run src/middleware/compress/index.test.ts` — 45 passed
- `npx tsc -p tsconfig.spec.json --pretty false`
- ESLint and Prettier on the four changed files

### The author should do the following, if applicable

- [x] Add tests
- [x] Run focused tests and type checking
- [x] Format and lint the changed files
- [ ] Add TSDoc/JSDoc — no public API added