### PR TITLE
fix(request): preserve urlencoded media type when cloning a consumed request

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -650,8 +650,6 @@ describe('cloneRawRequest', () => {
         body,
       })
     )
-    // Reading a urlencoded body through formData() is legal, but the cache
-    // now holds a FormData while the original media type is still urlencoded.
     await req.formData()
 
     const clonedReq = await cloneRawRequest(req)

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -639,6 +639,27 @@ describe('cloneRawRequest', () => {
     expect(await clonedReq.json()).toEqual({ foo: 'bar' })
   })
 
+  test('clones consumed urlencoded request without flipping the media type', async () => {
+    const body = 'foo=bar&baz=qux'
+    const req = new HonoRequest(
+      new Request('http://localhost', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body,
+      })
+    )
+    // Reading a urlencoded body through formData() is legal, but the cache
+    // now holds a FormData while the original media type is still urlencoded.
+    await req.formData()
+
+    const clonedReq = await cloneRawRequest(req)
+
+    expect(clonedReq.headers.get('Content-Type')).toBe('application/x-www-form-urlencoded')
+    expect(await clonedReq.text()).toBe(body)
+  })
+
   test('clones GET request without body', async () => {
     const req = new HonoRequest(
       new Request('http://localhost', {

--- a/src/request.ts
+++ b/src/request.ts
@@ -489,22 +489,16 @@ export const cloneRawRequest = async (req: HonoRequest): Promise<Request> => {
     delete headers['content-length']
   } else if (body instanceof FormData) {
     const contentType = headers['content-type']
-    // A urlencoded body read through formData() is cached as a FormData, but
-    // re-serializing it would flip the media type to multipart. Keep the
-    // original urlencoded encoding instead of letting the runtime choose.
     const isURLEncoded = contentType
       ? contentType.trim().toLowerCase().startsWith('application/x-www-form-urlencoded')
       : false
     if (isURLEncoded) {
-      // A urlencoded body never contains files, but stay defensive anyway.
       body = new URLSearchParams(
         [...(body as FormData).entries()].map(([k, v]) => [k, typeof v === 'string' ? v : v.name])
       )
     } else {
       delete headers['content-type']
     }
-    // The FormData is re-serialized, so the original content headers no longer
-    // describe the body. Let the runtime generate them for the new representation.
     delete headers['content-length']
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -488,7 +488,23 @@ export const cloneRawRequest = async (req: HonoRequest): Promise<Request> => {
     body = JSON.stringify(body)
     delete headers['content-length']
   } else if (body instanceof FormData) {
-    delete headers['content-type']
+    const contentType = headers['content-type']
+    // A urlencoded body read through formData() is cached as a FormData, but
+    // re-serializing it would flip the media type to multipart. Keep the
+    // original urlencoded encoding instead of letting the runtime choose.
+    const isURLEncoded = contentType
+      ? contentType.trim().toLowerCase().startsWith('application/x-www-form-urlencoded')
+      : false
+    if (isURLEncoded) {
+      // A urlencoded body never contains files, but stay defensive anyway.
+      body = new URLSearchParams(
+        [...(body as FormData).entries()].map(([k, v]) => [k, typeof v === 'string' ? v : v.name])
+      )
+    } else {
+      delete headers['content-type']
+    }
+    // The FormData is re-serialized, so the original content headers no longer
+    // describe the body. Let the runtime generate them for the new representation.
     delete headers['content-length']
   }
 


### PR DESCRIPTION
## Summary

`cloneRawRequest()` silently flips an `application/x-www-form-urlencoded` body into `multipart/form-data` when the body was consumed through `formData()` (directly, via `parseBody()`, or via the form validator) before cloning.

Reading a urlencoded body with `formData()` is legal — the WHATWG `FormData` parser accepts both encodings — but it caches the parsed result as a `FormData`. The current clone logic treats any cached `FormData` as multipart: it deletes the original `Content-Type` and lets the runtime re-serialize the body as multipart.

The reconstructed request therefore violates the documented contract that it is rebuilt "with the same properties" (JSDoc of `cloneRawRequest`). Any downstream consumer keyed on the media type breaks. Concrete example: forwarding an OAuth2 token-endpoint request after validating it — RFC 6749 §4.1.3 requires `application/x-www-form-urlencoded`, and servers such as Keycloak/Auth0 reject the multipart clone.

## Reproduction

```ts
import { Hono } from 'hono'
import { cloneRawRequest } from 'hono/request'

const app = new Hono()

app.post('/oauth/token', async (c) => {
  const body = await c.req.parseBody() // consumes + caches as FormData
  const cloned = await cloneRawRequest(c.req)
  return c.text(cloned.headers.get('content-type') ?? '')
})
```

`curl -X POST /oauth/token -H 'content-type: application/x-www-form-urlencoded' -d 'grant_type=authorization_code'`
→ returns `multipart/form-data; boundary=----formdata-undici-...`, expected `application/x-www-form-urlencoded`.

## Fix

When the cached body is a `FormData` **and** the original content type is urlencoded, rebuild the clone body as `URLSearchParams` (which serializes back to urlencoded and carries its own correct `Content-Type`) instead of dropping the header. Multipart behavior is unchanged: the header is still dropped so the runtime generates a fresh boundary (as fixed in #5133), and stale `Content-Length` is still removed (as fixed in #5282).

Note: a urlencoded body can never contain files, so mapping `File` entries is purely defensive (`File.name`) — in practice only string values appear.

## Test plan

- [x] New test: `clones consumed urlencoded request without flipping the media type` — fails on `main` (asserts `multipart/form-data; boundary=...`), passes with the fix
- [x] Full suite: 147 files / 4935 tests passed
- [x] `eslint src/request.ts src/request.test.ts` clean
- [x] `prettier --check` clean on staged content