### PR TITLE
fix(method-override): preserve repeated form fields

### DIFF
--- a/src/middleware/method-override/index.test.ts
+++ b/src/middleware/method-override/index.test.ts
@@ -59,6 +59,23 @@ describe('Method Override Middleware', () => {
     })
 
     describe('application/x-www-form-urlencoded', () => {
+      it.each(['tag', 'tag[]'])('Should preserve repeated %s fields', async (field) => {
+        const app = new Hono()
+        app.use('/posts', methodOverride({ app }))
+        app.delete('/posts', async (c) => {
+          const form = await c.req.formData()
+          return c.json({ values: form.getAll(field), methodField: form.get('_method') })
+        })
+        const params = new URLSearchParams([
+          ['_method', 'DELETE'],
+          [field, 'first'],
+          [field, 'second'],
+        ])
+        const res = await app.request('/posts', { method: 'POST', body: params })
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ values: ['first', 'second'], methodField: null })
+      })
+
       it('Should override POST to DELETE', async () => {
         const params = new URLSearchParams()
         params.append('message', 'Hello')

--- a/src/middleware/method-override/index.ts
+++ b/src/middleware/method-override/index.ts
@@ -6,7 +6,6 @@
 import type { Context, ExecutionContext } from '../../context'
 import type { Hono } from '../../hono'
 import type { MiddlewareHandler } from '../../types'
-import { parseBody } from '../../utils/body'
 
 type MethodOverrideOptions = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,14 +89,13 @@ export const methodOverride = (options: MethodOverrideOptions): MiddlewareHandle
       }
       // Content-Type is `application/x-www-form-urlencoded`
       if (contentType?.startsWith('application/x-www-form-urlencoded')) {
-        const params = await parseBody<Record<string, string>>(clonedRequest)
-        const method = params[methodFormName]
+        const params = new URLSearchParams(await clonedRequest.text())
+        const method = params.getAll(methodFormName).at(-1)
         if (method) {
-          delete params[methodFormName]
-          const newParams = new URLSearchParams(params)
+          params.delete(methodFormName)
           const request = new Request(newRequest, {
-            body: newParams,
-            method: method as string,
+            body: params,
+            method,
           })
           return app.fetch(request, c.env, getExecutionCtx(c))
         }


### PR DESCRIPTION
Form-based method overrides currently lose repeated URL-encoded fields: `tag=a&tag=b` becomes `tag=b`, while `tag[]=a&tag[]=b` becomes a single `a,b` value. This breaks multi-select and checkbox submissions after the request is forwarded.

Parse the body directly as URLSearchParams and remove only the override field. Keep the existing last-value behavior when the override field itself is repeated. Add regression coverage for ordinary and bracket-suffixed field names; both cases fail without the change.

Validated with `env -u NO_COLOR bun run test`, `bun run format:fix`, and `bun run lint:fix`. The environment sets NO_COLOR, which must be unset for the existing color-output tests.

Implemented and validated with OpenAI Codex.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc (not applicable: no public API change)
