### PR TITLE
fix(router): make RegExpRouter wildcard match line terminators

### DIFF
--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -1,8 +1,8 @@
 import { createNullObject } from '../utils'
 
 export const LABEL_REG_EXP_STR = '[^/]+'
-export const ONLY_WILDCARD_REG_EXP_STR = '.*'
-export const TAIL_WILDCARD_REG_EXP_STR = '(?:|/.*)'
+export const ONLY_WILDCARD_REG_EXP_STR = '[\\s\\S]*'
+export const TAIL_WILDCARD_REG_EXP_STR = '(?:|/[\\s\\S]*)'
 export const PATH_ERROR = Symbol()
 
 export type ParamAssocArray = [string, number][]

--- a/src/router/reg-exp-router/prepared-router.test.ts
+++ b/src/router/reg-exp-router/prepared-router.test.ts
@@ -122,7 +122,7 @@ describe('buildInitParams() and serializeInitParams()', () => {
     })
     expect(params).toEqual([
       {
-        [METHOD_NAME_ALL]: [/^.*$()/, [0, []], {}],
+        [METHOD_NAME_ALL]: [/^[\s\S]*$()/, [0, []], {}],
       },
       {},
     ])
@@ -136,7 +136,7 @@ describe('buildInitParams() and serializeInitParams()', () => {
     expect(params).toEqual([
       {
         [METHOD_NAME_ALL]: [
-          /^(?:\/hello\/([^/]+)(?:$()|\/posts\/([^/]+)$())|.*$())/,
+          /^(?:\/hello\/([^/]+)(?:$()|\/posts\/([^/]+)$())|[\s\S]*$())/,
           [0, 0, [], 0, [], []],
           {
             '/hello': [[], []],

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -247,6 +247,69 @@ describe('RegExpRouter', () => {
     })
   })
 
+  describe('Wildcard matching paths with line terminators', () => {
+    // Regression test for https://github.com/honojs/hono/issues/5345
+    // getPath() decodes the URL, so %0A becomes a real newline.
+    // The wildcard pattern must match all characters including line terminators.
+    it('Only-wildcard should match a path containing a newline', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '*', 'wildcard')
+
+      const [res] = router.match('GET', '/a\nb')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('wildcard')
+    })
+
+    it('Only-wildcard should match a path containing a carriage return', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '*', 'wildcard')
+
+      const [res] = router.match('GET', '/a\rb')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('wildcard')
+    })
+
+    it('Only-wildcard should match a path containing LS and PS', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '*', 'wildcard')
+
+      for (const ch of ['\u2028', '\u2029']) {
+        const [res] = router.match('GET', `/a${ch}b`)
+        expect(res.length).toBe(1)
+        expect(res[0][0]).toBe('wildcard')
+      }
+    })
+
+    it('Tail-wildcard should match a path containing a newline', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/files/*', 'wildcard')
+
+      const [res] = router.match('GET', '/files/a\nb')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('wildcard')
+    })
+
+    it('Tail-wildcard should match a path containing a carriage return', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/files/*', 'wildcard')
+
+      const [res] = router.match('GET', '/files/a\rb')
+      expect(res.length).toBe(1)
+      expect(res[0][0]).toBe('wildcard')
+    })
+
+    it('Tail-wildcard should match a path containing LS and PS', () => {
+      const router = new RegExpRouter<string>()
+      router.add('GET', '/files/*', 'wildcard')
+
+      for (const ch of ['\u2028', '\u2029']) {
+        const [res] = router.match('GET', `/files/a${ch}b`)
+        expect(res.length).toBe(1)
+        expect(res[0][0]).toBe('wildcard')
+      }
+    })
+  })
+
   describe('Static path including a colon in the middle', () => {
     it('Should be treated as a static path', () => {
       for (const paths of [


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

---

### Description

The wildcard patterns `.*` and `(?:|/.*)` in `RegExpRouter` currently do not match JavaScript line terminators (`\n`, `\r`, `\u2028`, `\u2029`) because the `.` metacharacter excludes them by default. 

Since `getPath()` decodes the URL prior to routing, encoded line terminators (e.g. `%0A`) become real newline characters. As a result, wildcard routes fail to match these paths, resulting in an unexpected 404 response.

This PR replaces `.*` with `[\s\S]*` and `(?:|/.*)` with `(?:|/[\s\S]*)` in `RegExpRouter` so that wildcard patterns match all characters unconditionally. This aligns its behavior with `TrieRouter`, `PatternRouter`, and `LinearRouter` which already handle these paths correctly.

Tests have been added to verify that both only-wildcard (`*`) and tail-wildcard (`/*`) patterns correctly match paths containing line terminators. Hardcoded regex snapshots in tests were also updated to reflect the new internal wildcard representation.

Closes #5345
