### PR TITLE
fix(aws-lambda): respect backpressure when streaming the response body

### DIFF
--- a/runtime-tests/lambda/stream-backpressure.test.ts
+++ b/runtime-tests/lambda/stream-backpressure.test.ts
@@ -1,0 +1,107 @@
+import { Writable } from 'node:stream'
+import { streamHandle } from '../../src/adapter/aws-lambda/handler'
+import type { LambdaContext } from '../../src/adapter/aws-lambda/types'
+import { Hono } from '../../src/hono'
+
+const awslambda = {
+  streamifyResponse: <T>(handlerFunc: T): T => handlerFunc,
+  HttpResponseStream: {
+    from: (stream: Writable): Writable => stream,
+  },
+}
+
+vi.stubGlobal('awslambda', awslambda)
+
+type StreamingHandler = (
+  event: unknown,
+  responseStream: Writable,
+  context: LambdaContext
+) => Promise<void>
+
+const CHUNK_SIZE = 16 * 1024
+const CHUNK_COUNT = 128
+
+const event = {
+  headers: {},
+  rawPath: '/',
+  rawQueryString: '',
+  body: null,
+  isBase64Encoded: false,
+  requestContext: { http: { method: 'GET' } },
+}
+
+describe('streamHandle backpressure', () => {
+  it('should pace reads against the destination and resolve only once it has finished', async () => {
+    let emittedChunks = 0
+    let writtenBytes = 0
+    let maxChunksAhead = 0
+
+    const app = new Hono()
+    app.get(
+      '/',
+      () =>
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              if (emittedChunks < CHUNK_COUNT) {
+                emittedChunks++
+                controller.enqueue(new Uint8Array(CHUNK_SIZE))
+              } else {
+                controller.close()
+              }
+            },
+          })
+        )
+    )
+
+    const responseStream = new Writable({
+      highWaterMark: CHUNK_SIZE,
+      write(buffer: Buffer, _encoding, callback) {
+        maxChunksAhead = Math.max(maxChunksAhead, emittedChunks - writtenBytes / CHUNK_SIZE)
+        setImmediate(() => {
+          writtenBytes += buffer.length
+          callback()
+        })
+      },
+    })
+
+    const handler = streamHandle(app) as unknown as StreamingHandler
+    await handler(event, responseStream, {} as LambdaContext)
+
+    expect(writtenBytes).toBe(CHUNK_SIZE * CHUNK_COUNT)
+    expect(responseStream.writableFinished).toBe(true)
+    expect(maxChunksAhead).toBeLessThan(CHUNK_COUNT / 2)
+  })
+
+  it('should report a body that errors mid-stream without rejecting', async () => {
+    const app = new Hono()
+    app.get(
+      '/',
+      () =>
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              controller.enqueue(new Uint8Array(CHUNK_SIZE))
+              controller.error(new Error('body failed'))
+            },
+          })
+        )
+    )
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const responseStream = new Writable({
+      write(_buffer, _encoding, callback) {
+        setImmediate(callback)
+      },
+    })
+
+    const handler = streamHandle(app) as unknown as StreamingHandler
+    await expect(handler(event, responseStream, {} as LambdaContext)).resolves.toBeUndefined()
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error processing request:',
+      expect.objectContaining({ message: 'body failed' })
+    )
+    consoleError.mockRestore()
+  })
+})

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -1,3 +1,4 @@
+import { pipeline } from 'node:stream/promises'
 import type { Hono } from '../../hono'
 import type { Env, Schema } from '../../types'
 import { decodeBase64, encodeBase64 } from '../../utils/encode'
@@ -123,17 +124,20 @@ const getRequestContext = (
   return event.requestContext
 }
 
-const streamToNodeStream = async (
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  writer: NodeJS.WritableStream
-): Promise<void> => {
+async function* readWebStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): AsyncGenerator<Uint8Array> {
   let readResult = await reader.read()
   while (!readResult.done) {
-    writer.write(readResult.value)
+    yield readResult.value
     readResult = await reader.read()
   }
-  writer.end()
 }
+
+const streamToNodeStream = (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  writer: NodeJS.WritableStream
+): Promise<void> => pipeline(readWebStream(reader), writer)
 
 export const streamHandle = <
   E extends Env = Env,


### PR DESCRIPTION
Fixes #5333.

## Problem

`streamToNodeStream` in the AWS Lambda adapter ignored the return value of `writer.write()`:

```ts
while (!readResult.done) {
  writer.write(readResult.value)
  readResult = await reader.read()
}
writer.end()
```

Two consequences:

1. **No backpressure.** Once the response exceeds the destination's `highWaterMark`, `write()` returns `false`, but the loop keeps reading and writing. The whole body accumulates in the writable's internal buffer.
2. **Resolves too early.** `writer.end()` only signals that no more data is coming — it does not mean the stream has finished. `streamHandle` could resolve while `responseStream.writableFinished` was still `false`, so a Lambda invocation could complete before the response had actually been delivered.

## Fix

Read the body through an async generator and hand it to `pipeline` from `node:stream/promises`. `pipeline` paces reads against the destination, waits for `finish`, and propagates errors from either side — which is the behaviour the issue asks for, without hand-rolling the stream lifecycle.

`node:` imports are already used elsewhere in the Lambda adapters (`src/adapter/lambda-edge/handler.ts` imports `node:crypto`), and `stream/promises` is available on every Node version that supports Lambda response streaming.

## Tests

`runtime-tests/lambda/stream-backpressure.test.ts` streams 2 MiB in 16 KiB chunks into a slow writable with a 16 KiB `highWaterMark` and asserts that:

- every byte is written by the time the handler resolves,
- `writableFinished` is `true`,
- the source never runs more than a bounded number of chunks ahead of the sink.

Against `main` the first assertion fails with `expected +0 to be 2097152` — the handler resolves before a single chunk has been flushed.

A second test covers a body that errors mid-stream, confirming the handler still logs and resolves rather than rejecting, so the error contract is unchanged.

Full suite passes: 148 files, 5026 tests.
