### PR TITLE
fix(accepts, language): skip accept entries with quality 0 when matching

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -70,6 +70,54 @@ describe('accepts', () => {
     expect(result).toBe('text/html')
   })
 
+  test('should not match candidate rejected with q=0', () => {
+    const c = {
+      req: {
+        header: () => 'application/json;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
+  test('should skip q=0 candidate and fall through to next acceptable type', () => {
+    const c = {
+      req: {
+        header: () => 'application/json;q=0, text/html;q=0.8',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json', 'text/html'],
+      default: 'text/plain',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
+  test('should not match a subtype wildcard the client rejected with q=0', () => {
+    const c = {
+      req: {
+        header: () => 'application/*;q=0',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+    const options: acceptsConfig = {
+      header: 'Accept',
+      supports: ['application/json'],
+      default: 'text/html',
+    }
+    const result = accepts(c, options)
+    expect(result).toBe('text/html')
+  })
+
   test('should match wildcard subtype application/*', () => {
     const c = {
       req: {

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -53,6 +53,9 @@ export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string =
   })
 
   for (const accept of sortedAccepts) {
+    if (accept.q === 0) {
+      continue
+    }
     const matched = supports.find((supported) => matchType(accept.type, supported))
     if (matched) {
       return matched

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -77,6 +77,51 @@ describe('languageDetector', () => {
       expect(await res.text()).toBe('fr')
     })
 
+    it('should not detect language rejected with q=0', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr'],
+        fallbackLanguage: 'fr',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'en;q=0',
+        },
+      })
+      expect(await res.text()).toBe('fr')
+    })
+
+    it('should skip q=0 language and fall through to next acceptable language', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr', 'es'],
+        fallbackLanguage: 'es',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'en;q=0, fr;q=0.5',
+        },
+      })
+      expect(await res.text()).toBe('fr')
+    })
+
+    it('should fallback when all header languages have q=0', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr', 'es'],
+        fallbackLanguage: 'es',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'accept-language': 'en;q=0, fr;q=0',
+        },
+      })
+      expect(await res.text()).toBe('es')
+    })
+
     it('should fallback to language code when locale code is not in supportedLanguages', async () => {
       const app = createTestApp({
         supportedLanguages: ['en', 'ja'],

--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -158,7 +158,10 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
     }
 
     const languages = parseAcceptLanguage(acceptLanguage)
-    for (const { lang } of languages) {
+    for (const { lang, q } of languages) {
+      if (q === 0) {
+        continue
+      }
       const normalizedLang = normalizeLanguage(lang, options)
       if (normalizedLang) {
         return normalizedLang


### PR DESCRIPTION
Fixes #5310

### Description

Per RFC 9110 §12.5.1 and §12.5.4, a quality value of `q=0` indicates that a representation is explicitly not acceptable. The `compress` middleware already filters out `q=0` entries, but `defaultMatch` in `accepts` and `detectFromHeader` in the `language` middleware were matching `q=0` candidates when present.

This change skips entries with `q === 0` in both `defaultMatch` and `detectFromHeader`, falling through to subsequent acceptable values or configured defaults, and adds test coverage including subtype wildcards (`*/*` and `type/*`).

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code