### PR TITLE
fix(sse): validate retry is a finite number before emitting the SSE frame

### DIFF
--- a/src/helper/streaming/sse.test.ts
+++ b/src/helper/streaming/sse.test.ts
@@ -1,0 +1,96 @@
+import { SSEStreamingApi } from './sse'
+
+const makeApi = () => {
+  const { readable, writable } = new TransformStream<Uint8Array>()
+  const api = new SSEStreamingApi(writable, readable)
+  return api
+}
+
+const readAll = async (readable: ReadableStream<Uint8Array>): Promise<string> => {
+  const reader = readable.getReader()
+  const chunks: Uint8Array[] = []
+  for (;;) {
+    const { value, done } = await reader.read()
+    if (done) {
+      break
+    }
+    chunks.push(value)
+  }
+  return new TextDecoder().decode(
+    chunks.reduce((a, b) => {
+      const merged = new Uint8Array(a.length + b.length)
+      merged.set(a)
+      merged.set(b, a.length)
+      return merged
+    }, new Uint8Array())
+  )
+}
+
+describe('SSEStreamingApi', () => {
+  it('writes a basic data message', async () => {
+    const api = makeApi()
+    await api.writeSSE({ data: 'hello' })
+    api.close()
+    expect(await readAll(api.responseReadable)).toBe('data: hello\n\n')
+  })
+
+  it('writes event, id, and retry fields', async () => {
+    const api = makeApi()
+    await api.writeSSE({ data: 'msg', event: 'update', id: '42', retry: 3000 })
+    api.close()
+    expect(await readAll(api.responseReadable)).toBe('event: update\ndata: msg\nid: 42\nretry: 3000\n\n')
+  })
+
+  it('splits multi-line data into multiple data: lines', async () => {
+    const api = makeApi()
+    await api.writeSSE({ data: 'line1\nline2' })
+    api.close()
+    expect(await readAll(api.responseReadable)).toBe('data: line1\ndata: line2\n\n')
+  })
+
+  it('throws when event contains CR or LF', async () => {
+    const api = makeApi()
+    await expect(api.writeSSE({ data: 'x', event: 'foo\nbar' })).rejects.toThrow(
+      'event must not contain "\\r" or "\\n"'
+    )
+  })
+
+  it('throws when id contains CR or LF', async () => {
+    const api = makeApi()
+    await expect(api.writeSSE({ data: 'x', id: 'id\r\ninjected' })).rejects.toThrow(
+      'id must not contain "\\r" or "\\n"'
+    )
+  })
+
+  it('throws when retry is NaN', async () => {
+    const api = makeApi()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(api.writeSSE({ data: 'x', retry: NaN as any })).rejects.toThrow(
+      'retry must be a finite number'
+    )
+  })
+
+  it('throws when retry is Infinity', async () => {
+    const api = makeApi()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(api.writeSSE({ data: 'x', retry: Infinity as any })).rejects.toThrow(
+      'retry must be a finite number'
+    )
+  })
+
+  it('throws when retry is a CRLF-containing string (as any bypass)', async () => {
+    const api = makeApi()
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      api.writeSSE({ data: 'hello', retry: '0\r\nevent: injected\r\ndata: pwned\r\n\r\n' as any })
+    ).rejects.toThrow('retry must be a finite number')
+  })
+
+  it('accepts a valid finite retry value', async () => {
+    const api = makeApi()
+    await api.writeSSE({ data: 'ok', retry: 5000 })
+    api.close()
+    const text = await readAll(api.responseReadable)
+    expect(text).toContain('retry: 5000')
+  })
+})

--- a/src/helper/streaming/sse.ts
+++ b/src/helper/streaming/sse.ts
@@ -31,6 +31,10 @@ export class SSEStreamingApi extends StreamingApi {
       }
     }
 
+    if (message.retry !== undefined && !Number.isFinite(message.retry)) {
+      throw new Error('retry must be a finite number')
+    }
+
     const sseData =
       [
         message.event && `event: ${message.event}`,


### PR DESCRIPTION
## Summary

`writeSSE` validates `event` and `id` against CR/LF injection but left `retry` unguarded.

Although `SSEMessage` declares `retry` as `number`, callers using `as any` (or values from external sources) could pass a string containing `\r\n`, which terminates the current SSE frame and allows trailing content to be parsed as new `event:`/`id:`/`data:` fields by every connected client — the same response-splitting class the existing checks already defend against.

**Fix:** coerce the check to `Number.isFinite`. Non-finite values (`NaN`, `±Infinity`) and non-numeric strings fail, consistent with the SSE spec requirement that `retry` carries a decimal integer.

Closes #5299

## Changes

- Added `Number.isFinite` guard on `retry` in `writeSSE`
- Extended `sse.test.ts` to cover basic writes, multi-line data, the existing `event`/`id` rejections, and four new `retry` cases