### PR TITLE
fix(ssg): do not reuse created directories across toSSG runs

### DIFF
--- a/src/helper/ssg/ssg.test.tsx
+++ b/src/helper/ssg/ssg.test.tsx
@@ -284,6 +284,26 @@ describe('toSSG function', () => {
     expect(fsMock.writeFile).toHaveBeenCalledWith('/tmp/out/index.html', expect.any(String))
   })
 
+  it('Should create the output directories again on a later run', async () => {
+    const app = new Hono()
+    app.get('/about/team', (c) => c.html('Hello, World!'))
+    const createFsMock = (): FileSystemModule => ({
+      writeFile: vi.fn(() => Promise.resolve()),
+      mkdir: vi.fn(() => Promise.resolve()),
+    })
+
+    const firstFsMock = createFsMock()
+    await toSSG(app, firstFsMock, { dir: './static-rerun' })
+    expect(firstFsMock.mkdir).toHaveBeenCalledWith('static-rerun/about', { recursive: true })
+
+    // The directory may have been removed between runs, e.g. by a clean step,
+    // so a later run must not assume that an earlier run's directories still exist.
+    const secondFsMock = createFsMock()
+    const result = await toSSG(app, secondFsMock, { dir: './static-rerun' })
+    expect(result.success).toBe(true)
+    expect(secondFsMock.mkdir).toHaveBeenCalledWith('static-rerun/about', { recursive: true })
+  })
+
   it('Should correctly generate files with the expected paths', async () => {
     app.get('/data', (c) =>
       c.text(JSON.stringify({ title: 'hono' }), 200, {

--- a/src/helper/ssg/ssg.ts
+++ b/src/helper/ssg/ssg.ts
@@ -306,12 +306,14 @@ export const fetchRoutesContent = function* <
  * `saveContentToFile` is an experimental feature.
  * The API might be changed.
  */
-const createdDirs: Set<string> = new Set()
 export const saveContentToFile = async (
   data: Promise<{ routePath: string; content: string | ArrayBuffer; mimeType: string } | undefined>,
   fsModule: FileSystemModule,
   outDir: string,
-  extensionMap?: Record<string, string>
+  extensionMap?: Record<string, string>,
+  // Directories already created by the current run. It must not outlive the run:
+  // the output may be removed between runs, and a stale entry would skip `mkdir`.
+  createdDirs: Set<string> = new Set()
 ): Promise<string | undefined> => {
   const awaitedData = await data
   if (!awaitedData) {
@@ -428,6 +430,7 @@ export const toSSG: ToSSGInterface = async (app, fs, options) => {
     const combinedAfterResponseHook = combineAfterResponseHooks(
       afterResponseHooks.length > 0 ? afterResponseHooks : [(req) => req]
     )
+    const createdDirs: Set<string> = new Set()
     const getInfoGen = fetchRoutesContent(
       app,
       combinedBeforeRequestHook,
@@ -442,7 +445,9 @@ export const toSSG: ToSSGInterface = async (app, fs, options) => {
           }
           for (const content of getContentGen) {
             savePromises.push(
-              saveContentToFile(content, fs, outputDir, options?.extensionMap).catch((e) => e)
+              saveContentToFile(content, fs, outputDir, options?.extensionMap, createdDirs).catch(
+                (e) => e
+              )
             )
           }
         })


### PR DESCRIPTION
I noticed that `saveContentToFile` in the SSG helper keeps the directories it has already created in a module-level `Set`, and nothing ever clears it. The cache is meant to avoid calling `mkdir` once per file, but it outlives the `toSSG` call that filled it.

So when `toSSG` runs a second time in the same process and the output directory was removed in between (a clean step before a rebuild, or tests writing into a fresh directory), every directory created by the earlier run is skipped. Nested routes then fail to write. I reproduced it with the real `node:fs/promises`:

```ts
const app = new Hono()
app.get('/about/team', (c) => c.html('<h1>team</h1>'))
const dir = '/tmp/hono-ssg-repro'

await fs.rm(dir, { recursive: true, force: true })
await toSSG(app, fs, { dir }) // success: true

await fs.rm(dir, { recursive: true, force: true })
await toSSG(app, fs, { dir })
// success: false, error: ENOENT: no such file or directory, open '/tmp/hono-ssg-repro/about/team.html'
```

With this change the second run succeeds as well.

The fix scopes the `Set` to a single run: `toSSG` creates one and passes it to `saveContentToFile` as a new optional last parameter. When `saveContentToFile` is called on its own it falls back to a fresh `Set`, so existing callers keep working (they just no longer share state between calls). `mkdir` is still called once per directory within a run.

I added a test that runs `toSSG` twice with two fs mocks and checks that the second run calls `mkdir` for `static-rerun/about` too. It fails on `main` (the second mock gets 0 calls) and passes with the fix. The full `vitest run` passes locally.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code

AI tools used
