### PR TITLE
perf(jsx/dom): optimize matching-head child lookup during reconciliation

### DIFF
--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -1707,6 +1707,59 @@ describe('DOM', () => {
     )
   })
 
+  it('reconciles large keyed list updates and reordering efficiently', async () => {
+    let findIndexCalls = 0
+    const originalFindIndex = Array.prototype.findIndex
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Array.prototype.findIndex = function (this: unknown[], ...args: [any]) {
+      findIndexCalls++
+      return originalFindIndex.apply(this, args)
+    }
+
+    try {
+      const ListApp = () => {
+        const [items, setItems] = useState(() => Array.from({ length: 100 }, (_, i) => `item-${i}`))
+        return (
+          <div>
+            <ul>
+              {items.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            <button id='reverse' onClick={() => setItems((prev) => [...prev].reverse())}>
+              reverse
+            </button>
+            <button id='update' onClick={() => setItems((prev) => [...prev])}>
+              update
+            </button>
+          </div>
+        )
+      }
+
+      render(<ListApp />, root)
+      expect(root.querySelectorAll('li')).toHaveLength(100)
+      expect(root.querySelector('li')?.textContent).toBe('item-0')
+
+      findIndexCalls = 0
+      const updateBtn = root.querySelector('#update') as HTMLButtonElement
+      updateBtn.click()
+      await Promise.resolve()
+
+      expect(findIndexCalls).toBe(0)
+      expect(root.querySelectorAll('li')).toHaveLength(100)
+      expect(root.querySelector('li')?.textContent).toBe('item-0')
+
+      const reverseBtn = root.querySelector('#reverse') as HTMLButtonElement
+      reverseBtn.click()
+      await Promise.resolve()
+
+      expect(root.querySelectorAll('li')).toHaveLength(100)
+      expect(root.querySelector('li')?.textContent).toBe('item-99')
+    } finally {
+      Array.prototype.findIndex = originalFindIndex
+    }
+  })
+
   it('swap deferent type of child component', async () => {
     const Even = () => <p>Even</p>
     const Odd = () => <div>Odd</div>

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -542,17 +542,29 @@ export const build = (context: Context, node: NodeObject, children?: Child[]): v
 
         let oldChild: NodeObject | undefined
         if (oldVChildren && oldVChildren.length) {
-          const i = oldVChildren.findIndex(
-            isNodeString(child)
-              ? (c) => isNodeString(c)
-              : child.key !== undefined
-                ? (c) => c.key === (child as Node).key && c.tag === (child as Node).tag
-                : (c) => c.tag === (child as Node).tag
-          )
+          const first = oldVChildren[0]
+          const isMatchFirst = isNodeString(child)
+            ? isNodeString(first)
+            : child.key !== undefined
+              ? (first as Node).key === (child as Node).key &&
+                (first as Node).tag === (child as Node).tag
+              : (first as Node).tag === (child as Node).tag
 
-          if (i !== -1) {
-            oldChild = oldVChildren[i] as NodeObject
-            oldVChildren.splice(i, 1)
+          if (isMatchFirst) {
+            oldChild = oldVChildren.shift() as NodeObject
+          } else {
+            const i = oldVChildren.findIndex(
+              isNodeString(child)
+                ? (c) => isNodeString(c)
+                : child.key !== undefined
+                  ? (c) => c.key === (child as Node).key && c.tag === (child as Node).tag
+                  : (c) => c.tag === (child as Node).tag
+            )
+
+            if (i !== -1) {
+              oldChild = oldVChildren[i] as NodeObject
+              oldVChildren.splice(i, 1)
+            }
           }
         }
 


### PR DESCRIPTION
## Problem
During JSX DOM children reconciliation in `hono/jsx/dom/render.ts`, each child in `children` searches `oldVChildren` using `findIndex()` and removes the matched node via `splice()`. When reconciling large child lists where the order is preserved or appended, this produces $O(N^2)$ linear searches and array shift operations.

## Root Cause
Reconciliation did not check the head of `oldVChildren` before falling back to full-array `findIndex()` and `splice()`.

## Fix
Check if `oldVChildren[0]` matches the current child (by string type, key+tag, or tag) and consume it directly via `oldVChildren.shift()`, reducing lookup from $O(N)$ to $O(1)$ for in-order children, while retaining `findIndex()` and `splice()` fallback for reordered or interspersed items.

Related to #5306

## Testing
1. Added unit test in `src/jsx/dom/index.test.tsx` verifying reconciliation and reordering across 100 keyed items.
2. Ran `npm test -- src/jsx/dom/` (all 24 test files pass, 1296 passed).
