### PR TITLE
fix(context): widen untyped Variables fallback to accept symbol keys

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -149,6 +149,11 @@ describe('Context', () => {
     c.set('foo', 'bar')
     expect(c.get('foo')).toBe('bar')
     expect(c.get('foo2')).toBe(undefined)
+
+    const sym = Symbol('foo')
+    expect(c.get(sym)).toBe(undefined)
+    c.set(sym, 'symbol-value')
+    expect(c.get(sym)).toBe('symbol-value')
   })
 
   it('c.var', async () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -551,10 +551,10 @@ export class Context<
     IsAny<E> extends true
       ? {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Variables: ContextVariableMap & Record<string, any>
+          Variables: ContextVariableMap & Record<string | symbol, any>
         }
       : E
-  > = (key: string, value: unknown) => {
+  > = (key: string | symbol, value: unknown) => {
     this.#var ??= new Map()
     this.#var.set(key, value)
   }
@@ -576,10 +576,10 @@ export class Context<
     IsAny<E> extends true
       ? {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Variables: ContextVariableMap & Record<string, any>
+          Variables: ContextVariableMap & Record<string | symbol, any>
         }
       : E
-  > = (key: string) => {
+  > = (key: string | symbol) => {
     return this.#var ? this.#var.get(key) : undefined
   }
 
@@ -595,8 +595,9 @@ export class Context<
    */
   // c.var.propName is a read-only
   get var(): Readonly<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ContextVariableMap & (IsAny<E['Variables']> extends true ? Record<string, any> : E['Variables'])
+    ContextVariableMap &
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (IsAny<E['Variables']> extends true ? Record<string | symbol, any> : E['Variables'])
   > {
     if (!this.#var) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1971,6 +1971,45 @@ describe('ContextVariableMap type tests', () => {
     // @ts-expect-error the value of payload should be string
     expectTypeOf(c.set('payload', 123))
   })
+
+  it('Should accept symbol keys with c.get and c.set when c is Context<any>', () => {
+    const c = new Context(new Request('http://localhost'))
+    const sym = Symbol('foo')
+    c.set(sym, { data: 'test' })
+    expectTypeOf(c.get(sym)).toEqualTypeOf<any>()
+
+    const mw = createMiddleware(async (c, next) => {
+      const symKey = Symbol('middleware-key')
+      c.set(symKey, 'hello')
+      expectTypeOf(c.get(symKey)).toEqualTypeOf<any>()
+      await next()
+    })
+
+    const appAny = new Hono<any>()
+    appAny.get('/', (c) => {
+      const symKey = Symbol('route-key')
+      c.set(symKey, 123)
+      expectTypeOf(c.get(symKey)).toEqualTypeOf<any>()
+      return c.text('ok')
+    })
+  })
+
+  it('Should accept symbol keys when declared in Variables generic', () => {
+    const symKey = Symbol('typed-key')
+    const app = new Hono<{
+      Variables: {
+        [symKey]: number
+      }
+    }>()
+
+    app.get('/', (c) => {
+      c.set(symKey, 42)
+      expectTypeOf(c.get(symKey)).toEqualTypeOf<number>()
+      // @ts-expect-error value should be number
+      c.set(symKey, 'invalid')
+      return c.text('ok')
+    })
+  })
 })
 
 /**


### PR DESCRIPTION
Fixes #5298

### What this PR does
Widens `Context<E>`'s untyped fallback (`IsAny<E> extends true`) for `set`, `get`, and `var` from `ContextVariableMap & Record<string, any>` to `ContextVariableMap & Record<string | symbol, any>`.

### Why
At runtime, `Context` stores variables in a `Map<unknown, unknown>`, which natively accepts `Symbol` keys. However, when using untyped `Context` (such as `new Hono()`, `Context<any>`, or standard untyped middlewares), TypeScript previously constrained keys to `string | number` via `Record<string, any>`, preventing frameworks and libraries from stashing collision-free per-request state using `Symbol()` without type-casting.

### Changes
- Updated `set`, `get`, and `var` fallback types in `src/context.ts` to `Record<string | symbol, any>`.
- Updated `set` and `get` parameter types in `src/context.ts` from `key: string` to `key: string | symbol`.
- Added unit and type tests in `src/context.test.ts` and `src/types.test.ts`.

### Checklist
- [x] Add tests
- [x] Run tests (`vitest` / `tsc`)
- [x] `npm run format && npm run lint` to format and lint the code
