### PR TITLE
fix(linear-router): don't match an empty path segment as a param

### DIFF
--- a/src/router/common.case.test.ts
+++ b/src/router/common.case.test.ts
@@ -878,6 +878,23 @@ export const runTest = ({
       })
     })
 
+    describe('Empty path segment', () => {
+      beforeEach(() => {
+        router.add('GET', '/u/:id/posts', 'posts')
+      })
+
+      it('GET /u/42/posts', () => {
+        const res = match('GET', '/u/42/posts')
+        expect(res.length).toBe(1)
+        expect(res[0].params['id']).toBe('42')
+      })
+
+      it('GET /u//posts does not match with an empty param', () => {
+        const res = match('GET', '/u//posts')
+        expect(res.length).toBe(0)
+      })
+    })
+
     describe('Same path', () => {
       beforeEach(() => {
         router.add('GET', '/hey', 'Middleware A')

--- a/src/router/linear-router/router.ts
+++ b/src/router/linear-router/router.ts
@@ -115,6 +115,11 @@ export class LinearRouter<T> implements Router<T> {
                     continue ROUTES_LOOP
                   }
                   endValuePos = path.length
+                } else if (endValuePos === pos + 1) {
+                  // an empty segment, as in `/u//posts`. A trailing empty segment
+                  // is already rejected above; reject it mid-path too instead of
+                  // capturing an empty param value.
+                  continue ROUTES_LOOP
                 }
                 value = path.slice(pos + 1, endValuePos)
                 pos = endValuePos


### PR DESCRIPTION
Fixes #5372.

`LinearRouter` matched `/u//posts` against `/u/:id/posts` and set `id` to an empty string. RegExpRouter, TrieRouter and PatternRouter all return 404 for that path.

```ts
const app = new Hono({ router: new LinearRouter() })
app.get('/u/:id/posts', (c) => c.json({ id: c.req.param('id') }))
await app.request('http://localhost/u//posts')   // was 200 { id: "" }
```

### Cause

The value extraction already rejected an empty segment at the end of the path, but not one in the middle. For `/u//posts`, `path.indexOf('/', pos + 1)` returns `pos + 1`, so the slice is empty and the match carries on. That is why `/a/:p` correctly 404s on `/a/` while `/u/:id/posts` matched `/u//posts`.

### Fix

Reject `endValuePos === pos + 1` the same way the trailing case is already rejected. Added the case to `common.case.test.ts`; all four routers pass it.
