### PR TITLE
fix(request): keep the request media type when reusing a cached body

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -377,6 +377,58 @@ describe('Body methods with caching', () => {
     expect(async () => await req.blob()).not.toThrow()
   })
 
+  describe('formData() after another representation has been cached', () => {
+    const urlencoded = 'application/x-www-form-urlencoded'
+    const body = 'foo=bar&baz=qux'
+
+    for (const first of ['text', 'arrayBuffer', 'bytes', 'blob'] as const) {
+      test(`req.formData() after req.${first}()`, async () => {
+        const req = new HonoRequest(
+          new Request('http://localhost', {
+            method: 'POST',
+            headers: { 'Content-Type': urlencoded },
+            body,
+          })
+        )
+        await req[first]()
+        const formData = await req.formData()
+        expect(formData.get('foo')).toBe('bar')
+        expect(formData.get('baz')).toBe('qux')
+      })
+    }
+
+    test('req.formData() after req.text() for multipart/form-data', async () => {
+      const boundary = '----hono-test-boundary'
+      const multipart =
+        `--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="foo"\r\n\r\n' +
+        'bar\r\n' +
+        `--${boundary}--\r\n`
+      const req = new HonoRequest(
+        new Request('http://localhost', {
+          method: 'POST',
+          headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+          body: multipart,
+        })
+      )
+      await req.text()
+      expect((await req.formData()).get('foo')).toBe('bar')
+    })
+
+    test('the cached representation is still returned unchanged', async () => {
+      const req = new HonoRequest(
+        new Request('http://localhost', {
+          method: 'POST',
+          headers: { 'Content-Type': urlencoded },
+          body,
+        })
+      )
+      expect(await req.text()).toBe(body)
+      expect(await req.text()).toBe(body)
+      expect(await req.arrayBuffer()).toEqual(new TextEncoder().encode(body).buffer)
+    })
+  })
+
   describe('req.parseBody()', async () => {
     it('should parse form data', async () => {
       const data = new FormData()

--- a/src/request.ts
+++ b/src/request.ts
@@ -227,7 +227,15 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
         if (anyCachedKey === 'json') {
           body = JSON.stringify(body)
         }
-        return new Response(body)[key]()
+        // Rebuilding the body through a bare `Response` loses the request's media
+        // type, so a representation that needs it (e.g. `formData()`) can no longer
+        // be produced even though the bytes are still available. Carry the original
+        // `Content-Type` over, except for `FormData`, where `Response` must generate
+        // a fresh multipart boundary of its own.
+        const contentType = body instanceof FormData ? undefined : raw.headers.get('content-type')
+        return new Response(body, {
+          headers: contentType ? { 'Content-Type': contentType } : undefined,
+        })[key]()
       })
     }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -232,7 +232,8 @@ export class HonoRequest<P extends string = '/', I extends Input['out'] = {}> {
         // be produced even though the bytes are still available. Carry the original
         // `Content-Type` over, except for `FormData`, where `Response` must generate
         // a fresh multipart boundary of its own.
-        const contentType = body instanceof FormData ? undefined : raw.headers.get('content-type')
+        const contentType =
+          anyCachedKey === 'formData' ? undefined : raw.headers.get('content-type')
         return new Response(body, {
           headers: contentType ? { 'Content-Type': contentType } : undefined,
         })[key]()


### PR DESCRIPTION
Fixes #5365

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

### What this fixes

Reading the body one way and then calling `c.req.formData()` threw, even though the body was already cached:

```ts
app.post('/', async (c) => {
  const raw = await c.req.text() // e.g. verify a signature over the raw body first
  const form = await c.req.formData() // TypeError
})
```

```
TypeError: Content-Type was not one of "multipart/form-data" or "application/x-www-form-urlencoded".
```

Same for `arrayBuffer()` and `bytes()` first, and same for `multipart/form-data`. It works when `formData()` is the first call, so the same request behaved differently depending on which accessor happened to run first.

### Why it happened

`#cachedBody()` rebuilds a missing representation from a cached one with a bare `Response`:

```ts
return new Response(body)[key]()
```

That `Response` has no `Content-Type`, so `Response.formData()` has nothing to decide the parser with. The original media type is still on `this.raw.headers`, it just was not passed along.

`c.req.blob()` was unaffected (a `Blob` keeps its own type) and `c.req.parseBody()` was unaffected (it reads the media type from `req.raw.headers`), which is why the inconsistency was easy to miss.

### The change

Carry the request's `Content-Type` over when rebuilding the body. `FormData` is excluded on purpose, because `Response` has to generate a fresh multipart boundary for it.

```ts
const contentType = body instanceof FormData ? undefined : raw.headers.get('content-type')
return new Response(body, {
  headers: contentType ? { 'Content-Type': contentType } : undefined,
})[key]()
```

### Tests

Added to `src/request.test.ts`, under *Body methods with caching*:

- `formData()` after `text()` / `arrayBuffer()` / `bytes()` / `blob()` for a urlencoded body
- `formData()` after `text()` for a `multipart/form-data` body
- the cached representation itself is still returned unchanged

Four of them fail before the change and pass after. The `blob()` one passes either way, since a `Blob` already carries its type.

- `vitest --run src/request.test.ts`: 50 passed
- full suite: 5125 passed, 44 skipped. The 12 failures in `color` / `logger` / `dev` / `compress(node)` are colour- and TTY-related and fail the same way on an unmodified checkout
- `tsc -p tsconfig.spec.json --noEmit`: clean
