### PR TITLE
fix(accepts, language): ignore entries rejected with q=0

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -234,6 +234,40 @@ describe('Usage', () => {
     expect(req4.headers.get('Content-Encoding')).toBeNull()
   })
 
+  test('should not match a type the client rejected with q=0', async () => {
+    const app = new Hono()
+    app.get('/', (c) =>
+      c.text(
+        accepts(c, {
+          header: 'Accept',
+          supports: ['application/json'],
+          default: 'text/html',
+        })
+      )
+    )
+
+    const res = await app.request('/', { headers: { Accept: 'application/json;q=0' } })
+    expect(await res.text()).toBe('text/html')
+  })
+
+  test('should skip q=0 entries and match the next acceptable type', async () => {
+    const app = new Hono()
+    app.get('/', (c) =>
+      c.text(
+        accepts(c, {
+          header: 'Accept',
+          supports: ['application/json', 'text/plain'],
+          default: 'text/html',
+        })
+      )
+    )
+
+    const res = await app.request('/', {
+      headers: { Accept: 'application/json;q=0,text/plain;q=0.5' },
+    })
+    expect(await res.text()).toBe('text/plain')
+  })
+
   test('decide language by Accept-Language header', async () => {
     const app = new Hono()
     const SUPPORTED_LANGS = ['en', 'ja', 'zh']

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -53,6 +53,10 @@ export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string =
   })
 
   for (const accept of sortedAccepts) {
+    // q=0 means the client explicitly rejects this range (RFC 9110 §12.5.1)
+    if (accept.q === 0) {
+      continue
+    }
     const matched = supports.find((supported) => matchType(accept.type, supported))
     if (matched) {
       return matched

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -77,6 +77,36 @@ describe('languageDetector', () => {
       expect(await res.text()).toBe('fr')
     })
 
+    it('should not detect a language the client rejected with q=0', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['fr', 'en'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0',
+        },
+      })
+      expect(await res.text()).toBe('en')
+    })
+
+    it('should skip q=0 languages and detect the next acceptable one', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['fr', 'es', 'en'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'fr;q=0,es;q=0.9',
+        },
+      })
+      expect(await res.text()).toBe('es')
+    })
+
     it('should fallback to language code when locale code is not in supportedLanguages', async () => {
       const app = createTestApp({
         supportedLanguages: ['en', 'ja'],

--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -158,7 +158,11 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
     }
 
     const languages = parseAcceptLanguage(acceptLanguage)
-    for (const { lang } of languages) {
+    for (const { lang, q } of languages) {
+      // q=0 means the client explicitly rejects this language (RFC 9110 §12.5.4)
+      if (q === 0) {
+        continue
+      }
       const normalizedLang = normalizeLanguage(lang, options)
       if (normalizedLang) {
         return normalizedLang


### PR DESCRIPTION
Per RFC 9110 §12.5.1 (§12.5.4 for `Accept-Language`), `q=0` means the range is explicitly not acceptable. The `compress` middleware already honors this with its `q > 0` check in `getEncoding`, but the two other `parseAccept` consumers did not — `accepts()` matched `q=0` types instead of returning the configured default, and `languageDetector`'s header detection returned `q=0` languages instead of falling through.

This adds the same guard to both call sites, making all three consumers consistent.

One note for review: `parseQuality` maps the literal string `'NaN'` to `0`, so `q=NaN` now counts as rejected too. That seemed right for a malformed value, but happy to narrow it if you'd prefer.

Closes #5310

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
