### PR TITLE
fix(lambda-edge): fail with a descriptive error on a malformed event

### DIFF
--- a/src/adapter/lambda-edge/handler.test.ts
+++ b/src/adapter/lambda-edge/handler.test.ts
@@ -365,3 +365,73 @@ describe('handle', () => {
     expect(res).not.toHaveProperty('bodyEncoding')
   })
 })
+
+describe('handle with a malformed event', () => {
+  const invalidEventMessage =
+    'Unable to map the CloudFront event to a Request: expected `Records[0].cf.request` in the Lambda@Edge event.'
+
+  it('Should reject with a descriptive error when Records holds no CloudFront record', async () => {
+    const app = new Hono()
+    const handler = handle(app)
+
+    // The payload the AWS Lambda console prefills is an array of dummy ids.
+    const event = { Records: ['foo', 'bar'] } as unknown as CloudFrontEdgeEvent
+
+    await expect(handler(event)).rejects.toThrow(TypeError)
+    await expect(handler(event)).rejects.toThrow(invalidEventMessage)
+  })
+
+  it('Should reject with a descriptive error when Records is empty or absent', async () => {
+    const app = new Hono()
+    const handler = handle(app)
+
+    for (const event of [{ Records: [] }, {}] as unknown as CloudFrontEdgeEvent[]) {
+      await expect(handler(event)).rejects.toThrow(invalidEventMessage)
+    }
+  })
+
+  it('Should reject with a descriptive error when cf carries no request', async () => {
+    const app = new Hono()
+    const handler = handle(app)
+
+    const event = {
+      Records: [{ cf: { config: { distributionDomainName: 'd111111abcdef8.cloudfront.net' } } }],
+    } as unknown as CloudFrontEdgeEvent
+
+    await expect(handler(event)).rejects.toThrow(invalidEventMessage)
+  })
+
+  it('Should fall back to the distribution domain name when the request has no headers', async () => {
+    const app = new Hono()
+    app.get('/test-path', (c) => c.text(c.req.url))
+    const handler = handle(app)
+
+    const event = {
+      Records: [
+        {
+          cf: {
+            config: {
+              distributionDomainName: 'd111111abcdef8.cloudfront.net',
+              distributionId: 'EDFDVBD6EXAMPLE',
+              eventType: 'viewer-request',
+              requestId: '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
+            },
+            request: {
+              clientIp: '1.2.3.4',
+              method: 'GET',
+              querystring: '',
+              uri: '/test-path',
+            },
+          },
+        },
+      ],
+    } as unknown as CloudFrontEdgeEvent
+
+    const res = await handler(event)
+
+    expect(res).toMatchObject({
+      status: '200',
+      body: 'https://d111111abcdef8.cloudfront.net/test-path',
+    })
+  })
+})

--- a/src/adapter/lambda-edge/handler.ts
+++ b/src/adapter/lambda-edge/handler.ts
@@ -125,7 +125,8 @@ export const handle = (
     const [context, callback] = args
     let callbackError: Error | null = null
     let callbackResult: CloudFrontResult | CloudFrontRequest | undefined
-    const res = await app.fetch(createRequest(event), {
+    const cf = getCloudFrontRecord(event)
+    const res = await app.fetch(createRequest(cf), {
       event,
       context,
       callback: (err: Error | null, result?: CloudFrontResult | CloudFrontRequest) => {
@@ -135,9 +136,9 @@ export const handle = (
         }
         callback?.(err, result)
       },
-      config: event.Records[0].cf.config,
-      request: event.Records[0].cf.request,
-      response: event.Records[0].cf.response,
+      config: cf.config,
+      request: cf.request,
+      response: cf.response,
     })
     if (callbackError) {
       throw callbackError
@@ -161,21 +162,38 @@ const createResult = async (res: Response): Promise<CloudFrontResult> => {
   }
 }
 
-const createRequest = (event: CloudFrontEdgeEvent): Request => {
-  const queryString = event.Records[0].cf.request.querystring
-  const host =
-    event.Records[0].cf.request.headers?.host?.[0]?.value ||
-    event.Records[0].cf.config.distributionDomainName
-  const urlPath = `https://${host}${event.Records[0].cf.request.uri}`
+/**
+ * Reads the CloudFront record out of a Lambda@Edge event.
+ *
+ * The event is supplied by the runtime, so a malformed one means the function
+ * was invoked with something other than a Lambda@Edge event. Fail with a
+ * message naming the adapter and the missing field, rather than letting an
+ * unattributable property access error escape.
+ */
+const getCloudFrontRecord = (event: CloudFrontEdgeEvent): CloudFrontEvent['cf'] => {
+  const cf = event?.Records?.[0]?.cf
+  if (!cf?.request) {
+    throw new TypeError(
+      'Unable to map the CloudFront event to a Request: expected `Records[0].cf.request` in the Lambda@Edge event.'
+    )
+  }
+  return cf
+}
+
+const createRequest = (cf: CloudFrontEvent['cf']): Request => {
+  const request = cf.request
+  const queryString = request.querystring
+  const host = request.headers?.host?.[0]?.value || cf.config?.distributionDomainName
+  const urlPath = `https://${host}${request.uri}`
   const url = queryString ? `${urlPath}?${queryString}` : urlPath
 
   const headers = new Headers()
-  Object.entries(event.Records[0].cf.request.headers).forEach(([k, v]) => {
+  Object.entries(request.headers ?? {}).forEach(([k, v]) => {
     v.forEach((header) => headers.append(k, header.value))
   })
 
-  const requestBody = event.Records[0].cf.request.body
-  const method = event.Records[0].cf.request.method
+  const requestBody = request.body
+  const method = request.method
   const rawBody = createBody(method, requestBody)
 
   let body: string | Uint8Array<ArrayBuffer> | undefined = rawBody


### PR DESCRIPTION
Closes #4417

## Problem

`handle()` and `createRequest()` dereference `event.Records[0].cf.request` nine times with no guard. When the function is invoked with something that isn't a Lambda@Edge event, the failure surfaces as:

```
TypeError: Cannot read properties of undefined (reading '0')
```

That names neither the adapter nor the field that was missing, so there's nothing in the CloudWatch log pointing at the event shape as the cause.

## Change

Read the record once through a small `getCloudFrontRecord()` helper that throws a `TypeError` naming the expected field, and pass it down to `createRequest()`:

```
TypeError: Unable to map the CloudFront event to a Request: expected `Records[0].cf.request` in the Lambda@Edge event.
```

The function still throws, so the invocation still fails and Lambda still records the error — only the message changes. Behaviour for well-formed events is unchanged.

While in here, two crashes of the same class on *otherwise valid* events:

- `Object.entries(request.headers)` threw `Cannot convert undefined or null to object` when a request carried no `headers` key → `request.headers ?? {}`.
- `cf.config.distributionDomainName` was read without a guard on the host fallback path → `cf.config?.distributionDomainName`.

## Note on the open question in the issue

@watany-dev asked whether the payload the Lambda console prefills matches the documented Lambda@Edge event schema. It doesn't — so this PR deliberately doesn't try to *support* that payload. It only makes the resulting error attributable. That holds regardless of how the event came to be malformed, and the two `headers`/`config` fixes above are reachable from genuinely valid CloudFront events.

## Side effect on bundle size

Hoisting the repeated `event.Records[0].cf.request` chain into a local removes eight duplicated property-access chains from the minified output.

## Tests

Four new cases in `src/adapter/lambda-edge/handler.test.ts`:

- `Records` holding no CloudFront record (the console-style payload)
- `Records` empty, and absent entirely
- `cf` present but carrying no `request`
- a well-formed request with `headers` omitted → still resolves 200 and falls back to `distributionDomainName`

Verified red/green: with `handler.ts` at its pre-change state all four fail (three with the opaque property-access error, one with `Cannot convert undefined or null to object`); with the change all 21 tests in the file pass.

- `vitest --run --project main` → 4051 passed, 37 skipped, 123 files
- `bun run test:lambda-edge` → 15 passed
- `tsc -p tsconfig.spec.json` → clean

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
