### PR TITLE
feat(method-not-allowed): add ignorePaths option to exclude wildcard catch-all routes

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -289,4 +289,49 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.has('Allow')).toBe(false)
     expect(await res.text()).toBe('Missing')
   })
+
+  it('respects ignorePaths option for wildcard catch-all routes', async () => {
+    const app = new Hono()
+    app.use(
+      methodNotAllowed({
+        app,
+        ignorePaths: ['/*', '*'],
+      })
+    )
+    app.get('/api/users', (c) => c.text('users'))
+    app.post('/api/users', (c) => c.text('created'))
+    app.get('/*', (c) => c.text('static fallback'))
+
+    // Explicit registered route returns 405 with proper Allow header on unsupported method
+    const res1 = await app.request('/api/users', { method: 'DELETE' })
+    expect(res1.status).toBe(405)
+    expect(res1.headers.get('Allow')).toBe('GET, HEAD, POST')
+
+    // Non-existent route with POST returns 404 (not corrupted by wildcard GET /*)
+    const res2 = await app.request('/non-existent-file.png', { method: 'POST' })
+    expect(res2.status).toBe(404)
+    expect(res2.headers.has('Allow')).toBe(false)
+  })
+
+  it('supports RegExp in ignorePaths option', async () => {
+    const app = new Hono()
+    app.use(
+      methodNotAllowed({
+        app,
+        ignorePaths: [/^\/static/],
+      })
+    )
+    app.get('/api/data', (c) => c.text('data'))
+    app.get('/static/*', (c) => c.text('static'))
+
+    // Registered API route still returns 405 on PUT
+    const res1 = await app.request('/api/data', { method: 'PUT' })
+    expect(res1.status).toBe(405)
+    expect(res1.headers.get('Allow')).toBe('GET, HEAD')
+
+    // Ignored static path pattern returns 404 on POST instead of 405
+    const res2 = await app.request('/static/missing.jpg', { method: 'POST' })
+    expect(res2.status).toBe(404)
+    expect(res2.headers.has('Allow')).toBe(false)
+  })
 })

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -19,6 +19,7 @@ type MethodNotAllowedOptions<E extends Env> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app: Hono<E, any, any>
   onMethodNotAllowed?: MethodNotAllowedHandler<E>
+  ignorePaths?: (string | RegExp)[]
 }
 
 /**
@@ -30,6 +31,7 @@ type MethodNotAllowedOptions<E extends Env> = {
  * @param {MethodNotAllowedOptions} options - The options for the middleware.
  * @param {Hono} options.app - The Hono instance used by the application.
  * @param {MethodNotAllowedHandler} [options.onMethodNotAllowed] - Generates the response, including its `Allow` header.
+ * @param {(string | RegExp)[]} [options.ignorePaths] - Route paths or patterns to exclude from contributing to the Allow header (e.g. wildcard routes like '/*').
  * @returns {MiddlewareHandler} The middleware handler function.
  *
  * @example
@@ -79,7 +81,13 @@ export const methodNotAllowed = <E extends Env = Env>(
       for (const route of options.app.routes) {
         // Hono does not distinguish middleware registered with `app.use()` from handlers
         // registered with `app.all()`, so `ALL` routes cannot contribute to the Allow header.
-        if (route.method === METHOD_NAME_ALL || route.method === 'HEAD') {
+        if (
+          route.method === METHOD_NAME_ALL ||
+          route.method === 'HEAD' ||
+          options.ignorePaths?.some((p) =>
+            typeof p === 'string' ? route.path === p : p.test(route.path)
+          )
+        ) {
           continue
         }
 


### PR DESCRIPTION
## Summary

Fixes the issue where using wildcard catch-all routes (such as `app.get('/*', serveStatic())` or fallback handlers) together with `methodNotAllowed` causes every non-existent URL in the app to return `405 Method Not Allowed` instead of `404 Not Found`.

### Problem
When wildcard routes like `/*` or `*` are registered on a specific HTTP method (e.g. `GET`), `methodNotAllowed` indexes the wildcard route into its internal `TrieRouter`. As a result, subsequent non-GET requests to non-existent endpoints (e.g. `POST /non-existent-file.png`) match the wildcard route, falsely advertising `Allow: GET, HEAD` and responding with 405 instead of the expected 404.

### Solution
- Add an optional `ignorePaths?: (string | RegExp)[]` property to `MethodNotAllowedOptions`.
- When constructing the internal method router, routes matching any pattern in `ignorePaths` are skipped.
- Backwards-compatible: without `ignorePaths`, behavior is unchanged.

### Testing
- Added unit tests in `src/middleware/method-not-allowed/index.test.ts` verifying string patterns (`['/*', '*']`) and `RegExp` patterns (`[/^\/static/]`).
- Passed all tests (`vitest`) and linter checks (`eslint`, `prettier`).