### PR TITLE
Fix: handle serveStatic and methodNotAllowed correctly for non-GET methods and wildcard routes

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -197,6 +197,52 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
   })
 
+  it('ignores trailing wildcard routes when inferring allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('ok'))
+    app.get('/*', (c) => c.text('wildcard'))
+
+    const res = await app.request('/nonexistent', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+
+    const res2 = await app.request('/api', { method: 'POST' })
+
+    expect(res2.status).toBe(405)
+    expect(res2.headers.get('Allow')).toBe('GET, HEAD')
+  })
+
+  it('ignores wildcard routes with prefix like /static/*', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/static/*', (c) => c.text('static'))
+    app.get('/api/resource', (c) => c.text('GET'))
+
+    const res = await app.request('/static/other.txt', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+
+    const res2 = await app.request('/api/resource', { method: 'POST' })
+
+    expect(res2.status).toBe(405)
+    expect(res2.headers.get('Allow')).toBe('GET, HEAD')
+  })
+
+  it('still returns 405 for non-wildcard routes when wildcard exists', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/resource', (c) => c.text('GET'))
+    app.get('/*', (c) => c.text('wildcard'))
+
+    const res = await app.request('/resource', { method: 'POST' })
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('GET, HEAD')
+  })
+
   it('does not invoke the error handler for a 405 response', async () => {
     const app = new Hono()
     const onError = vi.fn(() => new Response('error', { status: 500 }))

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -27,6 +27,13 @@ type MethodNotAllowedOptions<E extends Env> = {
  * Returns a `405 Method Not Allowed` response with an `Allow` header when the request path
  * matches a registered route but the request method is not supported.
  *
+ * Routes with a trailing wildcard (e.g. `/*`, `/static/*`) are ignored when
+ * inferring allowed methods, because a wildcard match does not reliably prove
+ * that a concrete resource exists. This prevents every unhandled request in a
+ * wildcard namespace from being converted from `404 Not Found` to `405`.
+ *
+ * `ALL` and explicit `HEAD` routes are also ignored for `Allow` inference.
+ *
  * @param {MethodNotAllowedOptions} options - The options for the middleware.
  * @param {Hono} options.app - The Hono instance used by the application.
  * @param {MethodNotAllowedHandler} [options.onMethodNotAllowed] - Generates the response, including its `Allow` header.
@@ -80,6 +87,10 @@ export const methodNotAllowed = <E extends Env = Env>(
         // Hono does not distinguish middleware registered with `app.use()` from handlers
         // registered with `app.all()`, so `ALL` routes cannot contribute to the Allow header.
         if (route.method === METHOD_NAME_ALL || route.method === 'HEAD') {
+          continue
+        }
+
+        if (route.path.endsWith('*')) {
           continue
         }
 

--- a/src/middleware/serve-static/index.test.ts
+++ b/src/middleware/serve-static/index.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from '../../hono'
+import { methodNotAllowed } from '../method-not-allowed'
 import { serveStatic as baseServeStatic } from '.'
 
 describe('Serve Static Middleware', () => {
@@ -241,6 +242,65 @@ describe('Serve Static Middleware', () => {
     } as Request)
     expect(res.status).toBe(200)
     expect(res.body).toBe(body)
+  })
+
+  it('Should skip non-GET/HEAD requests and not call getContent', async () => {
+    const getContent = vi.fn(async () => 'file')
+    const app = new Hono().use('*', baseServeStatic({ getContent }))
+
+    const res = await app.request('/static/hello.html', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(getContent).not.toBeCalled()
+  })
+
+  it('Should skip various non-GET/HEAD methods', async () => {
+    const getContent = vi.fn(async () => 'file')
+    const app = new Hono().use('*', baseServeStatic({ getContent }))
+
+    for (const method of ['PUT', 'DELETE', 'PATCH', 'OPTIONS', 'POST']) {
+      getContent.mockClear()
+      const res = await app.request('/static/hello.html', { method })
+      expect(res.status).toBe(404)
+      expect(getContent).not.toBeCalled()
+    }
+  })
+
+  it('Should still serve HEAD requests', async () => {
+    const getContent = vi.fn(async () => 'file-content')
+    const app = new Hono().use('*', baseServeStatic({ getContent }))
+
+    const res = await app.request('/static/hello.html', { method: 'HEAD' })
+
+    expect(res.status).toBe(200)
+    expect(getContent).toBeCalled()
+  })
+
+  it('Should allow methodNotAllowed to handle POST to existing route while static falls through', async () => {
+    const getContent = vi.fn(async (path) => {
+      if (path.includes('hello.html')) {
+        return 'file-content'
+      }
+      return null
+    })
+    const serveStatic = baseServeStatic({ getContent })
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('ok'))
+    app.use('/*', serveStatic)
+
+    const res1 = await app.request('/static/hello.html', { method: 'POST' })
+    expect(res1.status).toBe(404)
+    expect(getContent).not.toBeCalled()
+
+    getContent.mockClear()
+    const res2 = await app.request('/api', { method: 'POST' })
+    expect(res2.status).toBe(405)
+    expect(res2.headers.get('Allow')).toBe('GET, HEAD')
+
+    const res3 = await app.request('/static/hello.html')
+    expect(res3.status).toBe(200)
+    expect(getContent).toBeCalled()
   })
 
   describe('Changing root path', () => {

--- a/src/middleware/serve-static/index.ts
+++ b/src/middleware/serve-static/index.ts
@@ -30,7 +30,14 @@ const ENCODINGS_ORDERED_KEYS = Object.keys(ENCODINGS) as (keyof typeof ENCODINGS
 const DEFAULT_DOCUMENT = 'index.html'
 
 /**
- * This middleware is not directly used by the user. Create a wrapper specifying `getContent()` by the environment such as Deno or Bun.
+ * Serve Static middleware.
+ *
+ * Serves static files from the given root. Only `GET` and `HEAD` requests are
+ * handled; other methods fall through to `next()` so downstream middleware
+ * (e.g. `methodNotAllowed`) can respond with `405 Method Not Allowed`.
+ *
+ * This middleware is not directly used by the user. Create a wrapper specifying
+ * `getContent()` by the environment such as Deno or Bun.
  */
 export const serveStatic = <E extends Env = Env>(
   options: ServeStaticOptions<E> & {
@@ -54,6 +61,10 @@ export const serveStatic = <E extends Env = Env>(
   return async (c, next) => {
     // Do nothing if Response is already set
     if (c.finalized) {
+      return next()
+    }
+
+    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
       return next()
     }
 


### PR DESCRIPTION
Fixes #5223

## Summary

This PR fixes the interaction between `serveStatic` and `methodNotAllowed` middleware. Currently two bugs cause incorrect status codes when both are used together:

1. `serveStatic` serves files for **any** HTTP method when registered via `app.use("/*", serveStatic())`, so `POST /static/file.html` incorrectly returns `200` instead of falling through to `404`/`405`.
2. `methodNotAllowed` infers allowed methods from trailing wildcard routes like `/*` or `/static/*`, so `POST /non-existent` incorrectly returns `405` instead of `404` (every unhandled request in a wildcard namespace is converted).

Both are fixed with minimal, non-breaking changes.

## Changes

### 1. `src/middleware/serve-static/index.ts`

- Return `next()` early for non-`GET`/`HEAD` methods before resolving the file path or calling `getContent`.
- Ensures `getContent` is not invoked for `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`, etc., and allows downstream middleware (e.g. `methodNotAllowed`) to handle the request.

```ts
if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
  return next()
}
```

Only `GET` and `HEAD` are handled because Hono dispatches `HEAD` to `GET` routes; all other methods must fall through.

### 2. `src/middleware/method-not-allowed/index.ts`

- Ignore routes with a trailing wildcard (`route.path.endsWith('*')`) when building the `methodRouter` for `Allow` header inference:

```ts
if (route.path.endsWith('*')) {
  continue
}
```

Rationale (per @usualoma discussion on #5223): a trailing wildcard matches an arbitrary remainder of the path and does not reliably prove a concrete resource exists. Ignoring it prevents `404` → `405` conversion for arbitrary paths like `/random-not-found`.

Existing filters for `ALL` and explicit `HEAD` routes are retained.

## Documentation

- Updated TSDoc for `serveStatic` to document `GET`/`HEAD`-only handling and fallthrough behavior.
- Updated TSDoc for `methodNotAllowed` to document wildcard, `ALL`, and `HEAD` ignoring.

## Testing

### Added tests

**`src/middleware/serve-static/index.test.ts` (4 tests):**

- `Should skip non-GET/HEAD requests and not call getContent` – `POST /static/hello.html` → `404`, `getContent` not called
- `Should skip various non-GET/HEAD methods` – `PUT`, `DELETE`, `PATCH`, `OPTIONS`, `POST` all `404` without `getContent`
- `Should still serve HEAD requests` – `HEAD` → `200` and `getContent` called
- `Should allow methodNotAllowed to handle POST to existing route while static falls through` – combined `methodNotAllowed` + `serveStatic` test: `POST /static/hello.html` → `404` (no `getContent`), `POST /api` → `405 Allow: GET, HEAD`, `GET /static/hello.html` → `200`

**`src/middleware/method-not-allowed/index.test.ts` (3 tests):**

- `ignores trailing wildcard routes when inferring allowed methods` – `GET /*` exists, `POST /nonexistent` → `404` (not `405`), while `POST /api` → `405`
- `ignores wildcard routes with prefix like /static/*` – similar with `/static/*`
- `still returns 405 for non-wildcard routes when wildcard exists` – `POST /resource` → `405` even with `/*` present

### Test results

```bash
bun run format:fix  # prettier --write – All matched files use Prettier code style!
bun run lint:fix    # eslint --fix – 0 errors, 34 warnings (pre-existing)
node node_modules/vitest/vitest.mjs --run src/middleware/serve-static/index.test.ts --project main
# Test Files  1 passed (1)
# Tests  24 passed (24)

node node_modules/vitest/vitest.mjs --run src/middleware/method-not-allowed/index.test.ts --project main
# Test Files  1 passed (1)
# Tests  23 passed (23)

node node_modules/vitest/vitest.mjs --run src/middleware/serve-static/index.test.ts src/middleware/method-not-allowed/index.test.ts --project main
# Tests  47 passed (47)
```

All existing tests continue to pass; no breaking change (treated as patch per maintainer note on #5223).

## Checklist

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add TSDoc/JSDoc to document the code

## Reference

- Issue: #5223
- Related discussion: https://github.com/honojs/hono/issues/5223#issuecomment- (usualoma proposal to ignore trailing wildcard and restrict serveStatic to GET/HEAD)
- Related closed PR: #5224 (partial fix, closed per AI policy)