### PR TITLE
fix(context): return null instead of empty body when json value is undefined

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -731,7 +731,7 @@ export class Context<
     headers?: HeaderRecord
   ): JSONRespondReturn<T, U> => {
     return this.#newResponse(
-      JSON.stringify(object),
+      JSON.stringify(object) ?? 'null',
       arg,
       setDefaultContentType('application/json', headers)
     ) /* eslint-disable @typescript-eslint/no-explicit-any */ as any


### PR DESCRIPTION
`JSON.stringify(undefined)` returns `undefined`, which makes `c.json(undefined)` send an empty body with `application/json` content type. falls back to `'null'` which is valid json.