### PR TITLE
fix(jsx): preserve self-closing void elements in cloneElement

### DIFF
--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -36,7 +36,7 @@ describe('cloneElement', () => {
   })
 
   it('should preserve self-closing empty tag when cloned', () => {
-    const element = <img src="foo.png" />
+    const element = <img src='foo.png' />
     const clonedElement = cloneElement(element, { alt: 'bar' })
     expect(element.toString()).toBe('<img src="foo.png"/>')
     expect(clonedElement.toString()).toBe('<img src="foo.png" alt="bar"/>')

--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -34,6 +34,13 @@ describe('cloneElement', () => {
     const element = <Hr />
     expect(element.toString()).toBe('<hr/>')
   })
+
+  it('should preserve self-closing empty tag when cloned', () => {
+    const element = <img src="foo.png" />
+    const clonedElement = cloneElement(element, { alt: 'bar' })
+    expect(element.toString()).toBe('<img src="foo.png"/>')
+    expect(clonedElement.toString()).toBe('<img src="foo.png" alt="bar"/>')
+  })
 })
 
 describe('createElement', () => {

--- a/src/jsx/base.test.tsx
+++ b/src/jsx/base.test.tsx
@@ -41,6 +41,17 @@ describe('cloneElement', () => {
     expect(element.toString()).toBe('<img src="foo.png"/>')
     expect(clonedElement.toString()).toBe('<img src="foo.png" alt="bar"/>')
   })
+
+  it('should clone an element with array children', () => {
+    const element = (
+      <div>
+        <span>1</span>
+        <span>2</span>
+      </div>
+    )
+    const clonedElement = cloneElement(element, { className: 'cloned' })
+    expect(clonedElement.toString()).toBe('<div class="cloned"><span>1</span><span>2</span></div>')
+  })
 })
 
 describe('createElement', () => {

--- a/src/jsx/base.ts
+++ b/src/jsx/base.ts
@@ -478,7 +478,7 @@ export const cloneElement = <T extends JSXNode | JSX.Element>(
     childrenToClone = children
   } else {
     const c = (element as JSXNode).props.children
-    childrenToClone = Array.isArray(c) ? c : [c]
+    childrenToClone = c !== undefined ? (Array.isArray(c) ? c : [c]) : []
   }
   return jsx(
     (element as JSXNode).tag,


### PR DESCRIPTION
### Summary
Fixes an issue where `cloneElement()` on elements with `undefined` children (such as HTML void elements `<img />`, `<input />`, `<br />`, `<hr />`, `<link />`) wrapped `undefined` into `[undefined]`, causing void elements to lose self-closing tag rendering in SSR.

### Problem
In `src/jsx/base.ts`, when `cloneElement` was called without new children, it extracted the existing element's `props.children`:

```ts
const c = (element as JSXNode).props.children
childrenToClone = Array.isArray(c) ? c : [c]

When an element has no children (e.g. <img src="foo.png" />), props.children is undefined. Because c was undefined, Array.isArray(c) ? c : [c] evaluated to [undefined], passing an array of length 1 containing undefined to jsx().

During SSR stringification (JSXNode.prototype.toStringToBuffer), the self-closing check emptyTags.includes(tag) && children.length === 0 failed because children.length was 1. This resulted in invalid non-self-closing HTML tags like <img src="foo.png"></img> instead of <img src="foo.png"/>.

###Solution

Check if c !== undefined before wrapping it into an array:

childrenToClone = c !== undefined ? (Array.isArray(c) ? c : [c]) : []

###Verification
Added a unit test in src/jsx/base.test.tsx verifying that cloning a void element (e.g. cloneElement(<img src="foo.png" />, { alt: 'bar' })) preserves <img src="foo.png" alt="bar"/> self-closing HTML output.