### PR TITLE
feat(jwt): add leeway option for clock skew tolerance

### DIFF
--- a/src/middleware/jwt/index.test.ts
+++ b/src/middleware/jwt/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf } from 'vitest'
 import { Hono } from '../../hono'
 import { HTTPException } from '../../http-exception'
-import { jwt } from '.'
+import { jwt, sign } from '.'
 import type { JwtVariables } from '.'
 
 describe('JWT', () => {
@@ -797,6 +797,34 @@ describe('JWT', () => {
       expect(res.headers.get('WWW-Authenticate')).toBe(
         'Bearer realm="my \\"quoted\\" api",error="invalid_request",error_description="no authorization included in request"'
       )
+    })
+
+    it('Should accept token within clock leeway when configured in verification options', async () => {
+      const app = new Hono()
+      app.use(
+        '/auth/*',
+        jwt({
+          secret: 'a-secret',
+          alg: 'HS256',
+          verification: {
+            leeway: 60,
+          },
+        })
+      )
+      app.get('/auth/*', (c) => c.text('ok'))
+
+      const now = Math.floor(Date.now() / 1000)
+      const token = await sign(
+        { sub: 'user123', iat: now + 10, exp: now + 3600 },
+        'a-secret',
+        'HS256'
+      )
+      const req = new Request('http://localhost/auth/page')
+      req.headers.set('Authorization', `Bearer ${token}`)
+      const res = await app.request(req)
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('ok')
     })
   })
 })

--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -1772,3 +1772,82 @@ describe('PEM parsing', async () => {
     expect(verified).toEqual(payload)
   })
 })
+
+describe('leeway (clock skew tolerance)', () => {
+  const secret = 'a-secret'
+
+  it('should accept a token with nbf slightly in the future within leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const tok = await JWT.sign({ message: 'hello', nbf: now + 5 }, secret, AlgorithmTypes.HS256)
+
+    await expect(JWT.verify(tok, secret, AlgorithmTypes.HS256)).rejects.toThrow(JwtTokenNotBefore)
+
+    const verified = await JWT.verify(tok, secret, {
+      alg: AlgorithmTypes.HS256,
+      leeway: 10,
+    })
+    expect(verified.message).toBe('hello')
+  })
+
+  it('should reject a token with nbf in the future exceeding leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const tok = await JWT.sign({ message: 'hello', nbf: now + 20 }, secret, AlgorithmTypes.HS256)
+
+    await expect(
+      JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        leeway: 10,
+      })
+    ).rejects.toThrow(JwtTokenNotBefore)
+  })
+
+  it('should accept an expired token within leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const tok = await JWT.sign({ message: 'hello', exp: now - 5 }, secret, AlgorithmTypes.HS256)
+
+    await expect(JWT.verify(tok, secret, AlgorithmTypes.HS256)).rejects.toThrow(JwtTokenExpired)
+
+    const verified = await JWT.verify(tok, secret, {
+      alg: AlgorithmTypes.HS256,
+      leeway: 10,
+    })
+    expect(verified.message).toBe('hello')
+  })
+
+  it('should reject an expired token exceeding leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const tok = await JWT.sign({ message: 'hello', exp: now - 20 }, secret, AlgorithmTypes.HS256)
+
+    await expect(
+      JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        leeway: 10,
+      })
+    ).rejects.toThrow(JwtTokenExpired)
+  })
+
+  it('should accept a token with iat slightly in the future within leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const tok = await JWT.sign({ message: 'hello', iat: now + 5 }, secret, AlgorithmTypes.HS256)
+
+    await expect(JWT.verify(tok, secret, AlgorithmTypes.HS256)).rejects.toThrow(JwtTokenIssuedAt)
+
+    const verified = await JWT.verify(tok, secret, {
+      alg: AlgorithmTypes.HS256,
+      leeway: 10,
+    })
+    expect(verified.message).toBe('hello')
+  })
+
+  it('should reject a token with iat in the future exceeding leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const tok = await JWT.sign({ message: 'hello', iat: now + 20 }, secret, AlgorithmTypes.HS256)
+
+    await expect(
+      JWT.verify(tok, secret, {
+        alg: AlgorithmTypes.HS256,
+        leeway: 10,
+      })
+    ).rejects.toThrow(JwtTokenIssuedAt)
+  })
+})

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -86,6 +86,8 @@ export type VerifyOptions = {
   iat?: boolean
   /** Acceptable audience(s) for the token */
   aud?: string | string[] | RegExp
+  /** Clock tolerance in seconds to account for clock skew (default: `0`) */
+  leeway?: number
 }
 
 export type VerifyOptionsWithAlg = {
@@ -109,6 +111,7 @@ export const verify = async (
     exp = true,
     iat = true,
     aud,
+    leeway = 0,
   } = typeof algOrOptions === 'string' ? { alg: algOrOptions } : algOrOptions
 
   if (!alg) {
@@ -129,17 +132,29 @@ export const verify = async (
   }
   const now = Math.floor(Date.now() / 1000)
   if (nbf && payload.nbf !== undefined) {
-    if (typeof payload.nbf !== 'number' || !Number.isFinite(payload.nbf) || payload.nbf > now) {
+    if (
+      typeof payload.nbf !== 'number' ||
+      !Number.isFinite(payload.nbf) ||
+      payload.nbf > now + leeway
+    ) {
       throw new JwtTokenNotBefore(token)
     }
   }
   if (exp && payload.exp !== undefined) {
-    if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp) || payload.exp <= now) {
+    if (
+      typeof payload.exp !== 'number' ||
+      !Number.isFinite(payload.exp) ||
+      payload.exp <= now - leeway
+    ) {
       throw new JwtTokenExpired(token)
     }
   }
   if (iat && payload.iat !== undefined) {
-    if (typeof payload.iat !== 'number' || !Number.isFinite(payload.iat) || now < payload.iat) {
+    if (
+      typeof payload.iat !== 'number' ||
+      !Number.isFinite(payload.iat) ||
+      now < payload.iat - leeway
+    ) {
       throw new JwtTokenIssuedAt(now, payload.iat)
     }
   }


### PR DESCRIPTION
 Adds an optional `leeway` (in seconds) to `VerifyOptions` for JWT verification to account for distributed clock skew (NTP drift) per [RFC 7519 Section 4.1.4](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4).

### Changes
- Added `leeway?: number` to `VerifyOptions` in `src/utils/jwt/jwt.ts` (default: `0`).
- Updated `nbf`, `exp`, and `iat` checks to account for `leeway` tolerance.
- Added comprehensive unit and middleware tests.

### Author Checklist
- [x] Add tests
- [x] Run tests (all 139 passed)
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add TSDoc/JSDoc to document the code