### PR TITLE
fix(jwt): reject non-JSON JWKS responses

### DIFF
--- a/src/utils/jwt/jwt.test.ts
+++ b/src/utils/jwt/jwt.test.ts
@@ -1514,6 +1514,35 @@ describe('verifyWithJwks key handling', () => {
 
     expect(localKeys).toEqual(originalKeys)
   })
+
+  it('Should throw when JWKS response is not valid JSON', async () => {
+    const originalFetch = globalThis.fetch
+    const header = Buffer.from(
+      JSON.stringify({ alg: 'RS256', typ: 'JWT', kid: 'unknown-key' })
+    ).toString('base64url')
+    const payload = Buffer.from(JSON.stringify({})).toString('base64url')
+    const token = `${header}.${payload}.x`
+
+    try {
+      globalThis.fetch = (async () => {
+        return new Response('not-json', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }) as typeof globalThis.fetch
+
+      await expect(
+        verifyWithJwks(token, {
+          jwks_uri: 'https://example.invalid/.well-known/jwks.json',
+          allowedAlgorithms: ['RS256'],
+        })
+      ).rejects.toThrow(
+        'failed to parse JWKS JSON from https://example.invalid/.well-known/jwks.json'
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })
 
 async function exportPEMPrivateKey(key: CryptoKey): Promise<string> {

--- a/src/utils/jwt/jwt.ts
+++ b/src/utils/jwt/jwt.ts
@@ -232,7 +232,12 @@ export const verifyWithJwks = async (
     if (!response.ok) {
       throw new Error(`failed to fetch JWKS from ${options.jwks_uri}`)
     }
-    const data = (await response.json()) as { keys?: JsonWebKey[] }
+    let data: { keys?: JsonWebKey[] }
+    try {
+      data = (await response.json()) as { keys?: JsonWebKey[] }
+    } catch {
+      throw new Error(`failed to parse JWKS JSON from ${options.jwks_uri}`)
+    }
     if (!data.keys) {
       throw new Error('invalid JWKS response. "keys" field is missing')
     }


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### Description

`verifyWithJwks` already throws a clear error when the JWKS HTTP response is not `ok`, when `keys` is missing, and when `keys` is not an array. A 200 body that is not JSON (`response.json()` rejecting) still threw a raw `SyntaxError` with no indication that the JWKS URI was the source.

This wraps `response.json()` and rethrows `failed to parse JWKS JSON from ${jwks_uri}`, same shape as the existing fetch failure.

`bunx vitest --run src/utils/jwt/jwt.test.ts` — 89 passed.
