### PR TITLE
fix(client): normalize root WebSocket URLs

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1548,25 +1548,37 @@ describe('WebSocket URL Protocol Translation', () => {
   it('Translates HTTP to ws', async () => {
     const client = hc<AppType>('http://localhost')
     client.index.$ws()
-    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index')
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/')
   })
 
   it('Translates HTTPS to wss', async () => {
     const client = hc<AppType>('https://localhost')
     client.index.$ws()
-    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index')
+    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/')
   })
 
   it('Keeps ws unchanged', async () => {
     const client = hc<AppType>('ws://localhost')
     client.index.$ws()
-    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index')
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/')
   })
 
   it('Keeps wss unchanged', async () => {
     const client = hc<AppType>('wss://localhost')
     client.index.$ws()
-    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index')
+    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/')
+  })
+
+  it('Preserves an index path parameter value', async () => {
+    const dynamicRoute = new Hono().get(
+      '/:id',
+      upgradeWebSocket(() => ({}))
+    )
+    const client = hc<typeof dynamicRoute>('http://localhost')
+
+    client[':id'].$ws({ param: { id: 'index' } })
+
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index')
   })
 })
 
@@ -1608,7 +1620,7 @@ describe('WebSocket URL Protocol Translation with Query Parameters', () => {
         tag: ['a', 'b'],
       },
     })
-    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index?id=123&type=test&tag=a&tag=b')
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/?id=123&type=test&tag=a&tag=b')
   })
 
   it('Translates HTTPS to wss and includes query parameters', async () => {
@@ -1619,7 +1631,7 @@ describe('WebSocket URL Protocol Translation with Query Parameters', () => {
         type: 'secure',
       },
     })
-    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index?id=456&type=secure')
+    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/?id=456&type=secure')
   })
 
   it('Keeps ws unchanged and includes query parameters', async () => {
@@ -1630,7 +1642,7 @@ describe('WebSocket URL Protocol Translation with Query Parameters', () => {
         type: 'plain',
       },
     })
-    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/index?id=789&type=plain')
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/?id=789&type=plain')
   })
 
   it('Keeps wss unchanged and includes query parameters', async () => {
@@ -1641,7 +1653,7 @@ describe('WebSocket URL Protocol Translation with Query Parameters', () => {
         type: 'secure',
       },
     })
-    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/index?id=1011&type=secure')
+    expect(webSocketMock).toHaveBeenCalledWith('wss://localhost/?id=1011&type=secure')
   })
 })
 
@@ -1796,13 +1808,13 @@ describe('WebSocket Provider Integration', () => {
       description: 'should initialize the WebSocket provider correctly',
       url: 'http://localhost',
       query: undefined,
-      expectedUrl: 'ws://localhost/index',
+      expectedUrl: 'ws://localhost/',
     },
     {
       description: 'should correctly add query parameters to the WebSocket URL',
       url: 'http://localhost',
       query: { id: '123', type: 'test', tag: ['a', 'b'] },
-      expectedUrl: 'ws://localhost/index?id=123&type=test&tag=a&tag=b',
+      expectedUrl: 'ws://localhost/?id=123&type=test&tag=a&tag=b',
     },
   ])('$description', ({ url, expectedUrl, query }) => {
     const webSocketMock = vi.fn()

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -203,8 +203,9 @@ export const hc = <T extends Hono<any, any, any>, Prefix extends string = string
       return result.slice(baseUrl.replace(/\/+$/, '').length).replace(/^\/?/, '/')
     }
     if (method === 'ws') {
+      const normalizedUrl = removeIndexString(url)
       const webSocketUrl = replaceUrlProtocol(
-        opts.args[0]?.param ? replaceUrlParam(url, opts.args[0].param) : url,
+        opts.args[0]?.param ? replaceUrlParam(normalizedUrl, opts.args[0].param) : normalizedUrl,
         'ws'
       )
       const targetUrl = new URL(webSocketUrl)


### PR DESCRIPTION
## Summary

- normalize the Hono Client `index` alias before constructing WebSocket URLs
- keep protocol translation, query serialization, and custom WebSocket providers unchanged
- preserve real path parameter values equal to `index`

## Before / after

| Typed route | Before | After |
| --- | --- | --- |
| `client.index.$ws()` for `/` | `ws://host/index` | `ws://host/` |
| nested root route | `ws://host/api/index` | `ws://host/api` |
| `/:id` with `id: "index"` | `ws://host/index` | unchanged |

## Impact

`index` is the client-side alias for a root route. `$get()`, `$url()`, and `$path()` already remove that synthetic segment, but `$ws()` did not. As a result, a typed WebSocket client for `/` attempted its handshake against `/index` (and a nested root against `/api/index`), which targets a different route and commonly returns `404`.

Normalization runs before path parameter substitution, so a genuine dynamic value named `index` is not removed.

## Verification

- `npx vitest --run src/client/client.test.ts` — 119 passed
- `npx vitest --run src/client/types.test.ts --coverage.enabled=false` — 13 passed
- `npx tsc -p tsconfig.spec.json --pretty false`
- Prettier, ESLint, and `git diff --check` on the changed files

### The author should do the following, if applicable

- [x] Add tests
- [x] Run focused tests and type checking
- [x] Format and lint the changed files
- [ ] Add TSDoc/JSDoc — no public API added