### PR TITLE
fix(aws-lambda): respect backpressure and completion when streaming responses

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { setCookie } from '../../helper/cookie'
 import { Hono } from '../../hono'
 import { bodyLimit } from '../../middleware/body-limit'
@@ -7,8 +8,9 @@ import {
   handle,
   isContentEncodingBinary,
   defaultIsContentTypeBinary,
+  streamHandle,
 } from './handler'
-import type { ApiGatewayRequestContextV2 } from './types'
+import type { ApiGatewayRequestContextV2, LambdaContext } from './types'
 
 // Base event objects to reduce duplication
 const baseV1Event: LambdaEvent = {
@@ -629,5 +631,113 @@ describe('V2 request context authorizer', () => {
     >()
     // A JWT authorizer reports no scopes as `null`.
     expectTypeOf<null>().toMatchTypeOf<NonNullable<typeof authorizer.jwt>['scopes']>()
+  })
+})
+
+describe('streamHandle', () => {
+  // A minimal Node.js-writable-like stream that simulates the 16KiB
+  // highWaterMark behavior of the Lambda response stream: writes that exceed
+  // it return false and 'drain' is only emitted on a later tick, and 'finish'
+  // is only emitted on a later tick after end().
+  class MockResponseStream extends EventEmitter {
+    writes: number[] = []
+    maxBuffered = 0
+    writesWhileDrainPending = 0
+    finishEmitted = false
+
+    private buffered = 0
+    private drainPending = false
+    private ended = false
+
+    write(chunk: Uint8Array | string): boolean {
+      const size = typeof chunk === 'string' ? chunk.length : chunk.byteLength
+      this.writes.push(size)
+      if (this.drainPending) {
+        this.writesWhileDrainPending++
+      }
+      this.buffered += size
+      this.maxBuffered = Math.max(this.maxBuffered, this.buffered)
+      if (this.buffered > 16 * 1024) {
+        this.drainPending = true
+        setTimeout(() => {
+          this.buffered = 0
+          this.drainPending = false
+          this.emit('drain')
+        }, 0)
+        return false
+      }
+      return true
+    }
+
+    end(cb?: () => void): void {
+      if (this.ended) {
+        cb?.()
+        return
+      }
+      this.ended = true
+      setTimeout(() => {
+        this.finishEmitted = true
+        this.emit('finish')
+        cb?.()
+      }, 0)
+    }
+  }
+
+  const mockContext = { callbackWaitsForEmptyEventLoop: false } as unknown as LambdaContext
+
+  // The Lambda runtime globals do not exist under vitest.
+  const setupRuntime = () => {
+    ;(globalThis as unknown as Record<string, unknown>).awslambda = {
+      streamifyResponse: (lambdaHandler: unknown) => lambdaHandler,
+      HttpResponseStream: {
+        from: (stream: unknown) => stream,
+      },
+    }
+  }
+
+  it('Should pause writing while the response stream applies backpressure (2MiB response)', async () => {
+    setupRuntime()
+    const app = new Hono()
+    app.post('/my/path', (c) => {
+      const chunk = new Uint8Array(64 * 1024).fill(97)
+      const body = new ReadableStream({
+        start(controller) {
+          for (let i = 0; i < 32; i++) {
+            controller.enqueue(chunk)
+          }
+          controller.close()
+        },
+      })
+      return c.body(body)
+    })
+
+    const handler = streamHandle(app)
+    const stream = new MockResponseStream()
+    await (handler as unknown as (...args: unknown[]) => Promise<void>)(
+      baseV2Event,
+      stream,
+      mockContext
+    )
+
+    // Nothing may be written while the stream is full, and the whole 2MiB
+    // body must never be buffered at once.
+    expect(stream.writesWhileDrainPending).toBe(0)
+    expect(stream.maxBuffered).toBeLessThanOrEqual(128 * 1024)
+  })
+
+  it('Should resolve only after the response stream emits finish', async () => {
+    setupRuntime()
+    const app = new Hono()
+    app.post('/my/path', (c) => c.text('Hello from Lambda'))
+
+    const handler = streamHandle(app)
+    const stream = new MockResponseStream()
+    await (handler as unknown as (...args: unknown[]) => Promise<void>)(
+      baseV2Event,
+      stream,
+      mockContext
+    )
+
+    expect(stream.finishEmitted).toBe(true)
   })
 })

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,3 +1,4 @@
+import { once } from 'node:events'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
 import { decodeBase64, encodeBase64 } from '../../utils/encode'
@@ -129,10 +130,19 @@ const streamToNodeStream = async (
 ): Promise<void> => {
   let readResult = await reader.read()
   while (!readResult.done) {
-    writer.write(readResult.value)
+    const drained = writer.write(readResult.value)
+    if (!drained) {
+      // The writable's buffer is full (e.g. the 16KiB highWaterMark of the
+      // Lambda response stream): wait until it has drained before writing on,
+      // otherwise large responses are buffered without bound.
+      await once(writer, 'drain')
+    }
     readResult = await reader.read()
   }
   writer.end()
+  // Wait until all written data is flushed, so that the Lambda runtime does
+  // not freeze the execution environment before the response is complete.
+  await once(writer, 'finish')
 }
 
 export const streamHandle = <


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

No exported API changed (the fixed `streamToNodeStream` helper is internal), so no new TSDoc was added.

Fixes #5333

`streamToNodeStream` ignored the boolean returned by `writer.write()`, so a large response (e.g. 2MiB against the 16KiB highWaterMark of the Lambda response stream) got buffered in memory all at once; it now waits for `drain` when a write reports backpressure. It also resolved right after `end()` without waiting for the data to be flushed; it now waits for `finish`, so the Lambda runtime cannot freeze the execution environment before the response is complete.

Verified with two new tests in `src/adapter/aws-lambda/handler.test.ts` using a mock writable that mimics 16KiB highWaterMark behavior: a 2MiB response (32×64KiB chunks) now pauses on `drain` (max buffered 64KiB; before the fix all 2MiB were buffered and 31 writes landed while the stream was full), and the handler resolves only after `finish` is emitted. All 45 tests under `src/adapter/aws-lambda` pass, `tsc -p tsconfig.spec.json` is clean, and prettier/eslint pass on both changed files.
