### PR TITLE
fix(accepts,language): never match entries the client rejected with q=0

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -259,3 +259,71 @@ describe('Usage', () => {
     expect(await req2.text()).toBe('lang: en')
   })
 })
+
+describe('q=0 means explicitly not acceptable (RFC 9110 §12.5.1)', () => {
+  it('Should not match a supported type the client rejected with q=0', async () => {
+    const app = new Hono()
+    app.get('/', (c) =>
+      c.text(
+        accepts(c, {
+          header: 'Accept',
+          supports: ['application/json'],
+          default: 'text/html',
+        })
+      )
+    )
+
+    const res = await app.request('/', { headers: { Accept: 'application/json;q=0' } })
+    expect(await res.text()).toBe('text/html')
+  })
+
+  it('Should fall through to a lower-priority type that is still acceptable', async () => {
+    const app = new Hono()
+    app.get('/', (c) =>
+      c.text(
+        accepts(c, {
+          header: 'Accept',
+          supports: ['application/json', 'text/plain'],
+          default: 'text/html',
+        })
+      )
+    )
+
+    const res = await app.request('/', {
+      headers: { Accept: 'application/json;q=0, text/plain;q=0.5' },
+    })
+    expect(await res.text()).toBe('text/plain')
+  })
+
+  it('Should not match a wildcard the client rejected with q=0', async () => {
+    const app = new Hono()
+    app.get('/', (c) =>
+      c.text(
+        accepts(c, {
+          header: 'Accept',
+          supports: ['text/plain'],
+          default: 'text/html',
+        })
+      )
+    )
+
+    const res = await app.request('/', { headers: { Accept: 'text/*;q=0' } })
+    expect(await res.text()).toBe('text/html')
+  })
+
+  it('Should still match entries with a positive q value', async () => {
+    const app = new Hono()
+    app.get('/', (c) =>
+      c.text(
+        accepts(c, {
+          header: 'Accept',
+          supports: ['application/json'],
+          default: 'text/html',
+        })
+      )
+    )
+
+    const res = await app.request('/', { headers: { Accept: 'application/json;q=0.1' } })
+    expect(await res.text()).toBe('application/json')
+  })
+})

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -45,12 +45,17 @@ const getSpecificity = (type: string): number => {
 
 export const defaultMatch = (accepts: Accept[], config: acceptsConfig): string => {
   const { supports, default: defaultSupport } = config
-  const sortedAccepts = accepts.slice().sort((a, b) => {
-    if (b.q !== a.q) {
-      return b.q - a.q
-    }
-    return getSpecificity(b.type) - getSpecificity(a.type)
-  })
+  // A quality value of 0 means the range is explicitly not acceptable
+  // (RFC 9110 §12.5.1), so those entries must never match. This mirrors the
+  // `q > 0` check the compress middleware already performs.
+  const sortedAccepts = accepts
+    .filter((accept) => accept.q > 0)
+    .sort((a, b) => {
+      if (b.q !== a.q) {
+        return b.q - a.q
+      }
+      return getSpecificity(b.type) - getSpecificity(a.type)
+    })
 
   for (const accept of sortedAccepts) {
     const matched = supports.find((supported) => matchType(accept.type, supported))

--- a/src/middleware/language/index.test.ts
+++ b/src/middleware/language/index.test.ts
@@ -13,6 +13,43 @@ describe('languageDetector', () => {
     return app
   }
 
+  describe('q=0 means explicitly not acceptable (RFC 9110 §12.5.4)', () => {
+    it('should not detect a language the client rejected with q=0', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', { headers: { 'Accept-Language': 'fr;q=0' } })
+      expect(await res.text()).toBe('en')
+    })
+
+    it('should fall through to the next acceptable language', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr', 'es'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', {
+        headers: { 'Accept-Language': 'fr;q=0, es;q=0.8' },
+      })
+      expect(await res.text()).toBe('es')
+    })
+
+    it('should still detect languages with a positive q value', async () => {
+      const app = createTestApp({
+        supportedLanguages: ['en', 'fr'],
+        fallbackLanguage: 'en',
+        order: ['header'],
+      })
+
+      const res = await app.request('/', { headers: { 'Accept-Language': 'fr;q=0.1' } })
+      expect(await res.text()).toBe('fr')
+    })
+  })
+
   describe('Query Parameter Detection', () => {
     it('should detect language from query parameter', async () => {
       const app = createTestApp({

--- a/src/middleware/language/language.ts
+++ b/src/middleware/language/language.ts
@@ -158,7 +158,11 @@ export function detectFromHeader(c: Context, options: DetectorOptions): string |
     }
 
     const languages = parseAcceptLanguage(acceptLanguage)
-    for (const { lang } of languages) {
+    for (const { lang, q } of languages) {
+      // q=0 means the client explicitly rejected this language (RFC 9110 §12.5.4).
+      if (q <= 0) {
+        continue
+      }
       const normalizedLang = normalizeLanguage(lang, options)
       if (normalizedLang) {
         return normalizedLang


### PR DESCRIPTION
Fixes #5310

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code — no public API change

---

## Problem

RFC 9110 §12.5.1 defines a quality value of `0` as **not acceptable**, and §12.5.4 applies
the same rule to `Accept-Language`. The `compress` middleware already honours this with a
`q > 0` check in `getEncoding`. The other two consumers of `parseAccept` did not.

**`accepts()` / `defaultMatch`** sorted candidates by `q` but never excluded `q=0`:

```ts
accepts(c, { header: 'Accept', supports: ['application/json'], default: 'text/html' })
// Accept: application/json;q=0  ->  'application/json'
// the client said "anything but JSON"
```

**`languageDetector`'s header detection** destructured only `lang`, discarding `q` entirely:

```ts
// supportedLanguages: ['en', 'fr'], order: ['header']
// Accept-Language: fr;q=0  ->  'fr'
```

## Fix

Filter out non-acceptable entries before matching, in both places, consistent with what
`compress` already does.

In `defaultMatch` the filter runs before the sort, which also replaces the `.slice()` that
was there only to avoid mutating the caller's array — `.filter()` already returns a new one.

## Tests

`accepts.test.ts`:
- a supported type rejected with `q=0` returns the configured default
- matching falls through to a lower-priority type that is still acceptable
- a wildcard rejected with `q=0` does not match
- entries with a positive `q` still match

`language/index.test.ts`:
- a language rejected with `q=0` is not detected
- detection falls through to the next acceptable language
- languages with a positive `q` are still detected

Verified failing before the change and passing after.

| | before | after |
|---|---|---|
| the two suites above | 3 failed, 51 passed | **54 passed** |

Full suite: **5137 passed, 44 skipped**. The one failure, `build/remove-private-fields.test.ts`,
is present on a clean checkout and unrelated. `tsc -p tsconfig.spec.json` clean.
