### PR TITLE
fix(method-not-allowed): ignore trailing wildcard routes when inferring allowed methods

### DIFF
--- a/src/middleware/method-not-allowed/index.test.ts
+++ b/src/middleware/method-not-allowed/index.test.ts
@@ -186,6 +186,22 @@ describe('Method Not Allowed Middleware', () => {
     expect(res.headers.get('Allow')).toBe('GET, HEAD, POST')
   })
 
+
+  it('ignores trailing wildcard routes when collecting allowed methods', async () => {
+    const app = new Hono()
+    app.use(methodNotAllowed({ app }))
+    app.get('/api', (c) => c.text('API'))
+    app.get('/*', (c) => c.text('Wildcard'))
+
+    const apiRes = await app.request('/api', { method: 'POST' })
+    expect(apiRes.status).toBe(405)
+    expect(apiRes.headers.get('Allow')).toBe('GET, HEAD')
+
+    const wildcardRes = await app.request('/other', { method: 'POST' })
+    expect(wildcardRes.status).toBe(404)
+    expect(wildcardRes.headers.has('Allow')).toBe(false)
+  })
+
   it('ignores ALL routes when collecting allowed methods', async () => {
     const app = new Hono()
     app.use(methodNotAllowed({ app }))

--- a/src/middleware/method-not-allowed/index.ts
+++ b/src/middleware/method-not-allowed/index.ts
@@ -79,7 +79,12 @@ export const methodNotAllowed = <E extends Env = Env>(
       for (const route of options.app.routes) {
         // Hono does not distinguish middleware registered with `app.use()` from handlers
         // registered with `app.all()`, so `ALL` routes cannot contribute to the Allow header.
-        if (route.method === METHOD_NAME_ALL || route.method === 'HEAD') {
+        // Trailing wildcard routes match arbitrary paths and should not convert unhandled paths to 405.
+        if (
+          route.method === METHOD_NAME_ALL ||
+          route.method === 'HEAD' ||
+          route.path.endsWith('*')
+        ) {
           continue
         }
 


### PR DESCRIPTION
## Problem
When trailing wildcard routes (e.g. `app.get('/*', serveStatic())`) are registered on an app using `methodNotAllowed`, unhandled paths inside the namespace are incorrectly converted from 404 to 405 because the trailing wildcard matches any path remainder.

## Root Cause
In `src/middleware/method-not-allowed/index.ts`, route collection skips `ALL` and `HEAD` routes but includes wildcard routes ending with `*`. Because trailing wildcards match arbitrary path remainders, they falsely imply that a target resource exists for other HTTP methods on any requested path.

## Fix
Skip routes whose paths end with `*` (`route.path.endsWith('*')`) when collecting allowed methods in `methodNotAllowed`.

## Testing
Added a unit test in `src/middleware/method-not-allowed/index.test.ts` ensuring trailing wildcard routes are ignored and unhandled paths retain 404 status.