### PR TITLE
fix(context): serialize undefined values to null in c.json()

### DIFF
--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -70,6 +70,28 @@ describe('Context', () => {
     expect(res.headers.get('X-Custom')).toBe('Message')
   })
 
+  it('c.json() with undefined', async () => {
+    const res = c.json(undefined)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toMatch('application/json')
+    expect(await res.text()).toBe('null')
+
+    const res2 = c.json(undefined)
+    expect(await res2.json()).toBe(null)
+
+    const res3 = c.json(undefined, 201, { 'X-Custom': 'Message' })
+    expect(res3.status).toBe(201)
+    expect(res3.headers.get('Content-Type')).toMatch('application/json')
+    expect(res3.headers.get('X-Custom')).toBe('Message')
+    expect(await res3.text()).toBe('null')
+
+    const resFunc = c.json((() => {}) as unknown as string)
+    expect(await resFunc.text()).toBe('null')
+
+    const resSymbol = c.json(Symbol('foo') as unknown as string)
+    expect(await resSymbol.text()).toBe('null')
+  })
+
   it('c.html()', async () => {
     const res: Response = c.html('<h1>Hello! Hono!</h1>', 201, { 'X-Custom': 'Message' })
     expect(res.status).toBe(201)

--- a/src/context.ts
+++ b/src/context.ts
@@ -731,7 +731,7 @@ export class Context<
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
     return this.#newResponse(
-      JSON.stringify(object),
+      JSON.stringify(object) ?? 'null',
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
### Summary

When `c.json()` is invoked with `undefined` (or non-serializable top-level values such as functions or symbols), `JSON.stringify(object)` returns `undefined`. This previously passed `undefined` to `new Response()`, yielding an empty 0-byte body with `Content-Type: application/json`. Consuming clients attempting `await res.json()` subsequently failed with a JSON syntax parse error (`SyntaxError: Unexpected end of JSON input`).

This PR adds a null fallback (`JSON.stringify(object) ?? 'null'`) in `c.json()` so that undefined values serialize to `"null"`, conforming with RFC 8259 JSON specifications and standard Web API `Response.json()` semantics.

Fixes #2343

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `npm run format` and `npm run lint` to format and lint the code
- [x] TypeScript compiles cleanly with `tsc --noEmit`
