### PR TITLE
fix(utils/concurrent): release pool slot and propagate rejection when a job fails

### DIFF
--- a/src/utils/concurrent.test.ts
+++ b/src/utils/concurrent.test.ts
@@ -37,6 +37,38 @@ describe('concurrent execution', () => {
     expect(results).toEqual(expectedResults)
   })
 
+  describe('with a rejecting job', () => {
+    test('releases the slot and rejects the caller when the job is not queued', async () => {
+      const pool = createPool({ concurrency: 2 })
+
+      await expect(pool.run(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom')
+
+      // If the slot from the failed job were never released, these would hang forever.
+      const results = await Promise.all([pool.run(async () => 1), pool.run(async () => 2)])
+      expect(results).toEqual([1, 2])
+    })
+
+    test('propagates the rejection to a queued caller instead of hanging', async () => {
+      const pool = createPool({ concurrency: 1 })
+
+      let releaseFirst: () => void
+      const firstDone = new Promise<void>((r) => {
+        releaseFirst = r
+      })
+      const first = pool.run(async () => {
+        await firstDone
+        return 'first'
+      })
+      // Queued immediately since concurrency is 1 and the first job is still running.
+      const second = pool.run(() => Promise.reject(new Error('queued-boom')))
+
+      releaseFirst!()
+
+      await expect(first).resolves.toBe('first')
+      await expect(second).rejects.toThrow('queued-boom')
+    })
+  })
+
   describe('with interval', () => {
     test.each`
       concurrency | interval

--- a/src/utils/concurrent.ts
+++ b/src/utils/concurrent.ts
@@ -29,26 +29,50 @@ export const createPool = ({
   const run = async <T>(
     fn: () => T,
     promise?: Promise<T>,
-    resolve?: (result: T) => void
+    resolve?: (result: T) => void,
+    reject?: (reason: unknown) => void
   ): Promise<T> => {
     if (pool.size >= (concurrency as number)) {
-      promise ||= new Promise<T>((r) => (resolve = r))
-      setTimeout(() => run(fn, promise, resolve))
+      if (!promise) {
+        promise = new Promise<T>((res, rej) => {
+          resolve = res
+          reject = rej
+        })
+      }
+      setTimeout(() => {
+        // `run`'s own returned promise settles to the same state as `promise` (which the
+        // caller already awaits with its own handler), so swallow it here to avoid a
+        // duplicate unhandled-rejection warning when the job fails.
+        run(fn, promise, resolve, reject).catch(() => {})
+      })
       return promise
     }
     const marker = {}
     pool.add(marker)
-    const result = await fn()
-    if (interval) {
-      setTimeout(() => pool.delete(marker), interval)
-    } else {
-      pool.delete(marker)
+    const release = () => {
+      if (interval) {
+        setTimeout(() => pool.delete(marker), interval)
+      } else {
+        pool.delete(marker)
+      }
     }
-    if (resolve) {
-      resolve(result)
-      return promise as Promise<T>
-    } else {
-      return result
+    try {
+      const result = await fn()
+      release()
+      if (resolve) {
+        resolve(result)
+        return promise as Promise<T>
+      } else {
+        return result
+      }
+    } catch (e) {
+      release()
+      if (reject) {
+        reject(e)
+        return promise as Promise<T>
+      } else {
+        throw e
+      }
     }
   }
   return { run }


### PR DESCRIPTION
## Summary

`createPool()`'s internal `run()` had two related bugs when a job's `fn()` rejects:

- **Slot leak**: `pool.delete(marker)` only ran after a successful `await fn()`. If `fn()` rejected, the marker was never removed from `pool`, permanently shrinking the effective concurrency by one for the lifetime of the pool.
- **Hung queued callers**: when the pool was full, a queued call only captured a `resolve` for its wait promise, never a `reject`. If that queued job's `fn()` eventually rejected, the error had nowhere to go — the caller's promise just never settled.

Combined, a single failing job run through a low-concurrency pool (e.g. the SSG helper's default concurrency of 2) can permanently wedge the pool: the failed job's slot is never freed, and any subsequent caller queued behind it hangs forever instead of seeing the rejection.

## Fix

- Wrap `await fn()` in `try/catch` so the slot-release logic (`release()`) always runs, on both success and failure.
- Capture `reject` alongside `resolve` when constructing the queued-caller promise, and call it on failure so the rejection propagates instead of being swallowed.
- The retry `setTimeout` callback now `.catch()`s its own recursive `run()` call — once rejections propagate correctly, that inner call's own returned promise (which nothing else awaits) would otherwise trigger a duplicate "unhandled rejection", since the real error is already delivered to the caller through the shared `promise`.

## Test plan

- [x] Added two regression tests in `src/utils/concurrent.test.ts`:
  - a non-queued job rejecting releases its slot (verified by running further jobs afterward)
  - a queued job rejecting propagates the rejection to its caller instead of hanging
- [x] `bun run test` (tsc + vitest): 147 test files / 4962 tests passed
- [x] `bun run lint`: 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `bunx prettier --check` on changed files: passes