### PR TITLE
fix(timing): honor a precision of 0 in setMetric

### DIFF
--- a/src/middleware/timing/index.test.ts
+++ b/src/middleware/timing/index.test.ts
@@ -307,4 +307,95 @@ describe('Server-Timing API', () => {
       consoleWarnSpy.mockRestore()
     })
   })
+
+  describe('Should handle precision', () => {
+    it('Should honor an explicit precision of 0 (whole milliseconds)', async () => {
+      const precisionApp = new Hono()
+
+      precisionApp.use('*', timing())
+      precisionApp.get('/', (c) => {
+        setMetric(c, 'value', 23.86, undefined, 0)
+        return c.text('/')
+      })
+
+      const res = await precisionApp.request('http://localhost/')
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('server-timing')).toContain('value;dur=24')
+    })
+
+    it('Should honor an explicit precision of 1', async () => {
+      const precisionApp = new Hono()
+
+      precisionApp.use('*', timing())
+      precisionApp.get('/', (c) => {
+        setMetric(c, 'value', 23.86, undefined, 1)
+        return c.text('/')
+      })
+
+      const res = await precisionApp.request('http://localhost/')
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('server-timing')).toContain('value;dur=23.9')
+    })
+
+    it('Should default to one decimal place when precision is omitted', async () => {
+      const precisionApp = new Hono()
+
+      precisionApp.use('*', timing())
+      precisionApp.get('/', (c) => {
+        setMetric(c, 'value', 23.86)
+        return c.text('/')
+      })
+
+      const res = await precisionApp.request('http://localhost/')
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('server-timing')).toContain('value;dur=23.9')
+    })
+
+    it('Should forward an explicit precision of 0 from endTime', async () => {
+      const precisionApp = new Hono()
+
+      precisionApp.use('*', timing())
+      precisionApp.get('/', (c) => {
+        startTime(c, 'db')
+        endTime(c, 'db', 0)
+        return c.text('/')
+      })
+
+      const res = await precisionApp.request('http://localhost/')
+      const metric = res.headers
+        .get('server-timing')
+        ?.split(',')
+        .find((part) => part.startsWith('db;dur='))
+      const dur = metric?.match(/dur=([\d.]+)/)?.[1]
+
+      expect(res.status).toBe(200)
+      expect(dur).toBeDefined()
+      // precision 0 rounds to a whole number, so there is no decimal point
+      expect(dur).not.toContain('.')
+    })
+
+    it('Should forward an explicit precision of 0 from wrapTime', async () => {
+      const precisionApp = new Hono()
+
+      precisionApp.use('*', timing())
+      precisionApp.get('/', async (c) => {
+        await wrapTime(c, 'db', Promise.resolve('data'), undefined, 0)
+        return c.text('/')
+      })
+
+      const res = await precisionApp.request('http://localhost/')
+      const metric = res.headers
+        .get('server-timing')
+        ?.split(',')
+        .find((part) => part.startsWith('db;dur='))
+      const dur = metric?.match(/dur=([\d.]+)/)?.[1]
+
+      expect(res.status).toBe(200)
+      expect(dur).toBeDefined()
+      expect(dur).not.toContain('.')
+    })
+  })
 })

--- a/src/middleware/timing/timing.ts
+++ b/src/middleware/timing/timing.ts
@@ -159,7 +159,7 @@ export const setMetric: SetMetric = (
     return
   }
   if (typeof valueDescription === 'number') {
-    const dur = valueDescription.toFixed(precision || 1)
+    const dur = valueDescription.toFixed(precision ?? 1)
 
     const metric = description ? `${name};dur=${dur};desc="${description}"` : `${name};dur=${dur}`
 


### PR DESCRIPTION
The Server-Timing middleware silently ignores an explicit `precision: 0`. If you ask for whole-millisecond metrics, you still get a decimal value. This is a small but real bug, and this PR fixes it and adds tests.

## The issue

`setMetric` formats a numeric metric with `valueDescription.toFixed(precision || 1)`. Because `||` treats `0` as falsy, passing `precision: 0` is dropped and it falls back to `1`, so the metric renders with one decimal place instead of as a whole number. `0` is a valid precision, so a caller that asks for it does not get what they asked for.

```ts
setMetric(c, 'db', 24.3, 'DB', { precision: 0 })
// Server-Timing: db;dur=24.3   (expected db;dur=24)
```

## The fix

Use `??` instead of `||`, so only `null` or `undefined` fall back to the default of `1` while an explicit `0` is honored:

```ts
const dur = valueDescription.toFixed(precision ?? 1)
```

One character of behavior, no API change. Any existing caller that relied on the default (no precision, or `undefined`) is unaffected.

## Tests

Added cases in `src/middleware/timing/index.test.ts` for `precision: 0`, `precision: 1`, and the default, plus `endTime`/`wrapTime` forwarding. All 21 timing tests pass, and reverting the fix to `||` fails the `precision: 0` cases, so the tests actually guard the behavior.
