### PR TITLE
fix(streaming/sse): include retry in CR/LF validation and use strict non-null check

### DIFF
--- a/src/helper/streaming/sse.test.tsx
+++ b/src/helper/streaming/sse.test.tsx
@@ -409,6 +409,26 @@ describe('SSE Streaming helper', () => {
     expect(onError).toBeCalledTimes(1)
   })
 
+  it('Should throw error if retry contains \\n or \\r', async () => {
+    const onError = vi.fn()
+    const res = streamSSE(
+      c,
+      async (stream) => {
+        await stream.writeSSE({ data: 'test', retry: '1000\n' as unknown as number })
+      },
+      onError
+    )
+    if (!res.body) {
+      throw new Error('Body is null')
+    }
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    const { value } = await reader.read()
+    const decodedValue = decoder.decode(value)
+    expect(decodedValue).toContain('event: error')
+    expect(onError).toBeCalledTimes(1)
+  })
+
   it('Check streamSSE handles consecutive \\r correctly', async () => {
     const res = streamSSE(c, async (stream) => {
       await stream.writeSSE({

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -24,9 +24,9 @@ export class SSEStreamingApi extends StreamingApi {
       })
       .join('\n')
 
-    for (const key of ['event', 'id'] as const) {
+    for (const key of ['event', 'id', 'retry'] as const) {
       const value = message[key]
-      if (value && /[\r\n]/.test(value)) {
+      if (value !== undefined && value !== null && /[\r\n]/.test(String(value))) {
         throw new Error(`${key} must not contain "\\r" or "\\n"`)
       }
     }


### PR DESCRIPTION
Fixes #5299

### Summary
In `writeSSE`, `event` and `id` fields were checked for CR/LF characters (`\r` / `\n`), but:
1. `retry` was omitted from the validation loop, allowing potential CR/LF injection if an invalid or coerced value was provided.
2. The falsy `if (value)` check skipped falsy non-undefined values (such as `0` or `""`).

This PR updates the validation loop in `src/helper/streaming/sse.ts` to include `retry` and uses a strict `value !== undefined && value !== null` check before testing `/[\r\n]/.test(String(value))`.

### Verification
- Added unit tests for `retry` field containing CR/LF characters.
- Verified all 20 SSE streaming tests pass cleanly.