### PR TITLE
fix(trie-router): don't run a handler twice for a literal `*` path segment

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -370,6 +370,24 @@ export const runTest = ({
       })
     })
 
+    describe('Request path segment that is literally a star', () => {
+      beforeEach(() => {
+        router.add('GET', '/a/*', 'wildcard')
+      })
+
+      it('GET /a/* matches once, not twice', () => {
+        const res = match('GET', '/a/*')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('wildcard')
+      })
+
+      it('GET /a/*/b still matches', () => {
+        const res = match('GET', '/a/*/b')
+        expect(res.length).toBe(1)
+        expect(res[0].handler).toEqual('wildcard')
+      })
+    })
+
     describe('Suffix wildcard', () => {
       beforeEach(() => {
         router.add('GET', '/assets*', 'assets')

--- a/src/router/trie-router/node.ts
+++ b/src/router/trie-router/node.ts
@@ -119,6 +119,15 @@ export class Node<T> {
         }
 
         for (const child of node.#patterns) {
+          // A pattern node is also stored under its own key in `#children`, so a
+          // final request part that is literally the pattern (e.g. `*`) already
+          // had its handlers pushed above. Pushing them again would run the
+          // handler twice. Earlier parts still need the pattern branch, which is
+          // what lets a wildcard match the rest of the path.
+          if (isLast && child === nextNode) {
+            continue
+          }
+
           const pattern = child.#pattern!
           const params = node.#params === emptyParams ? {} : { ...node.#params }
 


### PR DESCRIPTION
Fixes #5370.

A handler runs twice when the last segment of the request path is literally `*`. Requesting `/a/*` against a route `/a/*` ran the matching middleware two times, every other path ran it once.

It is reachable on a default app, not only when TrieRouter is chosen explicitly, because SmartRouter falls back to TrieRouter whenever RegExpRouter throws `UnsupportedPathError`.

### Cause

`insert()` stores a pattern node twice, under its own key in `#children` and in `#patterns`. In `search()` a request part of `*` finds it through the `#children` lookup and pushes its handlers, then the `#patterns` loop reaches the same node and pushes them again. Any other part misses the `#children` lookup and only takes the pattern branch, which is why only a literal `*` duplicates.

### Fix

Skip the pattern branch when it resolves to the node the `#children` lookup already handled. Limited to the last segment, so a wildcard still matches the rest of the path for earlier segments. Without that limit `/a/*` stops matching `/a/*/b`.

Added the case to `common.case.test.ts`. All four routers pass it.
