### PR TITLE
fix(accept): honour an uppercase Q weight parameter

### DIFF
--- a/src/utils/accept.test.ts
+++ b/src/utils/accept.test.ts
@@ -265,3 +265,35 @@ describe('parseAccept Comprehensive Tests', () => {
     })
   })
 })
+
+describe('case-insensitive weight parameter', () => {
+  it('Should honour an uppercase Q', () => {
+    // RFC 9110 §12.4.2: the weight parameter name is case-insensitive.
+    expect(parseAccept('text/html;Q=0.5')).toEqual([
+      { type: 'text/html', params: { Q: '0.5' }, q: 0.5 },
+    ])
+  })
+
+  it('Should treat Q=0 as not acceptable', () => {
+    expect(parseAccept('text/html;Q=0')[0].q).toBe(0)
+  })
+
+  it('Should sort correctly when weights are spelled inconsistently', () => {
+    expect(parseAccept('application/json;Q=0.2, text/html;q=0.9')).toEqual([
+      { type: 'text/html', params: { q: '0.9' }, q: 0.9 },
+      { type: 'application/json', params: { Q: '0.2' }, q: 0.2 },
+    ])
+  })
+
+  it('Should prefer a lowercase q when both spellings are present', () => {
+    expect(parseAccept('text/html;q=0.5;Q=0.2')[0].q).toBe(0.5)
+  })
+
+  it('Should keep other parameter names case-sensitive', () => {
+    // Only the weight parameter is looked up case-insensitively.
+    const result = parseAccept('text/html;key=2;KEY=3;Q=0.4')
+    expect(result[0].params.key).toBe('2')
+    expect(result[0].params.KEY).toBe('3')
+    expect(result[0].q).toBe(0.4)
+  })
+})

--- a/src/utils/accept.ts
+++ b/src/utils/accept.ts
@@ -221,7 +221,11 @@ export const parseAccept = (acceptHeader: string): Accept[] => {
   while (i < acceptHeader.length) {
     ;[i, accept] = getNextAcceptValue(acceptHeader, i)
     if (accept) {
-      accept.q = parseQuality(accept.params.q)
+      // RFC 9110 §12.4.2 defines the weight parameter name as case-insensitive.
+      // Parameter names are otherwise stored verbatim, so both spellings are
+      // checked here rather than normalising the whole params record. The name is
+      // a single character, so `q` and `Q` are the only possibilities.
+      accept.q = parseQuality(accept.params.q ?? accept.params.Q)
       values.push(accept)
       if (lastAccept && lastAccept.q < accept.q) {
         // find higher quality accept value, so we need to sort


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add TSDoc/JSDoc to document the code — no public API change

---

## Problem

RFC 9110 §12.4.2 defines the weight parameter name as case-insensitive, but `parseAccept`
only ever reads `params.q`. Parameter names are stored verbatim, so a header that spells
the weight `Q` leaves that lookup `undefined` and `parseQuality` falls back to its default
of `1`.

The result is the inverse of what the client asked for:

```ts
parseAccept('text/html;Q=0')[0].q     // 1  — should be 0, "not acceptable"
parseAccept('text/html;Q=0.5')[0].q   // 1  — should be 0.5
```

`Q=0` is the worst case: the client is explicitly rejecting the type, and it is parsed as
the *highest* possible priority. Weighted entries are also mis-sorted, since every `Q`
entry is treated as unweighted:

```ts
parseAccept('application/json;Q=0.2, text/html;q=0.9')
// both parsed as q=1, so the client's ordering is lost
```

This was found while working on #5310; the two compound, because with #5359 applied a
`Q=0` entry would still be matched rather than rejected.

## Fix

Read both spellings when resolving the weight.

Parameter names are deliberately left case-sensitive otherwise — that is existing
behaviour, covered by the `params.key` / `params.KEY` assertions in `accept.test.ts`, so
normalising the whole record would be a breaking change. The weight parameter name is a
single character, so `q` and `Q` are the only spellings that exist, which makes the
targeted lookup complete rather than a partial workaround.

A lowercase `q` still wins if a header somehow carries both.

## Tests

Added to `accept.test.ts`:

- an uppercase `Q` weight is honoured
- `Q=0` parses as `0`
- entries sort correctly when weights are spelled inconsistently across a header
- a lowercase `q` is preferred when both spellings are present
- other parameter names remain case-sensitive, and a `Q` weight still resolves alongside them

Verified failing before the change and passing after.

| | before | after |
|---|---|---|
| `accept.test.ts` | 4 failed, 30 passed | **34 passed** |

Full suite: **5142 passed, 44 skipped**. The single failure,
`build/remove-private-fields.test.ts`, is present on a clean checkout and unrelated.
`tsc -p tsconfig.spec.json` clean.
