### PR TITLE
fix(aws-lambda): preserve empty query parameters

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -231,6 +231,45 @@ describe('EventProcessor.createRequest', () => {
     expect(url.searchParams.get('ampersand')).toBe('a&b&c')
   })
 
+  it('Should preserve empty query parameters for version 1.0', () => {
+    const event: LambdaEvent = {
+      ...baseV1Event,
+      queryStringParameters: {
+        empty: '',
+        present: '0',
+        omitted: undefined,
+      },
+    }
+
+    const request = getProcessor(event).createRequest(event)
+
+    expect(request.url).toBe(
+      'https://id.execute-api.us-east-1.amazonaws.com/my/path?empty=&present=0'
+    )
+  })
+
+  it('Should preserve empty query parameters for ALB events', () => {
+    const event: LambdaEvent = {
+      httpMethod: 'GET',
+      path: '/my/path',
+      headers: { host: 'example.test' },
+      body: null,
+      isBase64Encoded: false,
+      queryStringParameters: {
+        empty: '',
+        present: '0',
+        omitted: undefined,
+      },
+      requestContext: {
+        elb: { targetGroupArn: 'arn:aws:elasticloadbalancing:...' },
+      },
+    }
+
+    const request = getProcessor(event).createRequest(event)
+
+    expect(request.url).toBe('https://example.test/my/path?empty=&present=0')
+  })
+
   it('Should return valid Request object from version 1.0 API Gateway event', () => {
     const event: LambdaEvent = {
       ...baseV1Event,

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -461,7 +461,7 @@ export class EventV1Processor extends EventProcessor<APIGatewayProxyEvent> {
         .join('&')
     } else {
       return Object.entries(event.queryStringParameters || {})
-        .filter(([, value]) => value)
+        .filter(([, value]) => value !== undefined)
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value || '')}`)
         .join('&')
     }
@@ -551,7 +551,7 @@ export class ALBProcessor extends EventProcessor<ALBProxyEvent> {
         .join('&')
     } else {
       return Object.entries(event.queryStringParameters || {})
-        .filter(([, value]) => value)
+        .filter(([, value]) => value !== undefined)
         .map(([key, value]) => `${key}=${value}`)
         .join('&')
     }


### PR DESCRIPTION
## Summary

- preserve present-but-empty query values when reconstructing API Gateway v1 and ALB requests
- continue omitting absent (`undefined`) entries
- add focused coverage for both affected AWS event formats

## Before / after

| Event input | Before | After |
| --- | --- | --- |
| v1 `{ flag: "" }` | query omitted | `?flag=` |
| ALB `{ flag: "" }` | query omitted | `?flag=` |
| `{ missing: undefined }` | omitted | unchanged |

## Impact

AWS event types distinguish an empty string from an absent value, but the single-value v1 and ALB processors filtered both through a truthiness check. This made `?flag=` indistinguishable from no `flag`, changing `URLSearchParams.has()`, request validation, feature-flag, and logging behavior before the request reached the Hono application.

The fix uses the declared `undefined` boundary. API Gateway v2 raw queries, multi-value queries, Lattice events, v1 encoding, and ALB serialization remain unchanged. AWS documents the relevant event mappings for [API Gateway proxy integrations](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html) and [ALB Lambda targets](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html).

## Verification

- `npx vitest --run src/adapter/aws-lambda/handler.test.ts` — 40 passed
- `npx tsc -p tsconfig.spec.json --pretty false`
- Prettier, ESLint, and `git diff --check` on the changed files

### The author should do the following, if applicable

- [x] Add tests
- [x] Run focused tests and type checking
- [x] Format and lint the changed files
- [ ] Add TSDoc/JSDoc — no public API added