### PR TITLE
docs: fix typos in code comments and link third-party middleware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Contributions Welcome! You can contribute in the following ways.
 
 - Create an Issue - Propose a new feature. Report a bug.
 - Pull Request - Fix a bug or typo. Refactor the code.
-- Create third-party middleware - See instructions below.
+- Create third-party middleware - See [Third-party middleware](docs/CONTRIBUTING.md#third-party-middleware).
 - Share - Share your thoughts on the Blog, X, and others.
 - Make your application - Please try to use Hono.
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -771,7 +771,7 @@ export class Context<
     const locationString = String(location)
     this.header(
       'Location',
-      // Multibyes should be encoded
+      // Multibytes should be encoded
       // eslint-disable-next-line no-control-regex
       !/[^\x00-\xFF]/.test(locationString) ? locationString : encodeURI(locationString)
     )

--- a/src/helper/cookie/index.test.ts
+++ b/src/helper/cookie/index.test.ts
@@ -314,7 +314,7 @@ describe('Cookie Middleware', () => {
       await setSignedCookie(c, 'delicious_cookie', 'macha', 'secret choco chips', {
         prefix: 'host',
         domain: 'example.com', // this will be ignored
-        path: 'example.com', // thi will be ignored
+        path: 'example.com', // this will be ignored
         secure: false, // this will be ignored
       })
       return c.text('Set host prefix cookie')

--- a/src/helper/proxy/index.ts
+++ b/src/helper/proxy/index.ts
@@ -116,7 +116,7 @@ const preprocessRequestInit = (requestInit: RequestInit): RequestInit => {
  * Fetch API wrapper for proxy.
  * The parameters and return value are the same as for `fetch` (except for the proxy-specific options).
  *
- * The “Accept-Encoding” header is replaced with an encoding that the current runtime can handle.
+ * The "Accept-Encoding" header is replaced with an encoding that the current runtime can handle.
  * Unnecessary response headers are deleted and a Response object is returned that can be returned
  * as is as a response from the handler.
  *

--- a/src/helper/route/index.ts
+++ b/src/helper/route/index.ts
@@ -37,7 +37,7 @@ export const matchedRoutes = (c: Context): RouterRoute[] =>
  * Get the route path registered within the handler
  *
  * @param {Context} c - The context object
- * @param {number} index - The index of the root from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching root. Defaults to the current root index.
+ * @param {number} index - The index of the route from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching route. Defaults to the current route index.
  * @returns The route path registered within the handler
  *
  * @example
@@ -62,7 +62,7 @@ export const routePath = (c: Context, index?: number): string =>
  * Get the basePath of the as-is route specified by routing.
  *
  * @param {Context} c - The context object
- * @param {number} index - The index of the root from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching root. Defaults to the current root index.
+ * @param {number} index - The index of the route from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching route. Defaults to the current route index.
  * @returns The basePath of the as-is route specified by routing.
  *
  * @example
@@ -86,7 +86,7 @@ export const baseRoutePath = (c: Context, index?: number): string =>
  * Get the basePath with embedded parameters
  *
  * @param {Context} c - The context object
- * @param {number} index - The index of the root from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching root. Defaults to the current root index.
+ * @param {number} index - The index of the route from which to retrieve the path, similar to Array.prototype.at(), where a negative number is the index counted from the end of the matching route. Defaults to the current route index.
  * @returns The basePath with embedded parameters.
  *
  * @example

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -46,7 +46,7 @@ export type JSONValue = JSONObject | JSONArray | JSONPrimitive
  * `JSON.stringify()` throws a `TypeError` when it encounters a `bigint` value,
  * unless a custom `replacer` function or `.toJSON()` method is provided.
  *
- * This behaviour can be controlled by the `TError` generic type parameter,
+ * This behavior can be controlled by the `TError` generic type parameter,
  * which defaults to `bigint | ReadonlyArray<bigint>`.
  * You can set it to `never` to disable this check.
  */


### PR DESCRIPTION
### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
