### PR TITLE
Reject non-finite retry values in writeSSE

### DIFF
--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -389,6 +389,30 @@ describe('SSE Streaming helper', () => {
     expect(onError).toBeCalledTimes(1)
   })
 
+  it('Should throw error if retry is a string with CR/LF', async () => {
+    const onError = vi.fn()
+    const res = streamSSE(
+      c,
+      async (stream) => {
+        await stream.writeSSE({
+          data: 'hello',
+          retry: '0\r\nevent: admin\r\ndata: pwned' as unknown as number,
+        })
+      },
+      onError
+    )
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    const { value } = await reader.read()
+    const decodedValue = decoder.decode(value)
+    expect(decodedValue).toContain('event: error')
+    expect(decodedValue).not.toContain('event: admin')
+    expect(onError).toBeCalledTimes(1)
+  })
+
   it('Should throw error if id contains \\r', async () => {
     const onError = vi.fn()
     const res = streamSSE(

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -31,6 +31,12 @@ export class SSEStreamingApi extends StreamingApi {
       }
     }
 
+    if (message.retry !== undefined) {
+      if (typeof message.retry !== 'number' || !Number.isFinite(message.retry)) {
+        throw new Error('retry must be a finite number')
+      }
+    }
+
     const sseData =
       [
         message.event && `event: ${message.event}`,


### PR DESCRIPTION
`writeSSE` already throws if `event` or `id` contain CR/LF. `retry` was concatenated as-is, so a non-number with line breaks could split the SSE frame.

Require a finite number before emitting `retry:`. `retry: 0` still works.

Fixes #5299