### PR TITLE
feat(context): add preparedHeaders getter for a non-allocating read of pending headers

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,5 +1,6 @@
 import { Context } from './context'
 import { setCookie } from './helper/cookie'
+import { Hono } from './hono'
 
 const makeResponseHeaderImmutable = (res: Response) => {
   Object.defineProperty(res, 'headers', {
@@ -554,6 +555,50 @@ describe('c.preparedHeaders', () => {
     expect(c.preparedHeaders).toBe(c.res.headers)
     expect(c.preparedHeaders?.get('X-Before')).toBe('a')
     expect(c.preparedHeaders?.get('X-After')).toBe('b')
+  })
+
+  it('Should reflect the append option', () => {
+    const c = new Context(req)
+    c.header('Vary', 'Accept-Encoding', { append: true })
+    c.header('Vary', 'User-Agent', { append: true })
+    expect(c.preparedHeaders?.get('Vary')).toBe('Accept-Encoding, User-Agent')
+  })
+
+  it('Should reflect a header removed with an undefined value', () => {
+    const c = new Context(req)
+    c.header('X-Temp', 'val')
+    c.header('X-Temp', undefined)
+    expect(c.preparedHeaders?.get('X-Temp')).toBeNull()
+  })
+
+  it('Should create an empty Headers when deleting a header that was never set', () => {
+    // header() unconditionally does #preparedHeaders ??= new Headers() before
+    // the delete, even when there is nothing to delete
+    const c = new Context(req)
+    c.header('X-Never-Set', undefined)
+    expect(c.preparedHeaders).toBeInstanceOf(Headers)
+    expect(c.preparedHeaders?.get('X-Never-Set')).toBeNull()
+  })
+
+  it('Should work from middleware without forcing finalized or breaking the fast path', async () => {
+    let inspected: Headers | undefined
+    let finalizedDuringMiddleware: boolean | undefined
+
+    const app = new Hono()
+    app.use(async (ctx, next) => {
+      ctx.header('X-From-Middleware', 'yes')
+      inspected = ctx.preparedHeaders
+      finalizedDuringMiddleware = ctx.finalized
+      await next()
+    })
+    app.get('/', (ctx) => ctx.text('hi'))
+
+    const res = await app.request('/')
+
+    expect(finalizedDuringMiddleware).toBe(false)
+    expect(inspected?.get('X-From-Middleware')).toBe('yes')
+    expect(res.headers.get('X-From-Middleware')).toBe('yes')
+    expect(await res.text()).toBe('hi')
   })
 })
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -516,6 +516,47 @@ describe('Context header', () => {
   })
 })
 
+describe('c.preparedHeaders', () => {
+  const req = new Request('http://localhost/')
+
+  it('Should be undefined when no header has been set', () => {
+    const c = new Context(req)
+    expect(c.preparedHeaders).toBeUndefined()
+  })
+
+  it('Should expose the headers set with c.header()', () => {
+    const c = new Context(req)
+    c.header('X-Message', 'Hello')
+    expect(c.preparedHeaders?.get('X-Message')).toBe('Hello')
+  })
+
+  it('Should not create a Response, unlike c.res', () => {
+    const respond = (observe?: (c: Context) => void) => {
+      const c = new Context(req)
+      observe?.(c)
+      return c.text('Hi')
+    }
+
+    const untouched = respond().headers.get('Content-Type')
+
+    // reading c.preparedHeaders leaves the response exactly as it was
+    expect(respond((c) => void c.preparedHeaders).headers.get('Content-Type')).toBe(untouched)
+
+    // reading c.res materialises one, which is what this getter exists to avoid
+    expect(respond((c) => void c.res).headers.get('Content-Type')).not.toBe(untouched)
+  })
+
+  it('Should follow c.header() once a Response has been materialised', () => {
+    const c = new Context(req)
+    c.header('X-Before', 'a')
+    void c.res
+    c.header('X-After', 'b')
+    expect(c.preparedHeaders).toBe(c.res.headers)
+    expect(c.preparedHeaders?.get('X-Before')).toBe('a')
+    expect(c.preparedHeaders?.get('X-After')).toBe('b')
+  })
+})
+
 describe('Pass a ResponseInit to respond methods', () => {
   const req = new Request('http://localhost/')
   let c: Context

--- a/src/context.ts
+++ b/src/context.ts
@@ -397,6 +397,29 @@ export class Context<
   }
 
   /**
+   * The response headers set so far, or `undefined` if none have been set.
+   *
+   * Unlike {@link Context.res}, reading this does not create a `Response`, so it can
+   * be used to find out whether anything has touched the response headers without
+   * paying for that allocation. It returns the same `Headers` instance `c.header()`
+   * would write into, which means mutating it mutates the response.
+   *
+   * @example
+   * ```ts
+   * app.use(async (c, next) => {
+   *   await next()
+   *   // does not allocate a Response when no header has been set
+   *   if (c.preparedHeaders?.has('x-request-id')) {
+   *     // ...
+   *   }
+   * })
+   * ```
+   */
+  get preparedHeaders(): Headers | undefined {
+    return this.#res ? this.#res.headers : this.#preparedHeaders
+  }
+
+  /**
    * @see {@link https://hono.dev/docs/api/context#res}
    * The Response object for the current request.
    */


### PR DESCRIPTION
Closes #5313.

`c.header()` writes into a private field and does not set `finalized`, so today there is no way to find out whether the response headers have been touched without reading `c.res` — which allocates a `Response` and, because `header()` then writes into `#res.headers` instead, is observable rather than a neutral inspection.

```ts
get preparedHeaders(): Headers | undefined {
  return this.#res ? this.#res.headers : this.#preparedHeaders
}
```

It mirrors `header()`'s own branch rather than returning `#preparedHeaders` directly, and that part is load-bearing: `get res()` builds the `Response` with a **copy** of the prepared headers (`new Response(null, { headers: h }).headers !== h`), so after materialisation `#preparedHeaders` is stale and `#res.headers` is live. One test covers that case directly.

Eight tests in `src/context.test.ts`, covering: undefined when nothing is set, exposing values set via `c.header()`, that reading the getter never allocates a `Response` (unlike `c.res`), the post-materialisation case above, the `append` option, deleting a header, a real `Hono()` + middleware flow through the fast path, and one edge case worth calling out explicitly: `header()` does `#preparedHeaders ??= new Headers()` unconditionally, even on a delete, so calling `c.header('X', undefined)` for a header that was never set makes `preparedHeaders` return an empty `Headers` instance rather than `undefined`. That's existing `header()` behaviour, not something this PR introduces, but it's easy to be surprised by, so I added a test to pin it down.

On the shape: I went with `Headers | undefined` over the `hasPreparedHeaders(): boolean` alternative from the issue because it answers both questions at once. One correction to the numbers I posted in #5313 — I measured a naive `return this.#preparedHeaders` there (+37 B). The ternary this actually needs costs **+61 B** on the minified ESM bundle (18134 B → 18195 B, `perf-measures/bundle-check`). Still happy to switch to the boolean or to rename.

hono.dev docs are not in this repo — I'll send a companion PR to honojs/website if this lands.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
