### PR TITLE
fix(utils/url): fix getPath pathname extraction for file:/// scheme URLs

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -117,6 +117,11 @@ describe('url', () => {
       expect(path).toBe('/hello/')
     })
 
+    it('getPath - file URL', () => {
+      expect(getPath(new Request('file:///test'))).toBe('/test')
+      expect(getPath(new Request('file:///path/to/file'))).toBe('/path/to/file')
+    })
+
     it.each([
       'http:/example.com/hello', // invalid HTTP URL
       'http:///hello', // invalid HTTP URL

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -105,7 +105,7 @@ export const tryDecodeURI = (str: string): string => tryDecode(str, decodeURI)
 
 export const getPath = (request: Request): string => {
   const url = request.url
-  const start = url.indexOf('/', url.indexOf(':') + 4)
+  const start = url.indexOf('/', url.indexOf(':') + (url.startsWith('file:') ? 3 : 4))
   let i = start
   for (; i < url.length; i++) {
     const charCode = url.charCodeAt(i)


### PR DESCRIPTION
## Summary
Fixes an issue in `getPath(request)` where `file:///` scheme URLs (e.g. `file:///test` or `file:///path/to/file`) fail to extract the full pathname correctly.

## Problem
In `src/utils/url.ts`, `getPath` computes the pathname start index using:
```ts
const start = url.indexOf('/', url.indexOf(':') + 4)
```

While + 4 correctly skips past ://host/ for standard HTTP/HTTPS URLs, file:/// scheme URLs do not contain a domain host.

As a result:

For file:///test, url.indexOf('/', 8) returns -1, causing url.slice() to return "t" instead of "/test".

For file:///path/to/file, url.indexOf('/', 8) skips the first path segment and returns "/to/file".

### Solution
Adjusted the search offset to 3 specifically for file: scheme URLs (url.startsWith('file:') ? 3 : 4), preserving the leading root slash for file:/// paths while maintaining fast-path performance for standard HTTP/HTTPS requests.

### Verification
Added unit tests in src/utils/url.test.ts to verify file:/// scheme pathname resolution.

All unit tests pass (npx vitest run src/utils/url.test.ts).

Type check passes clean (npx tsc --noEmit).

### Checklist
[x] Added unit tests in src/utils/url.test.ts

[x] All unit tests pass (npx vitest run src/utils/url.test.ts)

[x] Type checking passes (npx tsc --noEmit)