### PR TITLE
fix(accept): clamp a negative q to 0, not 1

### DIFF
--- a/src/utils/accept.test.ts
+++ b/src/utils/accept.test.ts
@@ -28,7 +28,26 @@ describe('parseAccept Comprehensive Tests', () => {
     test('handles extreme q values', () => {
       const header = 'a;q=999999,b;q=-99999,c;q=Infinity,d;q=-Infinity,e;q=NaN'
       const result = parseAccept(header)
-      expect(result.map((x) => x.q)).toEqual([1, 1, 1, 0, 0])
+      // Each side clamps to the bound it is past, so a negative q sorts below a real one
+      // rather than above it -- `-99999` lands where `-Infinity` already did. Asserted as
+      // pairs because the clamp makes the sequence non-monotonic, which sorts the result.
+      expect(result.map((x) => [x.type, x.q])).toEqual([
+        ['a', 1],
+        ['c', 1],
+        ['b', 0],
+        ['d', 0],
+        ['e', 0],
+      ])
+    })
+
+    test('a negative q does not outrank a valid one', () => {
+      const result = parseAccept('application/json;q=0.9,text/html;q=-1')
+      expect(result.map((x) => [x.type, x.q])).toEqual([
+        ['application/json', 0.9],
+        ['text/html', 0],
+      ])
+      // The sort is by descending q, so the refused type must not come first.
+      expect(result[0].type).toBe('application/json')
     })
 
     test('handles malformed q values', () => {
@@ -138,7 +157,7 @@ describe('parseAccept Comprehensive Tests', () => {
     })
 
     test('handles escaped quote and semicolon inside quoted parameter', () => {
-      const header = 'text/plain;meta="a\\\";b";q=0.5'
+      const header = 'text/plain;meta="a\\";b";q=0.5'
       const result = parseAccept(header)
       expect(result).toEqual([
         {

--- a/src/utils/accept.test.ts
+++ b/src/utils/accept.test.ts
@@ -157,7 +157,7 @@ describe('parseAccept Comprehensive Tests', () => {
     })
 
     test('handles escaped quote and semicolon inside quoted parameter', () => {
-      const header = 'text/plain;meta="a\\";b";q=0.5'
+      const header = 'text/plain;meta="a\\\";b";q=0.5'
       const result = parseAccept(header)
       expect(result).toEqual([
         {

--- a/src/utils/accept.ts
+++ b/src/utils/accept.ts
@@ -249,16 +249,16 @@ const parseQuality = (qVal?: string): number => {
   }
 
   const num = Number(qVal)
-  if (num === Infinity) {
-    return 1
-  }
-  if (num === -Infinity) {
-    return 0
-  }
   if (Number.isNaN(num)) {
     return 1
   }
-  if (num < 0 || num > 1) {
+  // A qvalue is 0-1 (RFC 9110 12.4.2). Clamp rather than reject, but clamp each side to the
+  // bound it is past: sending a negative q below every real one instead of above them, which
+  // is what `-Infinity` already did.
+  if (num < 0) {
+    return 0
+  }
+  if (num > 1) {
     return 1
   }
 


### PR DESCRIPTION
## What

`parseQuality` sent every out-of-range `q` to `1`, so a **negative** q came back as the *highest* possible quality:

```
Accept: application/json;q=0.9, text/html;q=-1
```

`parseAccept` sorts by descending q and `accepts()` takes the first match, so `text/html` wins — even though `-1` is the one q value that cannot plausibly mean "prefer this".

## Why it is a bug rather than a policy

The function already clamps `-Infinity` to `0`. So the two disagreed on the same sign:

| q | before | after |
|---|---|---|
| `-1` | **1** | 0 |
| `-0.5` | **1** | 0 |
| `-99999` | **1** | 0 |
| `-Infinity` | 0 | 0 |
| `999999` | 1 | 1 |
| `Infinity` | 1 | 1 |

`-Infinity` sorted last and `-99999` sorted first purely because the `-Infinity` check ran before the range check. Each side now clamps to the bound it is past, which is what the `Infinity` branch was already doing for the top end. A qvalue is `0-1` per [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110#section-12.4.2).

Selection, end to end:

```
before   application/json;q=0.9, text/html;q=-1  ->  text/html
after    application/json;q=0.9, text/html;q=-1  ->  application/json
```

## Scope

Deliberately narrow. I did **not** touch two adjacent behaviours, because both are judgement calls rather than clear defects:

- an unparseable q (`q=invalid`) still returns `1`, while the literal string `q=NaN` returns `0`. Those disagree with each other, but which one is right is a policy question — happy to follow up if you want them unified.
- `q > 1` still clamps to `1`, unchanged.

This is also independent of the q=0 work in #5310/#5311/#5321 and the `Q` casing in #5349 — none of those touch `parseQuality`'s body.

## Tests

`handles extreme q values` had pinned the old value, so its expectation moves for `-99999` only. It is now asserted as `[type, q]` pairs, because clamping makes the sequence non-monotonic and `parseAccept` therefore sorts the result — the pair form says which input produced which q instead of hiding it behind position.

Added `a negative q does not outrank a valid one` for the selection case above.

```
red (src/utils/accept.ts reverted, tests kept)   28 pass, 2 fail
green (accept + accepts helper)                  43 pass, 0 fail
```

Wider sweep over `src/utils src/helper src/middleware`: 968 pass / 74 fail / 17 errors — and the clean tree gives the identical 74/17, so none of those are from this change. (They are environmental: `bun install` would not complete here, so I ran the suite under `bun test`.) `prettier --check` clean on both files.

## AI disclosure

Written with Claude Opus 5 via Claude Code. The bug was found by reading `parseQuality`, reproduced against the real `parseAccept`/`defaultMatch` path before any fix, and verified by reverting the source alone to confirm only the two intended tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
