### PR TITLE
fix(accepts,language): skip q=0 entries per RFC 9110 §12.4.2

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -166,6 +166,38 @@ describe('accepts', () => {
     expect(result).toBe('text/html')
   })
 
+  test('should not match types with q=0 (RFC 9110 §12.4.2 explicitly-not-acceptable)', () => {
+    const c = {
+      req: {
+        header: () => 'application/json;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
+  test('should skip q=0 entries and still match an acceptable type', () => {
+    const c = {
+      req: {
+        header: () => 'text/html, application/json;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['text/html', 'application/json'],
+      default: 'application/octet-stream',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
   test('should return matched support with custom match function', () => {
     const c = {
       req: {

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -53,6 +53,10 @@ export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string =
   })
 
   for (const accept of sortedAccepts) {
+    // RFC 9110 §12.4.2: q=0 means explicitly not acceptable; skip these entries
+    if (accept.q === 0) {
+      continue
+    }
     const matched = supports.find((supported) => matchType(accept.type, supported))
     if (matched) {
       return matched

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -168,6 +168,36 @@ describe('languageDetector', () => {
       expect(await res.text()).toBe('ja')
     })
 
+    it('should not match languages with q=0 (RFC 9110 §12.4.2 explicitly-not-acceptable)', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0',
+        },
+      })
+      expect(await res.text()).toBe('en')
+    })
+
+    it('should skip q=0 languages and still match an acceptable language', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'en, fr;q=0',
+        },
+      })
+      expect(await res.text()).toBe('en')
+    })
+
     it('should handle malformed Accept-Language headers', async () => {
       const app = createTestApp({
         supportedLanguages: ['en', 'fr'],

--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -158,7 +158,11 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
     }
 
     const languages = parseAcceptLanguage(acceptLanguage)
-    for (const { lang } of languages) {
+    for (const { lang, q } of languages) {
+      // RFC 9110 §12.4.2: q=0 means explicitly not acceptable; skip these entries
+      if (q === 0) {
+        continue
+      }
       const normalizedLang = normalizeLanguage(lang, options)
       if (normalizedLang) {
         return normalizedLang


### PR DESCRIPTION
## Problem

Per [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110#section-12.4.2), a quality value of `0` means the media type or language tag is **explicitly not acceptable** — the client is actively saying "don't give me this". The `compress` middleware already handles this correctly (it has a `q > 0` guard), but two other consumers of `parseAccept` do not:

1. **`accepts()` / `defaultMatch`** (`src/helper/accepts/accepts.ts`): entries with `q=0` are still iterated and can match.
2. **`languageDetector`'s `detectFromHeader`** (`src/middleware/language/language.ts`): languages with `q=0` are still detected.

**Reproduction:**
```ts
// accepts() — client says "anything but JSON"
accepts(c, { header: 'Accept', supports: ['application/json'], default: 'text/html' })
// Accept: application/json;q=0  → currently returns 'application/json' ❌

// languageDetector — client says "not French"
// Accept-Language: fr;q=0  → currently detects 'fr' ❌
```

## Fix

Add a `continue` guard for `q === 0` entries in both `defaultMatch` and `detectFromHeader`, consistent with the existing pattern in the `compress` middleware.

## Tests

- `accepts()`: two new tests — reject a sole `q=0` entry; skip a `q=0` entry while still matching an acceptable type.
- `languageDetector`: two new tests — reject a sole `q=0` language; skip a `q=0` language while still matching an acceptable language.

All existing tests still pass.

Closes #5310