### PR TITLE
fix(client): keep a param value of "index" in $url() and $path()

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1243,6 +1243,10 @@ describe.each(['$path', '$url'] as const)('%s() with a param option', (cmd) => {
   const app = new Hono()
     .get('/posts/:id/comments', (c) => c.json({ ok: true }))
     .get('/something/:firstId/:secondId/:version?', (c) => c.json({ ok: true }))
+    .get('/docs/:page', (c) => c.json({ ok: true }))
+    .get('/files/:dir/', (c) => c.json({ ok: true }))
+    .get('/:page', (c) => c.json({ ok: true }))
+    .get('/index/:v?', (c) => c.json({ ok: true }))
   type AppType = typeof app
   const client = hc<AppType>('http://localhost')
 
@@ -1270,16 +1274,54 @@ describe.each(['$path', '$url'] as const)('%s() with a param option', (cmd) => {
     })
     expect(pathname(value)).toBe('/something/123/456')
   })
+
+  it('Should keep a param value of "index" - /docs/index', async () => {
+    const value = client.docs[':page'][cmd]({
+      param: {
+        page: 'index',
+      },
+    })
+    expect(pathname(value)).toBe('/docs/index')
+  })
+
+  it('Should keep a root-level param value of "index" - /index', async () => {
+    const value = client[':page'][cmd]({
+      param: {
+        page: 'index',
+      },
+    })
+    expect(pathname(value)).toBe('/index')
+  })
+
+  it('Should keep a literal index segment when an optional param is omitted - /index', async () => {
+    const value = client.index[':v?'][cmd]({
+      param: {
+        v: undefined,
+      },
+    })
+    expect(pathname(value)).toBe('/index')
+  })
+
+  it('Should still drop the index alias of a route with a param - /files/123', async () => {
+    const value = client.files[':dir'].index[cmd]({
+      param: {
+        dir: '123',
+      },
+    })
+    expect(pathname(value)).toBe('/files/123')
+  })
 })
 
 describe('$url() / $path() with a query option', () => {
-  const app = new Hono().get(
-    '/posts',
-    validator('query', () => {
-      return {} as { filter: 'test' }
-    }),
-    (c) => c.json({ ok: true })
-  )
+  const app = new Hono()
+    .get(
+      '/posts',
+      validator('query', () => {
+        return {} as { filter: 'test' }
+      }),
+      (c) => c.json({ ok: true })
+    )
+    .get('/docs/:page', (c) => c.json({ ok: true }))
   type AppType = typeof app
   const client = hc<AppType>('http://localhost')
 
@@ -1297,6 +1339,28 @@ describe('$url() / $path() with a query option', () => {
       },
     })
     expect(path).toBe('/posts?filter=test')
+  })
+
+  it('Should return the correct path - /docs/index?filter=test', async () => {
+    const url = client.docs[':page'].$url({
+      param: {
+        page: 'index',
+      },
+      query: {
+        filter: 'test',
+      },
+    })
+    expect(url.href).toBe('http://localhost/docs/index?filter=test')
+
+    const path = client.docs[':page'].$path({
+      param: {
+        page: 'index',
+      },
+      query: {
+        filter: 'test',
+      },
+    })
+    expect(path).toBe('/docs/index?filter=test')
   })
 })
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -187,16 +187,17 @@ export const hc = <T extends Hono<any, any, any>, Prefix extends string = string
     const path = parts.join('/')
     const url = mergePath(baseUrl, path)
     if (method === 'url' || method === 'path') {
-      let result = url
+      // Strip the synthetic `index` segment before substituting params, so that a param
+      // whose value is `index` is not mistaken for one.
+      let result = removeIndexString(url)
       if (opts.args[0]) {
         if (opts.args[0].param) {
-          result = replaceUrlParam(url, opts.args[0].param)
+          result = replaceUrlParam(result, opts.args[0].param)
         }
         if (opts.args[0].query) {
           result = appendQueryParams(result, buildSearchParamsOption(opts.args[0].query))
         }
       }
-      result = removeIndexString(result)
       if (method === 'url') {
         return new URL(result)
       }


### PR DESCRIPTION
## Summary

`removeIndexString()` strips a trailing `/index` so the synthetic `.index`
accessor resolves to the route it aliases. In the `$url()` / `$path()` branch it
runs *after* the path params have been substituted, so anything that merely
looks like the alias once substitution is done gets stripped as well.

Moving the call ahead of substitution fixes it: the alias is part of the route
template, and a param value is not.

## Before / after

| Typed route | Call | Before | After |
| --- | --- | --- | --- |
| `/docs/:page` | `param: { page: 'index' }` | `/docs` | `/docs/index` |
| `/:page` | `param: { page: 'index' }` | `/` | `/index` |
| `/index/:v?` | `param: { v: undefined }` | `/` | `/index` |

The third row is a route with a **literal** `/index` segment rather than a param
value. Dispatching against that route alone, `/` returns 404 and `/index`
returns 200, so the generated URL did not point at the route it came from.

## Why this ordering

`ClientRequestImpl.fetch` has done `removeIndexString` → `replaceUrlParam` since
`hc` was introduced in #862, which is why `$get()` already returns the right path
for all three rows above and only `$url()` / `$path()` disagreed.

This is a follow-up to #4267, which added the `removeIndexString` call to this
branch (fixing #4265) and placed it at the end of the sequence, immediately
before `return new URL(result)`. Moving it to the front brings the branch in line
with `fetch`.

`removeIndexString`'s `(?=\?|$)` lookahead, added in #4352, is left as-is: it is
still exercised directly by `src/client/utils.test.ts`, even though no `hc` call
site now passes it a query string.

## Relationship to #5291

#5291 adds the same normalization to the `$ws()` branch. The two are independent
hunks in the same function and complementary. I merged them locally in a scratch
branch to check: no conflict, and `src/client/client.test.ts` passes 128 with
both applied. With both in, all four accessors (`$get()`, `$url()`, `$path()`,
`$ws()`) strip the alias from the route template before substituting params.
Happy to rebase on top of #5291 if it lands first.

## Tests

5 tests added, 9 executions — four of them sit in the `$path` / `$url`
`describe.each`, and one in the query-option block. 7 fail on `main`. The one
that passes either way — `Should still drop the index alias of a route with a
param` — is a regression guard that the genuine alias is still removed.

## Verification

- `npx vitest --run src/client/client.test.ts` — 127 passed (120 with `client.ts`
  reverted to `main`, 7 failed)
- `npx tsc -p tsconfig.spec.json` — exit 0
- `npx eslint src` — exit 0
- Prettier clean on the committed blobs
- Full `npx vitest --run`: green with `--coverage.enabled=false`. With coverage
  on I see at least one pre-existing 5 s timeout,
  `src/middleware/compress/index.test.ts` "should compress streaming responses
  written in multiple chunks", which reproduces identically on a clean `main`
  checkout and passes 45/45 in isolation.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code (verified with `prettier --check` and `eslint` directly; the fixer itself rewrites every line ending on a CRLF checkout)
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
