### PR TITLE
fix(aws-lambda): preserve empty request headers

### DIFF
--- a/src/adapter/aws-lambda/handler.test.ts
+++ b/src/adapter/aws-lambda/handler.test.ts
@@ -269,6 +269,30 @@ describe('EventProcessor.createRequest', () => {
     })
   })
 
+  it('Should preserve empty header values', () => {
+    const v1Event: LambdaEvent = {
+      ...baseV1Event,
+      headers: { 'x-empty': '' },
+      multiValueHeaders: undefined,
+    }
+    const v2Event: LambdaEvent = {
+      ...baseV2Event,
+      headers: { 'x-empty': '' },
+    }
+    const albEvent = {
+      httpMethod: 'GET',
+      path: '/',
+      headers: { 'x-empty': '' },
+      body: null,
+      isBase64Encoded: false,
+      requestContext: { elb: { targetGroupArn: '' } },
+    } as LambdaEvent
+
+    for (const event of [v1Event, v2Event, albEvent]) {
+      expect(getProcessor(event).createRequest(event).headers.get('x-empty')).toBe('')
+    }
+  })
+
   it('Should preserve every repeated header value for version 1.0 API Gateway event', () => {
     const event: LambdaEvent = {
       ...baseV1Event,

--- a/src/adapter/aws-lambda/handler.ts
+++ b/src/adapter/aws-lambda/handler.ts
@@ -429,7 +429,7 @@ export class EventV2Processor extends EventProcessor<APIGatewayProxyEventV2> {
     this.getCookies(event, headers)
     if (event.headers) {
       for (const [k, v] of Object.entries(event.headers)) {
-        if (v) {
+        if (v !== undefined) {
           headers.set(k, v)
         }
       }
@@ -483,7 +483,7 @@ export class EventV1Processor extends EventProcessor<APIGatewayProxyEvent> {
     }
     if (event.headers) {
       for (const [k, v] of Object.entries(event.headers)) {
-        if (v && !headers.has(k)) {
+        if (v !== undefined && !headers.has(k)) {
           headers.set(k, sanitizeHeaderValue(v))
         }
       }
@@ -515,7 +515,7 @@ export class ALBProcessor extends EventProcessor<ALBProxyEvent> {
       }
     } else {
       for (const [key, value] of Object.entries(event.headers ?? {})) {
-        if (value) {
+        if (value !== undefined) {
           headers.set(key, sanitizeHeaderValue(value))
         }
       }


### PR DESCRIPTION
## Summary

- preserve present-but-empty request headers in API Gateway v1, API Gateway v2, and ALB events
- keep omitting entries whose value is `undefined`

## Before / after

| Event input | Before | After |
| --- | --- | --- |
| `headers: { "x-empty": "" }` | header absent | `x-empty` is present with an empty value |
| `headers: { "x-empty": undefined }` | header absent | unchanged |

## Impact

The event types distinguish `""` from `undefined`. The previous truthiness checks dropped `""`, so middleware and handlers observed the header as absent. This change preserves that distinction without changing multi-value header precedence or non-ASCII sanitization.

## Verification

- focused regression test failed before the change (`headers.get("x-empty")` was `null`)
- `npx vitest --run src/adapter/aws-lambda/handler.test.ts` — 39 passed
- `npx tsc -p tsconfig.spec.json --pretty false`
- Prettier, ESLint, and `git diff --check`

## Checklist

- [x] Tests added
- [x] Focused tests run
- [x] Typecheck, formatting, and lint run
- [x] No public API change
- [ ] CI — workflows await maintainer approval for this fork