### PR TITLE
fix(method-not-allowed): ignore trailing wildcard routes when inferring allowed methods

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -289,4 +289,41 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
     expect(await res.text()).toBe('Missing')
   })
+
+  it('ignores trailing wildcard routes when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/static/*', (c) => c.text('static'))
+
+    const res = await app.request('/static/file.txt', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+  })
+
+  it('ignores root wildcard route when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/*', (c) => c.text('catch-all'))
+
+    const res = await app.request('/unregistered', { method: 'POST' })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.has('Allow')).toBe(false)
+  })
+
+  it('still returns 405 for an exact route even if a trailing wildcard route is also registered', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/static/*', (c) => c.text('static wildcard'))
+    app.get('/static/file.txt', (c) => c.text('specific file'))
+
+    const wildcardRes = await app.request('/static/other.txt', { method: 'POST' })
+    expect(wildcardRes.status).toBe(404)
+    expect(wildcardRes.headers.has('Allow')).toBe(false)
+
+    const exactRes = await app.request('/static/file.txt', { method: 'POST' })
+    expect(exactRes.status).toBe(405)
+    expect(exactRes.headers.get('Allow')).toBe('GET, HEAD')
+  })
 })

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -79,7 +79,13 @@ export const methodNotAllowed = <E extends Env = Env>(
       for (const route of options.app.routes) {
         // Hono does not distinguish middleware registered with `app.use()` from handlers
         // registered with `app.all()`, so `ALL` routes cannot contribute to the Allow header.
-        if (route.method === METHOD_NAME_ALL || route.method === 'HEAD') {
+        // Routes ending with a wildcard do not provide evidence of a specific target resource,
+        // so they are ignored when inferring allowed methods.
+        if (
+          route.method === METHOD_NAME_ALL ||
+          route.method === 'HEAD' ||
+          route.path.endsWith('*')
+        ) {
           continue
         }
 


### PR DESCRIPTION
## Summary

Addresses #5223: ignores routes ending with a wildcard (`*`) when inferring allowed methods in `methodNotAllowed`.

## Motivation & Context

A trailing wildcard route (e.g. `/*`, `/static/*`) matches arbitrary subpaths and does not provide evidence that a specific target resource exists. When registering such routes (e.g. for fallback or static asset serving), `methodNotAllowed` previously matched all subpaths against the wildcard and converted unhandled requests from `404 Not Found` into `405 Method Not Allowed`.

As discussed in #5223, ignoring routes ending with `*` avoids converting unhandled subpaths to 405 while preserving 405 responses for specific routes.

## Changes

- In `src/middleware/method-not-allowed/index.ts`, skip routes where `route.path.endsWith('*')` when populating the allowed methods router.
- In `src/middleware/method-not-allowed/index.test.ts`, added unit tests verifying:
  - Trailing wildcard routes (e.g. `/static/*`) return 404 for unhandled subpaths.
  - Catch-all root wildcard route (`/*`) returns 404.
  - Specific routes (e.g. `/static/file.txt`) still return 405 with the proper `Allow` header.

## Verification

- `npm test`: all 4,940+ tests passed
- `npm run lint`: clean (0 errors)
- `npm run format`: clean

Closes #5223