### PR TITLE
fix(timeout): prevent unhandled rejection on late downstream failures

### DIFF
--- a/src/middleware/timeout/index.test.ts
+++ b/src/middleware/timeout/index.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest'
 import type { Context } from '../../context'
 import { Hono } from '../../hono'
 import { HTTPException } from '../../http-exception'
@@ -66,5 +67,38 @@ describe('Timeout API', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('This should not show up')
+  })
+
+  it('Should propagate error if handler rejects before timeout', async () => {
+    const customApp = new Hono()
+    customApp.use('/fast-error', timeout(500))
+    customApp.get('/fast-error', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      throw new Error('Immediate failure')
+    })
+
+    const res = await customApp.request('http://localhost/fast-error')
+    expect(res.status).toBe(500)
+  })
+
+  it('Should not trigger unhandledRejection when handler rejects after timeout', async () => {
+    const unhandledRejectionHandler = vi.fn()
+    process.on('unhandledRejection', unhandledRejectionHandler)
+
+    const customApp = new Hono()
+    customApp.use('/late-error', timeout(50))
+    customApp.get('/late-error', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150))
+      throw new Error('Delayed background failure')
+    })
+
+    const res = await customApp.request('http://localhost/late-error')
+    expect(res.status).toBe(504)
+
+    // Wait for background task to reject
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(unhandledRejectionHandler).not.toHaveBeenCalled()
+    process.removeListener('unhandledRejection', unhandledRejectionHandler)
   })
 })

--- a/src/middleware/timeout/index.ts
+++ b/src/middleware/timeout/index.ts
@@ -41,14 +41,16 @@ export const timeout = (
 ): MiddlewareHandler => {
   return async function timeout(context, next) {
     let timer: number | undefined
+    const nextPromise = next()
     const timeoutPromise = new Promise<void>((_, reject) => {
       timer = setTimeout(() => {
+        nextPromise.catch(() => {})
         reject(typeof exception === 'function' ? exception(context) : exception)
       }, duration) as unknown as number
     })
 
     try {
-      await Promise.race([next(), timeoutPromise])
+      await Promise.race([nextPromise, timeoutPromise])
     } finally {
       if (timer !== undefined) {
         clearTimeout(timer)


### PR DESCRIPTION
 When `timeoutPromise` rejects in `Promise.race([next(), timeoutPromise])`, the middleware exits immediately without attaching a rejection handler to `next()`. If the background handler encounters an error later (e.g. database disconnect or rejected fetch), an `unhandledRejection` event is emitted on the process, which terminates modern Node.js processes.

### Solution
Attached a silent `.catch(() => {})` handler to `nextPromise` inside the timeout trigger. Downstream errors occurring *before* the timeout continue to be caught and handled normally by `Promise.race`.

### The author should do the following, if applicable

- [X] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
