### PR TITLE
fix(trie-router): match a pattern node once when the path is its token

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -106,6 +106,52 @@ export const runTest = ({
       })
     })
 
+    describe('Path segment equal to a pattern token', () => {
+      it('Wildcard', async () => {
+        router.add('GET', '/a/*', 'wildcard')
+        const res = match('GET', '/a/*')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('wildcard')
+      })
+
+      it('Named parameter', async () => {
+        router.add('GET', '/a/:id', 'param')
+        const res = match('GET', '/a/:id')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('param')
+        expect(res[0].params['id']).toBe(':id')
+      })
+
+      it('Named parameters in every segment', async () => {
+        router.add('GET', '/:a/:b/:c', 'params')
+        const res = match('GET', '/:a/:b/:c')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('params')
+        expect(res[0].params['a']).toBe(':a')
+        expect(res[0].params['b']).toBe(':b')
+        expect(res[0].params['c']).toBe(':c')
+      })
+
+      it('Prefixed wildcard', async () => {
+        router.add('GET', '/a/foo*', 'prefixed')
+        const res = match('GET', '/a/foo*')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('prefixed')
+      })
+
+      it('Named parameter with a trailing wildcard', async () => {
+        router.add('GET', '/a/:id/*', 'param wildcard')
+        const res = match('GET', '/a/:id')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('param wildcard')
+      })
+
+      it('Constrained parameter matches nothing', async () => {
+        router.add('GET', '/a/:id{[0-9]+}', 'constrained')
+        expect(match('GET', '/a/:id{[0-9]+}').length).toBe(0)
+      })
+    })
+
     describe('Complex', () => {
       it('Named Param', async () => {
         router.add('GET', '/entry/:id', 'get entry')

--- a/src/router/linear-router/router.test.ts
+++ b/src/router/linear-router/router.test.ts
@@ -22,6 +22,7 @@ describe('LinearRouter', () => {
           'Trailing wildcard after a pattern label > GET /user/123/profile with the default pattern',
           'Trailing wildcard after a pattern label > GET /user/123/profile with the default pattern in reverse registration order',
           'Complex > Parameter with {.*} regexp',
+          'Path segment equal to a pattern token > Named parameter with a trailing wildcard',
         ],
       },
       {

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -105,15 +105,24 @@ export class Node<T> {
         const node = curNodes[j]
         const nextNode = node.#children[part]
 
+        // A pattern node is also stored in `#children` under its key, so a part that is
+        // literally that key arrives here as well as in the pattern loop below. Each job below
+        // leaves pattern nodes to that loop, and the set it leaves differs per job.
         if (nextNode) {
           nextNode.#params = node.#params
           if (isLast) {
-            // '/hello/*' => match '/hello'
-            if (nextNode.#children['*']) {
+            // '/hello/*' => match '/hello'. The loop makes this push itself when an array
+            // pattern matches, and never for a string one.
+            if (nextNode.#children['*'] && !Array.isArray(nextNode.#pattern)) {
               this.#pushHandlerSets(handlerSets, nextNode.#children['*'], method, node.#params)
             }
-            this.#pushHandlerSets(handlerSets, nextNode, method, node.#params)
-          } else {
+            // The loop matches any pattern node whose pattern accepts the part.
+            if (nextNode.#pattern === undefined) {
+              this.#pushHandlerSets(handlerSets, nextNode, method, node.#params)
+            }
+          } else if (nextNode.#pattern !== '*' && !Array.isArray(nextNode.#pattern)) {
+            // The loop descends through `*` and parameters itself, but not through a
+            // prefixed wildcard.
             tempNodes.push(nextNode)
           }
         }


### PR DESCRIPTION
`TrieRouter` returns the same handler more than once when a request path segment is
literally a pattern token.

`insert()` stores a pattern node in `#children` under its own key as well as in
`#patterns`, so a part equal to that key reaches the node twice — once through the
literal `#children[part]` lookup, once through the pattern loop. The copies compound
per segment: route `/:a/:b/:c` matched by the path `/:a/:b/:c` returned the handler
8 times, and `/:a/:b/:c/:d` 16 times.

Because the match list is the middleware chain, this runs middleware more than once:

```js
const app = new Hono()
app.get('/f/:path{.*}', ...)  // RegExpRouter can't take this, so SmartRouter
app.use('*', mw)              // falls back to TrieRouter
app.get('/*', ...)
await app.request('/*')       // mw ran twice
```

The path doesn't have to be written by hand — `getPath()` decodes the segment, so a
request for `/a/%2A` arrives as `/a/*`, and `/a/:id%7B%5B0-9%5D+%7D` as
`/a/:id{[0-9]+}`.

### The fix

The literal branch does three jobs, and each has to stand down for the patterns the
loop already covers — which is a different set for each:

- the `#children['*']` push: the loop makes this itself when an array pattern
  matches, and never for a string one, so `*` and a prefixed wildcard still need it
  here;
- the terminal push: the loop makes it for any pattern node whose pattern accepts
  the part;
- the descent: the loop descends through `*` and parameters itself, but not through
  a prefixed wildcard, so that one still descends from here.

Gating all three on one predicate does not work. In particular the `#children['*']`
push must be gated on `Array.isArray`, not on "is a pattern node" — the latter drops
real matches (`/a/foo*` + `/a/foo*/*` at path `/a/foo*` loses the `*` handler, and
`/*` + `/*/*` at `/*` likewise). The existing router suite passes under the wrong
gate, so that distinction isn't covered by current tests.

### Behaviour changes beyond de-duplication

Matches are removed where the literal lookup was the only route to a pattern node.
Two shapes:

1. **A constrained parameter whose regexp rejects its own key.** `{[0-9]+}`,
   `{[a-z]+}` and `{a}` reject theirs; `{.*}` accepts. So `/a/:id{[0-9]+}` no longer
   matches the path `/a/:id{[0-9]+}`, and neither do routes carrying anything after
   that node (`/a/:id{[0-9]+}/*`, `/a/:id{[0-9]+}/:s`). RegExpRouter and
   PatternRouter return nothing in all of these.
2. **A `{.*}` parameter that is not the last segment**, e.g. `/a/:p{.*}/:s`. Its
   regexp runs against the rest of the path rather than the segment, so the loop
   consumes the whole remainder and the segment after it is never reached. The
   literal lookup was the only way through, so on `main` such a route matched only
   when that segment was literally `:p{.*}` — `/a/qq/z` already returned nothing.
   PatternRouter still matches these; RegExpRouter rejects the route outright.

Ordinary paths are unaffected in both: `/a/:id{[0-9]+}` still matches `/a/123`, and
a terminal `{.*}` is untouched (`/a/:p{.*}` still matches `/a/:p{.*}` and `/a/x/y`).

### Verification

Over a corpus of one route per router, with routes and paths being every
one-to-three-segment sequence of the tokens `*`, `foo*`, `:id`, `:n{[0-9]+}`,
`:p{.*}`, `a` and `:x` — 399 of each, so 159,201 combinations:

- results containing a repeated handler: **8,008 on `main`, 0 here**;
- combinations disagreeing with both `RegExpRouter` and `PatternRouter`: 1,478 on
  `main`, 144 here, and every one of the 144 already disagreed on `main` — nothing
  new disagrees;
- no added matches, and no changed params on a surviving match.

Tests go in the shared router suite so every configuration covers them. Five of the
six run all six new cases; `LinearRouter` throws `UnsupportedPathError` for a
parameter with a trailing wildcard, so that one case carries a skip alongside its
existing entries.

### Relationship to #5243

Independent of #5243, but the two touch the same lines of `node.ts` and conflict
textually in `common.case.test.ts` (both insert a `describe` block at the same
anchor). If #5243 lands first, the descent gate here needs revisiting: its pattern
loop walks prefixed wildcards too, which this change deliberately leaves to the
literal branch.
