### PR TITLE
perf(jsx/dom): reduce lookup work for large keyed updates

### DIFF
--- a/benchmarks/jsx-dom/benchmark.ts
+++ b/benchmarks/jsx-dom/benchmark.ts
@@ -1,0 +1,65 @@
+// Run from the repository root: bun benchmarks/jsx-dom/benchmark.ts
+// Measures build() only, excluding JSX creation and DOM updates.
+import { jsx } from '../../src/jsx/dom/jsx-runtime'
+import type { NodeObject } from '../../src/jsx/dom/render'
+import { build, buildNode } from '../../src/jsx/dom/render'
+
+for (const size of [100, 1000, 5000]) {
+  for (const kind of [
+    'same-order',
+    'remove-second',
+    'adjacent-swap',
+    'reverse',
+    'reverse-unkeyed-footer',
+  ]) {
+    const ids = Array.from({ length: size }, (_, i) => i)
+    const hasFooter = kind === 'reverse-unkeyed-footer'
+    const createChildren = (ids: number[]) => {
+      const children = ids.map((id) => jsx('p', {}, String(id)))
+      if (hasFooter) {
+        children.push(jsx('p', {}))
+      }
+      return children
+    }
+    const nextIds = [...ids]
+    if (kind === 'remove-second') {
+      nextIds.splice(1, 1)
+    } else if (kind === 'adjacent-swap') {
+      ;[nextIds[1], nextIds[2]] = [nextIds[2], nextIds[1]]
+    } else if (kind.startsWith('reverse')) {
+      nextIds.reverse()
+    }
+    const samples: number[] = []
+    // Use fresh nodes in short batches instead of mixing long-lived node states.
+    for (let batch = 0; batch < 5; batch++) {
+      const parent = buildNode(jsx('div', { children: createChildren(ids) })) as NodeObject
+      build([], parent)
+      const initialChildren = parent.vC
+      const update = (children: ReturnType<typeof createChildren>) => {
+        parent.vC = initialChildren
+        parent.props.children = children
+        build([], parent)
+      }
+      for (let i = 0; i < 10; i++) {
+        update(createChildren(nextIds))
+      }
+      const inputs = Array.from({ length: 20 }, () => createChildren(nextIds))
+      const start = performance.now()
+      for (const children of inputs) {
+        update(children)
+      }
+      samples.push((performance.now() - start) / inputs.length)
+      if (
+        parent.vC.length !== nextIds.length + Number(hasFooter) ||
+        parent.vC.some(
+          (child, i) => child !== initialChildren[i < nextIds.length ? nextIds[i] : size]
+        )
+      ) {
+        throw new Error('Unexpected child identity after update')
+      }
+    }
+    samples.sort((a, b) => a - b)
+    const ms = samples[Math.floor(samples.length / 2)]
+    console.log(`${kind}, ${size} keyed children: ${ms.toFixed(3)} ms/build (median)`)
+  }
+}

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -15,6 +15,8 @@ import {
   useRef,
   useState,
 } from '../hooks'
+import type { NodeObject } from './render'
+import { build, buildNode } from './render'
 import DefaultExport, {
   cloneElement,
   cloneElement as cloneElementForDom,
@@ -136,6 +138,315 @@ describe('DOM', () => {
         Array.from({ length: 1000 }, (_, i) => `<div><span>${i}</span></div>`).join('')
       )
     })
+
+    it.each(['same-order', 'remove-second', 'adjacent-swap'])(
+      'preserves keyed children during common updates: %s',
+      (kind) => {
+        const size = 100
+        const ids = Array.from({ length: size }, (_, i) => i)
+        const createRow = (id: number) => <div key={id}>{id}</div>
+        const parent = buildNode(<section>{ids.map(createRow)}</section>) as NodeObject
+        build([], parent)
+        const initialChildren = parent.vC
+        const nextIds = [...ids]
+        if (kind === 'remove-second') {
+          nextIds.splice(1, 1)
+        } else if (kind === 'adjacent-swap') {
+          ;[nextIds[1], nextIds[2]] = [nextIds[2], nextIds[1]]
+        }
+        parent.props.children = [[], ...nextIds.map(createRow)]
+
+        build([], parent)
+
+        expect(parent.vC).toHaveLength(nextIds.length)
+        nextIds.forEach((id, i) => expect(parent.vC[i]).toBe(initialChildren[id]))
+        expect(parent.vR).toHaveLength(kind === 'remove-second' ? 1 : 0)
+        if (kind === 'remove-second') {
+          expect(parent.vR[0]).toBe(initialChildren[1])
+        }
+      }
+    )
+  })
+
+  describe('large keyed updates', () => {
+    it.each([
+      'reverse',
+      'rotate-half',
+      'replace-all',
+      'footer-unkeyed',
+      'footer-text',
+      'insert-text',
+      'move-text',
+    ])('matches keyed list updates in linear work: %s', (kind) => {
+      const measure = (size: number) => {
+        let oldKeyReads = 0
+        let newKeyReads = 0
+        const createRow = (id: number, old = false) => {
+          const row = <div>{id}</div>
+          // Count both sides so node normalization cannot silently disable the check.
+          Object.defineProperty(row, 'key', {
+            configurable: true,
+            get: () => {
+              if (old) {
+                oldKeyReads++
+              } else {
+                newKeyReads++
+              }
+              return id
+            },
+          })
+          return row
+        }
+        const ids = Array.from({ length: size }, (_, i) => i)
+        const before: Child[] = ids.map((id) => createRow(id, true))
+        if (kind === 'footer-unkeyed') {
+          before.push(<div>footer</div>)
+        } else if (kind === 'footer-text' || kind === 'move-text') {
+          before.push('original')
+        }
+        const parent = buildNode(<section>{before}</section>) as NodeObject
+        build([], parent)
+        const initial = parent.vC
+        const next = [...ids]
+        if (kind === 'rotate-half') {
+          next.push(...next.splice(0, size / 2))
+        } else if (kind === 'replace-all') {
+          next.splice(0, size, ...ids.map((id) => id + size))
+        } else {
+          next.reverse()
+        }
+        const after: Child[] = next.map((id) => createRow(id))
+        const expected = next.map((id) => (id < size ? initial[id] : undefined))
+        if (kind === 'footer-unkeyed' || kind === 'footer-text') {
+          after.push(kind === 'footer-unkeyed' ? <div>footer</div> : 'updated')
+          expected.push(initial[size])
+        } else if (kind === 'insert-text' || kind === 'move-text') {
+          after.splice(4, 0, 'updated')
+          expected.splice(4, 0, kind === 'move-text' ? initial[size] : undefined)
+          if (kind === 'move-text') {
+            after.splice(8, 0, 'extra')
+            expected.splice(8, 0, undefined)
+          }
+        }
+        parent.props.children = after
+        oldKeyReads = newKeyReads = 0
+        build([], parent)
+        const reads = { old: oldKeyReads, new: newKeyReads }
+
+        expect(parent.vC).toHaveLength(expected.length)
+        expected.forEach((child, i) => {
+          if (child) {
+            expect(parent.vC[i]).toBe(child)
+          } else {
+            expect(initial.includes(parent.vC[i])).toBe(false)
+          }
+        })
+        if (kind === 'footer-text' || kind === 'insert-text' || kind === 'move-text') {
+          expect(parent.vC[kind === 'footer-text' ? size : 4]).toMatchObject({ t: 'updated' })
+        }
+        if (kind === 'move-text') {
+          expect(parent.vC[8]).toMatchObject({ t: 'extra' })
+        }
+        expect(parent.vR).toHaveLength(kind === 'replace-all' ? size : 0)
+        parent.vR.forEach((child, i) => expect(child).toBe(initial[i]))
+        return reads
+      }
+
+      const small = measure(64)
+      const large = measure(128)
+      expect(small.old).toBeGreaterThan(0)
+      expect(small.new).toBeGreaterThan(0)
+      expect(large.old).toBeLessThan(small.old * 3)
+      expect(large.old + large.new).toBeLessThan((small.old + small.new) * 3)
+    })
+
+    it.each(['unkeyed-to-text', 'undefined-tag-to-text', 'text-to-unkeyed'])(
+      'replaces incompatible children after indexing: %s',
+      (kind) => {
+        const ids = Array.from({ length: 40 }, (_, i) => i)
+        const createRow = (id: number) => <div key={id}>{id}</div>
+        let footer: Child = kind === 'text-to-unkeyed' ? 'original' : <span>footer</span>
+        if (kind === 'undefined-tag-to-text') {
+          // @ts-expect-error An undefined component still creates a NodeObject at runtime.
+          footer = createElementForDom(undefined, {})
+        }
+        const parent = buildNode(<section>{[...ids.map(createRow), footer]}</section>) as NodeObject
+        build([], parent)
+        const initial = parent.vC
+        const next = [...ids].reverse()
+        const after: Child[] = next.map(createRow)
+        // Consume an indexed child before replacing the incompatible footer.
+        after.splice(4, 0, kind === 'text-to-unkeyed' ? <span>updated</span> : 'updated')
+        parent.props.children = after
+
+        build([], parent)
+
+        expect(parent.vC).toHaveLength(ids.length + 1)
+        next.forEach((id, i) => expect(parent.vC[i < 4 ? i : i + 1]).toBe(initial[id]))
+        expect(initial.includes(parent.vC[4])).toBe(false)
+        expect(parent.vC[4]).toMatchObject(
+          kind === 'text-to-unkeyed' ? { tag: 'span' } : { t: 'updated', d: true }
+        )
+        expect(parent.vR).toHaveLength(1)
+        expect(parent.vR[0]).toBe(initial[ids.length])
+      }
+    )
+
+    it('restores previous children with indexed matching and ordered removals', () => {
+      const ids = Array.from({ length: 40 }, (_, i) => i)
+      const createRow = (id: number) => <div key={id}>{id}</div>
+      const parent = buildNode(<section>{ids.map(createRow)}</section>) as NodeObject
+      build([], parent)
+      const initial = parent.vC
+      let keyReads = 0
+      initial.forEach((child, id) => {
+        Object.defineProperty(child, 'key', {
+          configurable: true,
+          get: () => {
+            keyReads++
+            return id
+          },
+        })
+      })
+
+      // Explicit fallback children preserve the original list in pC.
+      build([], parent, [<span>Loading</span>])
+      const fallback = parent.vC
+      expect(parent.pC).toBe(initial)
+      const next = [...ids].reverse().filter((id) => id !== 10 && id !== 20)
+      parent.props.children = next.map(createRow)
+      keyReads = 0
+      build([], parent)
+      const matchingReads = keyReads
+
+      expect(matchingReads).toBeGreaterThan(0)
+      expect(matchingReads).toBeLessThan(ids.length * 8)
+      expect(parent.vC).toHaveLength(next.length)
+      next.forEach((id, i) => expect(parent.vC[i]).toBe(initial[id]))
+      const removed = [...fallback, initial[10], initial[20]]
+      expect(parent.vR).toHaveLength(removed.length)
+      removed.forEach((child, i) => expect(parent.vR[i]).toBe(child))
+      expect(parent.pC).toBeUndefined()
+    })
+
+    it.each([
+      { name: 'duplicate old keys', oldKeys: [0, 0], newKeys: [0, 0], matches: [0, 1] },
+      { name: 'an unkeyed old child', oldKeys: [undefined, 1], newKeys: [undefined], matches: [0] },
+      {
+        name: 'multiple unkeyed old children',
+        oldKeys: [undefined, undefined],
+        newKeys: [undefined, undefined],
+        matches: [0, 1],
+      },
+      { name: 'NaN keys', oldKeys: [NaN, 1], newKeys: [NaN, 1], matches: [-1, 1] },
+      {
+        name: 'a different tag for the same key',
+        oldKeys: [0, 1],
+        newKeys: [0, 0],
+        firstNewTag: 'span',
+        matches: [-1, 0],
+      },
+      { name: 'a repeated new key', oldKeys: [0, 1], newKeys: [0, 0], matches: [0, -1] },
+      {
+        name: 'different old tags sharing a key',
+        oldKeys: [0, 0],
+        oldSecondTag: 'span',
+        newKeys: [0, 0],
+        firstNewTag: 'span',
+        matches: [1, 0],
+      },
+    ])(
+      'preserves matching and removal order with $name',
+      ({ oldKeys, newKeys, matches, oldSecondTag, firstNewTag }) => {
+        const before = Array.from({ length: 40 }, (_, i) =>
+          createElement(i === 1 ? oldSecondTag || 'div' : 'div', {
+            key: i < oldKeys.length ? oldKeys[i] : i,
+          })
+        )
+        const parent = buildNode(<section>{before}</section>) as NodeObject
+        build([], parent)
+        const initial = parent.vC
+        // This prefix exceeds the scan budget and attempts to index the remaining nodes.
+        const prefix = [39, 38, 37, 36]
+        parent.props.children = [
+          ...prefix.map((key) => <div key={key} />),
+          ...newKeys.map((key, i) =>
+            createElement(i === 0 ? firstNewTag || 'div' : 'div', { key })
+          ),
+        ]
+        build([], parent)
+
+        const expected = [...prefix, ...matches]
+        expect(parent.vC).toHaveLength(expected.length)
+        expected.forEach((oldIndex, i) => {
+          if (oldIndex === -1) {
+            expect(initial.includes(parent.vC[i])).toBe(false)
+          } else {
+            expect(parent.vC[i]).toBe(initial[oldIndex])
+          }
+        })
+        const removed = initial.filter((_, i) => !expected.includes(i))
+        expect(parent.vR).toHaveLength(removed.length)
+        removed.forEach((child, i) => expect(parent.vR[i]).toBe(child))
+      }
+    )
+
+    it.each(['keyed', 'unkeyed', 'text'])(
+      'preserves state and cleanup order after indexing followed by %s children',
+      async (kind) => {
+        let update: () => void = () => {}
+        const cleaned: number[] = []
+        const Row = ({ id }: { id: number }) => {
+          const [initialId] = useState(id)
+          const [count, setCount] = useState(0)
+          useLayoutEffect(
+            () => () => {
+              cleaned.push(initialId)
+            },
+            []
+          )
+          return (
+            <button onClick={() => setCount(count + 1)}>
+              {id}:{initialId}:{count}
+            </button>
+          )
+        }
+        const before = Array.from({ length: 40 }, (_, i) => i)
+        const after = [...before]
+          .reverse()
+          .filter((id) => id !== 10 && id !== 20 && (kind !== 'unkeyed' || id !== 0))
+        // Consume an indexed child before introducing an unkeyed or text child.
+        if (kind !== 'keyed') {
+          after.splice(4, 0, kind === 'unkeyed' ? 100 : 101)
+        }
+        const App = () => {
+          const [ids, setIds] = useState(before)
+          update = () => setIds(after)
+          return ids.map((id) =>
+            id === 101 ? 'inserted' : <Row key={id === 100 ? undefined : id} id={id} />
+          )
+        }
+
+        render(<App />, root)
+        const initial = [...root.querySelectorAll('button')]
+        initial[0].click()
+        await Promise.resolve()
+        update()
+        await Promise.resolve()
+
+        const rows = after.filter((id) => id !== 101)
+        expect(root.children).toHaveLength(rows.length)
+        rows.forEach((id, i) => {
+          const oldId = id === 100 ? 0 : id
+          expect(root.children[i]).toBe(initial[oldId])
+          expect(root.children[i].textContent).toBe(`${id}:${oldId}:${oldId === 0 ? 1 : 0}`)
+        })
+        if (kind === 'text') {
+          expect(root.childNodes[4].textContent).toBe('inserted')
+        }
+        expect(cleaned).toEqual([10, 20])
+      }
+    )
   })
 
   describe('attribute', () => {

--- a/src/jsx/dom/index.test.tsx
+++ b/src/jsx/dom/index.test.tsx
@@ -1707,6 +1707,296 @@ describe('DOM', () => {
     )
   })
 
+  it('preserves keyed child identity and state when reordering', async () => {
+    let reverse: () => void = () => {}
+    const Row = ({ id }: { id: string }) => {
+      const [count, setCount] = useState(0)
+      return (
+        <button data-id={id} onClick={() => setCount(count + 1)}>
+          {id}:{count}
+        </button>
+      )
+    }
+    const App = () => {
+      const [ids, setIds] = useState(['a', 'b', 'c'])
+      reverse = () => setIds((ids) => [...ids].reverse())
+      return ids.map((id) => <Row key={id} id={id} />)
+    }
+
+    render(<App />, root)
+    const initialRows = Object.fromEntries(
+      [...root.querySelectorAll<HTMLButtonElement>('button')].map((element) => [
+        element.dataset.id,
+        element,
+      ])
+    )
+
+    initialRows.b.click()
+    await Promise.resolve()
+    reverse()
+    await Promise.resolve()
+
+    const reorderedRows = [...root.querySelectorAll<HTMLButtonElement>('button')]
+    expect(reorderedRows.map((element) => element.textContent)).toEqual(['c:0', 'b:1', 'a:0'])
+    expect(reorderedRows[0]).toBe(initialRows.c)
+    expect(reorderedRows[1]).toBe(initialRows.b)
+    expect(reorderedRows[2]).toBe(initialRows.a)
+  })
+
+  it('reuses duplicate keyed children in their previous order', async () => {
+    let rotate: () => void = () => {}
+    const Row = ({ label }: { label: string }) => {
+      const [initialLabel] = useState(label)
+      return <div>{`${label}:${initialLabel}`}</div>
+    }
+    const App = () => {
+      const [labels, setLabels] = useState(['other', 'first', 'second'])
+      rotate = () => setLabels(['first', 'second', 'other'])
+      return labels.map((label) => (
+        <Row key={label === 'other' ? 'other' : 'duplicate'} label={label} />
+      ))
+    }
+
+    render(<App />, root)
+    const initialRows = [...root.querySelectorAll('div')]
+    rotate()
+    await Promise.resolve()
+
+    const reorderedRows = [...root.querySelectorAll('div')]
+    expect(reorderedRows.map((element) => element.textContent)).toEqual([
+      'first:first',
+      'second:second',
+      'other:other',
+    ])
+    expect(reorderedRows[0]).toBe(initialRows[1])
+    expect(reorderedRows[1]).toBe(initialRows[2])
+    expect(reorderedRows[2]).toBe(initialRows[0])
+  })
+
+  it.each([
+    {
+      consumedBy: 'an earlier keyed child',
+      before: [2, 1, 5, 1],
+      after: [9, 2, 1, 1],
+      matches: [-1, 0, 1, 3],
+      statefulIndex: 3,
+      removedIndices: [2],
+    },
+    {
+      consumedBy: 'an earlier unkeyed child',
+      before: ['other', 1, 1, 1, 3],
+      after: [1, undefined, 1, 1],
+      matches: [1, 2, 3, -1],
+      statefulIndex: 2,
+      removedIndices: [0, 4],
+    },
+  ])(
+    'does not reuse children already consumed by $consumedBy',
+    async ({ before, after, matches, statefulIndex, removedIndices }) => {
+      let reorder: () => void = () => {}
+      const Other = () => <button>Other</button>
+      const Row = () => {
+        const [count, setCount] = useState(0)
+        return <button onClick={() => setCount(count + 1)}>{count}</button>
+      }
+      const App = () => {
+        const [keys, setKeys] = useState<Array<number | string | undefined>>(before)
+        reorder = () => setKeys(after)
+        return keys.map((key) => (key === 'other' ? <Other /> : <Row key={key} />))
+      }
+
+      render(<App />, root)
+      const initialRows = [...root.querySelectorAll('button')]
+      initialRows[statefulIndex].click()
+      await Promise.resolve()
+      reorder()
+      await Promise.resolve()
+
+      const reorderedRows = [...root.querySelectorAll('button')]
+      expect(reorderedRows).toHaveLength(matches.length)
+      matches.forEach((oldIndex, newIndex) => {
+        if (oldIndex === -1) {
+          expect(initialRows.includes(reorderedRows[newIndex])).toBe(false)
+        } else {
+          expect(reorderedRows[newIndex]).toBe(initialRows[oldIndex])
+        }
+        expect(reorderedRows[newIndex].textContent).toBe(oldIndex === statefulIndex ? '1' : '0')
+      })
+      removedIndices.forEach((index) => {
+        expect(initialRows[index].isConnected).toBe(false)
+      })
+    }
+  )
+
+  it('preserves existing keyed children when prepending', async () => {
+    let prepend: () => void = () => {}
+    const App = () => {
+      const [ids, setIds] = useState(['a', 'b'])
+      prepend = () => setIds(['x', 'a', 'b'])
+      return ids.map((id) => <div key={id}>{id}</div>)
+    }
+
+    render(<App />, root)
+    const initialRows = [...root.querySelectorAll('div')]
+    prepend()
+    await Promise.resolve()
+
+    const prependedRows = [...root.querySelectorAll('div')]
+    expect(prependedRows.map((element) => element.textContent)).toEqual(['x', 'a', 'b'])
+    expect(prependedRows[1]).toBe(initialRows[0])
+    expect(prependedRows[2]).toBe(initialRows[1])
+  })
+
+  it('unmounts a keyed child removed from the middle', async () => {
+    let removeMiddle: () => void = () => {}
+    const cleanup = vi.fn()
+    const ref = vi.fn().mockReturnValue(cleanup)
+    const App = () => {
+      const [ids, setIds] = useState(['a', 'b', 'c'])
+      removeMiddle = () => setIds(['a', 'c'])
+      return ids.map((id) => (
+        <div key={id} ref={id === 'b' ? ref : undefined}>
+          {id}
+        </div>
+      ))
+    }
+
+    render(<App />, root)
+    const initialRows = [...root.querySelectorAll('div')]
+    removeMiddle()
+    await Promise.resolve()
+
+    const remainingRows = [...root.querySelectorAll('div')]
+    expect(remainingRows.map((element) => element.textContent)).toEqual(['a', 'c'])
+    expect(remainingRows[0]).toBe(initialRows[0])
+    expect(remainingRows[1]).toBe(initialRows[2])
+    expect(initialRows[1].isConnected).toBe(false)
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('cleans up removed keyed children in their previous order', async () => {
+    let remove: () => void = () => {}
+    const cleanedUp: string[] = []
+    const Row = ({ id }: { id: string }) => {
+      useLayoutEffect(
+        () => () => {
+          cleanedUp.push(id)
+        },
+        []
+      )
+      return <div>{id}</div>
+    }
+    const App = () => {
+      const [ids, setIds] = useState(['a', 'b', 'c', 'd'])
+      remove = () => setIds(['b'])
+      return ids.map((id) => <Row key={id} id={id} />)
+    }
+
+    render(<App />, root)
+    const initialRows = [...root.children]
+    remove()
+    await Promise.resolve()
+
+    expect(root.children).toHaveLength(1)
+    expect(root.firstElementChild).toBe(initialRows[1])
+    expect(cleanedUp).toEqual(['a', 'c', 'd'])
+    expect(initialRows.filter((row) => row.isConnected)).toHaveLength(1)
+  })
+
+  it('allows an unkeyed child to reuse a keyed child with the same tag', async () => {
+    let removeKeyedSiblings: () => void = () => {}
+    const Row = ({ label }: { label: string }) => {
+      const [initialLabel] = useState(label)
+      return <div>{`${label}:${initialLabel}`}</div>
+    }
+    const App = () => {
+      const [showSingle, setShowSingle] = useState(false)
+      removeKeyedSiblings = () => setShowSingle(true)
+      return showSingle ? (
+        <Row label='replacement' />
+      ) : (
+        [<Row key='keyed' label='keyed' />, <Row label='unkeyed' />]
+      )
+    }
+
+    render(<App />, root)
+    const initialRows = [...root.querySelectorAll('div')]
+    removeKeyedSiblings()
+    await Promise.resolve()
+
+    const replacement = root.querySelector('div') as HTMLDivElement
+    expect(replacement.textContent).toBe('replacement:keyed')
+    expect(replacement).toBe(initialRows[0])
+    expect(initialRows[1].isConnected).toBe(false)
+  })
+
+  it('preserves unkeyed elements and text when removing a leading sibling', async () => {
+    let hideHeading: () => void = () => {}
+    const App = () => {
+      const [showHeading, setShowHeading] = useState(true)
+      hideHeading = () => setShowHeading(false)
+      return [
+        showHeading && <h2>Heading</h2>,
+        <p>First paragraph</p>,
+        'First text',
+        <span>First span</span>,
+        <p>Second paragraph</p>,
+        'Second text',
+        <span>Second span</span>,
+      ]
+    }
+
+    render(<App />, root)
+    const initialNodes = [...root.childNodes]
+    hideHeading()
+    await Promise.resolve()
+
+    expect(root.childNodes).toHaveLength(initialNodes.length - 1)
+    initialNodes.slice(1).forEach((node, i) => {
+      expect(root.childNodes[i]).toBe(node)
+    })
+    expect(initialNodes[0].isConnected).toBe(false)
+  })
+
+  it('resumes unkeyed matching after a keyed sibling consumes the next candidate', async () => {
+    let reorder: () => void = () => {}
+    const App = () => {
+      const [updated, setUpdated] = useState(false)
+      reorder = () => setUpdated(true)
+      return updated
+        ? [<p>A</p>, <p key='b'>B</p>, <p>C</p>, <p>D</p>, <span>X</span>, <span>Y</span>]
+        : [<h2>Heading</h2>, <p key='a'>A</p>, <p key='b'>B</p>, <p>C</p>]
+    }
+
+    render(<App />, root)
+    const initialNodes = [...root.children]
+    reorder()
+    await Promise.resolve()
+
+    expect(root.innerHTML).toBe('<p>A</p><p>B</p><p>C</p><p>D</p><span>X</span><span>Y</span>')
+    initialNodes.slice(1).forEach((node, i) => {
+      expect(root.children[i]).toBe(node)
+    })
+    expect(initialNodes[0].isConnected).toBe(false)
+  })
+
+  it('does not reuse children with NaN keys', async () => {
+    let rerender: () => void = () => {}
+    const App = () => {
+      const [count, setCount] = useState(0)
+      rerender = () => setCount((count) => count + 1)
+      return <div key={Number.NaN}>{count}</div>
+    }
+
+    render(<App />, root)
+    const initialChild = root.firstElementChild
+    rerender()
+    await Promise.resolve()
+
+    expect(root.textContent).toBe('1')
+    expect(root.firstElementChild).not.toBe(initialChild)
+  })
+
   it('swap deferent type of child component', async () => {
     const Even = () => <p>Even</p>
     const Odd = () => <div>Odd</div>

--- a/src/jsx/dom/render.ts
+++ b/src/jsx/dom/render.ts
@@ -492,6 +492,19 @@ const isSameContext = (
     oldContexts.every((ctx, i) => ctx[1] === newContexts[i][1])
   )
 
+const indexChildrenByKey = (children: Node[]): Map<unknown, Node> | undefined => {
+  const index = new Map<unknown, Node>()
+  // Insert in the original order so map iteration preserves removal order.
+  for (const child of children) {
+    const key = child.key
+    if (index.has(key)) {
+      return
+    }
+    index.set(key, child)
+  }
+  return index
+}
+
 const fallbackUpdateFnArrayMap: WeakMap<
   NodeObject,
   Array<() => Promise<NodeObject | undefined>>
@@ -512,13 +525,15 @@ export const build = (context: Context, node: NodeObject, children?: Child[]): v
       foundErrorHandler = (children[0] as any)[DOM_ERROR_HANDLER] as ErrorHandler
       context[5]!.push([context, foundErrorHandler, node])
     }
-    const oldVChildren: Node[] | undefined = buildWithPreviousChildren
+    let oldVChildren: Node[] | undefined = buildWithPreviousChildren
       ? [...(node.pC as Node[])]
       : node.vC
         ? [...node.vC]
         : undefined
     const vChildren: Node[] = []
     let prevNode: Node | undefined
+    let scanBudget = (oldVChildren?.length || 0) * 2
+    let oldChildrenByKey: Map<unknown, Node> | undefined
     for (let i = 0; i < children.length; i++) {
       if (Array.isArray(children[i])) {
         children.splice(i, 1, ...((children[i] as unknown[]).flat(Infinity) as Child[]))
@@ -541,7 +556,24 @@ export const build = (context: Context, node: NodeObject, children?: Child[]): v
         }
 
         let oldChild: NodeObject | undefined
-        if (oldVChildren && oldVChildren.length) {
+        if (oldChildrenByKey && child.key === undefined && !isNodeString(child)) {
+          oldVChildren = [...oldChildrenByKey.values()]
+          oldChildrenByKey = undefined
+        }
+        if (oldChildrenByKey) {
+          const key = child.key
+          const candidate = oldChildrenByKey.get(key)
+          // The strict check also preserves the existing behavior for NaN keys.
+          if (
+            candidate &&
+            (isNodeString(child)
+              ? isNodeString(candidate)
+              : candidate.tag === child.tag && candidate.key === key)
+          ) {
+            oldChild = candidate as NodeObject
+            oldChildrenByKey.delete(key)
+          }
+        } else if (oldVChildren && oldVChildren.length) {
           const i = oldVChildren.findIndex(
             isNodeString(child)
               ? (c) => isNodeString(c)
@@ -550,9 +582,15 @@ export const build = (context: Context, node: NodeObject, children?: Child[]): v
                 : (c) => c.tag === (child as Node).tag
           )
 
+          scanBudget -= i === -1 ? oldVChildren.length : i
           if (i !== -1) {
             oldChild = oldVChildren[i] as NodeObject
             oldVChildren.splice(i, 1)
+          }
+          // Try indexing once, after searches exceed a linear budget.
+          if (scanBudget < 0) {
+            scanBudget = Infinity
+            oldChildrenByKey = indexChildrenByKey(oldVChildren)
           }
         }
 
@@ -604,6 +642,7 @@ export const build = (context: Context, node: NodeObject, children?: Child[]): v
         prevNode = child
       }
     }
+    oldVChildren = oldChildrenByKey ? [...oldChildrenByKey.values()] : oldVChildren
     node.vR = buildWithPreviousChildren ? [...node.vC, ...(oldVChildren || [])] : oldVChildren || []
     node.vC = vChildren
     if (buildWithPreviousChildren) {


### PR DESCRIPTION
fixes #5306.

Reduce repeated linear searches during large keyed child updates while preserving existing node reuse, component state, and cleanup order.

- Keep the existing forward `findIndex()` / `splice()` path for inexpensive updates.
- Try building a key index once accumulated search work exceeds a linear budget.
- Use the index only when the remaining old children have unique keys, including at most one `undefined` key.
- Preserve strict key and tag matching, distinguish text nodes from elements, and retain the original removal order.
- Fall back to array matching for new unkeyed elements so they can still reuse keyed old children with the same tag.

## Scope and relationship to #5329

This targets expensive searches during large keyed reorders. It does not make all reconciliation linear: in-order array shifts remain, and duplicate-key or unkeyed fallback paths can still require quadratic work. DOM placement is unchanged.

This branch is based directly on main and does not include #5329. That PR optimizes matching-head updates; this one addresses expensive searches. If #5329 lands first, this branch can be rebased to preserve its fast path alongside the indexed path.

## Benchmark

```sh
bun benchmarks/jsx-dom/benchmark.ts
```

The benchmark measures `build()` only, excluding JSX creation and DOM updates. It covers 100, 1,000, and 5,000 keyed children.

The same benchmark script was run against main (`eebdf7be`) and this branch (`0130dd16`) using **Bun 1.3.12 on an Apple M5 Pro**. Results below are for **5,000 keyed children**, with one additional unkeyed child in the footer case.

| Update | main (ms/build) | This PR (ms/build) |
| --- | ---: | ---: |
| Same order | 1.389 | 1.428 |
| Remove the second child | 1.564 | 1.586 |
| Adjacent swap | 1.362 | 1.413 |
| Reverse | 38.586 | 0.753 |
| Reverse with an unkeyed footer | 38.812 | 0.765 |

Values are medians of three separate process runs, with the comparison order reversed in the second run. Each run reports the median of five fresh-node batches, each with 10 warm-up updates and 20 measured updates.

These results demonstrate the benefit for large keyed reorders, rather than a general speedup for every update. They are local microbenchmark results, not browser rendering times.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
