### PR TITLE
fix(etag): preserve commas within quoted entity tags

### DIFF
--- a/src/middleware/etag/index.test.ts
+++ b/src/middleware/etag/index.test.ts
@@ -499,3 +499,31 @@ describe('Etag Middleware', () => {
     expect(res2.headers.get('X-Custom-4')).toBeNull()
   })
 })
+
+describe('ETag values containing commas', () => {
+  it.each([
+    ['"revision,1"', '"revision,1"'],
+    ['"revision,1"', 'W/"revision,1"'],
+    ['W/"revision,1"', '"other", "revision,1" , "last"'],
+    ['"revision,1"', '"other,2", W/"revision,1"'],
+  ])('matches %s against %s', async (tag, ifNoneMatch) => {
+    const app = new Hono()
+    app.use(etag())
+    app.get('/', (c) => c.text('cached content', 200, { ETag: tag }))
+    const res = await app.request('/', { headers: { 'If-None-Match': ifNoneMatch } })
+    expect(res.status).toBe(304)
+    expect(await res.text()).toBe('')
+    expect(res.headers.get('ETag')).toBe(tag)
+  })
+
+  it('does not match a portion of a quoted tag', async () => {
+    const app = new Hono()
+    app.use(etag())
+    app.get('/', (c) => c.text('cached content', 200, { ETag: '"revision"' }))
+    const res = await app.request('/', {
+      headers: { 'If-None-Match': '"revision,1", "other"' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('cached content')
+  })
+})

--- a/src/middleware/etag/index.ts
+++ b/src/middleware/etag/index.ts
@@ -30,10 +30,23 @@ export const RETAINED_304_HEADERS = [
 const stripWeak = (tag: string) => tag.replace(/^W\//, '')
 
 function etagMatches(etag: string, ifNoneMatch: string | null) {
-  return (
-    ifNoneMatch != null &&
-    ifNoneMatch.split(',').some((t) => stripWeak(t.trim()) === stripWeak(etag))
-  )
+  if (ifNoneMatch === null) {
+    return false
+  }
+  const expected = stripWeak(etag)
+  let start = 0
+  let quoted = false
+  for (let i = 0; i <= ifNoneMatch.length; i++) {
+    if (ifNoneMatch[i] === '"') {
+      quoted = !quoted
+    } else if (i === ifNoneMatch.length || (ifNoneMatch[i] === ',' && !quoted)) {
+      if (stripWeak(ifNoneMatch.slice(start, i).trim()) === expected) {
+        return true
+      }
+      start = i + 1
+    }
+  }
+  return false
 }
 
 function initializeGenerator(


### PR DESCRIPTION
An application-provided ETag such as `"revision,1"` fails to match the identical `If-None-Match` value because the middleware splits on every comma. It returns 200 with the full body instead of 304. Commas are allowed inside opaque entity tags by [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3).

Split only at commas outside quotes, retaining whitespace handling and weak comparison. Tests cover single/list values, weak tags, and a nonmatching tag sharing a prefix. Four new cases fail before the fix.

Validation: `env -u NO_COLOR bun run test` — 147 test files passed, 5,029 tests passed, 44 skipped; `bun run format:fix`, `bun run lint:fix`, and `git diff --check` passed. NO_COLOR is set by the local terminal; unsetting it restores the existing color-test expectations.

Implemented and validated with OpenAI Codex.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code — N/A: private matching logic, no API change
