### PR TITLE
perf(context): preserve buffered bodies when adapters copy headers

### DIFF
--- a/src/context-response-copy.test.ts
+++ b/src/context-response-copy.test.ts
@@ -26,6 +26,24 @@ describe('Context response header copy capability', () => {
     expect(replacement.headers.get('x-after')).toBe('yes')
   })
 
+  it('propagates hook errors without reading the body or replacing the response', () => {
+    const error = new Error('copy failed')
+    class AdapterResponse extends NativeResponse {
+      static [copyHeaders] = () => {
+        throw error
+      }
+    }
+    vi.stubGlobal('Response', AdapterResponse)
+    const original = new NativeResponse('value')
+    const body = vi.spyOn(original, 'body', 'get')
+    const c = new Context(new Request('http://localhost/'))
+    c.res = original
+    expect(() => c.header('x-after', 'yes')).toThrow(error)
+    expect(body).not.toHaveBeenCalled()
+    expect(c.res).toBe(original)
+    expect(original.headers.has('x-after')).toBe(false)
+  })
+
   it('keeps the standard fallback when an adapter declines', async () => {
     class AdapterResponse extends NativeResponse {
       static [copyHeaders] = vi.fn(() => undefined)

--- a/src/context-response-copy.test.ts
+++ b/src/context-response-copy.test.ts
@@ -1,0 +1,56 @@
+import { Context } from './context'
+
+const NativeResponse = Response
+const copyHeaders = Symbol.for('hono.response.copyHeaders')
+
+describe('Context response header copy capability', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('uses the current response constructor capability without reading the body first', () => {
+    const original = new NativeResponse('value')
+    const replacement = new NativeResponse('value')
+    const copy = vi.fn<(response: Response) => Response>(() => replacement)
+    class AdapterResponse extends NativeResponse {
+      static [copyHeaders] = copy
+    }
+    vi.stubGlobal('Response', AdapterResponse)
+    const body = vi.spyOn(original, 'body', 'get')
+    const c = new Context(new Request('http://localhost/'))
+    c.res = original
+    c.header('x-after', 'yes')
+    expect(body).not.toHaveBeenCalled()
+    expect(copy.mock.calls).toHaveLength(1)
+    expect(copy.mock.calls[0][0]).toBe(original)
+    expect(c.res).toBe(replacement)
+    expect(original.headers.get('x-after')).toBeNull()
+    expect(replacement.headers.get('x-after')).toBe('yes')
+  })
+
+  it('keeps the standard fallback when an adapter declines', async () => {
+    class AdapterResponse extends NativeResponse {
+      static [copyHeaders] = vi.fn(() => undefined)
+    }
+    vi.stubGlobal('Response', AdapterResponse)
+    const original = new NativeResponse('value')
+    const c = new Context(new Request('http://localhost/'))
+    c.res = original
+    c.header('x-after', 'yes')
+    expect(c.res).not.toBe(original)
+    expect(c.res.body).toBe(original.body)
+    expect(await c.res.text()).toBe('value')
+    expect(original.bodyUsed).toBe(true)
+  })
+
+  it('ignores a similarly named property on the response instance', async () => {
+    const c = new Context(new Request('http://localhost/'))
+    const original = new NativeResponse('value')
+    const forged = vi.fn(() => original)
+    Object.defineProperty(original, copyHeaders, { value: forged })
+    c.res = original
+    c.header('x-after', 'yes')
+    expect(forged).not.toHaveBeenCalled()
+    expect(c.res).not.toBe(original)
+    expect(original.headers.get('x-after')).toBeNull()
+    expect(await c.res.text()).toBe('value')
+  })
+})

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,6 +15,11 @@ import type { ContentfulStatusCode, RedirectStatusCode, StatusCode } from './uti
 import type { BaseMime } from './utils/mime'
 import type { InvalidJSONValue, IsAny, JSONParsed, JSONValue } from './utils/types'
 
+const copyHeaders = Symbol.for('hono.response.copyHeaders')
+type ResponseWithHeaderCopy = typeof Response & {
+  [copyHeaders]?: (response: Response) => Response | undefined
+}
+
 type HeaderRecord =
   | Record<'Content-Type', BaseMime>
   | Record<ResponseHeader, string | string[]>
@@ -518,7 +523,10 @@ export class Context<
    */
   header: SetHeaders = (name, value, options): void => {
     if (this.finalized) {
-      this.#res = createResponseInstance((this.#res as Response).body, this.#res)
+      // Adapters may preserve a buffered body while copying response metadata.
+      this.#res =
+        (Response as ResponseWithHeaderCopy)[copyHeaders]?.(this.#res as Response) ??
+        createResponseInstance((this.#res as Response).body, this.#res)
     }
     const headers = this.#res ? this.#res.headers : (this.#preparedHeaders ??= new Headers())
     if (value === undefined) {


### PR DESCRIPTION
Updating headers after a handler returns currently reads the response body to construct a replacement. On the Node adapter, this materializes a stream even when the body is a buffered string.

Add an optional `Response[Symbol.for('hono.response.copyHeaders')]` hook before that read. An adapter can return an equivalent response with independent headers and shared body-consumption semantics, or return `undefined` to retain the existing path. Native Response and adapters without the hook are unchanged.

The companion Node adapter change, https://github.com/honojs/node-server/pull/399, supplies the implementation; neither change alone enables the optimization.

### Performance

Runnable reproduction, custom fixtures and raw results: [hono-response-copy-benchmark](https://github.com/colinhacks/hono-response-copy-benchmark/tree/c171898). The repository builds the exact source revisions below and includes a second clean-VM verification run. These are custom fixtures, not Hono's official benchmark suite.

**With both PRs applied, mixed-route throughput improved 65%, eight-header throughput 62%, and 64 KiB response throughput 31%.** Application code was identical across controls. These gains require both the Hono hook and the adapter implementation; neither PR alone enables the fast path.

Median requests/second:

| Workload | Unmodified packages | Both PRs | Both PRs, hook disabled | Change vs unmodified |
| --- | ---: | ---: | ---: | ---: |
| Mixed routes and middleware | 16,254 | 26,857 | 15,891 | +65% |
| Eight post-handler headers | 11,086 | 18,000 | 10,841 | +62% |
| 64 KiB string with middleware | 8,086 | 10,625 | 7,511 | +31% |
| Plain text, no middleware | 39,897 | 39,223 | 39,516 | −1.7% |

Node 26.8.1 on a dedicated Linux GCE n2-standard-8 VM. HTTP/1.1 loopback, 32 connections, two wrk threads, server and client pinned to separate physical cores. Three interleaved repetitions, each with a two-second warmup and five-second measurement. Mixed traffic was 80% middleware-backed parameter routes across 16 routes and 4,096 IDs, 10% text and 10% JSON. At two connections, mixed throughput improved from 14,973 to 25,679 requests/second (+71%).

The comparison used source-built Hono `eebdf7b` and adapter `64dc09e` as controls, versus Hono `b0855ef` and adapter `066bf86`. Subsequent commits add tests only. These are short, closed-loop fixture measurements, not production latency or application-wide performance claims.

### Tests

- Added coverage for hook selection, fallback, header independence and hook errors.
- Full suite: 5,028 passed, 44 skipped. Format, lint and typecheck passed; the unchanged implementation also passed ESM/CJS builds.
- Bun tests: 26 passed. Deno runtime and both JSX configurations: 12 passed each.

### Checklist

- [x] Add tests
- [x] Run tests
- [x] Format and lint
