### PR TITLE
fix(accepts,language): never match an entry the client rejected with q=0

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -70,6 +70,54 @@ describe('accepts', () => {
     expect(result).toBe('text/html')
   })
 
+  test('should not match a type the client rejected with q=0', () => {
+    const c = {
+      req: {
+        header: () => 'application/json;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
+  test('should fall through a q=0 type to the next acceptable one', () => {
+    const c = {
+      req: {
+        header: () => 'application/json;q=0, text/html;q=0.5',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json', 'text/html'],
+      default: 'application/xml',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
+  test('should not match a subtype wildcard the client rejected with q=0', () => {
+    const c = {
+      req: {
+        header: () => 'application/*;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
   test('should match wildcard subtype application/*', () => {
     const c = {
       req: {

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -45,7 +45,10 @@ const getSpecificity = (type: string): number => {
 
 export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {
   const { supports, default: defaultSupport } = config
-  const sortedAccepts = accepts.slice().sort((a, b) => {
+  // `q=0` means the range is explicitly not acceptable (RFC 9110 §12.5.1), so it must
+  // never match — the same rule the compress middleware applies when picking an encoding.
+  const acceptable = accepts.filter((accept) => accept.q > 0)
+  const sortedAccepts = acceptable.sort((a, b) => {
     if (b.q !== a.q) {
       return b.q - a.q
     }

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -77,6 +77,36 @@ describe('languageDetector', () => {
       expect(await res.text()).toBe('fr')
     })
 
+    it('should not detect a language the client rejected with q=0', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0',
+        },
+      })
+      expect(await res.text()).toBe('en')
+    })
+
+    it('should skip a q=0 language and detect the next acceptable one', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr', 'es'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0, es;q=0.5',
+        },
+      })
+      expect(await res.text()).toBe('es')
+    })
+
     it('should fallback to language code when locale code is not in supportedLanguages', async () => {
       const app = createTestApp({
         supportedLanguages: ['en', 'ja'],

--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -158,7 +158,12 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
     }
 
     const languages = parseAcceptLanguage(acceptLanguage)
-    for (const { lang } of languages) {
+    // `q=0` means the language is explicitly not acceptable (RFC 9110 §12.5.4), so skip
+    // it and fall through to the next source or the fallback rather than detecting it.
+    for (const { lang, q } of languages) {
+      if (q === 0) {
+        continue
+      }
       const normalizedLang = normalizeLanguage(lang, options)
       if (normalizedLang) {
         return normalizedLang


### PR DESCRIPTION
Closes #5310.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

## What

A quality value of `0` means the range is *explicitly not acceptable* (RFC 9110 §12.5.1, and §12.5.4 for `Accept-Language`). The `compress` middleware already honours this with its `q > 0` check in `getEncoding`, but the other two consumers of `parseAccept` did not.

I confirmed both against `main` before changing anything — each new test fails on the current code with exactly the reported symptom:

```
accepts:  AssertionError: expected 'application/json' to be 'text/html'
language: AssertionError: expected 'fr' to be 'en'
```

**`defaultMatch`** (`src/helper/accepts/accepts.ts`) sorted by quality but never excluded `q=0`, so `Accept: application/json;q=0` returned `application/json` — the one type the client said it would not take.

**`detectFromHeader`** (`src/middleware/language/language.ts`) destructured only `lang`, discarding `q` entirely, so `Accept-Language: fr;q=0` detected `fr` rather than falling through to the next source or the fallback.

## Fix

Both drop `q=0` entries, so all three `parseAccept` consumers now agree.

## Tests

Five added — three for `accepts`, two for the language detector:

| test | fails without the fix |
| --- | --- |
| `application/json;q=0` returns the default | yes |
| `application/*;q=0` returns the default | yes |
| `application/json;q=0, text/html;q=0.5` still returns `text/html` | no — guard |
| `fr;q=0` falls back to `en` | yes |
| `fr;q=0, es;q=0.5` detects `es` | no — guard |

The two marked "no" pass either way by design: `parseAccept` sorts by quality, so a `q=0` entry already loses to an acceptable one. They are there to catch over-correction — a fix that dropped too much would fail them.

```
vitest --run                 -> 147 files, 4966 passed | 44 skipped
prettier --check <4 files>   -> All matched files use Prettier code style
eslint src/helper/accepts src/middleware/language -> 0 errors
```

`tsc -p tsconfig.spec.json` reports 500 errors on my machine both with and without this change (`Type 'Uint8Array' is not generic`, etc.) — pre-existing local TS/lib skew, none in the files touched here.

## Notes

I have deliberately kept this to the reported behaviour. One adjacent case is out of scope: `Accept: application/json;q=0, application/*;q=0.5` still resolves to `application/json`, because the wildcard matches it and nothing implements most-specific-range precedence. That needs a precedence rule rather than a `q` filter, so it felt like a separate change — happy to follow up if you want it.

AI was used to help write this change; I have verified the behaviour, the RFC references, and the tests myself.