### PR TITLE
fix(sse): reject CR/LF in retry to prevent frame injection

### DIFF
--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -409,6 +409,30 @@ describe('SSE Streaming helper', () => {
     expect(onError).toBeCalledTimes(1)
   })
 
+  it('Should throw error if retry contains \\r\\n', async () => {
+    const onError = vi.fn()
+    const res = streamSSE(
+      c,
+      async (stream) => {
+        await stream.writeSSE({
+          data: 'test',
+          retry: '0\r\nevent: injected' as unknown as number,
+        })
+      },
+      onError
+    )
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    const { value } = await reader.read()
+    const decodedValue = decoder.decode(value)
+    expect(decodedValue).toContain('event: error')
+    expect(decodedValue).not.toContain('event: injected')
+    expect(onError).toBeCalledTimes(1)
+  })
+
   it('Check streamSSE handles consecutive \\r correctly', async () => {
     const res = streamSSE(c, async (stream) => {
       await stream.writeSSE({

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -31,6 +31,10 @@ export class SSEStreamingApi extends StreamingApi {
       }
     }
 
+    if (message.retry !== undefined && /[\r\n]/.test(String(message.retry))) {
+      throw new Error('retry must not contain "\\r" or "\\n"')
+    }
+
     const sseData =
       [
         message.event && `event: ${message.event}`,


### PR DESCRIPTION
Closes #5299

### What

`writeSSE` validates `event` and `id` against CR/LF but interpolates `retry` into the frame verbatim. When `retry` carries a CRLF (JS callers, `as any` boundaries, values read from config/DB), the injected newline terminates the current frame and the remainder is parsed as new SSE fields by every connected client.

```ts
if (message.retry !== undefined && /[\r\n]/.test(String(message.retry))) {
  throw new Error('retry must not contain "\\r" or "\\n"')
}
```

### Reproduced at runtime

The issue was filed as a static-analysis finding, so I verified it actually happens. Reverting the guard and running the new test on `main`:

```
× Should throw error if retry contains \r\n
AssertionError: expected 'data: test\nretry: 0\r\nevent: inject…' to contain 'event: error'
+ event: injected
```

The spoofed `event: injected` does reach the wire. With the guard: 20/20 SSE tests pass.

### Notes on scope

- Mirrors the existing `event`/`id` check, including the error wording.
- Deliberately a CR/LF check rather than `Number.isInteger()`, so valid values are unaffected — `retry: 0` and non-integers keep working. No behavior change for any caller passing a number.
- Not folded into the existing `['event', 'id']` loop: that loop uses `value &&`, which would skip `retry: 0` and regress the behavior covered by "Should accept retry: 0 and not skip it".
- I saw #5127 was closed unmerged. That PR *removed* `retry` from validation and changed `retry: 0` emission; this one only adds a guard and changes no existing behavior. If narrowing validation to string fields was an intentional decision, happy to close this.

### Checklist

- [x] Add tests
- [x] Run tests — 20/20 in `src/helper/streaming/sse.test.tsx`
- [x] `bun run format:fix && bun run lint:fix` — 0 errors, no new warnings
- [x] TSDoc — no public API change