### PR TITLE
fix(streaming): validate retry field in writeSSE against CRLF injection

### DIFF
--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -409,6 +409,53 @@ describe('SSE Streaming helper', () => {
     expect(onError).toBeCalledTimes(1)
   })
 
+  it('Should throw error if retry contains \\n', async () => {
+    const onError = vi.fn()
+    const res = streamSSE(
+      c,
+      async (stream) => {
+        await stream.writeSSE({
+          data: 'hello',
+          retry: '0\nevent: admin\ndata: pwned\n\n' as unknown as number,
+        })
+      },
+      onError
+    )
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    const { value } = await reader.read()
+    const decodedValue = decoder.decode(value)
+    expect(decodedValue).toContain('event: error')
+    expect(decodedValue).not.toContain('event: admin')
+    expect(onError).toBeCalledTimes(1)
+  })
+
+  it('Should throw error if retry contains \\r', async () => {
+    const onError = vi.fn()
+    const res = streamSSE(
+      c,
+      async (stream) => {
+        await stream.writeSSE({
+          data: 'test',
+          retry: '0\revent' as unknown as number,
+        })
+      },
+      onError
+    )
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    const { value } = await reader.read()
+    const decodedValue = decoder.decode(value)
+    expect(decodedValue).toContain('event: error')
+    expect(onError).toBeCalledTimes(1)
+  })
+
   it('Check streamSSE handles consecutive \\r correctly', async () => {
     const res = streamSSE(c, async (stream) => {
       await stream.writeSSE({

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -31,6 +31,10 @@ export class SSEStreamingApi extends StreamingApi {
       }
     }
 
+    if (message.retry !== undefined && /[\r\n]/.test(String(message.retry))) {
+      throw new Error('retry must not contain "\\r" or "\\n"')
+    }
+
     const sseData =
       [
         message.event && `event: ${message.event}`,


### PR DESCRIPTION
Fixes #5299

## Problem
`writeSSE` validates `event` and `id` for `\r`/`\n` but not `retry`, allowing SSE frame injection when `retry` contains CRLF.

## Solution
Add the same CRLF check for `retry` (using `String(message.retry)` so string payloads are caught).

## Test plan
- [x] Added unit tests for `\n` and `\r` in `retry` (mirrors event/id tests)
- [x] Repro from differential testing: injected payload no longer produces `event: admin`

## Notes
- Does not include non-finite `retry` validation (#5302 has an open PR for that scope)