### PR TITLE
fix(types): allow symbol keys in Context<any> get and set fallbacks

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -144,12 +144,11 @@ describe('Context', () => {
     expect(foo).toBe('Bar, Buzz')
   })
 
-
-  it("c.set() and c.get() with symbol key", () => {
-    const sym = Symbol("key")
+  it('c.set() and c.get() with symbol key', () => {
+    const sym = Symbol('key')
     expect(c.get(sym)).toBe(undefined)
-    c.set(sym, "value")
-    expect(c.get(sym)).toBe("value")
+    c.set(sym, 'value')
+    expect(c.get(sym)).toBe('value')
   })
 
   it('c.set() and c.get()', async () => {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -144,6 +144,14 @@ describe('Context', () => {
     expect(foo).toBe('Bar, Buzz')
   })
 
+
+  it("c.set() and c.get() with symbol key", () => {
+    const sym = Symbol("key")
+    expect(c.get(sym)).toBe(undefined)
+    c.set(sym, "value")
+    expect(c.get(sym)).toBe("value")
+  })
+
   it('c.set() and c.get()', async () => {
     expect(c.get('foo')).toBe(undefined)
     c.set('foo', 'bar')

--- a/src/context.ts
+++ b/src/context.ts
@@ -551,10 +551,10 @@ export class Context<
     IsAny<E> extends true
       ? {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Variables: ContextVariableMap & Record<string, any>
+          Variables: ContextVariableMap & Record<string | symbol, any>
         }
       : E
-  > = (key: string, value: unknown) => {
+  > = (key: string | symbol, value: unknown) => {
     this.#var ??= new Map()
     this.#var.set(key, value)
   }
@@ -576,10 +576,10 @@ export class Context<
     IsAny<E> extends true
       ? {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Variables: ContextVariableMap & Record<string, any>
+          Variables: ContextVariableMap & Record<string | symbol, any>
         }
       : E
-  > = (key: string) => {
+  > = (key: string | symbol) => {
     return this.#var ? this.#var.get(key) : undefined
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -551,10 +551,10 @@ export class Context<
     IsAny<E> extends true
       ? {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Variables: ContextVariableMap & Record<string | symbol, any>
+          Variables: ContextVariableMap & Record<PropertyKey, any>
         }
       : E
-  > = (key: string | symbol, value: unknown) => {
+  > = (key: PropertyKey, value: unknown) => {
     this.#var ??= new Map()
     this.#var.set(key, value)
   }
@@ -576,10 +576,10 @@ export class Context<
     IsAny<E> extends true
       ? {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Variables: ContextVariableMap & Record<string | symbol, any>
+          Variables: ContextVariableMap & Record<PropertyKey, any>
         }
       : E
-  > = (key: string | symbol) => {
+  > = (key: PropertyKey) => {
     return this.#var ? this.#var.get(key) : undefined
   }
 


### PR DESCRIPTION
## Problem

Fixes #5298.

Calling `c.set(sym, val)` or `c.get(sym)` with a `symbol` key on an untyped `Context<any>` (the default when no generic `Variables` map is passed) fails type checking because the fallback was typed as `Record<string, any>`, which rejects `symbol` keys.

## Cause

`Context<E>`'s untyped fallback in `src/context.ts` typed `Variables` as `ContextVariableMap & Record<string, any>` and parameter keys as `string`. At runtime, `this.#var` is a `Map` that natively accepts `symbol` keys.

## Fix

- Widen the untyped `Context<any>` fallback variable map to `Record<string | symbol, any>` and allow `string | symbol` parameter keys for `get` and `set`.
- Add unit test in `src/context.test.ts` verifying `c.set` and `c.get` with symbol keys.

## Testing

- Verified type check with `./node_modules/.bin/tsc -p tsconfig.spec.json --noEmit`.
- Verified tests with `bun x vitest run src/context.test.ts` (60/60 passing).