### PR TITLE
fix(accepts): match media types and language tags case-insensitively

### DIFF
--- a/src/helper/accepts/accepts.test.ts
+++ b/src/helper/accepts/accepts.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from '../..'
 import { parseAccept } from '../../utils/accept'
+import type { AcceptHeader } from '../../utils/headers'
 import type { Accept, acceptsConfig, acceptsOptions } from './accepts'
 import { accepts, defaultMatch } from './accepts'
 
@@ -237,6 +238,39 @@ describe('accepts', () => {
     }
     const result = accepts(c, options)
     expect(result).toBe('text/html')
+  })
+
+  describe('case insensitivity', () => {
+    const pick = async (header: AcceptHeader, value: string, supports: string[]) => {
+      const app = new Hono()
+      app.get('/', (c) => c.text(accepts(c, { header, supports, default: 'DEFAULT' })))
+      const res = await app.request('/', { headers: { [header]: value } })
+      return res.text()
+    }
+
+    // Media types are case-insensitive (RFC 9110 §8.3.1)
+    test.each(['text/html', 'TEXT/HTML', 'Text/Html', 'text/HTML'])(
+      'Accept: %s matches text/html',
+      async (value) => {
+        expect(await pick('Accept', value, ['text/html'])).toBe('text/html')
+      }
+    )
+
+    test('a case-different subtype wildcard still matches', async () => {
+      expect(await pick('Accept', 'TEXT/*', ['text/html'])).toBe('text/html')
+    })
+
+    // Language tags are case-insensitive (RFC 4647 §2.1)
+    test.each(['en-US', 'EN-US', 'en-us', 'En-Us'])(
+      'Accept-Language: %s matches en-US',
+      async (value) => {
+        expect(await pick('Accept-Language', value, ['en-US'])).toBe('en-US')
+      }
+    )
+
+    test('a case-different entry with q=0 is still not acceptable', async () => {
+      expect(await pick('Accept-Language', 'EN;q=0', ['en'])).toBe('DEFAULT')
+    })
   })
 })
 

--- a/src/helper/accepts/accepts.ts
+++ b/src/helper/accepts/accepts.ts
@@ -19,15 +19,21 @@ export interface acceptsOptions extends acceptsConfig {
 }
 
 const matchType = (acceptType: string, supportedType: string): boolean => {
-  if (acceptType === supportedType) {
+  // Media types and language tags are both case-insensitive (RFC 9110 §8.3.1,
+  // RFC 4647 §2.1), so compare them case-folded. `defaultMatch` returns the
+  // caller's own `supports` entry, so its casing is preserved.
+  const accept = acceptType.toLowerCase()
+  const supported = supportedType.toLowerCase()
+
+  if (accept === supported) {
     return true
   }
-  if (acceptType === '*/*' || acceptType === '*') {
+  if (accept === '*/*' || accept === '*') {
     return false
   }
-  if (acceptType.endsWith('/*')) {
-    const [acceptMain] = acceptType.split('/')
-    const [supportedMain] = supportedType.split('/')
+  if (accept.endsWith('/*')) {
+    const [acceptMain] = accept.split('/')
+    const [supportedMain] = supported.split('/')
     return acceptMain === supportedMain
   }
   return false


### PR DESCRIPTION
Fixes #5375.

`matchType()` compared the accept header entry and the supported value as raw strings, so `Accept: TEXT/HTML` did not match a supported `text/html`, and `Accept-Language: en-us` did not match `en-US`.

Media types are case-insensitive (RFC 9110 §8.3.1) and so are language tags (RFC 4647 §2.1). The subtype wildcard path had the same problem, so `TEXT/*` did not match `text/html` either.

#5064 already made `parseBody()` and `validator()` match media types case-insensitively, for #5060. `accepts()` was not part of that change.

### Change

Compare case-folded inside `matchType()`. `defaultMatch()` returns the caller's own `supports` entry, so the casing an application registered is preserved, and `q=0` entries are still rejected regardless of case.

Added tests for both headers, the wildcard case, and a case-different `q=0` entry.
