### PR TITLE
fix(reg-exp-router): allow wildcard routes to match paths containing line terminators

### DIFF
--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -1,8 +1,8 @@
 import { createNullObject } from '../utils'
 
 export const LABEL_REG_EXP_STR = '[^/]+'
-export const ONLY_WILDCARD_REG_EXP_STR = '.*'
-export const TAIL_WILDCARD_REG_EXP_STR = '(?:|/.*)'
+export const ONLY_WILDCARD_REG_EXP_STR = '[\\s\\S]*'
+export const TAIL_WILDCARD_REG_EXP_STR = '(?:|/[\\s\\S]*)'
 export const PATH_ERROR = Symbol()
 
 export type ParamAssocArray = [string, number][]

--- a/src/router/reg-exp-router/prepared-router.test.ts
+++ b/src/router/reg-exp-router/prepared-router.test.ts
@@ -122,7 +122,7 @@ describe('buildInitParams() and serializeInitParams()', () => {
     })
     expect(params).toEqual([
       {
-        [METHOD_NAME_ALL]: [/^.*$()/, [0, []], {}],
+        [METHOD_NAME_ALL]: [/^[\s\S]*$()/, [0, []], {}],
       },
       {},
     ])
@@ -136,7 +136,7 @@ describe('buildInitParams() and serializeInitParams()', () => {
     expect(params).toEqual([
       {
         [METHOD_NAME_ALL]: [
-          /^(?:\/hello\/([^/]+)(?:$()|\/posts\/([^/]+)$())|.*$())/,
+          /^(?:\/hello\/([^/]+)(?:$()|\/posts\/([^/]+)$())|[\s\S]*$())/,
           [0, 0, [], 0, [], []],
           {
             '/hello': [[], []],

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -262,4 +262,22 @@ describe('RegExpRouter', () => {
       }
     })
   })
+
+  describe('Wildcard with line terminators', () => {
+    it('Should match path with newlines', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/a/*', 'wildcard')
+      const [res] = router.match('GET', '/a/b\nc')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('wildcard')
+    })
+
+    it('Should match path with carriage return', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '*', 'wildcard')
+      const [res] = router.match('GET', '/a/b\rc')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('wildcard')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #5345

### Summary
In JavaScript regular expressions, dot () does not match line terminator characters (such as 
Usage: n [options] [COMMAND] [args]

Commands:

  n                              Display downloaded Node.js versions and install selection
  n latest                       Install the latest Node.js release (downloading if necessary)
  n lts                          Install the latest LTS Node.js release (downloading if necessary)
  n <version>                    Install Node.js <version> (downloading if necessary)
  n install <version>            Install Node.js <version> (downloading if necessary)
  n run <version> [args ...]     Execute downloaded Node.js <version> with [args ...]
  n which <version>              Output path for downloaded node <version>
  n exec <vers> <cmd> [args...]  Execute command with modified PATH, so downloaded node <version> and npm first
  n rm <version ...>             Remove the given downloaded version(s)
  n prune                        Remove all downloaded versions except the installed version
  n --latest                     Output the latest Node.js version available
  n --lts                        Output the latest LTS Node.js version available
  n ls                           Output downloaded versions
  n ls-remote [version]          Output matching versions available for download
  n uninstall                    Remove the installed Node.js
  n download <version>           Download Node.js <version> into cache

Options:

  -V, --version         Output version of n
  -h, --help            Display help information
  -p, --preserve        Preserve npm and npx during install of Node.js
  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels.
  -d, --download        Download if necessary. Used with run/exec/which.
  --cleanup             Remove cached version after install
  -a, --arch            Override system architecture
  --offline             Resolve target version against cached downloads instead of internet lookup
  --all                 ls-remote displays all matches instead of last 20
  --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)
  --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads.

Aliases:

  install: i
  latest: current
  ls: list
  lsr: ls-remote
  lts: stable
  rm: -
  run: use, as
  which: bin

Versions:

  Numeric version numbers can be complete or incomplete, with an optional leading 'v'.
  Versions can also be specified by label, or codename,
  and other downloadable releases by <remote-folder>/<version>

    4.9.1, 8, v6.1    Numeric versions
    lts               Newest Long Term Support official release
    latest, current   Newest official release
    auto              Read version from file: .n-node-version, .node-version, .nvmrc, or package.json
    engine            Read version from package.json
    boron, carbon     Codenames for release streams
    lts_latest        Node.js support aliases

    and nightly, rc/10 et al or ). When paths containing encoded newlines (, ) are passed to ,  () and  () failed to match the wildcard routes.

This PR updates  and  in  to use  instead of .

### Verification
- Added unit tests for matching wildcard paths containing newlines (
Usage: n [options] [COMMAND] [args]

Commands:

  n                              Display downloaded Node.js versions and install selection
  n latest                       Install the latest Node.js release (downloading if necessary)
  n lts                          Install the latest LTS Node.js release (downloading if necessary)
  n <version>                    Install Node.js <version> (downloading if necessary)
  n install <version>            Install Node.js <version> (downloading if necessary)
  n run <version> [args ...]     Execute downloaded Node.js <version> with [args ...]
  n which <version>              Output path for downloaded node <version>
  n exec <vers> <cmd> [args...]  Execute command with modified PATH, so downloaded node <version> and npm first
  n rm <version ...>             Remove the given downloaded version(s)
  n prune                        Remove all downloaded versions except the installed version
  n --latest                     Output the latest Node.js version available
  n --lts                        Output the latest LTS Node.js version available
  n ls                           Output downloaded versions
  n ls-remote [version]          Output matching versions available for download
  n uninstall                    Remove the installed Node.js
  n download <version>           Download Node.js <version> into cache

Options:

  -V, --version         Output version of n
  -h, --help            Display help information
  -p, --preserve        Preserve npm and npx during install of Node.js
  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels.
  -d, --download        Download if necessary. Used with run/exec/which.
  --cleanup             Remove cached version after install
  -a, --arch            Override system architecture
  --offline             Resolve target version against cached downloads instead of internet lookup
  --all                 ls-remote displays all matches instead of last 20
  --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)
  --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads.

Aliases:

  install: i
  latest: current
  ls: list
  lsr: ls-remote
  lts: stable
  rm: -
  run: use, as
  which: bin

Versions:

  Numeric version numbers can be complete or incomplete, with an optional leading 'v'.
  Versions can also be specified by label, or codename,
  and other downloadable releases by <remote-folder>/<version>

    4.9.1, 8, v6.1    Numeric versions
    lts               Newest Long Term Support official release
    latest, current   Newest official release
    auto              Read version from file: .n-node-version, .node-version, .nvmrc, or package.json
    engine            Read version from package.json
    boron, carbon     Codenames for release streams
    lts_latest        Node.js support aliases

    and nightly, rc/10 et al) and carriage returns ().
- Verified all 681 router unit tests pass cleanly.