### PR TITLE
feat(client): add hcx a callable-param RPC client

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -147,12 +147,8 @@ class ClientRequestImpl {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hc = <T extends Hono<any, any, any>, Prefix extends string = string>(
-  baseUrl: Prefix,
-  options?: ClientRequestOptions
-) =>
-  createProxy(function proxyCallback(opts) {
+const createCallback = (baseUrl: string, options?: ClientRequestOptions): Callback =>
+  function proxyCallback(opts) {
     const buildSearchParamsOption = options?.buildSearchParams ?? buildSearchParams
     const parts = [...opts.path]
     const lastParts = parts.slice(-3).reverse()
@@ -246,4 +242,10 @@ export const hc = <T extends Hono<any, any, any>, Prefix extends string = string
       return req.fetch(opts.args[0], args)
     }
     return req
-  }, []) as UnionToIntersection<Client<T, Prefix>>
+  }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const hc = <T extends Hono<any, any, any>, Prefix extends string = string>(
+  baseUrl: Prefix,
+  options?: ClientRequestOptions
+) => createProxy(createCallback(baseUrl, options), []) as UnionToIntersection<Client<T, Prefix>>

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import type { Hono } from '../hono'
 import type { FormValue, ValidationTargets } from '../types'
 import { serialize } from '../utils/cookie'
 import type { UnionToIntersection } from '../utils/types'
-import type { BuildSearchParamsFn, Callback, Client, ClientRequestOptions } from './types'
+import type { BuildSearchParamsFn, Callback, Client, ClientRequestOptions, ClientX } from './types'
 import {
   buildSearchParams,
   deepMerge,
@@ -249,3 +249,92 @@ export const hc = <T extends Hono<any, any, any>, Prefix extends string = string
   baseUrl: Prefix,
   options?: ClientRequestOptions
 ) => createProxy(createCallback(baseUrl, options), []) as UnionToIntersection<Client<T, Prefix>>
+
+/** What `hc`'s own proxy would have collected: `:name` segments in `path`, their values in `param`. */
+type Chain = { path: string[]; param: Record<string, string> }
+
+/**
+ * A `hono/client` RPC client where a path param is bound by calling the segment, the JSON body is
+ * positional and everything else rides in one options object. Same wire behavior and same response
+ * types as {@link hc}.
+ *
+ * @example
+ * ```ts
+ * const api = hcx<typeof app>('http://localhost')
+ * await api.users.$get({ query: { page: '2' } })  // GET /users?page=2
+ * await api.users({ id: '1' }).$get()             // GET /users/1
+ * await api.users.$post({ name: 'Bolt' })         // POST /users, JSON body
+ * await api.upload.$post.form({ file })           // multipart
+ * api.users({ id: '1' }).$path()                  // '/users/1'
+ * ```
+ *
+ * Known quirks, shared with `hc` unless noted: a static segment named like a `$method` collides;
+ * `/` is on the root node and under `api.index`; `/users` and `/users/:id?` union on `api.users`;
+ * a validated `header` shares the options object with `headers`; `InferRequestType` on a read
+ * yields that options type.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const hcx = <T extends Hono<any, any, any>, Prefix extends string = string>(
+  baseUrl: Prefix,
+  options?: ClientRequestOptions
+) => {
+  const callback = createCallback(baseUrl, options)
+  const send = (chain: Chain, method: string, args: unknown[], target: 'json' | 'form') => {
+    // `$get`, `$url`, `$path` and `$ws` take options first, every other method takes the body first.
+    const optionsFirst =
+      method === '$get' || method === '$url' || method === '$path' || method === '$ws'
+    const { query, header, cookie, ...rest } = ((optionsFirst ? args[0] : args[1]) ?? {}) as Record<
+      string,
+      unknown
+    >
+    const request = {
+      param: chain.param,
+      query,
+      header,
+      cookie,
+      [target]: optionsFirst ? undefined : args[0],
+    }
+    return callback({ path: [...chain.path, method], args: [request, rest] })
+  }
+  const leaf = (chain: Chain, method: string): unknown =>
+    new Proxy(() => {}, {
+      get: (target, key) =>
+        key === 'form'
+          ? (...args: unknown[]) => send(chain, method, args, 'form')
+          : Reflect.get(target, key),
+      apply: (_1, _2, args) => send(chain, method, args, 'json'),
+    })
+  const node = (chain: Chain): unknown =>
+    new Proxy(() => {}, {
+      get: (target, key) => {
+        if (typeof key !== 'string' || key === 'then') {
+          return undefined
+        }
+        if (key === 'toString' || key === 'valueOf') {
+          return Reflect.get(target, key)
+        }
+        if (key.startsWith(':')) {
+          throw new Error(
+            `hcx: \`${key}\` is a type-only key, bind the param by calling the segment instead: \`({ ${key.slice(1)}: value })\``
+          )
+        }
+        return key.startsWith('$')
+          ? leaf(chain, key)
+          : node({ path: [...chain.path, key], param: chain.param })
+      },
+      apply: (_1, _2, [params]) => {
+        const entries = params && typeof params === 'object' ? Object.entries(params) : []
+        if (entries.length !== 1) {
+          throw new Error(
+            "hcx: a segment call binds exactly one path param, e.g. `api.users({ id: '1' })`"
+          )
+        }
+        const [name, value] = entries[0]
+        return node({
+          path: [...chain.path, `:${name}`],
+          param: { ...chain.param, [name]: value as string },
+        })
+      },
+    })
+  return node({ path: [], param: {} }) as ClientX<T, Prefix>
+}

--- a/src/client/hcx.test.ts
+++ b/src/client/hcx.test.ts
@@ -1,0 +1,378 @@
+import { expectTypeOf, vi } from 'vitest'
+import { upgradeWebSocket } from '../adapter/deno/websocket'
+import { Hono } from '../hono'
+import type { FormValue } from '../types'
+import { validator } from '../validator'
+import { hcx } from './client'
+import type { InferRequestType, InferResponseType, TypedURL } from './types'
+
+const app = new Hono()
+  .get('/', (c) => c.json({ root: true }, 200))
+  .get('/users', (c) => c.json([{ id: 'u1' }], 200))
+  .post(
+    '/users',
+    validator('json', () => ({}) as { name: string; age: number }),
+    async (c) => c.json({ id: 'u1', body: await c.req.json<{ name: string }>() }, 201)
+  )
+  // trailing slash -> `index`
+  .get('/users/', (c) => c.json({ index: true }, 200))
+  // a real segment named `index` is not the trailing-slash marker
+  .get('/a/index/b', (c) => c.json({ mid: true }, 200))
+  .get('/users/:id', (c) =>
+    c.req.param('id') === 'missing'
+      ? c.json({ error: 'Not found' as const }, 404)
+      : c.json({ id: c.req.param('id'), name: 'Widget' }, 200)
+  )
+  .put(
+    '/users/:id',
+    validator('json', () => ({}) as { name: string }),
+    validator('query', () => ({}) as { dry?: string }),
+    async (c) =>
+      c.json(
+        {
+          id: c.req.param('id'),
+          body: await c.req.json<{ name: string }>(),
+          dry: c.req.query('dry') ?? null,
+        },
+        200
+      )
+  )
+  .delete(
+    '/users/:id',
+    validator('json', () => ({}) as { reason: string }),
+    async (c) => c.json({ deleted: c.req.param('id'), body: await c.req.json<unknown>() }, 200)
+  )
+  .delete(
+    '/users/:id/export',
+    validator('header', () => ({}) as { 'x-confirm': string }),
+    (c) => c.json({ confirmed: c.req.header('x-confirm') ?? null }, 200)
+  )
+  // sibling param at the same level as `:id`
+  .get('/users/:userId/posts', (c) => c.json({ posts: [c.req.param('userId')] }, 200))
+  .get('/users/:userId/posts/:postId', (c) =>
+    c.json({ userId: c.req.param('userId'), postId: c.req.param('postId') }, 200)
+  )
+  // regex param
+  .get('/posts/:pid{[0-9]+}', (c) => c.json({ pid: c.req.param('pid') }, 200))
+  .get(
+    '/search',
+    validator('query', () => ({}) as { q: string }),
+    (c) => c.json({ hits: [c.req.query('q') ?? ''] }, 200)
+  )
+  .get(
+    '/session',
+    validator('cookie', () => ({}) as { session: string }),
+    (c) => c.json({ cookie: c.req.header('cookie') ?? null }, 200)
+  )
+  .post(
+    '/upload',
+    validator('form', () => ({}) as { file: File; note: string }),
+    async (c) => {
+      const body = await c.req.parseBody()
+      return c.json({ note: String(body.note), file: (body.file as File).name }, 200)
+    }
+  )
+  // two trailing optionals
+  .get('/v1/lb/:version?/:platform?', (c) =>
+    c.json(
+      { version: c.req.param('version') ?? null, platform: c.req.param('platform') ?? null },
+      200
+    )
+  )
+  .all('/any', (c) => c.json({ method: c.req.method }, 200))
+  .get(
+    '/ws',
+    upgradeWebSocket(() => ({}))
+  )
+
+const api = hcx<typeof app, 'http://localhost'>('http://localhost', { fetch: app.request })
+
+describe('hcx', () => {
+  it('sends a static path through `$get`', async () => {
+    const res = await api.users.$get()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{ id: 'u1' }])
+  })
+
+  it('puts a query in the options slot', async () => {
+    const res = await api.search.$get({ query: { q: 'hono' } })
+    expect(await res.json()).toEqual({ hits: ['hono'] })
+  })
+
+  it('binds params by calling a segment, chained and back-to-back', async () => {
+    const res = await api.users({ id: 'u1' }).$get()
+    expect(await res.json()).toEqual({
+      id: 'u1',
+      name: 'Widget',
+    })
+    const res2 = await api.users({ userId: 'u1' }).posts({ postId: 'p9' }).$get()
+    expect(await res2.json()).toEqual({ userId: 'u1', postId: 'p9' })
+    const res3 = await api.v1.lb({ version: 'v2' })({ platform: 'ios' }).$get()
+    expect(await res3.json()).toEqual({
+      version: 'v2',
+      platform: 'ios',
+    })
+  })
+
+  it('resolves sibling params to their own subtree', async () => {
+    const res = await api.users({ userId: 'u1' }).posts.$get()
+    expect(await res.json()).toEqual({
+      posts: ['u1'],
+    })
+    expect(api.users({ id: 'u1' }).$path()).toBe('/users/u1')
+    expect(api.users({ userId: 'u1' }).posts.$path()).toBe('/users/u1/posts')
+  })
+
+  it('sends the json body positionally, with param and options', async () => {
+    const res = await api.users.$post({ name: 'Bolt', age: 3 })
+    expect(await res.json()).toEqual({
+      id: 'u1',
+      body: { name: 'Bolt', age: 3 },
+    })
+    const updated = await api.users({ id: 'u1' }).$put({ name: 'Nut' }, { query: { dry: '1' } })
+    expect(await updated.json()).toEqual({ id: 'u1', body: { name: 'Nut' }, dry: '1' })
+  })
+
+  it('sends `$delete` with and without a body', async () => {
+    const res = await api.users({ id: 'u1' }).$delete({ reason: 'spam' })
+    expect(await res.json()).toEqual({
+      deleted: 'u1',
+      body: { reason: 'spam' },
+    })
+    const confirmed = await api
+      .users({ id: 'u1' })
+      .export.$delete(undefined, { header: { 'x-confirm': 'yes' } })
+    expect(await confirmed.json()).toEqual({ confirmed: 'yes' })
+  })
+
+  it('serializes a validated cookie from the options slot', async () => {
+    const res = await api.session.$get({ cookie: { session: 's1' } })
+    expect(await res.json()).toEqual({ cookie: 'session=s1' })
+  })
+
+  it('sends `.form` as multipart', async () => {
+    const res = await api.upload.$post.form({
+      file: new File(['hi'], 'note.txt'),
+      note: 'hello',
+    })
+    expect(await res.json()).toEqual({ note: 'hello', file: 'note.txt' })
+  })
+
+  it('builds `$url` and `$path`, including a hoisted and a bound optional', () => {
+    expect(api.search.$url({ query: { q: 'hono' } }).href).toBe('http://localhost/search?q=hono')
+    expectTypeOf(api.users({ id: 'u1' }).$url().href).toEqualTypeOf<'http://localhost/users/u1'>()
+    expect(api.users({ id: 'u1' }).$url().href).toBe('http://localhost/users/u1')
+    expect(api.users({ id: 'u1' }).$path()).toBe('/users/u1')
+    const id: string = 'u1'
+    expectTypeOf(api.users({ id }).$path()).toEqualTypeOf<'/users/:id'>()
+    expect(api.users({ id }).$path()).toBe('/users/u1')
+    expectTypeOf(api.v1.lb.$url().href).toEqualTypeOf<'http://localhost/v1/lb'>()
+    expectTypeOf(api.v1.lb.$path()).toEqualTypeOf<'/v1/lb'>()
+    expect(api.v1.lb.$path()).toBe('/v1/lb')
+    expectTypeOf(api.v1.lb({ version: 'v2' }).$path()).toEqualTypeOf<'/v1/lb/v2'>()
+    expect(api.v1.lb({ version: 'v2' }).$path()).toBe('/v1/lb/v2')
+  })
+
+  it('opens a `$ws` with query through the `webSocket` option', () => {
+    const webSocketMock = vi.fn(() => ({}) as WebSocket)
+    const wsClient = hcx<typeof app, 'http://localhost'>('http://localhost', {
+      webSocket: webSocketMock,
+    })
+    wsClient.ws.$ws({ query: { room: 'lobby' } })
+    // @ts-expect-error `$ws` takes a query and nothing else, `hc` forwards nothing else
+    wsClient.ws.$ws({ init: {} })
+    expect(webSocketMock).toHaveBeenCalledWith('ws://localhost/ws?room=lobby')
+  })
+
+  it('calls an `$all` route through `$get` and `$post`', async () => {
+    const res = await api.any.$get()
+    expect(await res.json()).toEqual({ method: 'GET' })
+    const res2 = await api.any.$post()
+    expect(await res2.json()).toEqual({ method: 'POST' })
+  })
+
+  it('reaches a trailing optional both hoisted and bound', async () => {
+    const res = await api.v1.lb.$get()
+    expect(await res.json()).toEqual({ version: null, platform: null })
+    const res2 = await api.v1.lb({ version: 'v2' }).$get()
+    expect(await res2.json()).toEqual({
+      version: 'v2',
+      platform: null,
+    })
+  })
+
+  it('puts `/` on the root node and a trailing-slash route on `index`', async () => {
+    const res = await api.$get()
+    expect(await res.json()).toEqual({ root: true })
+    expectTypeOf(api.users.index.$path()).toEqualTypeOf<'/users'>()
+    expect(api.users.index.$path()).toBe('/users')
+    expect(api.$path()).toBe('/')
+    expectTypeOf(api.a.index.b.$path()).toEqualTypeOf<'/a/index/b'>()
+    expect(api.a.index.b.$path()).toBe('/a/index/b')
+    const res2 = await api.a.index.b.$get()
+    expect(await res2.json()).toEqual({ mid: true })
+  })
+
+  it('merges per-call `init` and `headers` over the client-level ones', async () => {
+    const fetchSpy = vi.fn(app.request)
+    const client = hcx<typeof app, 'http://localhost'>('http://localhost', {
+      fetch: fetchSpy,
+      headers: { 'x-base': 'base', 'x-both': 'base' },
+    })
+    await client.users.$get({ headers: { 'x-both': 'call' }, init: { cache: 'no-store' } })
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('http://localhost/users')
+    expect(init?.cache).toBe('no-store')
+    const headers = new Headers(init?.headers)
+    expect(headers.get('x-base')).toBe('base')
+    expect(headers.get('x-both')).toBe('call')
+  })
+
+  it('does not hang on `await` of a node or a leaf', async () => {
+    expect(await api.users).toBeTypeOf('function')
+    expect(await api.users.$get).toBeTypeOf('function')
+  })
+
+  it('binds a regex param by its bare name', async () => {
+    expectTypeOf(api.posts({ pid: '7' }).$path()).toEqualTypeOf<'/posts/7'>()
+    const res = await api.posts({ pid: '7' }).$get()
+    expect(await res.json()).toEqual({ pid: '7' })
+  })
+
+  it('can be stringified, like `hc`', () => {
+    expect(() => String(api.users)).not.toThrow()
+    expect(() => `${api.users.$get}`).not.toThrow()
+  })
+
+  it('throws on a segment call that does not bind exactly one param', () => {
+    // @ts-expect-error the param object is not optional.
+    expect(() => api.users()).toThrow(/exactly one path param/)
+    // @ts-expect-error a segment binds one param at a time.
+    expect(() => api.users({ id: 'u1', userId: 'u2' })).toThrow(/exactly one path param/)
+  })
+
+  it('throws on a `:` key, which only exists for the type', () => {
+    expect(() => api.users[':id']).toThrow(/type-only key/)
+  })
+
+  it('narrows the response body union on `res.ok`', async () => {
+    const notFound = await api.users({ id: 'missing' }).$get()
+    if (notFound.ok) {
+      throw new Error('expected a 404')
+    }
+    expect(await notFound.json()).toEqual({ error: 'Not found' })
+    const found = await api.users({ id: 'u1' }).$get()
+    if (!found.ok) {
+      throw new Error('expected a 200')
+    }
+    expect(await found.json()).toEqual({ id: 'u1', name: 'Widget' })
+  })
+})
+
+describe('hcx types', () => {
+  it('rejects a mistyped or missing param key', () => {
+    void (() => api.users({ id: 'u1' }))
+    // @ts-expect-error the segment is `:id`, not `:identifier`.
+    void (() => api.users({ identifier: 'u1' }))
+    // @ts-expect-error the param object is not optional.
+    void (() => api.users())
+    // @ts-expect-error hono drops a falsy segment, so params are strings only.
+    void (() => api.users({ id: 0 }))
+  })
+
+  it('resolves sibling params to their own subtree', () => {
+    expectTypeOf(api.users({ userId: 'u1' }).posts).toHaveProperty('$get')
+    // @ts-expect-error `posts` only lives under `:userId`.
+    void (() => api.users({ id: 'u1' }).posts)
+  })
+
+  it('types the body as the route json and rejects a bad one', () => {
+    expectTypeOf(api.users.$post).parameter(0).toEqualTypeOf<{ name: string; age: number }>()
+    // @ts-expect-error `age` is required.
+    void (() => api.users.$post({ name: 'Bolt' }))
+    expectTypeOf(api.users({ id: 'u1' }).export.$delete)
+      .parameter(0)
+      .toEqualTypeOf<undefined>()
+  })
+
+  it('makes options required only when the route needs them', () => {
+    void (() => api.users.$get())
+    void (() => api.search.$get({ query: { q: 'x' } }))
+    // @ts-expect-error the route declares a required query.
+    void (() => api.search.$get())
+    // @ts-expect-error the route declares a required header.
+    void (() => api.users({ id: 'u1' }).export.$delete(undefined))
+    void (() => api.users({ id: 'u1' }).export.$delete(undefined, { header: { 'x-confirm': 'y' } }))
+  })
+
+  it('exposes `.form` only on a route with a form validator', () => {
+    // hono widens a form input to the wire shape, the same as `hc`
+    expectTypeOf(api.upload.$post.form).parameter(0).toEqualTypeOf<{
+      file: FormValue | FormValue[]
+      note: FormValue | FormValue[]
+    }>()
+    // @ts-expect-error `/users` declares json, not form.
+    void (() => api.users.$post.form)
+  })
+
+  it('hoists a trailing optional onto the parent node', () => {
+    expectTypeOf(api.v1.lb.$get()).resolves.toHaveProperty('ok')
+    expectTypeOf(api.v1.lb({ version: 'v2' }).$get()).resolves.toHaveProperty('ok')
+    expectTypeOf(api.v1.lb({ version: 'v2' })({ platform: 'ios' }).$get()).resolves.toHaveProperty(
+      'ok'
+    )
+    // the wire path of a hoisted call is the short one; a bound one substitutes the value
+    expectTypeOf(api.v1.lb.$path()).toEqualTypeOf<'/v1/lb'>()
+    expectTypeOf(api.v1.lb({ version: 'v2' }).$path()).toEqualTypeOf<'/v1/lb/v2'>()
+  })
+
+  it('types `$url` and `$path` per node', () => {
+    expectTypeOf(api.users.$url()).toEqualTypeOf<TypedURL<'http:', 'localhost', '', '/users', ''>>()
+    expectTypeOf(api.users({ id: 'u1' }).$path()).toEqualTypeOf<'/users/u1'>()
+    expectTypeOf(api.search.$path({ query: { q: 'x' } })).toEqualTypeOf<`/search?${string}`>()
+  })
+
+  it('puts `/` on the root node and a trailing-slash route on `index`', () => {
+    expectTypeOf(api.$get()).resolves.toHaveProperty('ok')
+    expectTypeOf(api.users.index.$get()).resolves.toHaveProperty('ok')
+    expectTypeOf(api.$path()).toEqualTypeOf<'/'>()
+  })
+
+  it('expands `$all` into the standard methods', () => {
+    expectTypeOf(api.any).toHaveProperty('$get')
+    expectTypeOf(api.any).toHaveProperty('$post')
+    expectTypeOf(api.any.$post).parameter(0).toEqualTypeOf<undefined>()
+  })
+
+  it('adds `$ws` only on a websocket route', () => {
+    expectTypeOf(api.ws.$ws()).toEqualTypeOf<WebSocket>()
+    // @ts-expect-error `/users` is not a websocket route.
+    void (() => api.users.$ws)
+  })
+
+  it("keeps hono's Infer helpers working on the new signatures", () => {
+    expectTypeOf<InferRequestType<typeof api.users.$post>>().toEqualTypeOf<{
+      name: string
+      age: number
+    }>()
+    // on a read `InferRequestType` yields the options slot, not a body
+    expectTypeOf<InferRequestType<typeof api.search.$get>['query']>().toEqualTypeOf<{
+      q: string | string[]
+    }>()
+    // the type-only `:id` key still names the route for the `Infer*` helpers
+    expectTypeOf<InferRequestType<(typeof api.users)[':id']['$put']>>().toEqualTypeOf<{
+      name: string
+    }>()
+    expectTypeOf<InferResponseType<typeof api.users.$get, 200>>().toEqualTypeOf<{ id: string }[]>()
+    expectTypeOf<InferResponseType<(typeof api.users)[':id']['$get'], 404>>().toEqualTypeOf<{
+      error: 'Not found'
+    }>()
+  })
+
+  it('narrows the response union by status', () => {
+    expectTypeOf<InferResponseType<(typeof api.users)[':id']['$get'], 200>>().toEqualTypeOf<{
+      id: string
+      name: string
+    }>()
+  })
+})

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -3,9 +3,10 @@
  * The HTTP Client for Hono.
  */
 
-export { hc } from './client'
+export { hc, hcx } from './client'
 export { parseResponse, DetailedError } from './utils'
 export type {
+  ClientX,
   InferResponseType,
   InferRequestType,
   Fetch,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,9 +1,16 @@
 import type { Hono } from '../hono'
 import type { HonoBase } from '../hono-base'
 import type { METHODS, METHOD_NAME_ALL_LOWERCASE } from '../router'
-import type { Endpoint, ExtractSchema, KnownResponseFormat, ResponseFormat, Schema } from '../types'
+import type {
+  Endpoint,
+  ExtractSchema,
+  InputToDataByTarget,
+  KnownResponseFormat,
+  ResponseFormat,
+  Schema,
+} from '../types'
 import type { StatusCode, SuccessStatusCode } from '../utils/http-status'
-import type { HasRequiredKeys } from '../utils/types'
+import type { HasRequiredKeys, UnionToIntersection } from '../utils/types'
 
 /**
  * Type representing the '$all' method name
@@ -390,4 +397,145 @@ export type PickResponseByStatusCode<App, U extends StatusCode> =
     ? PickSchema<ExtractSchema<App>, U> extends infer S extends Schema
       ? Hono<E, S, B>
       : never
+    : never
+
+// hcx
+
+/** `ClientX` remaps the tree {@link Client} builds for `hc`, one mapped type per node. */
+type EmptyRecord = Record<never, never>
+
+/** `:id{[0-9]+}?` -> `id` */
+type ParamNameOf<K> = K extends `:${infer N}`
+  ? N extends `${infer B}{${string}`
+    ? B
+    : N extends `${infer B}?`
+      ? B
+      : N
+  : never
+
+type ParamSegmentKeys<N> = Extract<keyof N, `:${string}`>
+type OptionalSegmentKeys<N> = Extract<keyof N, `:${string}?`>
+type StaticSegmentKeys<N> = Exclude<keyof N, `:${string}` | `$${string}`>
+type MethodKeys<N> = Extract<keyof N, `$${string}`>
+type IsUnion<T, U = T> = T extends unknown ? ([U] extends [T] ? false : true) : never
+
+/** `hc`'s `args` minus `param` (bound by the chain) and the body (positional). */
+type RequestOptionsOf<A> = ClientRequestOptions & {
+  [K in keyof A as K extends 'query' | 'header' | 'cookie' ? K : never]: A[K]
+}
+type OptionsParam<A> =
+  HasRequiredKeys<RequestOptionsOf<A>> extends true
+    ? [options: RequestOptionsOf<A>]
+    : [options?: RequestOptionsOf<A>]
+type ReadCall<A, Out> = (...args: OptionsParam<A>) => Out
+/** A body-less write keeps its body slot so `$post(x, opts)` is never read as `$post(opts)`. */
+type WriteCall<A, Body, Out> = [Body] extends [never]
+  ? (body?: undefined, ...args: OptionsParam<A>) => Out
+  : (body: Body, ...args: OptionsParam<A>) => Out
+
+type JsonBodyOf<A extends {}> = InputToDataByTarget<A, 'json'>
+type FormBodyOf<A extends {}> = InputToDataByTarget<A, 'form'>
+/** Every query a node accepts, for its `$url` / `$path` argument. */
+type QueryOfNode<N> = InputToDataByTarget<
+  { [K in MethodKeys<N>]: InferRequestType<N[K]> }[MethodKeys<N>],
+  'query'
+>
+
+/** `$get` reads, everything else writes and carries `.form` when the route declares one. */
+type MethodCall<M, F> = F extends (args: infer A, options?: never) => Promise<infer R>
+  ? M extends '$get'
+    ? ReadCall<NonNullable<A>, Promise<R>>
+    : WriteCall<NonNullable<A>, JsonBodyOf<NonNullable<A>>, Promise<R>> &
+        ([FormBodyOf<NonNullable<A>>] extends [never]
+          ? unknown
+          : { form: WriteCall<NonNullable<A>, FormBodyOf<NonNullable<A>>, Promise<R>> })
+  : never
+
+/** The `{ param, query }` shape `BuildPathname` expects; `undefined & {}` would be `never`. */
+type UrlArgOf<Bound, Arg> = { param: Bound } & (Arg extends undefined ? unknown : Arg)
+
+/** `hc` only forwards `query` to a WebSocket, so that is all `$ws` accepts. */
+type WsCall = (options?: { query?: Record<string, string | string[]> }) => WebSocket
+
+/**
+ * `$url` / `$path` / `$ws` exist where `hc` has them. The branch lives inside the mapped type on
+ * purpose: outside it, the conditional is paid on every node instead of on read.
+ */
+type NodeMembers<N, Prefix extends string, Pre extends string, Bound> = {
+  [K in MethodKeys<N>]: K extends '$url'
+    ? <const Arg extends { query?: QueryOfNode<N> } | undefined = undefined>(
+        arg?: Arg
+      ) => HonoURL<Prefix, Pre, UrlArgOf<Bound, Arg>>
+    : K extends '$path'
+      ? <const Arg extends { query?: QueryOfNode<N> } | undefined = undefined>(
+          arg?: Arg
+        ) => BuildPath<Pre, UrlArgOf<Bound, Arg>>
+      : K extends '$ws'
+        ? WsCall
+        : MethodCall<K, N[K]>
+} & HoistedMembers<N, Prefix, Pre, Bound>
+
+/**
+ * `/a/:v?` also serves `/a`, so a node borrows the members (not the callable) of every node
+ * reachable through `:x?` keys. `EmptyRecord` is the fold identity: a `[keys] extends [never]`
+ * guard here costs on every node, measured.
+ */
+type HoistedMembers<N, Prefix extends string, Pre extends string, Bound> = UnionToIntersection<
+  | EmptyRecord
+  | { [K in OptionalSegmentKeys<N>]: NodeMembers<N[K], Prefix, Pre, Bound> }[OptionalSegmentKeys<N>]
+>
+
+/** Strings only (hono drops a falsy segment); `const V` lets `$path()` substitute a literal. */
+type ParamCall<N, P extends keyof N & string, Prefix extends string, Pre extends string, Bound> = <
+  const V extends string,
+>(params: { [Q in ParamNameOf<P> & string]: V }) => ClientXNode<
+  N[P],
+  Prefix,
+  `${Pre}/:${ParamNameOf<P> & string}`,
+  Bound & { [Q in ParamNameOf<P> & string]: V }
+>
+
+/**
+ * Sibling params (`/x/:id`, `/x/:xId`) become overloads. Fold only then: `UnionToIntersection` on
+ * a one-member union compares the whole child structurally, measured at ~6k instantiations a node.
+ */
+type ParamCallable<
+  N,
+  Prefix extends string,
+  Pre extends string,
+  Bound,
+  P extends keyof N & string = ParamSegmentKeys<N> & string,
+> = [P] extends [never]
+  ? unknown
+  : IsUnion<P> extends true
+    ? UnionToIntersection<{ [K in P]: ParamCall<N, K, Prefix, Pre, Bound> }[P]>
+    : ParamCall<N, P, Prefix, Pre, Bound>
+
+/**
+ * `Pre` is the route path rebuilt while descending. `:id` stays a plain key so
+ * `typeof api.users[':id'].$get` keeps naming a route; the runtime rejects that spelling.
+ */
+type ClientXNode<N, Prefix extends string, Pre extends string, Bound> = {
+  [K in StaticSegmentKeys<N>]: ClientXNode<
+    N[K],
+    Prefix,
+    // `hc`'s trailing-slash `index` is a leaf; a real segment named `index` has children.
+    K extends 'index'
+      ? [StaticSegmentKeys<N[K]> | ParamSegmentKeys<N[K]>] extends [never]
+        ? Pre
+        : `${Pre}/index`
+      : `${Pre}/${K & string}`,
+    Bound
+  >
+} & {
+  [K in ParamSegmentKeys<N>]: ClientXNode<N[K], Prefix, `${Pre}/:${ParamNameOf<K> & string}`, Bound>
+} & NodeMembers<N, Prefix, Pre, Bound> &
+  ParamCallable<N, Prefix, Pre, Bound>
+
+/** Client type for {@link hcx}. */
+export type ClientX<T, Prefix extends string = string> =
+  UnionToIntersection<Client<T, Prefix>> extends infer N
+    ? // `hc` files `/` under `index`; `hcx` also puts it on the root node.
+      ClientXNode<N, Prefix, '', EmptyRecord> &
+        ([N] extends [{ index: infer R }] ? NodeMembers<R, Prefix, '', EmptyRecord> : unknown)
     : never


### PR DESCRIPTION
Closes #3968. Credits to Elysia's Eden for the style.

This PR adds a second RPC client style, `hcx`, next to `hc` in `hono/client`. It cuts the boilerplate of the common JSON API call:

- path params are bound by calling the segment
- the JSON body is positional, and everything else in one options object.

```ts
// Before: PATCH /api/blog/:id/comment/:commentId
const res = await api.blog[":id"].comment[":commentId"].$patch({
  param: { id: blogId, commentId },
  json: newComment,
});
type PatchCommentInput = InferRequestType<
  (typeof api.blog)[":id"]["comment"][":commentId"]["$patch"]
>["json"];

// After
const res = await api.blog({ id: blogId }).comment({ commentId }).$patch(newComment);
type PatchCommentInput = InferRequestType<
  (typeof api.blog)[":id"]["comment"][":commentId"]["$patch"]
>;
```

The param name is written once instead of twice, the body loses its `{ json }` wrapper, and the `['json']` suffix on every inferred input type goes away.

Unlike Eden, request methods keep the `$` prefix, so a segment is never confused with a param value (the reasoning in #3827).

### A comparison of before vs after

| Use case                | `hc`                                                       | `hcx`                                  |
| ----------------------- | ---------------------------------------------------------- | -------------------------------------- |
| Path param              | `.users[':id'].$get({ param: { id } })`                    | `.users({ id }).$get()`                |
| Two params              | `.users[':id'].posts[':pid'].$get({ param: { id, pid } })` | `.users({ id }).posts({ pid }).$get()` |
| JSON body               | `.users.$post({ json: body })`                             | `.users.$post(body)`                   |
| Body + query            | `.users[':id'].$put({ param: { id }, json: body, query })` | `.users({ id }).$put(body, { query })` |
| Query only              | `.search.$get({ query: { q } })`                           | `.search.$get({ query: { q } })`       |
| Header / cookie         | `.$delete({ param, header })`                              | `.$delete(undefined, { header })`      |
| Form body               | `.upload.$post({ form: { file } })`                        | `.upload.$post.form({ file })`         |
| Optional `:v?`, omitted | `.lb[':v?'].$get({ param: { v: undefined } })`             | `.lb.$get()`                           |
| Optional `:v?`, given   | `.lb[':v?'].$get({ param: { v } })`                        | `.lb({ v }).$get()`                    |
| `$url` / `$path`        | `.users[':id'].$url({ param: { id } })`                    | `.users({ id }).$url()`                |
| WebSocket               | `.ws.$ws({ query })`                                       | `.ws.$ws({ query })`                   |
| Inferred input          | `InferRequestType<…>['json']`                              | `InferRequestType<…>`                  |
| Per-call options        | `.$get(args, { headers, init })`                           | `.$get({ headers, init })`             |

### Perf

`ClientX` is a remap of the tree `Client` already builds for `hc`, so client construction costs the same and each call site stays flat. Measured with `tsc --extendedDiagnostics` on the `perf-measures/type-check` app (200 routes `/routeN/:id`), one file with N call sites:

|                | `hc`, 1 site | `hcx`, 1 site | `hc`, 200 sites | `hcx`, 200 sites |
| -------------- | ------------ | ------------- | --------------- | ---------------- |
| Instantiations | 621,070      | 634,734       | 687,138         | 789,357          |
| Types          | 207,959      | 208,467       | 213,332         | 225,979          |
| Check time     | 0.74s        | 0.74s         | 0.81s           | 0.86s            |
| Memory         | 240 MB       | 258 MB        | 246 MB          | 281 MB           |

So about +2% at one call site and +15% instantiations at 200 distinct call sites, the per-node cost of rewriting the leaf signatures. Not a fix for #2399 / #3869 / #3945: the `Schema` dominates, and both clients share it.

### What changed

- `hcx(baseUrl, options?)` exported from `hono/client`, plus the `ClientX<T, Prefix>` type. Additive, nothing about `hc` changes.
- `hc`'s proxy callback is extracted into `createCallback` (first commit, behavior-preserving, `client.test.ts` untouched). `hcx` builds its own Proxy tree and hands that callback the exact `{ path, args }` shape `hc` produces, so URL building, header/cookie merging, `init`, `$url`/`$path`/`$ws`, `removeIndexString` and the form encoder are all the existing code.
- Tests in `src/client/hcx.test.ts`: every row of the table above at the wire level, plus type assertions (`@ts-expect-error` for wrong keys, non-string params, missing required options, `.form` on a JSON route).

### Known quirks (in the JSDoc)

- `api.users[':id']` is type-only, for `typeof api.users[':id'].$get`; the runtime throws on it.
- A validated `header` shares the options object with `headers`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
