### PR TITLE
fix(accepts, language): skip accept entries with quality 0 when matching

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -190,6 +190,38 @@ describe('accepts', () => {
     const result = accepts(c, options)
     expect(result).toBe('application/xml')
   })
+
+  test('should not match entries explicitly rejected with q=0', () => {
+    const c = {
+      req: {
+        header: () => 'application/json;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
+  test('should skip q=0 entries and match the remaining ones', () => {
+    const c = {
+      req: {
+        header: () => 'text/html;q=0.5, application/json;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'application/octet-stream',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('application/octet-stream')
+  })
 })
 
 describe('Usage', () => {

--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -222,6 +222,22 @@ describe('accepts', () => {
     const result = accepts(c, options)
     expect(result).toBe('application/octet-stream')
   })
+
+  test('should not match a subtype wildcard the client rejected with q=0', () => {
+    const c = {
+      req: {
+        header: () => 'application/*;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
 })
 
 describe('Usage', () => {

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -45,12 +45,16 @@ const getSpecificity = (type: string): number => {
 
 export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {
   const { supports, default: defaultSupport } = config
-  const sortedAccepts = accepts.slice().sort((a, b) => {
-    if (b.q !== a.q) {
-      return b.q - a.q
-    }
-    return getSpecificity(b.type) - getSpecificity(a.type)
-  })
+  // A quality value of 0 means "not acceptable" (RFC 9110 §12.5.1), so such
+  // entries must never match, the same rule the compress middleware applies.
+  const sortedAccepts = accepts
+    .filter((accept) => accept.q > 0)
+    .sort((a, b) => {
+      if (b.q !== a.q) {
+        return b.q - a.q
+      }
+      return getSpecificity(b.type) - getSpecificity(a.type)
+    })
 
   for (const accept of sortedAccepts) {
     const matched = supports.find((supported) => matchType(accept.type, supported))

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -122,6 +122,20 @@ describe('languageDetector', () => {
       expect(await res.text()).toBe('en')
     })
 
+    it('should continue to the next detector after a zero-quality language', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['fr', 'en', 'ja'],
+        fallbackLanguage: 'en',
+        order: ['header', 'querystring'],
+      })
+
+      const res = await app.request('/?lang=ja', {
+        headers: { 'accept-language': 'fr;q=0' },
+      })
+      expect(await res.text()).toBe('ja')
+      expect(res.headers.get('set-cookie')).toContain('language=ja')
+    })
+
     it('should match after multiple truncations', async () => {
       const app = createTestApp({
         supportedLanguages: ['zh-Hant', 'en'],

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -92,6 +92,36 @@ describe('languageDetector', () => {
       expect(await res.text()).toBe('ja')
     })
 
+    it('should not detect a language explicitly rejected with q=0', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['fr', 'en'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0',
+        },
+      })
+      expect(await res.text()).toBe('en')
+    })
+
+    it('should skip q=0 languages before falling back to the default', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['fr', 'en'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0,de;q=0.8',
+        },
+      })
+      expect(await res.text()).toBe('en')
+    })
+
     it('should match after multiple truncations', async () => {
       const app = createTestApp({
         supportedLanguages: ['zh-Hant', 'en'],

--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -158,7 +158,12 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
     }
 
     const languages = parseAcceptLanguage(acceptLanguage)
-    for (const { lang } of languages) {
+    for (const { lang, q } of languages) {
+      // A quality value of 0 means the language is explicitly rejected
+      // (RFC 9110 §12.5.4), so it must not be detected.
+      if (q === 0) {
+        continue
+      }
       const normalizedLang = normalizeLanguage(lang, options)
       if (normalizedLang) {
         return normalizedLang


### PR DESCRIPTION
`accepts()` (`defaultMatch`) and the language detector's header detection still match entries with quality `0`, which RFC 9110 §12.5.1/§12.5.4 defines as "explicitly not acceptable" — e.g. `Accept: application/json;q=0` was served `application/json`.

This change:

- `src/helper/accepts/accepts.ts` — `defaultMatch` filters out `q=0` entries before matching
- `src/middleware/language/language.ts` — `detectFromHeader` skips `q=0` languages

This aligns both consumers with the rule the `compress` middleware already applies (`q > 0` in `getEncoding`). `parseAccept` / `parseAcceptLanguage` are left unchanged, so custom `match` functions and direct callers still see the full list.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code (no public API change)

Tests: full suite `vitest --run` → 147 files, 4964 passed; `tsc -p tsconfig.spec.json` clean; new regression tests cover both `accepts()` and `languageDetector`.

Fixes #5310
