### PR TITLE
fix(accept): treat the q parameter name as case-insensitive

### DIFF
--- a/src/utils/accept.test.ts
+++ b/src/utils/accept.test.ts
@@ -43,6 +43,19 @@ describe('parseAccept Comprehensive Tests', () => {
       expect(result[0].params.q).toBe('invalid')
       expect(result[0].q).toBe(1) // Normalized q value
     })
+
+    test('treats the q parameter name as case-insensitive', () => {
+      // RFC 9110 §12.4.2: the "q" parameter is case-insensitive.
+      expect(parseAccept('text/html;Q=0.5')).toEqual([
+        { type: 'text/html', params: { Q: '0.5' }, q: 0.5 },
+      ])
+      expect(parseAccept('text/html;Q=0')[0].q).toBe(0)
+    })
+
+    test('sorts by quality when the q parameter is uppercase', () => {
+      const result = parseAccept('text/html;Q=0.5,application/json;q=0.9')
+      expect(result.map((x) => x.type)).toEqual(['application/json', 'text/html'])
+    })
   })
 
   describe('Parameter Handling', () => {

--- a/src/utils/accept.ts
+++ b/src/utils/accept.ts
@@ -221,7 +221,9 @@ export const parseAccept = (acceptHeader: string): Accept[] => {
   while (i < acceptHeader.length) {
     ;[i, accept] = getNextAcceptValue(acceptHeader, i)
     if (accept) {
-      accept.q = parseQuality(accept.params.q)
+      // The "q" parameter is case-insensitive (RFC 9110 §12.4.2). `params` keeps
+      // the name as it was sent, so both spellings are checked here.
+      accept.q = parseQuality(accept.params.q ?? accept.params.Q)
       values.push(accept)
       if (lastAccept && lastAccept.q < accept.q) {
         // find higher quality accept value, so we need to sort


### PR DESCRIPTION
`parseAccept` reads the quality value from `accept.params.q`, so a header that spells the parameter `Q=` is parsed as if it had no weight at all:

```ts
parseAccept('text/html;Q=0.5')
//=> [{ type: 'text/html', params: { Q: '0.5' }, q: 1 }]
```

RFC 9110 §12.4.2 says the parameter name is case-insensitive:

> The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.

The consequences show up wherever a weight decides something:

- `parseAccept` sorts by `q`, so `text/html;Q=0.5, application/json;q=0.9` keeps `text/html` first and `accepts()` picks the entry the client ranked lower.
- `compress` treats a missing weight as `1`, so `Accept-Encoding: gzip;Q=0` is read as "gzip strongly preferred" rather than "gzip not acceptable" — the exact inversion of what the client asked for.
- `languageDetector` inherits the same ordering through `parseAcceptLanguage`.

Real clients do send the uppercase form; it is valid HTTP and nothing else in the stack normalizes it.

## The change

One line in `parseAccept`:

```ts
accept.q = parseQuality(accept.params.q ?? accept.params.Q)
```

`params` deliberately keeps the parameter name as it was sent — that is observable through the `Accept` type and through custom `match` functions passed to `accepts()` — so the fix reads both spellings at the point of use instead of rewriting the key. `??` rather than `||` so an empty `q=` still goes through `parseQuality` and keeps its existing meaning.

Mixed-case spellings other than `q`/`Q` are not handled; a single-letter name has only those two forms.

## Validation

Two tests added under `Quality Values` in `src/utils/accept.test.ts`: `Q=0.5` parses to `q: 0.5` with `params` untouched, `Q=0` to `q: 0`, and an uppercase entry sorts correctly against a lowercase one.

`vitest run` on `src/utils/accept.test.ts`, `src/helper/accepts`, `src/middleware/compress` and `src/middleware/language`: 123 passed. Full suite: 5025 passed, 1 pre-existing failure in `src/client/utils.test.ts` (`parseResponse > should throw error matching snapshots`) that reproduces unchanged on `main`. `eslint` reports 0 errors and `tsc --noEmit` is clean.
