### PR TITLE
fix(routing): collapse a trailing ** into a single * before routing

### DIFF
--- a/src/hono-base.ts
+++ b/src/hono-base.ts
@@ -26,7 +26,7 @@ import type {
   Schema,
 } from './types'
 import { COMPOSED_HANDLER } from './utils/constants'
-import { getPath, getPathNoStrict, mergePath } from './utils/url'
+import { collapseWildcard, getPath, getPathNoStrict, mergePath } from './utils/url'
 
 const notFoundHandler: NotFoundHandler = (c) => {
   return c.text('404 Not Found', 404)
@@ -386,7 +386,7 @@ class Hono<
   }
 
   #addRoute(method: string, path: string, handler: H, baseRoutePath?: string): void {
-    path = mergePath(this._basePath, path)
+    path = collapseWildcard(mergePath(this._basePath, path))
     const r: RouterRoute = {
       basePath:
         baseRoutePath !== undefined ? mergePath(this._basePath, baseRoutePath) : this._basePath,

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -7,6 +7,8 @@ import { Hono } from './hono'
 import { HTTPException } from './http-exception'
 import { logger } from './middleware/logger'
 import { poweredBy } from './middleware/powered-by'
+import { LinearRouter } from './router/linear-router'
+import { PatternRouter } from './router/pattern-router'
 import { RegExpRouter } from './router/reg-exp-router'
 import { SmartRouter } from './router/smart-router'
 import { TrieRouter } from './router/trie-router'
@@ -304,6 +306,23 @@ describe('Options', () => {
         router: new RegExpRouter(),
       })
       expect(app.router instanceof RegExpRouter).toBe(true)
+    })
+
+    describe('`**` is treated the same as a trailing `*` on every router', () => {
+      // A trailing `*` already matches every remaining segment, so `**` (written
+      // out of habit from other routers) should behave identically instead of
+      // 404ing on routers whose own wildcard matching only strips one `*`.
+      it.each([
+        ['RegExpRouter', RegExpRouter],
+        ['TrieRouter', TrieRouter],
+        ['PatternRouter', PatternRouter],
+        ['LinearRouter', LinearRouter],
+      ])('%s matches /auth/** against /auth/hello', async (_name, Router) => {
+        const app = new Hono({ router: new Router() })
+        app.get('/auth/**', (c) => c.text('ok'))
+        const res = await app.request('/auth/hello')
+        expect(res.status).toBe(200)
+      })
     })
   })
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,5 +1,6 @@
 import {
   checkOptionalParameter,
+  collapseWildcard,
   getPath,
   getPathNoStrict,
   getPattern,
@@ -232,6 +233,22 @@ describe('url', () => {
     })
     it('Should be `/`', () => {
       expect(mergePath('/', '/')).toBe('/')
+    })
+  })
+
+  describe('collapseWildcard', () => {
+    it('collapses a trailing run of two or more `*` into one', () => {
+      expect(collapseWildcard('/api/**')).toBe('/api/*')
+      expect(collapseWildcard('/api/***')).toBe('/api/*')
+      expect(collapseWildcard('**')).toBe('*')
+    })
+    it('leaves a single trailing `*` unchanged', () => {
+      expect(collapseWildcard('/api/*')).toBe('/api/*')
+      expect(collapseWildcard('*')).toBe('*')
+    })
+    it('leaves paths without a trailing `*` unchanged', () => {
+      expect(collapseWildcard('/api/hello')).toBe('/api/hello')
+      expect(collapseWildcard('/api/*/hello')).toBe('/api/*/hello')
     })
   })
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -181,6 +181,19 @@ export const mergePath: (...paths: string[]) => string = (
   }`
 }
 
+/**
+ * A trailing `*` already matches every remaining path segment, so `**` (or
+ * more) written out of habit from other routers is not a distinct pattern.
+ * Collapse it to a single `*` so every router implementation sees the same,
+ * already-supported path.
+ * @param {string} path - The route path to normalize.
+ * @returns {string} The path with a collapsed trailing wildcard run.
+ * @example
+ * collapseWildcard('/api/**') // '/api/*'
+ * collapseWildcard('/api/*') // '/api/*'
+ */
+export const collapseWildcard = (path: string): string => path.replace(/\*{2,}$/, '*')
+
 export const checkOptionalParameter = (path: string): string[] | null => {
   /*
     If path is `/api/animals/:type?` it will return:


### PR DESCRIPTION
Fixes #4623.

## What

`TrieRouter` and `LinearRouter` both 404 on a route registered with a trailing `**` (e.g. `.get('/auth/**', ...)`), while `RegExpRouter` and `PatternRouter` happen to accept it — matching the issue's own cross-router repro. A trailing `*` already matches every remaining path segment in Hono, so `**` isn't meant to be a semantically distinct pattern; it should just behave like `*`.

I re-ran the issue's own repro against current `main` before touching anything, since the issue only reported `TrieRouter` as broken: it turns out `LinearRouter` *also* 404s on `main` today (only `RegExpRouter`/`PatternRouter` currently work), so the fix needed to cover both.

## Root cause

Same class of bug in each router, different mechanism:
- `TrieRouter`'s `getPattern()` only recognizes the exact string `'*'` as a wildcard pattern. For a `'**'` segment it returns `null`, so `insert()` never registers that child as a pattern node — it's just a dead literal-string child that nothing can match against.
- `LinearRouter`'s `hasStar` branch strips exactly one trailing `*` character (`routePath.slice(0, -1)`) before splitting on `*`. For `/auth/**` that leaves one `*` behind, which then gets treated as an ordinary mid-path wildcard segment expecting a following `/` — which doesn't exist, so the match fails.

## Fix

Rather than patching two different routers' internal matching logic separately, I normalized once at the single place every router implementation already passes through: `Hono#addRoute()`, where the request path is finalized right before `router.add()`. Added `collapseWildcard()` next to the existing `mergePath()` in `utils/url.ts` (same small-pure-function convention), and applied it there.

```ts
export const collapseWildcard = (path: string): string => path.replace(/\*{2,}$/, '*')
```

## Testing

- `src/utils/url.test.ts`: unit tests for `collapseWildcard` (collapses 2+ trailing `*`, leaves a single trailing `*` alone, leaves non-trailing occurrences alone).
- `src/hono.test.ts`: a parametrized test registering `/auth/**` and requesting `/auth/hello` against all four routers (`RegExpRouter`, `TrieRouter`, `PatternRouter`, `LinearRouter`) — the issue's own repro, generalized.
- **Negative control**: reverted just `hono-base.ts`/`utils/url.ts` (kept the new tests) and reran — exactly the `TrieRouter` and `LinearRouter` cases fail with the reported 404, `RegExpRouter`/`PatternRouter` keep passing on their own. Restored the fix, all green again.
- Full suite (`vitest run`): 4956/4967 passing. The 11 failing are pre-existing and unrelated — ANSI color-code string assertions in `middleware/logger/index.test.ts`, confirmed identical with and without this change via `git stash`.
- `tsc -p tsconfig.spec.json`: clean.
- `eslint` on the four changed files: clean.

## 🤖 Agent context

Since `docs/CONTRIBUTING.md`'s AI Usage Policy asks that AI-assisted contributions not waste maintainer time regardless of disclosure, I'm disclosing anyway: this fix was developed with AI assistance (Claude Code) and reviewed before submission, with the verification steps above actually run (built/reverted/rerun, not just described) before opening this PR, including catching that `LinearRouter` was also affected — something the original issue didn't report.

